### PR TITLE
feat: Add Agent Manifest JSON Schema (#3)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v1.18.2
     hooks:
       - id: mypy
-        additional_dependencies: [pydantic>=2.0]
+        additional_dependencies: [pydantic>=2.0, pytest]
   - repo: https://github.com/AleksaC/hadolint-py
     rev: v2.14.0
     hooks:

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://coreason.ai/schemas/agent.schema.json",
+  "title": "CoReason Agent Manifest",
+  "description": "The definitive source of truth for CoReason Agent definitions.",
+  "type": "object",
+  "required": ["metadata", "interface", "topology", "dependencies"],
+  "properties": {
+    "metadata": {
+      "type": "object",
+      "required": ["id", "version", "name", "author", "created_at"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "format": "uuid",
+          "description": "Unique Identifier for the Agent (UUID)."
+        },
+        "version": {
+          "type": "string",
+          "pattern": "^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "description": "Semantic Version of the Agent."
+        },
+        "name": {
+          "type": "string",
+          "description": "Name of the Agent."
+        },
+        "author": {
+          "type": "string",
+          "description": "Author of the Agent."
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "Creation timestamp (ISO 8601)."
+        }
+      }
+    },
+    "interface": {
+      "type": "object",
+      "required": ["inputs", "outputs"],
+      "properties": {
+        "inputs": {
+          "type": "object",
+          "description": "Typed arguments the agent accepts (JSON Schema)."
+        },
+        "outputs": {
+          "type": "object",
+          "description": "Typed structure of the result."
+        }
+      }
+    },
+    "topology": {
+      "type": "object",
+      "required": ["steps", "model_config"],
+      "properties": {
+        "steps": {
+          "type": "array",
+          "description": "A directed acyclic graph (DAG) of execution steps.",
+          "items": {
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Unique identifier for the step."
+              },
+              "description": {
+                "type": "string",
+                "description": "Description of the step."
+              }
+            }
+          }
+        },
+        "model_config": {
+          "type": "object",
+          "required": ["model", "temperature"],
+          "properties": {
+            "model": {
+              "type": "string",
+              "description": "The LLM model identifier."
+            },
+            "temperature": {
+              "type": "number",
+              "minimum": 0.0,
+              "maximum": 2.0,
+              "description": "Temperature for generation."
+            }
+          }
+        }
+      }
+    },
+    "dependencies": {
+      "type": "object",
+      "properties": {
+        "tools": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of MCP capability URIs required."
+        },
+        "libraries": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "List of Python packages required (if code execution is allowed)."
+        }
+      }
+    },
+    "integrity_hash": {
+      "type": "string",
+      "description": "SHA256 hash of the source code."
+    }
+  }
+}

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,82 @@
+# Prosperity-3.0
+import json
+import os
+import uuid
+from typing import Any, Dict
+
+import pytest
+from jsonschema import FormatChecker, ValidationError, validate
+
+SCHEMA_PATH = os.path.join(os.path.dirname(__file__), "..", "src", "coreason_manifest", "schemas", "agent.schema.json")
+
+
+def load_schema() -> Dict[str, Any]:
+    with open(SCHEMA_PATH, "r") as f:
+        data = json.load(f)
+        if not isinstance(data, dict):
+            raise ValueError("Schema must be a dictionary")
+        return data
+
+
+@pytest.fixture
+def agent_schema() -> Dict[str, Any]:
+    return load_schema()
+
+
+@pytest.fixture
+def valid_agent_data() -> Dict[str, Any]:
+    return {
+        "metadata": {
+            "id": str(uuid.uuid4()),
+            "version": "1.0.0",
+            "name": "Test Agent",
+            "author": "Test Author",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "interface": {
+            "inputs": {"type": "object", "properties": {"query": {"type": "string"}}},
+            "outputs": {"type": "string"},
+        },
+        "topology": {
+            "steps": [{"id": "step1", "description": "First step"}],
+            "model_config": {"model": "gpt-4", "temperature": 0.7},
+        },
+        "dependencies": {"tools": ["tool:search"], "libraries": ["pandas==2.0.1"]},
+    }
+
+
+def test_schema_valid_agent(agent_schema: Dict[str, Any], valid_agent_data: Dict[str, Any]) -> None:
+    """Test that a valid agent dictionary passes schema validation."""
+    validate(instance=valid_agent_data, schema=agent_schema, format_checker=FormatChecker())
+
+
+def test_schema_invalid_version(agent_schema: Dict[str, Any], valid_agent_data: Dict[str, Any]) -> None:
+    """Test that an invalid SemVer version fails schema validation."""
+    valid_agent_data["metadata"]["version"] = "invalid-version"
+    with pytest.raises(ValidationError):
+        validate(instance=valid_agent_data, schema=agent_schema, format_checker=FormatChecker())
+
+
+def test_schema_invalid_uuid(agent_schema: Dict[str, Any], valid_agent_data: Dict[str, Any]) -> None:
+    """Test that an invalid UUID fails schema validation."""
+    valid_agent_data["metadata"]["id"] = "not-a-uuid"
+    with pytest.raises(ValidationError):
+        validate(instance=valid_agent_data, schema=agent_schema, format_checker=FormatChecker())
+
+
+def test_schema_invalid_temperature(agent_schema: Dict[str, Any], valid_agent_data: Dict[str, Any]) -> None:
+    """Test that temperature outside range fails schema validation."""
+    valid_agent_data["topology"]["model_config"]["temperature"] = 2.5
+    with pytest.raises(ValidationError):
+        validate(instance=valid_agent_data, schema=agent_schema, format_checker=FormatChecker())
+
+    valid_agent_data["topology"]["model_config"]["temperature"] = -0.1
+    with pytest.raises(ValidationError):
+        validate(instance=valid_agent_data, schema=agent_schema, format_checker=FormatChecker())
+
+
+def test_schema_missing_required_field(agent_schema: Dict[str, Any], valid_agent_data: Dict[str, Any]) -> None:
+    """Test that missing required field fails schema validation."""
+    del valid_agent_data["metadata"]
+    with pytest.raises(ValidationError):
+        validate(instance=valid_agent_data, schema=agent_schema, format_checker=FormatChecker())


### PR DESCRIPTION
* feat: Add Agent Manifest JSON Schema

- Create `src/coreason_manifest/schemas/agent.schema.json` complying with JSON Schema Draft 2020-12.
- Define schema for metadata, interface, topology, and dependencies.
- Add `tests/test_schema.py` to validate the schema against valid and invalid payloads.
- Ensure strict format validation for UUID, SemVer, and Date-Time.