### PR TITLE
Implement TBOM Allowlist Enforcement (#10)

### DIFF
--- a/src/coreason_manifest/engine.py
+++ b/src/coreason_manifest/engine.py
@@ -1,9 +1,9 @@
 # Prosperity-3.0
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Union
+from typing import List, Optional, Union
 
 from coreason_manifest.integrity import IntegrityChecker
 from coreason_manifest.loader import ManifestLoader
@@ -21,6 +21,8 @@ class ManifestConfig:
 
     policy_path: Union[str, Path]
     opa_path: str = "opa"
+    tbom_path: Optional[Union[str, Path]] = None
+    extra_data_paths: List[Union[str, Path]] = field(default_factory=list)
 
 
 class ManifestEngine:
@@ -37,7 +39,17 @@ class ManifestEngine:
         """
         self.config = config
         self.schema_validator = SchemaValidator()
-        self.policy_enforcer = PolicyEnforcer(policy_path=config.policy_path, opa_path=config.opa_path)
+
+        # Collect data paths
+        data_paths = list(config.extra_data_paths)
+        if config.tbom_path:
+            data_paths.append(config.tbom_path)
+
+        self.policy_enforcer = PolicyEnforcer(
+            policy_path=config.policy_path,
+            opa_path=config.opa_path,
+            data_paths=data_paths,
+        )
 
     def load_and_validate(self, manifest_path: Union[str, Path], source_dir: Union[str, Path]) -> AgentDefinition:
         """

--- a/src/coreason_manifest/policies/tbom.json
+++ b/src/coreason_manifest/policies/tbom.json
@@ -1,0 +1,14 @@
+{
+  "tbom": [
+    "requests",
+    "pydantic",
+    "httpx",
+    "pandas",
+    "numpy",
+    "scipy",
+    "scikit-learn",
+    "torch",
+    "fastapi",
+    "uvicorn"
+  ]
+}

--- a/tests/test_coverage_fix.py
+++ b/tests/test_coverage_fix.py
@@ -1,0 +1,40 @@
+# Prosperity-3.0
+from pathlib import Path
+
+import pytest
+
+from coreason_manifest.engine import ManifestConfig, ManifestEngine
+from coreason_manifest.policy import PolicyEnforcer
+
+
+def test_policy_enforcer_init_missing_data_file() -> None:
+    """Test that PolicyEnforcer raises FileNotFoundError if data file missing."""
+    with pytest.raises(FileNotFoundError):
+        PolicyEnforcer(
+            policy_path=Path("src/coreason_manifest/policies/compliance.rego"),
+            data_paths=["non_existent.json"],
+        )
+
+
+def test_manifest_config_data_paths(tmp_path: Path) -> None:
+    """Test that ManifestEngine correctly assembles data paths from config."""
+    policy_path = tmp_path / "policy.rego"
+    policy_path.touch()
+    tbom_path = tmp_path / "tbom.json"
+    tbom_path.touch()
+    extra_path = tmp_path / "extra.json"
+    extra_path.touch()
+
+    config = ManifestConfig(
+        policy_path=policy_path,
+        tbom_path=tbom_path,
+        extra_data_paths=[extra_path],
+    )
+
+    engine = ManifestEngine(config)
+
+    # Check if paths were passed to enforcer
+    # We check if lists have same elements
+    assert len(engine.policy_enforcer.data_paths) == 2
+    assert tbom_path in engine.policy_enforcer.data_paths
+    assert extra_path in engine.policy_enforcer.data_paths

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -13,6 +13,7 @@ from coreason_manifest.policy import PolicyEnforcer
 
 # Path to the default policy
 POLICY_PATH = Path("src/coreason_manifest/policies/compliance.rego")
+TBOM_PATH = Path("src/coreason_manifest/policies/tbom.json")
 # Path to the OPA binary downloaded in the setup phase (assumed to be in repo root)
 OPA_BINARY = "./opa" if os.path.exists("./opa") else shutil.which("opa")
 
@@ -32,7 +33,7 @@ def valid_agent_data() -> Dict[str, Any]:
             "steps": [{"id": "step1", "description": "Long enough description"}],
             "model_config": {"model": "gpt-4", "temperature": 0.7},
         },
-        "dependencies": {"tools": [], "libraries": ["requests"]},
+        "dependencies": {"tools": [], "libraries": ["requests==2.31.0"]},
     }
 
 
@@ -127,7 +128,8 @@ def test_opa_invalid_json_output(valid_agent_data: Dict[str, Any], tmp_path: Pat
 def test_real_opa_integration(valid_agent_data: Dict[str, Any]) -> None:
     """Integration test with real OPA binary."""
     assert OPA_BINARY is not None
-    enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY)
+    # Must include TBOM for real integration to pass Rule 2
+    enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[TBOM_PATH])
 
     # 1. Valid Case
     enforcer.evaluate(valid_agent_data)

--- a/tests/test_policy_complex.py
+++ b/tests/test_policy_complex.py
@@ -14,6 +14,7 @@ from coreason_manifest.policy import PolicyEnforcer
 # We assume OPA is available or mocked.
 # If unavailable, we skip real execution tests.
 POLICY_PATH = Path("src/coreason_manifest/policies/compliance.rego")
+TBOM_PATH = Path("src/coreason_manifest/policies/tbom.json")
 OPA_BINARY = "./opa" if os.path.exists("./opa") else shutil.which("opa")
 
 
@@ -55,7 +56,7 @@ def test_dependency_pinning_enforcement(valid_agent_data: Dict[str, Any], tmp_pa
 def test_rego_pinning_logic_real(valid_agent_data: Dict[str, Any]) -> None:
     """Test actual Rego logic for pinning using OPA binary."""
     assert OPA_BINARY
-    enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY)
+    enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[TBOM_PATH])
 
     # Case 1: Valid pinned
     enforcer.evaluate(valid_agent_data)

--- a/tests/test_policy_tbom.py
+++ b/tests/test_policy_tbom.py
@@ -1,0 +1,118 @@
+# Prosperity-3.0
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from coreason_manifest.errors import PolicyViolationError
+from coreason_manifest.policy import PolicyEnforcer
+
+# Path to the default policy
+POLICY_PATH = Path("src/coreason_manifest/policies/compliance.rego")
+TBOM_PATH = Path("src/coreason_manifest/policies/tbom.json")
+# Path to the OPA binary downloaded in the setup phase (assumed to be in repo root)
+OPA_BINARY = "./opa" if os.path.exists("./opa") else shutil.which("opa")
+
+
+@pytest.fixture
+def valid_agent_data() -> Dict[str, Any]:
+    return {
+        "metadata": {
+            "id": "123e4567-e89b-12d3-a456-426614174000",
+            "version": "1.0.0",
+            "name": "Test Agent",
+            "author": "Test Author",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "interface": {"inputs": {}, "outputs": {}},
+        "topology": {
+            "steps": [{"id": "step1", "description": "Long enough description"}],
+            "model_config": {"model": "gpt-4", "temperature": 0.7},
+        },
+        "dependencies": {"tools": [], "libraries": ["requests==2.31.0"]},
+    }
+
+
+def test_tbom_enforcement_mock(valid_agent_data: Dict[str, Any], tmp_path: Path) -> None:
+    """Test TBOM enforcement with mock OPA output."""
+    policy_file = tmp_path / "test.rego"
+    policy_file.touch()
+    tbom_file = tmp_path / "tbom.json"
+    tbom_file.touch()
+
+    enforcer = PolicyEnforcer(policy_path=policy_file, opa_path="opa", data_paths=[tbom_file])
+
+    # Case 1: Library allowed (Mocked success)
+    mock_result_success = MagicMock()
+    mock_result_success.returncode = 0
+    mock_result_success.stdout = json.dumps({"result": [{"expressions": [{"value": []}]}]})
+
+    with patch("subprocess.run", return_value=mock_result_success) as mock_run:
+        enforcer.evaluate(valid_agent_data)
+        args, _ = mock_run.call_args
+        # Verify -d flags were passed
+        cmd = args[0]
+        assert "-d" in cmd
+        assert str(tbom_file) in cmd
+
+    # Case 2: Library not in TBOM (Mocked failure)
+    valid_agent_data["dependencies"]["libraries"] = ["malicious-lib==1.0.0"]
+
+    mock_result_fail = MagicMock()
+    mock_result_fail.returncode = 0
+    mock_result_fail.stdout = json.dumps(
+        {
+            "result": [
+                {
+                    "expressions": [
+                        {
+                            "value": [
+                                "Compliance Violation: Library 'malicious-lib' is not in the Trusted Bill of Materials (TBOM)."  # noqa: E501
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    )
+
+    with patch("subprocess.run", return_value=mock_result_fail):
+        with pytest.raises(PolicyViolationError) as excinfo:
+            enforcer.evaluate(valid_agent_data)
+        # Check violations attribute instead of string representation of exception
+        # as the message is generic "Policy violations found."
+        assert "not in the Trusted Bill of Materials" in str(excinfo.value.violations)
+
+
+@pytest.mark.skipif(not OPA_BINARY, reason="OPA binary not found")
+def test_tbom_real_opa_integration(valid_agent_data: Dict[str, Any]) -> None:
+    """Integration test with real OPA binary to verify regex parsing and TBOM lookup."""
+    assert OPA_BINARY is not None
+    # We use the real policy and tbom file
+    assert POLICY_PATH.exists()
+    assert TBOM_PATH.exists()
+
+    enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[TBOM_PATH])
+
+    # 1. Valid Case: requests is in TBOM
+    # valid_agent_data has "requests==2.31.0"
+    enforcer.evaluate(valid_agent_data)
+
+    # 2. Invalid Case: Library not in TBOM
+    valid_agent_data["dependencies"]["libraries"].append("unknown-lib==1.0.0")
+    with pytest.raises(PolicyViolationError) as excinfo:
+        enforcer.evaluate(valid_agent_data)
+    assert "is not in the Trusted Bill of Materials" in str(excinfo.value.violations)
+
+    # 3. Invalid Case: Library in TBOM but not pinned (Rule 1 still active)
+    valid_agent_data["dependencies"]["libraries"] = ["requests"]
+    with pytest.raises(PolicyViolationError) as excinfo:
+        enforcer.evaluate(valid_agent_data)
+    # This might fail Rule 1 or Rule 2 depending on how regex handles "requests" (no ==)
+    # Rule 1 explicitly checks for "==" so it should fail Rule 1.
+    violations = str(excinfo.value.violations)
+    assert "must be pinned with '=='" in violations

--- a/tests/test_tbom_complex.py
+++ b/tests/test_tbom_complex.py
@@ -1,0 +1,137 @@
+# Prosperity-3.0
+import json
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from coreason_manifest.errors import PolicyViolationError
+from coreason_manifest.policy import PolicyEnforcer
+
+# Path to the default policy
+POLICY_PATH = Path("src/coreason_manifest/policies/compliance.rego")
+OPA_BINARY = "./opa" if os.path.exists("./opa") else shutil.which("opa")
+
+
+@pytest.fixture
+def complex_tbom_file(tmp_path: Path) -> Path:
+    """Creates a temporary TBOM file with a variety of package names."""
+    tbom_path = tmp_path / "complex_tbom.json"
+    tbom_data = {
+        "tbom": ["requests", "zope.interface", "google-cloud-storage", "pandas", "hyphen-ated", "under_scored"]
+    }
+    with open(tbom_path, "w") as f:
+        json.dump(tbom_data, f)
+    return tbom_path
+
+
+@pytest.fixture
+def agent_data() -> Dict[str, Any]:
+    return {
+        "metadata": {
+            "id": "123e4567-e89b-12d3-a456-426614174000",
+            "version": "1.0.0",
+            "name": "Complex Agent",
+            "author": "Tester",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "interface": {"inputs": {}, "outputs": {}},
+        "topology": {
+            "steps": [],
+            "model_config": {"model": "gpt-4", "temperature": 0.5},
+        },
+        "dependencies": {"tools": [], "libraries": []},
+    }
+
+
+@pytest.mark.skipif(not OPA_BINARY, reason="OPA binary not found")
+class TestTBOMComplex:
+    def test_dotted_package_name(self, complex_tbom_file: Path, agent_data: Dict[str, Any]) -> None:
+        """Test that packages with dots (namespace packages) are correctly parsed and allowed."""
+        assert OPA_BINARY is not None
+        enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[complex_tbom_file])
+
+        # Allowed dotted package
+        agent_data["dependencies"]["libraries"] = ["zope.interface==5.0.0"]
+        enforcer.evaluate(agent_data)  # Should pass
+
+        # Disallowed dotted package
+        agent_data["dependencies"]["libraries"] = ["zope.component==5.0.0"]
+        with pytest.raises(PolicyViolationError) as excinfo:
+            enforcer.evaluate(agent_data)
+        assert "is not in the Trusted Bill of Materials" in str(excinfo.value.violations)
+
+    def test_package_with_extras(self, complex_tbom_file: Path, agent_data: Dict[str, Any]) -> None:
+        """Test that packages with extras (brackets) are correctly matched against base name in TBOM."""
+        assert OPA_BINARY is not None
+        enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[complex_tbom_file])
+
+        # 'requests' is in TBOM. 'requests[security]' should be allowed.
+        agent_data["dependencies"]["libraries"] = ["requests[security]==2.31.0"]
+        enforcer.evaluate(agent_data)
+
+        # 'pandas' is in TBOM.
+        agent_data["dependencies"]["libraries"] = ["pandas[excel,plot]==2.0.0"]
+        enforcer.evaluate(agent_data)
+
+    def test_similar_package_names(self, complex_tbom_file: Path, agent_data: Dict[str, Any]) -> None:
+        """Test strict matching to avoid prefix/suffix confusion."""
+        assert OPA_BINARY is not None
+        enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[complex_tbom_file])
+
+        # 'google-cloud-storage' is allowed.
+        # 'google-cloud' (prefix) should NOT be allowed unless explicitly in TBOM (it's not).
+        agent_data["dependencies"]["libraries"] = ["google-cloud==1.0.0"]
+        with pytest.raises(PolicyViolationError) as excinfo:
+            enforcer.evaluate(agent_data)
+        assert "is not in the Trusted Bill of Materials" in str(excinfo.value.violations)
+
+        # 'requests' is allowed. 'requests-toolbelt' should NOT be allowed.
+        agent_data["dependencies"]["libraries"] = ["requests-toolbelt==1.0.0"]
+        with pytest.raises(PolicyViolationError) as excinfo:
+            enforcer.evaluate(agent_data)
+        assert "is not in the Trusted Bill of Materials" in str(excinfo.value.violations)
+
+    def test_case_sensitivity(self, complex_tbom_file: Path, agent_data: Dict[str, Any]) -> None:
+        """Test handling of case sensitivity. TBOM is lowercase. Input might be mixed."""
+        assert OPA_BINARY is not None
+        enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[complex_tbom_file])
+
+        # Python packages are generally case-insensitive in pip, but best practice is lowercase.
+        # If input is 'Pandas==2.0.0', and TBOM has 'pandas', it ideally should pass if we normalize,
+        # or fail if we are strict. Given standard pip usage, normalization is safer, but strictly matching
+        # TBOM is more secure.
+        # Let's assume STRICT matching for now as per "Source of Truth" philosophy.
+        # So 'Pandas' should fail if TBOM has 'pandas'.
+
+        agent_data["dependencies"]["libraries"] = ["Pandas==2.0.0"]
+        with pytest.raises(PolicyViolationError) as excinfo:
+            enforcer.evaluate(agent_data)
+        # If the policy does NOT normalize, this will fail (which is what we test for now).
+        # If we decide to support normalization later, we update this test.
+        assert "is not in the Trusted Bill of Materials" in str(excinfo.value.violations)
+
+    def test_no_dependencies(self, complex_tbom_file: Path, agent_data: Dict[str, Any]) -> None:
+        """Test that empty dependencies list passes."""
+        assert OPA_BINARY is not None
+        enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[complex_tbom_file])
+
+        agent_data["dependencies"]["libraries"] = []
+        enforcer.evaluate(agent_data)  # Should pass
+
+    def test_malformed_tbom_structure(self, tmp_path: Path, agent_data: Dict[str, Any]) -> None:
+        """Test behavior when TBOM file exists but has wrong structure (missing 'tbom' key)."""
+        bad_tbom = tmp_path / "bad_tbom.json"
+        with open(bad_tbom, "w") as f:
+            json.dump({"allowed_libs": ["requests"]}, f)  # Wrong key
+
+        assert OPA_BINARY is not None
+        enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[bad_tbom])
+
+        # 'requests' is requested. It should fail because 'tbom' array is undefined/empty in the policy context.
+        agent_data["dependencies"]["libraries"] = ["requests==2.0.0"]
+        with pytest.raises(PolicyViolationError) as excinfo:
+            enforcer.evaluate(agent_data)
+        assert "is not in the Trusted Bill of Materials" in str(excinfo.value.violations)


### PR DESCRIPTION
* Implement TBOM allowlist enforcement using OPA

- Create `src/coreason_manifest/policies/tbom.json` with trusted libraries.
- Update `src/coreason_manifest/policies/compliance.rego` to enforce Rule 2 (TBOM check).
- Update `PolicyEnforcer` to support passing external data files to OPA.
- Update `ManifestConfig` and `ManifestEngine` to configure TBOM and extra data paths.
- Add comprehensive tests for TBOM enforcement.