### PR TITLE
fix(policy): Enforce description validation on all steps & add robust…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,4 @@ cython_debug/
 
 # Runtime Logs
 logs/
+opa

--- a/src/coreason_manifest/policies/compliance.rego
+++ b/src/coreason_manifest/policies/compliance.rego
@@ -24,9 +24,10 @@ deny contains msg if {
 }
 
 # Deny if description is too short (Business Rule example)
+# Iterates over ALL steps to ensure compliance.
 deny contains msg if {
-    count(input.topology.steps) > 0
-    count(input.topology.steps[0].description) < 5
+    some step in input.topology.steps
+    count(step.description) < 5
     msg := "Step description is too short."
 }
 

--- a/tests/test_policy_description_edge_cases.py
+++ b/tests/test_policy_description_edge_cases.py
@@ -1,0 +1,92 @@
+# Prosperity-3.0
+import os
+import shutil
+from pathlib import Path
+from typing import Any, Dict
+
+import pytest
+
+from coreason_manifest.errors import PolicyViolationError
+from coreason_manifest.policy import PolicyEnforcer
+
+POLICY_PATH = Path("src/coreason_manifest/policies/compliance.rego")
+TBOM_PATH = Path("src/coreason_manifest/policies/tbom.json")
+OPA_BINARY = "./opa" if os.path.exists("./opa") else shutil.which("opa")
+
+
+@pytest.fixture
+def base_agent_data() -> Dict[str, Any]:
+    return {
+        "metadata": {
+            "id": "123e4567-e89b-12d3-a456-426614174000",
+            "version": "1.0.0",
+            "name": "Test Agent",
+            "author": "Test Author",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "interface": {"inputs": {}, "outputs": {}},
+        "topology": {
+            "steps": [],
+            "model_config": {"model": "gpt-4", "temperature": 0.5},
+        },
+        "dependencies": {"tools": [], "libraries": []},
+    }
+
+
+@pytest.mark.skipif(not OPA_BINARY, reason="OPA binary not found")
+def test_description_boundary_conditions(base_agent_data: Dict[str, Any]) -> None:
+    """Test description length boundary conditions."""
+    assert OPA_BINARY is not None
+    enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[TBOM_PATH])
+
+    # 1. Length 4 (Fail)
+    base_agent_data["topology"]["steps"] = [{"id": "s1", "description": "abcd"}]
+    with pytest.raises(PolicyViolationError) as e:
+        enforcer.evaluate(base_agent_data)
+    assert "Step description is too short" in str(e.value.violations)
+
+    # 2. Length 5 (Pass)
+    base_agent_data["topology"]["steps"] = [{"id": "s1", "description": "abcde"}]
+    enforcer.evaluate(base_agent_data)
+
+    # 3. Empty (Fail)
+    base_agent_data["topology"]["steps"] = [{"id": "s1", "description": ""}]
+    with pytest.raises(PolicyViolationError) as e:
+        enforcer.evaluate(base_agent_data)
+    assert "Step description is too short" in str(e.value.violations)
+
+
+@pytest.mark.skipif(not OPA_BINARY, reason="OPA binary not found")
+def test_unicode_description_length(base_agent_data: Dict[str, Any]) -> None:
+    """Test how OPA counts unicode characters."""
+    assert OPA_BINARY is not None
+    enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[TBOM_PATH])
+
+    # 5 emojis
+    # Python len("😊"*5) is 5.
+    # OPA `count()` on string usually counts codepoints.
+    base_agent_data["topology"]["steps"] = [{"id": "s1", "description": "😊😊😊😊😊"}]
+    enforcer.evaluate(base_agent_data)
+
+    # 4 emojis (Fail)
+    base_agent_data["topology"]["steps"] = [{"id": "s1", "description": "😊😊😊😊"}]
+    with pytest.raises(PolicyViolationError) as e:
+        enforcer.evaluate(base_agent_data)
+    assert "Step description is too short" in str(e.value.violations)
+
+
+@pytest.mark.skipif(not OPA_BINARY, reason="OPA binary not found")
+def test_multiple_steps_validation(base_agent_data: Dict[str, Any]) -> None:
+    """Test that all steps are checked."""
+    assert OPA_BINARY is not None
+    enforcer = PolicyEnforcer(policy_path=POLICY_PATH, opa_path=OPA_BINARY, data_paths=[TBOM_PATH])
+
+    # Step 1: Good, Step 2: Good, Step 3: Bad
+    base_agent_data["topology"]["steps"] = [
+        {"id": "s1", "description": "Good Description 1"},
+        {"id": "s2", "description": "Good Description 2"},
+        {"id": "s3", "description": "Bad"},
+    ]
+    with pytest.raises(PolicyViolationError) as e:
+        enforcer.evaluate(base_agent_data)
+    assert "Step description is too short" in str(e.value.violations)


### PR DESCRIPTION
… tests

Updates the OPA policy to ensure description length validation is applied to every step in the topology, fixing a bug where subsequent steps were ignored.

Policy Logic:
* **compliance.rego:** Updated the rule to iterate over all steps in the topology list, rather than checking only the first entry.

Testing & Validation:
* **New Test Suite:** Added `tests/test_policy_description_edge_cases.py` to cover:
    * **Boundaries:** Verified behavior at length limits (4 vs 5 characters).
    * **Data Types:** Tested handling of empty strings and Unicode characters (emojis) within Rego.
    * **Iteration:** Confirmed that multiple steps are individually validated.
* **Environment:** Tests are configured to run successfully with a local OPA binary or skip gracefully if absent.

Refs: COREASON-123, COREASON-124