### PR TITLE
Refactor tools to List[AnyUrl] and enhance version normalization (#35)

### DIFF
--- a/src/coreason_manifest/models.py
+++ b/src/coreason_manifest/models.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from types import MappingProxyType
-from typing import Any, Dict, Mapping, Optional, Tuple
+from typing import Any, Dict, List, Mapping, Optional, Tuple
 from uuid import UUID
 
 from pydantic import (
@@ -118,9 +118,8 @@ class AgentDependencies(BaseModel):
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     # Use AnyUrl to enforce strictly valid URIs
-    # Changed from Tuple[Annotated[AnyUrl, ...]] to Tuple[AnyUrl, ...] based on refactor request.
-    # Note: We use Tuple for immutability (frozen=True), but type hint corresponds to "List[AnyUrl]" concept.
-    tools: Tuple[AnyUrl, ...] = Field(default_factory=tuple, description="List of MCP capability URIs required.")
+    # Changed to List[AnyUrl] as requested to strictly enforce valid URI formatting
+    tools: List[AnyUrl] = Field(default_factory=list, description="List of MCP capability URIs required.")
     libraries: Tuple[str, ...] = Field(
         default_factory=tuple, description="List of Python packages required (if code execution is allowed)."
     )


### PR DESCRIPTION
* Refactor tools field type and normalize versions in manifest loader

- Changed `AgentDependencies.tools` from `Tuple[AnyUrl, ...]` to `List[AnyUrl]` in `models.py` to enforce strict URI validation while allowing list semantics (though model remains frozen).
- Updated `ManifestLoader` to explicitly normalize version strings (strip 'v' prefix) in `load_from_dict`, ensuring consistency across all loading paths before Pydantic validation.
- Updated `tests/test_complex_cases.py` to reflect the change of `tools` to a list and correctly assert frozen model behavior (ValidationError instead of TypeError on assignment).
- Verified `MockOPARunner` in `conftest.py` correctly mocks OPA behavior for missing binary environments.

* Refactor Manifest Models and Enhance Normalization with Tests

- Updated `AgentDependencies.tools` to `List[AnyUrl]` for stricter URI validation while enabling list validation semantics.
- Implemented robust `ManifestLoader` version normalization that explicitly strips 'v'/'V' prefixes during raw and dictionary loading phases.
- Added comprehensive edge case tests in `tests/test_semver_uri_edge_cases.py` covering multi-prefix version strings (e.g., `vv1.0.0`) and complex normalization scenarios.
- Updated `tests/test_complex_cases.py` to align with the new mutable `tools` list structure and frozen model behavior.
- Verified test suite passes with 100% coverage, including all new edge cases.

* Refactor Manifest Models and Enhance Normalization with Tests

- Updated `AgentDependencies.tools` to `List[AnyUrl]` for stricter URI validation while enabling list validation semantics.
- Implemented robust `ManifestLoader` version normalization that explicitly strips 'v'/'V' prefixes during raw and dictionary loading phases.
- Added comprehensive edge case tests in `tests/test_semver_uri_edge_cases.py` covering multi-prefix version strings (e.g., `vv1.0.0`) and complex normalization scenarios.
- Updated `tests/test_complex_cases.py` to align with the new mutable `tools` list structure and frozen model behavior.
- Fixed type errors in tests by ensuring explicit `AnyUrl` object usage for list mutation.
- Verified test suite passes with 100% coverage, including all new edge cases.

---------