### PR TITLE
fix: sync [project] version with [tool.poetry] in pyproject.toml (#55…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.2.0"
+version = "0.3.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
…) (#56)

The [project] version was lagging behind at 0.2.0 while [tool.poetry] was at 0.3.0. This caused PyPI upload failures because 0.2.0 already exists. Updated [project] version to 0.3.0.