### PR TITLE
Refactor: Move RecipeManifest schema to shared kernel (#71) (#72)

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -1,0 +1,91 @@
+# Recipe Manifests (Workflows)
+
+The `coreason-manifest` package provides the schema definitions for **Recipes**, which are executable workflows managed by the `coreason-maco` runtime.
+
+## Overview
+
+A `RecipeManifest` defines a directed graph of nodes (steps) and edges (connections). It supports architectural triangulation via "Council" configurations and mixed-initiative workflows (human-in-the-loop).
+
+## Schema Structure
+
+### RecipeManifest
+
+The root object for a workflow.
+
+- **id**: Unique identifier for the recipe.
+- **version**: Semantic version (e.g., `1.0.0`).
+- **name**: Human-readable name.
+- **description**: Detailed description.
+- **inputs**: Global variables the recipe accepts (JSON Schema).
+- **graph**: The topology (`GraphTopology`).
+
+### GraphTopology
+
+Contains the nodes and edges.
+
+- **nodes**: List of `Node` objects.
+- **edges**: List of `Edge` objects.
+
+### Nodes
+
+Nodes are polymorphic and can be one of the following types:
+
+#### 1. AgentNode (`type="agent"`)
+Executes a specific atomic agent.
+- **agent_name**: The name of the agent to call.
+
+#### 2. HumanNode (`type="human"`)
+Pauses execution for user input or approval.
+- **timeout_seconds**: Optional timeout.
+
+#### 3. LogicNode (`type="logic"`)
+Executes pure Python logic.
+- **code**: The Python code to execute.
+
+### Edges
+
+Connections between nodes.
+
+- **source_node_id**: ID of the source node.
+- **target_node_id**: ID of the target node.
+- **condition**: Optional Python expression for conditional branching.
+
+## Example Usage
+
+```python
+from coreason_manifest import (
+    RecipeManifest, GraphTopology, AgentNode, HumanNode, Edge
+)
+
+# Define Nodes
+agent_node = AgentNode(
+    id="step_1",
+    type="agent",
+    agent_name="ResearchAgent",
+    visual={"label": "Research Phase"}
+)
+
+human_node = HumanNode(
+    id="step_2",
+    type="human",
+    timeout_seconds=3600,
+    visual={"label": "Approval"}
+)
+
+# Define Edge
+edge = Edge(source_node_id="step_1", target_node_id="step_2")
+
+# Create Manifest
+recipe = RecipeManifest(
+    id="research_workflow",
+    version="1.0.0",
+    name="Research Approval Workflow",
+    inputs={"topic": "str"},
+    graph=GraphTopology(
+        nodes=[agent_node, human_node],
+        edges=[edge]
+    )
+)
+
+print(recipe.model_dump_json(indent=2))
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,3 +5,4 @@ nav:
   - Home: index.md
   - Requirements: requirements.md
   - Usage: usage.md
+  - Recipes: recipes.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.5.1"
+version = "0.6.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -38,7 +38,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.5.1"
+version = "0.6.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -35,6 +35,17 @@ from .models import (
     Step,
 )
 from .policy import PolicyEnforcer
+from .recipes import (
+    AgentNode,
+    CouncilConfig,
+    Edge,
+    GraphTopology,
+    HumanNode,
+    LogicNode,
+    Node,
+    RecipeManifest,
+    VisualMetadata,
+)
 from .validator import SchemaValidator
 
 __all__ = [
@@ -42,9 +53,15 @@ __all__ = [
     "AgentDependencies",
     "AgentInterface",
     "AgentMetadata",
+    "AgentNode",
     "AgentTopology",
+    "CouncilConfig",
+    "Edge",
+    "GraphTopology",
+    "HumanNode",
     "IntegrityChecker",
     "IntegrityCompromisedError",
+    "LogicNode",
     "ManifestConfig",
     "ManifestEngine",
     "ManifestEngineAsync",
@@ -52,8 +69,11 @@ __all__ = [
     "ManifestLoader",
     "ManifestSyntaxError",
     "ModelConfig",
+    "Node",
     "PolicyEnforcer",
     "PolicyViolationError",
+    "RecipeManifest",
     "SchemaValidator",
     "Step",
+    "VisualMetadata",
 ]

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason_maco
+
+from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .models import VersionStr
+
+
+class CouncilConfig(BaseModel):
+    """Configuration for 'Architectural Triangulation'.
+
+    Attributes:
+        strategy: The strategy for the council (e.g., 'consensus').
+        voters: List of agents or models that vote.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    strategy: str = Field(default="consensus", description="The strategy for the council, e.g., 'consensus'.")
+    voters: List[str] = Field(..., description="List of agents or models that vote.")
+
+
+class VisualMetadata(BaseModel):
+    """Data explicitly for the UI.
+
+    Attributes:
+        label: The label to display for the node.
+        x_y_coordinates: The X and Y coordinates for the node on the canvas.
+        icon: The icon to represent the node.
+        animation_style: The animation style for the node.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    label: Optional[str] = Field(None, description="The label to display for the node.")
+    x_y_coordinates: Optional[List[float]] = Field(
+        None, description="The X and Y coordinates for the node on the canvas."
+    )
+    icon: Optional[str] = Field(None, description="The icon to represent the node.")
+    animation_style: Optional[str] = Field(None, description="The animation style for the node.")
+
+
+class BaseNode(BaseModel):
+    """Base model for all node types.
+
+    Attributes:
+        id: Unique identifier for the node.
+        council_config: Optional configuration for architectural triangulation.
+        visual: Visual metadata for the UI.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(..., description="Unique identifier for the node.")
+    council_config: Optional[CouncilConfig] = Field(
+        None, description="Optional configuration for architectural triangulation."
+    )
+    visual: Optional[VisualMetadata] = Field(None, description="Visual metadata for the UI.")
+
+
+class AgentNode(BaseNode):
+    """A node that calls a specific atomic agent.
+
+    Attributes:
+        type: The type of the node (must be 'agent').
+        agent_name: The name of the atomic agent to call.
+    """
+
+    type: Literal["agent"] = Field("agent", description="Discriminator for AgentNode.")
+    agent_name: str = Field(..., description="The name of the atomic agent to call.")
+
+
+class HumanNode(BaseNode):
+    """A node that pauses execution for user input/approval.
+
+    Attributes:
+        type: The type of the node (must be 'human').
+        timeout_seconds: Optional timeout in seconds for the user interaction.
+    """
+
+    type: Literal["human"] = Field("human", description="Discriminator for HumanNode.")
+    timeout_seconds: Optional[int] = Field(None, description="Optional timeout in seconds for the user interaction.")
+
+
+class LogicNode(BaseNode):
+    """A node that executes pure Python logic.
+
+    Attributes:
+        type: The type of the node (must be 'logic').
+        code: The Python logic code to execute.
+    """
+
+    type: Literal["logic"] = Field("logic", description="Discriminator for LogicNode.")
+    code: str = Field(..., description="The Python logic code to execute.")
+
+
+# Discriminated Union for polymorphism
+Node = Annotated[
+    Union[AgentNode, HumanNode, LogicNode], Field(discriminator="type", description="Polymorphic node definition.")
+]
+
+
+class Edge(BaseModel):
+    """Represents a connection between two nodes.
+
+    Attributes:
+        source_node_id: The ID of the source node.
+        target_node_id: The ID of the target node.
+        condition: Optional Python expression for conditional branching.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source_node_id: str = Field(..., description="The ID of the source node.")
+    target_node_id: str = Field(..., description="The ID of the target node.")
+    condition: Optional[str] = Field(None, description="Optional Python expression for conditional branching.")
+
+
+class GraphTopology(BaseModel):
+    """The topology definition of the recipe.
+
+    Attributes:
+        nodes: List of nodes in the graph.
+        edges: List of edges connecting the nodes.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    nodes: List[Node] = Field(..., description="List of nodes in the graph.")
+    edges: List[Edge] = Field(..., description="List of edges connecting the nodes.")
+
+
+class RecipeManifest(BaseModel):
+    """The executable specification for the MACO engine.
+
+    Attributes:
+        id: Unique identifier for the recipe.
+        version: Version of the recipe.
+        name: Human-readable name of the recipe.
+        description: Detailed description of the recipe.
+        inputs: Schema defining global variables this recipe accepts.
+        graph: The topology definition of the workflow.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    id: str = Field(..., description="Unique identifier for the recipe.")
+    version: VersionStr = Field(..., description="Version of the recipe.")
+    name: str = Field(..., description="Human-readable name of the recipe.")
+    description: Optional[str] = Field(None, description="Detailed description of the recipe.")
+    inputs: Dict[str, Any] = Field(..., description="Schema defining global variables this recipe accepts.")
+    graph: GraphTopology = Field(..., description="The topology definition of the workflow.")

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,84 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest import (
+    AgentNode,
+    Edge,
+    GraphTopology,
+    HumanNode,
+    LogicNode,
+    RecipeManifest,
+)
+
+
+def test_recipe_manifest_creation() -> None:
+    """Test creating a valid RecipeManifest."""
+    node1 = AgentNode(id="node1", type="agent", agent_name="TestAgent")
+    node2 = HumanNode(id="node2", type="human", timeout_seconds=60)
+    edge = Edge(source_node_id="node1", target_node_id="node2")
+
+    topology = GraphTopology(nodes=[node1, node2], edges=[edge])
+
+    manifest = RecipeManifest(
+        id="recipe1",
+        version="1.0.0",
+        name="Test Recipe",
+        description="A test recipe",
+        inputs={"param1": "value1"},
+        graph=topology,
+    )
+
+    assert manifest.id == "recipe1"
+    assert manifest.version == "1.0.0"
+    assert len(manifest.graph.nodes) == 2
+    assert isinstance(manifest.graph.nodes[0], AgentNode)
+    assert isinstance(manifest.graph.nodes[1], HumanNode)
+
+
+def test_version_validation() -> None:
+    """Test strict version validation."""
+    # Valid versions (normalized)
+    m = RecipeManifest(id="r1", version="v1.0.0", name="n", inputs={}, graph=GraphTopology(nodes=[], edges=[]))
+    assert m.version == "1.0.0"
+
+    m = RecipeManifest(id="r1", version="V2.0.0", name="n", inputs={}, graph=GraphTopology(nodes=[], edges=[]))
+    assert m.version == "2.0.0"
+
+    # Invalid version
+    with pytest.raises(ValidationError):
+        RecipeManifest(id="r1", version="invalid", name="n", inputs={}, graph=GraphTopology(nodes=[], edges=[]))
+
+
+def test_node_polymorphism() -> None:
+    """Test that nodes are correctly deserialized into their specific types."""
+    data = {
+        "nodes": [
+            {"id": "n1", "type": "agent", "agent_name": "A1"},
+            {"id": "n2", "type": "human", "timeout_seconds": 30},
+            {"id": "n3", "type": "logic", "code": "print('hello')"},
+        ],
+        "edges": [],
+    }
+
+    topology = GraphTopology(**data)
+
+    assert isinstance(topology.nodes[0], AgentNode)
+    assert topology.nodes[0].agent_name == "A1"
+
+    assert isinstance(topology.nodes[1], HumanNode)
+    assert topology.nodes[1].timeout_seconds == 30
+
+    assert isinstance(topology.nodes[2], LogicNode)
+    assert topology.nodes[2].code == "print('hello')"
+
+
+def test_serialization() -> None:
+    """Test JSON serialization."""
+    node = LogicNode(id="n1", type="logic", code="x=1")
+    manifest = RecipeManifest(
+        id="r1", version="1.0.0", name="n", inputs={}, graph=GraphTopology(nodes=[node], edges=[])
+    )
+
+    json_output = manifest.model_dump_json()
+    assert '"type":"logic"' in json_output
+    assert '"code":"x=1"' in json_output

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -1,0 +1,120 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest import (
+    AgentNode,
+    Edge,
+    GraphTopology,
+    HumanNode,
+    LogicNode,
+    RecipeManifest,
+)
+
+
+def test_invalid_node_discriminator() -> None:
+    """Test that an invalid discriminator value raises a ValidationError."""
+    raw_data = {"nodes": [{"id": "n1", "type": "alien", "agent_name": "A1"}], "edges": []}
+    with pytest.raises(ValidationError) as excinfo:
+        GraphTopology(**raw_data)
+
+    # Error should mention the discriminator 'type' or input value
+    assert "type" in str(excinfo.value) or "alien" in str(excinfo.value)
+
+
+def test_strict_schema_extra_fields() -> None:
+    """Test that extra fields are forbidden."""
+    # Test on Node
+    with pytest.raises(ValidationError) as excinfo:
+        AgentNode(
+            id="n1",
+            type="agent",
+            agent_name="A1",
+            extra_field="should_fail",  # type: ignore[call-arg]
+        )
+    assert "Extra inputs are not permitted" in str(excinfo.value)
+
+    # Test on Manifest
+    with pytest.raises(ValidationError) as excinfo:
+        RecipeManifest(
+            id="r1",
+            version="1.0.0",
+            name="N",
+            inputs={},
+            graph=GraphTopology(nodes=[], edges=[]),
+            extra_thing="bad",  # type: ignore[call-arg]
+        )
+    assert "Extra inputs are not permitted" in str(excinfo.value)
+
+
+def test_missing_required_fields() -> None:
+    """Test that missing required fields raises ValidationError."""
+    # AgentNode requires 'agent_name'
+    with pytest.raises(ValidationError) as excinfo:
+        AgentNode(id="n1", type="agent")  # type: ignore[call-arg]
+    assert "Field required" in str(excinfo.value)
+    assert "agent_name" in str(excinfo.value)
+
+
+def test_recursive_version_normalization() -> None:
+    """Test recursive stripping of 'v' prefixes."""
+    manifest = RecipeManifest(
+        id="r1", version="vVv1.5.0", name="Test", inputs={}, graph=GraphTopology(nodes=[], edges=[])
+    )
+    assert manifest.version == "1.5.0"
+
+
+def test_complex_inputs_structure() -> None:
+    """Test that 'inputs' can handle arbitrary complex nested structures."""
+    complex_inputs = {
+        "user": {"name": "Alice", "roles": ["admin", "editor"], "meta": {"login_count": 42}},
+        "config": [{"key": "k1", "value": 1.5}, {"key": "k2", "value": None}],
+    }
+
+    manifest = RecipeManifest(
+        id="r1", version="1.0.0", name="Test", inputs=complex_inputs, graph=GraphTopology(nodes=[], edges=[])
+    )
+
+    assert manifest.inputs["user"]["name"] == "Alice"
+    assert manifest.inputs["config"][0]["value"] == 1.5
+
+
+def test_large_topology_serialization() -> None:
+    """Test serialization/deserialization of a larger graph."""
+    nodes = []
+    edges = []
+    count = 100
+
+    for i in range(count):
+        nodes.append(LogicNode(id=f"node_{i}", type="logic", code=f"x = {i}"))
+        if i > 0:
+            edges.append(Edge(source_node_id=f"node_{i - 1}", target_node_id=f"node_{i}"))
+
+    topology = GraphTopology(nodes=nodes, edges=edges)
+
+    manifest = RecipeManifest(id="large_recipe", version="1.0.0", name="Large Recipe", inputs={}, graph=topology)
+
+    # Dump
+    json_str = manifest.model_dump_json()
+
+    # Load back
+    loaded = RecipeManifest.model_validate_json(json_str)
+
+    assert len(loaded.graph.nodes) == count
+    assert len(loaded.graph.edges) == count - 1
+    assert loaded.graph.nodes[99].id == "node_99"
+    assert isinstance(loaded.graph.nodes[0], LogicNode)
+
+
+def test_polymorphic_list_parsing() -> None:
+    """Test parsing a mixed list of node types from raw dictionaries."""
+    raw_nodes = [
+        {"id": "a1", "type": "agent", "agent_name": "A"},
+        {"id": "h1", "type": "human", "timeout_seconds": 10},
+        {"id": "l1", "type": "logic", "code": "pass"},
+    ]
+
+    topo = GraphTopology(nodes=raw_nodes, edges=[])
+
+    assert isinstance(topo.nodes[0], AgentNode)
+    assert isinstance(topo.nodes[1], HumanNode)
+    assert isinstance(topo.nodes[2], LogicNode)


### PR DESCRIPTION
* Refactor: Move RecipeManifest schema to shared kernel

- Added `src/coreason_manifest/recipes.py` containing `RecipeManifest`, `Node`, `Edge` and related classes.
- Exposed new classes in `src/coreason_manifest/__init__.py`.
- Added tests in `tests/test_recipes.py`.
- Bumped version to 0.6.0.
- Added documentation in `docs/recipes.md`.
- Enforced strict versioning using `VersionStr`.

https://github.com/CoReason-AI/coreason-manifest/commit/e9a1ecea2641293a7195a62635bcbf258cae854a