### PR TITLE
feat: Implement Message and Audit Trace models (#91)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.8.0"
+version = "0.9.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.8.0"
+version = "0.9.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/definitions/audit.py
+++ b/src/coreason_manifest/definitions/audit.py
@@ -1,7 +1,85 @@
-from pydantic import BaseModel
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from .message import ChatMessage
 
 
-class AuditLog(BaseModel):
-    """Audit log entry."""
+class GenAITokenUsage(BaseModel):
+    """Token consumption stats aligned with OTel conventions."""
 
-    pass
+    model_config = ConfigDict(extra="ignore")
+
+    input: int = Field(0, description="Number of input tokens (prompt).")
+    output: int = Field(0, description="Number of output tokens (completion).")
+    total: int = Field(0, description="Total number of tokens used.")
+
+    # Backward compatibility fields (mapped to new fields in logic if needed, but kept for schema)
+    prompt_tokens: int = 0
+    completion_tokens: int = 0
+    total_tokens: int = 0
+    details: Dict[str, Any] = Field(default_factory=dict)
+
+
+class GenAIOperation(BaseModel):
+    """An atomic operation in the reasoning process (e.g., one LLM call), aligning with OTel Spans."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    id: str = Field(..., description="Unique identifier for the operation/span.")
+    trace_id: str = Field(..., description="Trace ID this operation belongs to.")
+    parent_id: Optional[str] = Field(None, description="Parent span ID.")
+
+    operation_name: str = Field(..., description="Name of the operation (e.g., chat, embedding).")
+    provider: str = Field(..., description="GenAI provider (e.g., openai, anthropic).")
+    model: str = Field(..., description="Model name used.")
+
+    start_time: datetime = Field(default_factory=datetime.now)
+    end_time: Optional[datetime] = None
+    duration_ms: float = 0.0
+
+    # Context
+    input_messages: List[ChatMessage] = Field(default_factory=list)
+    output_messages: List[ChatMessage] = Field(default_factory=list)
+
+    # Metrics
+    token_usage: Optional[GenAITokenUsage] = None
+
+    # Metadata
+    status: str = "pending"  # success, error
+    error_type: Optional[str] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ReasoningTrace(BaseModel):
+    """The full audit trail of an Agent's execution session."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    trace_id: UUID
+    agent_id: str
+    session_id: Optional[str] = None
+
+    start_time: datetime
+    end_time: Optional[datetime] = None
+
+    # The chain of thought (Ordered list of operations)
+    steps: List[GenAIOperation] = Field(default_factory=list)
+
+    # Final outcome
+    status: str = "pending"  # options: success, failure, pending
+    final_result: Optional[str] = None
+    error: Optional[str] = None
+
+    # Aggregated stats
+    total_tokens: GenAITokenUsage = Field(default_factory=GenAITokenUsage)
+    total_cost: float = 0.0
+
+
+# --- Backward Compatibility ---
+# Adapters or Aliases
+AuditLog = ReasoningTrace
+CognitiveStep = GenAIOperation
+TokenUsage = GenAITokenUsage

--- a/src/coreason_manifest/definitions/message.py
+++ b/src/coreason_manifest/definitions/message.py
@@ -1,0 +1,126 @@
+from enum import Enum
+from typing import Any, Dict, List, Literal, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+# --- Enums ---
+
+
+class Role(str, Enum):
+    SYSTEM = "system"
+    USER = "user"
+    ASSISTANT = "assistant"
+    TOOL = "tool"
+
+
+class Modality(str, Enum):
+    TEXT = "text"
+    IMAGE = "image"
+    AUDIO = "audio"
+    VIDEO = "video"
+
+
+# --- Message Parts ---
+
+
+class TextPart(BaseModel):
+    """Represents text content sent to or received from the model."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["text"] = "text"
+    content: str
+
+
+class BlobPart(BaseModel):
+    """Represents blob binary data sent inline to the model."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["blob"] = "blob"
+    content: str  # Base64 encoded string
+    modality: Modality
+    mime_type: Optional[str] = None
+
+
+class FilePart(BaseModel):
+    """Represents an external referenced file sent to the model by file id."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["file"] = "file"
+    file_id: str
+    modality: Modality
+    mime_type: Optional[str] = None
+
+
+class UriPart(BaseModel):
+    """Represents an external referenced file sent to the model by URI."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["uri"] = "uri"
+    uri: str
+    modality: Modality
+    mime_type: Optional[str] = None
+
+
+class ToolCallRequestPart(BaseModel):
+    """Represents a tool call requested by the model."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["tool_call"] = "tool_call"
+    name: str
+    arguments: Dict[str, Any]  # Structured arguments
+    id: Optional[str] = None
+
+
+class ToolCallResponsePart(BaseModel):
+    """Represents a tool call result sent to the model."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["tool_call_response"] = "tool_call_response"
+    response: Any  # The result of the tool call
+    id: Optional[str] = None
+
+
+class ReasoningPart(BaseModel):
+    """Represents reasoning/thinking content received from the model."""
+
+    model_config = ConfigDict(extra="ignore")
+    type: Literal["reasoning"] = "reasoning"
+    content: str
+
+
+# --- Union of All Parts ---
+
+Part = Union[TextPart, BlobPart, FilePart, UriPart, ToolCallRequestPart, ToolCallResponsePart, ReasoningPart]
+
+# --- Main Message Model ---
+
+
+class ChatMessage(BaseModel):
+    """Represents a message in a conversation with an LLM."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    role: Role
+    parts: List[Part] = Field(..., description="List of message parts that make up the message content.")
+    name: Optional[str] = None
+
+
+# --- Backward Compatibility ---
+
+
+class FunctionCall(BaseModel):
+    """Deprecated: Use ToolCallRequestPart instead."""
+
+    name: str
+    arguments: str
+
+
+class ToolCall(BaseModel):
+    """Deprecated: Use ToolCallRequestPart instead."""
+
+    id: str
+    type: str = "function"
+    function: FunctionCall
+
+
+Message = ChatMessage

--- a/tests/test_audit_message.py
+++ b/tests/test_audit_message.py
@@ -1,0 +1,116 @@
+import json
+import uuid
+from datetime import datetime
+
+from coreason_manifest.definitions.audit import (
+    AuditLog,
+    GenAIOperation,
+    GenAITokenUsage,
+    ReasoningTrace,
+)
+from coreason_manifest.definitions.message import (
+    ChatMessage,
+    Message,
+    Role,
+    TextPart,
+    ToolCallRequestPart,
+)
+
+
+def test_message_creation() -> None:
+    """Test creating various types of messages with new schema."""
+    # User message with TextPart
+    user_msg = ChatMessage(role=Role.USER, parts=[TextPart(content="Hello")])
+    assert user_msg.role == "user"
+    part0 = user_msg.parts[0]
+    assert isinstance(part0, TextPart)
+    assert part0.content == "Hello"
+    assert part0.type == "text"
+
+    # Tool call message
+    tool_call = ToolCallRequestPart(name="get_weather", arguments={"city": "Paris"}, id="call_123")
+    assistant_msg = ChatMessage(role=Role.ASSISTANT, parts=[tool_call])
+    assert len(assistant_msg.parts) == 1
+    part = assistant_msg.parts[0]
+    assert isinstance(part, ToolCallRequestPart)
+    assert part.name == "get_weather"
+    assert part.arguments["city"] == "Paris"
+
+
+def test_message_alias_compatibility() -> None:
+    """Verify Message alias works."""
+    msg = Message(role=Role.SYSTEM, parts=[TextPart(content="System prompt")])
+    assert isinstance(msg, ChatMessage)
+
+
+def test_gen_ai_operation_creation() -> None:
+    """Test creating a GenAI operation (audit step)."""
+    trace_id = str(uuid.uuid4())
+    step_id = "step_1"
+
+    input_msg = ChatMessage(role=Role.USER, parts=[TextPart(content="Calculate 2+2")])
+
+    tool_call = ToolCallRequestPart(name="calculator", arguments={"expression": "2+2"}, id="call_math")
+    output_msg = ChatMessage(role=Role.ASSISTANT, parts=[tool_call])
+
+    operation = GenAIOperation(
+        id=step_id,
+        trace_id=trace_id,
+        operation_name="chat",
+        provider="openai",
+        model="gpt-4",
+        input_messages=[input_msg],
+        output_messages=[output_msg],
+        token_usage=GenAITokenUsage(input=5, output=10, total=15),
+    )
+
+    assert operation.id == step_id
+    assert operation.provider == "openai"
+    assert operation.token_usage is not None
+    assert operation.token_usage.total == 15
+    # Check backward compatibility fields on TokenUsage
+    # Default is 0 unless explicitly set, or we add a validator to sync them.
+    assert operation.token_usage.total_tokens == 0
+    # Note: If we wanted strict backward compat for values, we'd need a validator.
+    # For now, we just ensure the field exists on the schema.
+
+
+def test_reasoning_trace_creation() -> None:
+    """Test creating a full reasoning trace."""
+    trace_id = uuid.uuid4()
+
+    step = GenAIOperation(
+        id="step_1",
+        trace_id=str(trace_id),
+        operation_name="chat",
+        provider="openai",
+        model="gpt-4",
+        input_messages=[],
+        output_messages=[],
+    )
+
+    trace = ReasoningTrace(
+        trace_id=trace_id, agent_id="agent_v1", start_time=datetime.now(), steps=[step], status="success"
+    )
+
+    assert trace.trace_id == trace_id
+    assert len(trace.steps) == 1
+    assert trace.steps[0].id == "step_1"
+
+
+def test_audit_log_alias() -> None:
+    """Verify that AuditLog is an alias for ReasoningTrace."""
+    assert AuditLog is ReasoningTrace
+
+    log = AuditLog(trace_id=uuid.uuid4(), agent_id="test_agent", start_time=datetime.now())
+    assert isinstance(log, ReasoningTrace)
+
+
+def test_serialization() -> None:
+    """Test JSON serialization of the trace."""
+    trace = ReasoningTrace(trace_id=uuid.uuid4(), agent_id="agent_json", start_time=datetime.now(), steps=[])
+
+    json_str = trace.model_dump_json()
+    data = json.loads(json_str)
+    assert data["agent_id"] == "agent_json"
+    assert "start_time" in data


### PR DESCRIPTION
* Implement LLM Message and Audit Trace models (v0.9.0)

- Create `src/coreason_manifest/definitions/message.py` with `Message`, `Role`, `ToolCall`, and `FunctionCall`.
- Update `src/coreason_manifest/definitions/audit.py` with `ReasoningTrace`, `CognitiveStep`, and `TokenUsage`.
- Alias `AuditLog` to `ReasoningTrace` for backward compatibility.
- Add comprehensive tests in `tests/test_audit_message.py` for new models and serialization.
- Bump version to 0.9.0 in `pyproject.toml`.
- Update lock file.