### PR TITLE
Refactor RecipeManifest for OAS/LangGraph alignment (#94)

### DIFF
--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -6,6 +6,8 @@ The `coreason-manifest` package provides the schema definitions for **Recipes**,
 
 A `RecipeManifest` defines a directed graph of nodes (steps) and edges (connections). It supports architectural triangulation via "Council" configurations and mixed-initiative workflows (human-in-the-loop).
 
+Starting with v2, Recipes strictly define their **Interface** (Inputs/Outputs), **Internal State** (Memory), and **Build-time Parameters**.
+
 ## Schema Structure
 
 ### RecipeManifest
@@ -16,8 +18,24 @@ The root object for a workflow.
 - **version**: Semantic version (e.g., `1.0.0`).
 - **name**: Human-readable name.
 - **description**: Detailed description.
-- **inputs**: Global variables the recipe accepts (JSON Schema).
+- **interface**: Defines the Input/Output contract (`RecipeInterface`).
+- **state**: Defines the internal memory schema (`StateDefinition`).
+- **parameters**: Build-time configuration constants (`Dict[str, Any]`).
 - **graph**: The topology (`GraphTopology`).
+
+### RecipeInterface
+
+Defines the contract for interacting with the recipe.
+
+- **inputs**: JSON Schema defining valid entry arguments.
+- **outputs**: JSON Schema defining the guaranteed structure of the final result.
+
+### StateDefinition
+
+Defines the shared memory available to all nodes in the graph.
+
+- **schema**: JSON Schema of the keys available in the shared memory.
+- **persistence**: Configuration for state durability (`ephemeral` or `persistent`).
 
 ### GraphTopology
 
@@ -56,6 +74,7 @@ Connections between nodes.
 from coreason_manifest import (
     RecipeManifest, GraphTopology, AgentNode, HumanNode, Edge
 )
+from coreason_manifest.recipes import RecipeInterface, StateDefinition
 
 # Define Nodes
 agent_node = AgentNode(
@@ -75,17 +94,49 @@ human_node = HumanNode(
 # Define Edge
 edge = Edge(source_node_id="step_1", target_node_id="step_2")
 
+# Define Interface
+interface = RecipeInterface(
+    inputs={
+        "type": "object",
+        "properties": {
+            "topic": {"type": "string"}
+        },
+        "required": ["topic"]
+    },
+    outputs={
+        "type": "object",
+        "properties": {
+            "summary": {"type": "string"}
+        }
+    }
+)
+
+# Define State
+state = StateDefinition(
+    schema={
+        "type": "object",
+        "properties": {
+            "messages": {"type": "array"},
+            "draft": {"type": "string"}
+        }
+    },
+    persistence="ephemeral"
+)
+
 # Create Manifest
 recipe = RecipeManifest(
     id="research_workflow",
     version="1.0.0",
     name="Research Approval Workflow",
-    inputs={"topic": "str"},
+    interface=interface,
+    state=state,
+    parameters={"model": "gpt-4"},
     graph=GraphTopology(
         nodes=[agent_node, human_node],
         edges=[edge]
     )
 )
 
-print(recipe.model_dump_json(indent=2))
+# Dump to JSON (use by_alias=True to correctly serialize state.schema)
+print(recipe.model_dump_json(indent=2, by_alias=True))
 ```

--- a/tests/test_recipe_definitions.py
+++ b/tests/test_recipe_definitions.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.recipes import RecipeInterface, StateDefinition
+
+
+def test_recipe_interface_valid() -> None:
+    """Test creating a valid RecipeInterface."""
+    interface = RecipeInterface(
+        inputs={"type": "object", "properties": {"query": {"type": "string"}}},
+        outputs={"type": "object", "properties": {"answer": {"type": "string"}}},
+    )
+    assert interface.inputs["type"] == "object"
+    assert interface.outputs["type"] == "object"
+
+
+def test_recipe_interface_invalid_missing_fields() -> None:
+    """Test validation failure for missing fields in RecipeInterface."""
+    with pytest.raises(ValidationError):
+        RecipeInterface(inputs={})  # type: ignore[call-arg]
+
+
+def test_state_definition_valid_defaults() -> None:
+    """Test creating a valid StateDefinition with defaults."""
+    state = StateDefinition(schema={"type": "object", "properties": {"messages": {"type": "array"}}})
+    assert state.schema_["type"] == "object"
+    assert state.persistence == "ephemeral"
+
+
+def test_state_definition_valid_persistent() -> None:
+    """Test creating a valid StateDefinition with persistence."""
+    state = StateDefinition(
+        schema={"type": "object", "properties": {"messages": {"type": "array"}}},
+        persistence="persistent",
+    )
+    assert state.persistence == "persistent"
+
+
+def test_state_definition_invalid_persistence() -> None:
+    """Test validation failure for invalid persistence value."""
+    with pytest.raises(ValidationError):
+        StateDefinition(
+            schema={"type": "object"},
+            persistence="invalid_value",
+        )

--- a/tests/test_recipe_v2.py
+++ b/tests/test_recipe_v2.py
@@ -1,0 +1,126 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest import RecipeManifest, Topology
+from coreason_manifest.recipes import RecipeInterface, StateDefinition
+
+
+def test_full_recipe_v2_creation() -> None:
+    """Test creating a fully populated V2 RecipeManifest."""
+    interface = RecipeInterface(
+        inputs={
+            "type": "object",
+            "properties": {"topic": {"type": "string"}},
+            "required": ["topic"],
+        },
+        outputs={
+            "type": "object",
+            "properties": {"summary": {"type": "string"}},
+        },
+    )
+
+    state = StateDefinition(
+        schema={
+            "type": "object",
+            "properties": {
+                "messages": {"type": "array"},
+                "artifacts": {"type": "array"},
+            },
+        },
+        persistence="persistent",
+    )
+
+    parameters = {"model": "gpt-4", "max_tokens": 1000}
+
+    manifest = RecipeManifest(
+        id="recipe-v2",
+        version="2.0.0",
+        name="Research Agent",
+        description="An autonomous research agent.",
+        interface=interface,
+        state=state,
+        parameters=parameters,
+        graph=Topology(nodes=[], edges=[]),
+    )
+
+    assert manifest.interface.inputs["properties"]["topic"]["type"] == "string"
+    assert manifest.state.schema_["properties"]["messages"]["type"] == "array"
+    assert manifest.state.persistence == "persistent"
+    assert manifest.parameters["model"] == "gpt-4"
+
+
+def test_recipe_v2_serialization() -> None:
+    """Test that V2 RecipeManifest serializes correctly (with aliases)."""
+    manifest = RecipeManifest(
+        id="recipe-v2",
+        version="2.0.0",
+        name="Research Agent",
+        interface=RecipeInterface(inputs={}, outputs={}),
+        state=StateDefinition(schema={"foo": "bar"}, persistence="ephemeral"),
+        parameters={},
+        graph=Topology(nodes=[], edges=[]),
+    )
+
+    # Must use by_alias=True to get "schema" instead of "schema_"
+    json_output = manifest.model_dump_json(by_alias=True)
+    data = json.loads(json_output)
+
+    assert "interface" in data
+    assert "state" in data
+    assert "parameters" in data
+
+    # Check state schema alias
+    assert "schema" in data["state"]
+    assert "schema_" not in data["state"]
+    assert data["state"]["schema"] == {"foo": "bar"}
+
+
+def test_recipe_v2_validation_error() -> None:
+    """Test validation errors for missing new fields."""
+    # Missing interface
+    with pytest.raises(ValidationError) as excinfo:
+        RecipeManifest(
+            id="r1",
+            version="1.0.0",
+            name="n",
+            # interface missing
+            state=StateDefinition(schema={}, persistence="ephemeral"),
+            parameters={},
+            graph=Topology(nodes=[], edges=[]),
+        )  # type: ignore[call-arg]
+    assert "interface" in str(excinfo.value)
+    assert "Field required" in str(excinfo.value)
+
+    # Missing state
+    with pytest.raises(ValidationError) as excinfo:
+        RecipeManifest(
+            id="r1",
+            version="1.0.0",
+            name="n",
+            interface=RecipeInterface(inputs={}, outputs={}),
+            # state missing
+            parameters={},
+            graph=Topology(nodes=[], edges=[]),
+        )  # type: ignore[call-arg]
+    assert "state" in str(excinfo.value)
+    assert "Field required" in str(excinfo.value)
+
+
+def test_recipe_v2_extra_fields() -> None:
+    """Test that extra fields are forbidden in V2 manifest."""
+    with pytest.raises(ValidationError) as excinfo:
+        RecipeManifest(
+            id="r1",
+            version="1.0.0",
+            name="n",
+            interface=RecipeInterface(inputs={}, outputs={}),
+            state=StateDefinition(schema={}, persistence="ephemeral"),
+            parameters={},
+            graph=Topology(nodes=[], edges=[]),
+            extra_field="fail",  # type: ignore[call-arg]
+        )
+    assert "Extra inputs are not permitted" in str(excinfo.value)

--- a/tests/test_recipe_v2_extras.py
+++ b/tests/test_recipe_v2_extras.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest import RecipeManifest, Topology
+from coreason_manifest.recipes import RecipeInterface, StateDefinition
+
+
+def test_state_schema_aliasing_roundtrip() -> None:
+    """Test that 'schema' input maps to 'schema_' and serializes back to 'schema'."""
+    state_input = {"schema": {"foo": "bar"}, "persistence": "ephemeral"}
+
+    # 1. Input Mapping
+    state = StateDefinition(**state_input)
+    assert state.schema_ == {"foo": "bar"}
+    # Note: Pydantic v2 might expose the alias as an attribute depending on configuration
+    # or if it shadows a method. We primarily care that schema_ is populated correctly.
+
+    # 2. Serialization Mapping
+    dump = state.model_dump(by_alias=True)
+    assert "schema" in dump
+    assert dump["schema"] == {"foo": "bar"}
+
+    # 3. Roundtrip via Manifest
+    manifest = RecipeManifest(
+        id="r1",
+        version="1.0.0",
+        name="n",
+        interface=RecipeInterface(inputs={}, outputs={}),
+        state=state,
+        parameters={},
+        graph=Topology(nodes=[], edges=[]),
+    )
+    json_str = manifest.model_dump_json(by_alias=True)
+    reloaded = RecipeManifest.model_validate_json(json_str)
+    assert reloaded.state.schema_ == {"foo": "bar"}
+
+
+def test_empty_interface_and_state() -> None:
+    """Test that empty but valid objects are accepted."""
+    manifest = RecipeManifest(
+        id="empty-v2",
+        version="1.0.0",
+        name="Empty",
+        interface=RecipeInterface(inputs={}, outputs={}),
+        state=StateDefinition(schema={}, persistence="ephemeral"),
+        parameters={},
+        graph=Topology(nodes=[], edges=[]),
+    )
+    assert manifest.interface.inputs == {}
+    assert manifest.state.schema_ == {}
+
+
+def test_complex_parameters() -> None:
+    """Test parameters with nested complex types."""
+    params = {
+        "llm_config": {"model": "gpt-4", "temperature": 0.7, "stops": ["\n", "User:"]},
+        "retries": 3,
+        "features": ["logging", "monitoring"],
+    }
+
+    manifest = RecipeManifest(
+        id="complex-params",
+        version="1.0.0",
+        name="Complex",
+        interface=RecipeInterface(inputs={}, outputs={}),
+        state=StateDefinition(schema={}, persistence="ephemeral"),
+        parameters=params,
+        graph=Topology(nodes=[], edges=[]),
+    )
+
+    assert manifest.parameters["llm_config"]["model"] == "gpt-4"
+    assert manifest.parameters["features"][0] == "logging"
+
+
+def test_persistence_literal_strictness() -> None:
+    """Test that persistence validation is case-sensitive and strict."""
+    # Valid
+    StateDefinition(schema={}, persistence="ephemeral")
+    StateDefinition(schema={}, persistence="persistent")
+
+    # Invalid Case
+    with pytest.raises(ValidationError) as excinfo:
+        StateDefinition(schema={}, persistence="Ephemeral")
+    assert "Input should be 'ephemeral' or 'persistent'" in str(excinfo.value)
+
+    # Invalid Value
+    with pytest.raises(ValidationError) as excinfo:
+        StateDefinition(schema={}, persistence="in-memory")
+    assert "Input should be 'ephemeral' or 'persistent'" in str(excinfo.value)
+
+
+def test_interface_schema_structure_preservation() -> None:
+    """Test that nested JSON Schema structures in interface are preserved exactly."""
+    complex_schema = {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+            "billing_address": {"$ref": "#/definitions/address"},
+            "shipping_address": {"$ref": "#/definitions/address"},
+        },
+        "definitions": {
+            "address": {
+                "type": "object",
+                "properties": {
+                    "street_address": {"type": "string"},
+                    "city": {"type": "string"},
+                    "state": {"type": "string"},
+                },
+                "required": ["street_address", "city", "state"],
+            }
+        },
+    }
+
+    interface = RecipeInterface(inputs=complex_schema, outputs={})
+
+    # Verify deep nesting
+    assert interface.inputs["definitions"]["address"]["required"] == ["street_address", "city", "state"]
+    assert interface.inputs["properties"]["billing_address"]["$ref"] == "#/definitions/address"

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -4,6 +4,7 @@ from pydantic import ValidationError
 from coreason_manifest import Edge, RecipeManifest
 from coreason_manifest import Topology as GraphTopology
 from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode
+from coreason_manifest.recipes import RecipeInterface, StateDefinition
 
 
 def test_invalid_node_discriminator() -> None:
@@ -34,7 +35,9 @@ def test_strict_schema_extra_fields() -> None:
             id="r1",
             version="1.0.0",
             name="N",
-            inputs={},
+            interface=RecipeInterface(inputs={}, outputs={}),
+            state=StateDefinition(schema={}, persistence="ephemeral"),
+            parameters={},
             graph=GraphTopology(nodes=[], edges=[]),
             extra_thing="bad",  # type: ignore[call-arg]
         )
@@ -53,7 +56,13 @@ def test_missing_required_fields() -> None:
 def test_recursive_version_normalization() -> None:
     """Test recursive stripping of 'v' prefixes."""
     manifest = RecipeManifest(
-        id="r1", version="vVv1.5.0", name="Test", inputs={}, graph=GraphTopology(nodes=[], edges=[])
+        id="r1",
+        version="vVv1.5.0",
+        name="Test",
+        interface=RecipeInterface(inputs={}, outputs={}),
+        state=StateDefinition(schema={}, persistence="ephemeral"),
+        parameters={},
+        graph=GraphTopology(nodes=[], edges=[]),
     )
     assert manifest.version == "1.5.0"
 
@@ -66,11 +75,17 @@ def test_complex_inputs_structure() -> None:
     }
 
     manifest = RecipeManifest(
-        id="r1", version="1.0.0", name="Test", inputs=complex_inputs, graph=GraphTopology(nodes=[], edges=[])
+        id="r1",
+        version="1.0.0",
+        name="Test",
+        interface=RecipeInterface(inputs=complex_inputs, outputs={}),
+        state=StateDefinition(schema={}, persistence="ephemeral"),
+        parameters={},
+        graph=GraphTopology(nodes=[], edges=[]),
     )
 
-    assert manifest.inputs["user"]["name"] == "Alice"
-    assert manifest.inputs["config"][0]["value"] == 1.5
+    assert manifest.interface.inputs["user"]["name"] == "Alice"
+    assert manifest.interface.inputs["config"][0]["value"] == 1.5
 
 
 def test_large_topology_serialization() -> None:
@@ -86,10 +101,18 @@ def test_large_topology_serialization() -> None:
 
     topology = GraphTopology(nodes=nodes, edges=edges)
 
-    manifest = RecipeManifest(id="large_recipe", version="1.0.0", name="Large Recipe", inputs={}, graph=topology)
+    manifest = RecipeManifest(
+        id="large_recipe",
+        version="1.0.0",
+        name="Large Recipe",
+        interface=RecipeInterface(inputs={}, outputs={}),
+        state=StateDefinition(schema={}, persistence="ephemeral"),
+        parameters={},
+        graph=topology,
+    )
 
     # Dump
-    json_str = manifest.model_dump_json()
+    json_str = manifest.model_dump_json(by_alias=True)
 
     # Load back
     loaded = RecipeManifest.model_validate_json(json_str)


### PR DESCRIPTION
* Refactor RecipeManifest to align with OAS and LangGraph

- Introduced `RecipeInterface` (inputs/outputs schema) and `StateDefinition` (internal state schema/persistence) in `src/coreason_manifest/recipes.py`.
- Refactored `RecipeManifest` to replace loose `inputs` with `interface`, `state`, and `parameters`.
- Migrated existing tests (`tests/test_recipes.py`, `tests/test_recipes_edge_cases.py`) to the new structure.
- Added comprehensive tests for the new manifest structure in `tests/test_recipe_v2.py`, verifying full lifecycle including validation and aliased serialization.
- Ensured 100% test coverage.