### PR TITLE
Standardize IDs, Rename AgentTopology to AgentConfig, Fix Recipe Impo…

### DIFF
--- a/src/coreason_manifest/definitions/__init__.py
+++ b/src/coreason_manifest/definitions/__init__.py
@@ -1,3 +1,4 @@
+from .agent import AgentConfig, AgentDefinition
 from .events import (
     ArtifactGenerated,
     ArtifactGeneratedPayload,
@@ -23,6 +24,8 @@ from .events import (
 )
 
 __all__ = [
+    "AgentConfig",
+    "AgentDefinition",
     "GraphEvent",
     "NodeInit",
     "NodeStarted",

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -122,8 +122,8 @@ class ModelConfig(BaseModel):
     temperature: float = Field(..., ge=0.0, le=2.0, description="Temperature for generation.")
 
 
-class AgentTopology(BaseModel):
-    """Topology of the Agent execution.
+class AgentConfig(BaseModel):
+    """Configuration of the Agent execution.
 
     Attributes:
         nodes: A collection of execution units (Agents, Tools, Logic).
@@ -256,7 +256,7 @@ class AgentDefinition(BaseModel):
     Attributes:
         metadata: Metadata for the Agent.
         interface: Interface definition for the Agent.
-        topology: Topology of the Agent execution.
+        config: Configuration of the Agent execution.
         dependencies: External dependencies for the Agent.
         integrity_hash: SHA256 hash of the source code.
     """
@@ -273,7 +273,7 @@ class AgentDefinition(BaseModel):
 
     metadata: AgentMetadata
     interface: AgentInterface
-    topology: AgentTopology
+    config: AgentConfig
     dependencies: AgentDependencies
     policy: Optional[PolicyConfig] = Field(None, description="Governance policy configuration.")
     observability: Optional[ObservabilityConfig] = Field(None, description="Observability configuration.")

--- a/src/coreason_manifest/definitions/audit.py
+++ b/src/coreason_manifest/definitions/audit.py
@@ -31,7 +31,7 @@ class GenAIOperation(BaseModel):
 
     model_config = ConfigDict(extra="ignore")
 
-    id: str = Field(..., description="Unique identifier for the operation/span.")
+    span_id: str = Field(..., description="Unique identifier for the operation/span.")
     trace_id: str = Field(..., description="Trace ID this operation belongs to.")
     parent_id: Optional[str] = Field(None, description="Parent span ID.")
 
@@ -90,7 +90,8 @@ class AuditEventType(str, Enum):
 class AuditLog(BaseModel):
     """Tamper-evident legal record."""
 
-    id: UUID = Field(..., description="Unique identifier.")
+    audit_id: UUID = Field(..., description="Unique identifier.")
+    trace_id: str = Field(..., description="Trace ID for OTel correlation.")
     timestamp: datetime = Field(..., description="ISO8601 timestamp.")
     actor: str = Field(..., description="User ID or Agent Component ID.")
     event_type: AuditEventType = Field(..., description="Type of event.")

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -61,7 +61,7 @@ class RecipeManifest(BaseModel):
         interface: Defines the input/output contract for the Recipe.
         state: Defines the internal state (memory) of the Recipe.
         parameters: Dictionary of build-time constants.
-        graph: The topology definition of the workflow.
+        topology: The topology definition of the workflow.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -73,4 +73,4 @@ class RecipeManifest(BaseModel):
     interface: RecipeInterface = Field(..., description="Defines the input/output contract for the Recipe.")
     state: StateDefinition = Field(..., description="Defines the internal state (memory) of the Recipe.")
     parameters: Dict[str, Any] = Field(..., description="Dictionary of build-time constants.")
-    graph: GraphTopology = Field(..., description="The topology definition of the workflow.")
+    topology: GraphTopology = Field(..., description="The topology definition of the workflow.")

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -1,196 +1,9 @@
 {
   "$defs": {
-    "AgentDependencies": {
+    "AgentConfig": {
       "additionalProperties": false,
-      "description": "External dependencies for the Agent.\n\nAttributes:\n    tools: List of MCP tool requirements.\n    libraries: List of Python packages required (if code execution is allowed).",
+      "description": "Configuration of the Agent execution.\n\nAttributes:\n    nodes: A collection of execution units (Agents, Tools, Logic).\n    edges: Directed connections defining control flow.\n    entry_point: The ID of the starting node.\n    llm_config: Specific LLM parameters.",
       "properties": {
-        "tools": {
-          "description": "List of MCP tool requirements.",
-          "items": {
-            "$ref": "#/$defs/ToolRequirement"
-          },
-          "title": "Tools",
-          "type": "array"
-        },
-        "libraries": {
-          "description": "List of Python packages required (if code execution is allowed).",
-          "items": {
-            "type": "string"
-          },
-          "title": "Libraries",
-          "type": "array"
-        }
-      },
-      "title": "AgentDependencies",
-      "type": "object"
-    },
-    "AgentInterface": {
-      "additionalProperties": false,
-      "description": "Interface definition for the Agent.\n\nAttributes:\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.",
-      "properties": {
-        "inputs": {
-          "additionalProperties": true,
-          "description": "Typed arguments the agent accepts (JSON Schema).",
-          "title": "Inputs",
-          "type": "object"
-        },
-        "outputs": {
-          "additionalProperties": true,
-          "description": "Typed structure of the result.",
-          "title": "Outputs",
-          "type": "object"
-        },
-        "injected_params": {
-          "description": "List of parameters injected by the system.",
-          "items": {
-            "type": "string"
-          },
-          "title": "Injected Params",
-          "type": "array"
-        }
-      },
-      "required": [
-        "inputs",
-        "outputs"
-      ],
-      "title": "AgentInterface",
-      "type": "object"
-    },
-    "AgentMetadata": {
-      "additionalProperties": false,
-      "description": "Metadata for the Agent.\n\nAttributes:\n    id: Unique Identifier for the Agent (UUID).\n    version: Semantic Version of the Agent.\n    name: Name of the Agent.\n    author: Author of the Agent.\n    created_at: Creation timestamp (ISO 8601).",
-      "properties": {
-        "id": {
-          "description": "Unique Identifier for the Agent (UUID).",
-          "format": "uuid",
-          "title": "Id",
-          "type": "string"
-        },
-        "version": {
-          "description": "Semantic Version of the Agent.",
-          "pattern": "^[vV]*(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
-          "title": "Version",
-          "type": "string"
-        },
-        "name": {
-          "description": "Name of the Agent.",
-          "minLength": 1,
-          "title": "Name",
-          "type": "string"
-        },
-        "author": {
-          "description": "Author of the Agent.",
-          "minLength": 1,
-          "title": "Author",
-          "type": "string"
-        },
-        "created_at": {
-          "description": "Creation timestamp (ISO 8601).",
-          "format": "date-time",
-          "title": "Created At",
-          "type": "string"
-        },
-        "requires_auth": {
-          "default": false,
-          "description": "Whether the agent requires user authentication.",
-          "title": "Requires Auth",
-          "type": "boolean"
-        }
-      },
-      "required": [
-        "id",
-        "version",
-        "name",
-        "author",
-        "created_at"
-      ],
-      "title": "AgentMetadata",
-      "type": "object"
-    },
-    "AgentNode": {
-      "additionalProperties": false,
-      "description": "A node that calls a specific atomic agent.\n\nAttributes:\n    type: The type of the node (must be 'agent').\n    agent_name: The name of the atomic agent to call.",
-      "properties": {
-        "id": {
-          "description": "Unique identifier for the node.",
-          "title": "Id",
-          "type": "string"
-        },
-        "council_config": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CouncilConfig"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional configuration for architectural triangulation."
-        },
-        "visual": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VisualMetadata"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Visual metadata for the UI."
-        },
-        "type": {
-          "const": "agent",
-          "default": "agent",
-          "description": "Discriminator for AgentNode.",
-          "title": "Type",
-          "type": "string"
-        },
-        "agent_name": {
-          "description": "The name of the atomic agent to call.",
-          "title": "Agent Name",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id",
-        "agent_name"
-      ],
-      "title": "AgentNode",
-      "type": "object"
-    },
-    "AgentTopology": {
-      "additionalProperties": false,
-      "description": "Topology of the Agent execution.\n\nAttributes:\n    nodes: A collection of execution units (Agents, Tools, Logic).\n    edges: Directed connections defining control flow.\n    entry_point: The ID of the starting node.\n    llm_config: Specific LLM parameters.",
-      "properties": {
-        "nodes": {
-          "description": "A collection of execution units.",
-          "items": {
-            "description": "Polymorphic node definition.",
-            "discriminator": {
-              "mapping": {
-                "agent": "#/$defs/AgentNode",
-                "human": "#/$defs/HumanNode",
-                "logic": "#/$defs/LogicNode"
-              },
-              "propertyName": "type"
-            },
-            "oneOf": [
-              {
-                "$ref": "#/$defs/AgentNode"
-              },
-              {
-                "$ref": "#/$defs/HumanNode"
-              },
-              {
-                "$ref": "#/$defs/LogicNode"
-              }
-            ]
-          },
-          "title": "Nodes",
-          "type": "array"
-        },
         "edges": {
           "description": "Directed connections defining control flow.",
           "items": {
@@ -207,6 +20,41 @@
         "model_config": {
           "$ref": "#/$defs/ModelConfig",
           "description": "Specific LLM parameters."
+        },
+        "nodes": {
+          "description": "A collection of execution units.",
+          "items": {
+            "description": "Polymorphic node definition.",
+            "discriminator": {
+              "mapping": {
+                "agent": "#/$defs/AgentNode",
+                "human": "#/$defs/HumanNode",
+                "logic": "#/$defs/LogicNode",
+                "map": "#/$defs/MapNode",
+                "recipe": "#/$defs/RecipeNode"
+              },
+              "propertyName": "type"
+            },
+            "oneOf": [
+              {
+                "$ref": "#/$defs/AgentNode"
+              },
+              {
+                "$ref": "#/$defs/HumanNode"
+              },
+              {
+                "$ref": "#/$defs/LogicNode"
+              },
+              {
+                "$ref": "#/$defs/RecipeNode"
+              },
+              {
+                "$ref": "#/$defs/MapNode"
+              }
+            ]
+          },
+          "title": "Nodes",
+          "type": "array"
         }
       },
       "required": [
@@ -215,7 +63,167 @@
         "entry_point",
         "model_config"
       ],
-      "title": "AgentTopology",
+      "title": "AgentConfig",
+      "type": "object"
+    },
+    "AgentDependencies": {
+      "additionalProperties": false,
+      "description": "External dependencies for the Agent.\n\nAttributes:\n    tools: List of MCP tool requirements.\n    libraries: List of Python packages required (if code execution is allowed).",
+      "properties": {
+        "libraries": {
+          "description": "List of Python packages required (if code execution is allowed).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Libraries",
+          "type": "array"
+        },
+        "tools": {
+          "description": "List of MCP tool requirements.",
+          "items": {
+            "$ref": "#/$defs/ToolRequirement"
+          },
+          "title": "Tools",
+          "type": "array"
+        }
+      },
+      "title": "AgentDependencies",
+      "type": "object"
+    },
+    "AgentInterface": {
+      "additionalProperties": false,
+      "description": "Interface definition for the Agent.\n\nAttributes:\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.",
+      "properties": {
+        "injected_params": {
+          "description": "List of parameters injected by the system.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Injected Params",
+          "type": "array"
+        },
+        "inputs": {
+          "additionalProperties": true,
+          "description": "Typed arguments the agent accepts (JSON Schema).",
+          "title": "Inputs",
+          "type": "object"
+        },
+        "outputs": {
+          "additionalProperties": true,
+          "description": "Typed structure of the result.",
+          "title": "Outputs",
+          "type": "object"
+        }
+      },
+      "required": [
+        "inputs",
+        "outputs"
+      ],
+      "title": "AgentInterface",
+      "type": "object"
+    },
+    "AgentMetadata": {
+      "additionalProperties": false,
+      "description": "Metadata for the Agent.\n\nAttributes:\n    id: Unique Identifier for the Agent (UUID).\n    version: Semantic Version of the Agent.\n    name: Name of the Agent.\n    author: Author of the Agent.\n    created_at: Creation timestamp (ISO 8601).",
+      "properties": {
+        "author": {
+          "description": "Author of the Agent.",
+          "minLength": 1,
+          "title": "Author",
+          "type": "string"
+        },
+        "created_at": {
+          "description": "Creation timestamp (ISO 8601).",
+          "format": "date-time",
+          "title": "Created At",
+          "type": "string"
+        },
+        "id": {
+          "description": "Unique Identifier for the Agent (UUID).",
+          "format": "uuid",
+          "title": "Id",
+          "type": "string"
+        },
+        "name": {
+          "description": "Name of the Agent.",
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "requires_auth": {
+          "default": false,
+          "description": "Whether the agent requires user authentication.",
+          "title": "Requires Auth",
+          "type": "boolean"
+        },
+        "version": {
+          "description": "Semantic Version of the Agent.",
+          "pattern": "^[vV]*(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "title": "Version",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "version",
+        "name",
+        "author",
+        "created_at"
+      ],
+      "title": "AgentMetadata",
+      "type": "object"
+    },
+    "AgentNode": {
+      "additionalProperties": false,
+      "description": "A node that calls a specific atomic agent.\n\nAttributes:\n    type: The type of the node (must be 'agent').\n    agent_name: The name of the atomic agent to call.",
+      "properties": {
+        "agent_name": {
+          "description": "The name of the atomic agent to call.",
+          "title": "Agent Name",
+          "type": "string"
+        },
+        "council_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CouncilConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional configuration for architectural triangulation."
+        },
+        "id": {
+          "description": "Unique identifier for the node.",
+          "title": "Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "agent",
+          "default": "agent",
+          "description": "Discriminator for AgentNode.",
+          "title": "Type",
+          "type": "string"
+        },
+        "visual": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Visual metadata for the UI."
+        }
+      },
+      "required": [
+        "id",
+        "agent_name"
+      ],
+      "title": "AgentNode",
       "type": "object"
     },
     "CouncilConfig": {
@@ -247,16 +255,6 @@
       "additionalProperties": false,
       "description": "Represents a connection between two nodes.\n\nAttributes:\n    source_node_id: The ID of the source node.\n    target_node_id: The ID of the target node.\n    condition: Optional Python expression for conditional branching.",
       "properties": {
-        "source_node_id": {
-          "description": "The ID of the source node.",
-          "title": "Source Node Id",
-          "type": "string"
-        },
-        "target_node_id": {
-          "description": "The ID of the target node.",
-          "title": "Target Node Id",
-          "type": "string"
-        },
         "condition": {
           "anyOf": [
             {
@@ -269,6 +267,16 @@
           "default": null,
           "description": "Optional Python expression for conditional branching.",
           "title": "Condition"
+        },
+        "source_node_id": {
+          "description": "The ID of the source node.",
+          "title": "Source Node Id",
+          "type": "string"
+        },
+        "target_node_id": {
+          "description": "The ID of the target node.",
+          "title": "Target Node Id",
+          "type": "string"
         }
       },
       "required": [
@@ -282,11 +290,6 @@
       "additionalProperties": false,
       "description": "A node that pauses execution for user input/approval.\n\nAttributes:\n    type: The type of the node (must be 'human').\n    timeout_seconds: Optional timeout in seconds for the user interaction.",
       "properties": {
-        "id": {
-          "description": "Unique identifier for the node.",
-          "title": "Id",
-          "type": "string"
-        },
         "council_config": {
           "anyOf": [
             {
@@ -299,23 +302,9 @@
           "default": null,
           "description": "Optional configuration for architectural triangulation."
         },
-        "visual": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VisualMetadata"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Visual metadata for the UI."
-        },
-        "type": {
-          "const": "human",
-          "default": "human",
-          "description": "Discriminator for HumanNode.",
-          "title": "Type",
+        "id": {
+          "description": "Unique identifier for the node.",
+          "title": "Id",
           "type": "string"
         },
         "timeout_seconds": {
@@ -330,6 +319,25 @@
           "default": null,
           "description": "Optional timeout in seconds for the user interaction.",
           "title": "Timeout Seconds"
+        },
+        "type": {
+          "const": "human",
+          "default": "human",
+          "description": "Discriminator for HumanNode.",
+          "title": "Type",
+          "type": "string"
+        },
+        "visual": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Visual metadata for the UI."
         }
       },
       "required": [
@@ -342,9 +350,9 @@
       "additionalProperties": false,
       "description": "A node that executes pure Python logic.\n\nAttributes:\n    type: The type of the node (must be 'logic').\n    code: The Python logic code to execute.",
       "properties": {
-        "id": {
-          "description": "Unique identifier for the node.",
-          "title": "Id",
+        "code": {
+          "description": "The Python logic code to execute.",
+          "title": "Code",
           "type": "string"
         },
         "council_config": {
@@ -359,6 +367,18 @@
           "default": null,
           "description": "Optional configuration for architectural triangulation."
         },
+        "id": {
+          "description": "Unique identifier for the node.",
+          "title": "Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "logic",
+          "default": "logic",
+          "description": "Discriminator for LogicNode.",
+          "title": "Type",
+          "type": "string"
+        },
         "visual": {
           "anyOf": [
             {
@@ -370,18 +390,6 @@
           ],
           "default": null,
           "description": "Visual metadata for the UI."
-        },
-        "type": {
-          "const": "logic",
-          "default": "logic",
-          "description": "Discriminator for LogicNode.",
-          "title": "Type",
-          "type": "string"
-        },
-        "code": {
-          "description": "The Python logic code to execute.",
-          "title": "Code",
-          "type": "string"
         }
       },
       "required": [
@@ -389,6 +397,71 @@
         "code"
       ],
       "title": "LogicNode",
+      "type": "object"
+    },
+    "MapNode": {
+      "additionalProperties": false,
+      "description": "A node that spawns multiple parallel executions of a sub-branch.\n\nAttributes:\n    type: The type of the node (must be 'map').\n    items_path: Dot-notation path to the list in the state.\n    processor_node_id: The node (or subgraph) to run for each item.\n    concurrency_limit: Max parallel executions.",
+      "properties": {
+        "concurrency_limit": {
+          "description": "Max parallel executions.",
+          "title": "Concurrency Limit",
+          "type": "integer"
+        },
+        "council_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CouncilConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional configuration for architectural triangulation."
+        },
+        "id": {
+          "description": "Unique identifier for the node.",
+          "title": "Id",
+          "type": "string"
+        },
+        "items_path": {
+          "description": "Dot-notation path to the list in the state.",
+          "title": "Items Path",
+          "type": "string"
+        },
+        "processor_node_id": {
+          "description": "The node (or subgraph) to run for each item.",
+          "title": "Processor Node Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "map",
+          "default": "map",
+          "description": "Discriminator for MapNode.",
+          "title": "Type",
+          "type": "string"
+        },
+        "visual": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Visual metadata for the UI."
+        }
+      },
+      "required": [
+        "id",
+        "items_path",
+        "processor_node_id",
+        "concurrency_limit"
+      ],
+      "title": "MapNode",
       "type": "object"
     },
     "ModelConfig": {
@@ -419,16 +492,6 @@
       "additionalProperties": false,
       "description": "Observability configuration.\n\nAttributes:\n    trace_level: Level of tracing detail.\n    retention_policy: Retention policy identifier (e.g., '30_days').\n    encryption_key_id: Optional ID of the key used for log encryption.",
       "properties": {
-        "trace_level": {
-          "$ref": "#/$defs/TraceLevel",
-          "default": "full"
-        },
-        "retention_policy": {
-          "default": "30_days",
-          "description": "Retention policy identifier.",
-          "title": "Retention Policy",
-          "type": "string"
-        },
         "encryption_key_id": {
           "anyOf": [
             {
@@ -441,6 +504,16 @@
           "default": null,
           "description": "Optional ID of the key used for log encryption.",
           "title": "Encryption Key Id"
+        },
+        "retention_policy": {
+          "default": "30_days",
+          "description": "Retention policy identifier.",
+          "title": "Retention Policy",
+          "type": "string"
+        },
+        "trace_level": {
+          "$ref": "#/$defs/TraceLevel",
+          "default": "full"
         }
       },
       "title": "ObservabilityConfig",
@@ -450,6 +523,14 @@
       "additionalProperties": false,
       "description": "Governance policy configuration.\n\nAttributes:\n    budget_caps: Dictionary defining budget limits (e.g., {\"total_cost\": 10.0, \"total_tokens\": 1000}).\n    human_in_the_loop: List of Node IDs that require human approval.\n    allowed_domains: List of allowed domains for external access.",
       "properties": {
+        "allowed_domains": {
+          "description": "Allowed domains for external access.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Allowed Domains",
+          "type": "array"
+        },
         "budget_caps": {
           "additionalProperties": {
             "type": "number"
@@ -465,35 +546,95 @@
           },
           "title": "Human In The Loop",
           "type": "array"
-        },
-        "allowed_domains": {
-          "description": "Allowed domains for external access.",
-          "items": {
-            "type": "string"
-          },
-          "title": "Allowed Domains",
-          "type": "array"
         }
       },
       "title": "PolicyConfig",
+      "type": "object"
+    },
+    "RecipeNode": {
+      "additionalProperties": false,
+      "description": "A node that executes another Recipe as a sub-graph.\n\nAttributes:\n    type: The type of the node (must be 'recipe').\n    recipe_id: The ID of the recipe to execute.\n    input_mapping: How parent state maps to child inputs (parent_key -> child_key).\n    output_mapping: How child result maps back to parent state (child_key -> parent_key).",
+      "properties": {
+        "council_config": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CouncilConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional configuration for architectural triangulation."
+        },
+        "id": {
+          "description": "Unique identifier for the node.",
+          "title": "Id",
+          "type": "string"
+        },
+        "input_mapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Mapping of parent state keys to child input keys.",
+          "title": "Input Mapping",
+          "type": "object"
+        },
+        "output_mapping": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Mapping of child output keys to parent state keys.",
+          "title": "Output Mapping",
+          "type": "object"
+        },
+        "recipe_id": {
+          "description": "The ID of the recipe to execute.",
+          "title": "Recipe Id",
+          "type": "string"
+        },
+        "type": {
+          "const": "recipe",
+          "default": "recipe",
+          "description": "Discriminator for RecipeNode.",
+          "title": "Type",
+          "type": "string"
+        },
+        "visual": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VisualMetadata"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Visual metadata for the UI."
+        }
+      },
+      "required": [
+        "id",
+        "recipe_id",
+        "input_mapping",
+        "output_mapping"
+      ],
+      "title": "RecipeNode",
       "type": "object"
     },
     "ToolRequirement": {
       "additionalProperties": false,
       "description": "Requirement for an MCP tool.\n\nAttributes:\n    uri: The MCP endpoint URI.\n    hash: Integrity check for the tool definition (SHA256).\n    scopes: List of permissions required.\n    risk_level: The risk level of the tool.",
       "properties": {
-        "uri": {
-          "description": "The MCP endpoint URI.",
-          "format": "uri",
-          "minLength": 1,
-          "title": "Uri",
-          "type": "string"
-        },
         "hash": {
           "description": "Integrity check for the tool definition (SHA256).",
           "pattern": "^[a-fA-F0-9]{64}$",
           "title": "Hash",
           "type": "string"
+        },
+        "risk_level": {
+          "$ref": "#/$defs/ToolRiskLevel",
+          "description": "The risk level of the tool."
         },
         "scopes": {
           "description": "List of permissions required.",
@@ -503,9 +644,12 @@
           "title": "Scopes",
           "type": "array"
         },
-        "risk_level": {
-          "$ref": "#/$defs/ToolRiskLevel",
-          "description": "The risk level of the tool."
+        "uri": {
+          "description": "The MCP endpoint URI.",
+          "format": "uri",
+          "minLength": 1,
+          "title": "Uri",
+          "type": "string"
         }
       },
       "required": [
@@ -541,6 +685,32 @@
       "additionalProperties": false,
       "description": "Data explicitly for the UI.\n\nAttributes:\n    label: The label to display for the node.\n    x_y_coordinates: The X and Y coordinates for the node on the canvas.\n    icon: The icon to represent the node.\n    animation_style: The animation style for the node.",
       "properties": {
+        "animation_style": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The animation style for the node.",
+          "title": "Animation Style"
+        },
+        "icon": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The icon to represent the node.",
+          "title": "Icon"
+        },
         "label": {
           "anyOf": [
             {
@@ -569,32 +739,6 @@
           "default": null,
           "description": "The X and Y coordinates for the node on the canvas.",
           "title": "X Y Coordinates"
-        },
-        "icon": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The icon to represent the node.",
-          "title": "Icon"
-        },
-        "animation_style": {
-          "anyOf": [
-            {
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The animation style for the node.",
-          "title": "Animation Style"
         }
       },
       "title": "VisualMetadata",
@@ -605,29 +749,23 @@
   "additionalProperties": false,
   "description": "The definitive source of truth for CoReason Agent definitions.",
   "properties": {
-    "metadata": {
-      "$ref": "#/$defs/AgentMetadata"
-    },
-    "interface": {
-      "$ref": "#/$defs/AgentInterface"
-    },
-    "topology": {
-      "$ref": "#/$defs/AgentTopology"
+    "config": {
+      "$ref": "#/$defs/AgentConfig"
     },
     "dependencies": {
       "$ref": "#/$defs/AgentDependencies"
     },
-    "policy": {
-      "anyOf": [
-        {
-          "$ref": "#/$defs/PolicyConfig"
-        },
-        {
-          "type": "null"
-        }
-      ],
-      "default": null,
-      "description": "Governance policy configuration."
+    "integrity_hash": {
+      "description": "SHA256 hash of the source code.",
+      "pattern": "^[a-fA-F0-9]{64}$",
+      "title": "Integrity Hash",
+      "type": "string"
+    },
+    "interface": {
+      "$ref": "#/$defs/AgentInterface"
+    },
+    "metadata": {
+      "$ref": "#/$defs/AgentMetadata"
     },
     "observability": {
       "anyOf": [
@@ -641,17 +779,23 @@
       "default": null,
       "description": "Observability configuration."
     },
-    "integrity_hash": {
-      "description": "SHA256 hash of the source code.",
-      "pattern": "^[a-fA-F0-9]{64}$",
-      "title": "Integrity Hash",
-      "type": "string"
+    "policy": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/PolicyConfig"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Governance policy configuration."
     }
   },
   "required": [
     "metadata",
     "interface",
-    "topology",
+    "config",
     "dependencies",
     "integrity_hash"
   ],

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -10,7 +10,8 @@ def test_audit_tamper_evidence() -> None:
     now = datetime.now(timezone.utc)
 
     log = AuditLog(
-        id=log_id,
+        audit_id=log_id,
+        trace_id="trace_001",
         timestamp=now,
         actor="user_1",
         event_type=AuditEventType.PREDICTION,

--- a/tests/test_audit_edge_cases.py
+++ b/tests/test_audit_edge_cases.py
@@ -11,7 +11,8 @@ def test_audit_hash_stability() -> None:
 
     # Same data, different key order in safety_metadata
     log1 = AuditLog(
-        id=log_id,
+        audit_id=log_id,
+        trace_id="trace_abc",
         timestamp=now,
         actor="system",
         event_type=AuditEventType.SYSTEM_CHANGE,
@@ -21,7 +22,8 @@ def test_audit_hash_stability() -> None:
     )
 
     log2 = AuditLog(
-        id=log_id,
+        audit_id=log_id,
+        trace_id="trace_abc",
         timestamp=now,
         actor="system",
         event_type=AuditEventType.SYSTEM_CHANGE,
@@ -36,7 +38,8 @@ def test_audit_hash_stability() -> None:
 def test_audit_complex_types_serialization() -> None:
     """Test that compute_hash handles complex types like UUID and datetime."""
     log = AuditLog(
-        id=uuid.uuid4(),
+        audit_id=uuid.uuid4(),
+        trace_id="trace_complex",
         timestamp=datetime.now(timezone.utc),
         actor="system",
         event_type=AuditEventType.SYSTEM_CHANGE,
@@ -54,7 +57,8 @@ def test_audit_complex_types_serialization() -> None:
 def test_audit_integrity_sensitivity() -> None:
     """Test that modifying any field changes the hash."""
     log = AuditLog(
-        id=uuid.uuid4(),
+        audit_id=uuid.uuid4(),
+        trace_id="trace_mod",
         timestamp=datetime.now(timezone.utc),
         actor="actor_1",
         event_type=AuditEventType.PREDICTION,

--- a/tests/test_audit_message.py
+++ b/tests/test_audit_message.py
@@ -53,7 +53,7 @@ def test_gen_ai_operation_creation() -> None:
     output_msg = ChatMessage(role=Role.ASSISTANT, parts=[tool_call])
 
     operation = GenAIOperation(
-        id=step_id,
+        span_id=step_id,
         trace_id=trace_id,
         operation_name="chat",
         provider="openai",
@@ -63,7 +63,7 @@ def test_gen_ai_operation_creation() -> None:
         token_usage=GenAITokenUsage(input=5, output=10, total=15),
     )
 
-    assert operation.id == step_id
+    assert operation.span_id == step_id
     assert operation.provider == "openai"
     assert operation.token_usage is not None
     assert operation.token_usage.total == 15
@@ -79,7 +79,7 @@ def test_reasoning_trace_creation() -> None:
     trace_id = uuid.uuid4()
 
     step = GenAIOperation(
-        id="step_1",
+        span_id="step_1",
         trace_id=str(trace_id),
         operation_name="chat",
         provider="openai",
@@ -94,7 +94,7 @@ def test_reasoning_trace_creation() -> None:
 
     assert trace.trace_id == trace_id
     assert len(trace.steps) == 1
-    assert trace.steps[0].id == "step_1"
+    assert trace.steps[0].span_id == "step_1"
 
 
 def test_serialization() -> None:

--- a/tests/test_complex_cases.py
+++ b/tests/test_complex_cases.py
@@ -19,7 +19,7 @@ def test_deep_immutability_mapping_proxy() -> None:
             "created_at": "2023-01-01T00:00:00Z",
         },
         "interface": {"inputs": {"param": 1}, "outputs": {}},
-        "topology": {
+        "config": {
             "nodes": [],
             "edges": [],
             "entry_point": "start",
@@ -59,7 +59,7 @@ def test_deep_immutability_tuples() -> None:
             "created_at": "2023-01-01T00:00:00Z",
         },
         "interface": {"inputs": {}, "outputs": {}},
-        "topology": {
+        "config": {
             "nodes": [],
             "edges": [],
             "entry_point": "start",
@@ -112,7 +112,7 @@ def test_unicode_handling() -> None:
             "created_at": "2023-01-01T00:00:00Z",
         },
         "interface": {"inputs": {"key_Ω": "val_🤖"}, "outputs": {}},
-        "topology": {
+        "config": {
             "nodes": [],
             "edges": [],
             "entry_point": "start",
@@ -139,7 +139,7 @@ def test_hash_validation_edge_cases() -> None:
             "created_at": "2023-01-01T00:00:00Z",
         },
         "interface": {"inputs": {}, "outputs": {}},
-        "topology": {
+        "config": {
             "nodes": [],
             "edges": [],
             "entry_point": "start",

--- a/tests/test_edge_cases_topology.py
+++ b/tests/test_edge_cases_topology.py
@@ -1,6 +1,6 @@
 # Prosperity-3.0
 
-from coreason_manifest.definitions.agent import AgentTopology
+from coreason_manifest.definitions.agent import AgentConfig
 from coreason_manifest.definitions.topology import Edge, LogicNode
 
 
@@ -17,7 +17,7 @@ def test_topology_allows_cycles() -> None:
     ]
 
     # Should be valid
-    topology = AgentTopology(
+    topology = AgentConfig(
         nodes=[node_a, node_b],
         edges=edges,
         entry_point="A",
@@ -35,7 +35,7 @@ def test_topology_disconnected_graph_valid() -> None:
     edges = [Edge(source_node_id="A", target_node_id="B")]
 
     # Should be valid
-    topology = AgentTopology(
+    topology = AgentConfig(
         nodes=[node_a, node_b, node_c],
         edges=edges,
         entry_point="A",
@@ -49,7 +49,7 @@ def test_topology_self_loop_valid() -> None:
     node_a = LogicNode(id="A", type="logic", code="pass")
     edges = [Edge(source_node_id="A", target_node_id="A")]
 
-    topology = AgentTopology(
+    topology = AgentConfig(
         nodes=[node_a],
         edges=edges,
         entry_point="A",
@@ -64,7 +64,7 @@ def test_topology_entry_point_must_exist() -> None:
 
     # This is currently NOT validated by the model directly (it's a string),
     # but let's see if we should add a validator or if it's acceptable for now.
-    # The current AgentTopology model only validates unique node IDs.
+    # The current AgentConfig model only validates unique node IDs.
     # If the user requirement implies strict graph validation, we might need to add it.
     # However, for now, let's verify the current behavior (it accepts it).
     # If we want to be strict, we would add a model validator.
@@ -72,7 +72,7 @@ def test_topology_entry_point_must_exist() -> None:
 
     # Actually, a robust standard SHOULD probably validate this.
     # But I am writing tests for *current* implementation edge cases.
-    topology = AgentTopology(
+    topology = AgentConfig(
         nodes=[node_a],
         edges=[],
         entry_point="Z",  # Non-existent

--- a/tests/test_immutability.py
+++ b/tests/test_immutability.py
@@ -33,7 +33,7 @@ def test_agent_definition_immutability() -> None:
             "created_at": "2023-10-27T10:00:00Z",
         },
         "interface": {"inputs": {}, "outputs": {}},
-        "topology": {
+        "config": {
             "nodes": [],
             "edges": [],
             "entry_point": "start",
@@ -65,7 +65,7 @@ def test_nested_model_immutability() -> None:
             "created_at": "2023-10-27T10:00:00Z",
         },
         "interface": {"inputs": {}, "outputs": {}},
-        "topology": {
+        "config": {
             "nodes": [],
             "edges": [],
             "entry_point": "start",
@@ -79,7 +79,7 @@ def test_nested_model_immutability() -> None:
 
     # Try to modify a field on a nested object
     with pytest.raises(ValidationError):
-        agent.topology.llm_config.temperature = 0.9  # type: ignore[misc]
+        agent.config.llm_config.temperature = 0.9  # type: ignore[misc]
 
     with pytest.raises(ValidationError):
         agent.metadata.name = "New Name"  # type: ignore[misc]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -25,7 +25,7 @@ def test_agent_definition_valid() -> None:
             "inputs": {"type": "object", "properties": {"query": {"type": "string"}}},
             "outputs": {"type": "string"},
         },
-        "topology": {
+        "config": {
             "nodes": [{"id": "step1", "type": "logic", "code": "pass"}],
             "edges": [],
             "entry_point": "step1",
@@ -47,7 +47,7 @@ def test_agent_definition_valid() -> None:
 
     agent = AgentDefinition(**valid_data)
     assert agent.metadata.name == "Test Agent"
-    assert agent.topology.llm_config.temperature == 0.7
+    assert agent.config.llm_config.temperature == 0.7
     assert len(agent.dependencies.libraries) == 1
 
 
@@ -86,7 +86,7 @@ def test_validation_error_on_missing_fields() -> None:
             "created_at": "2023-10-27T10:00:00Z",
         },
         "interface": {"inputs": {}, "outputs": {}},
-        "topology": {
+        "config": {
             "nodes": [],
             "edges": [],
             "entry_point": "start",
@@ -115,7 +115,7 @@ def test_auth_validation_failure() -> None:
             "outputs": {"type": "string"},
             "injected_params": [],  # Missing user_context
         },
-        "topology": {
+        "config": {
             "nodes": [{"id": "step1", "type": "logic", "code": "pass"}],
             "edges": [],
             "entry_point": "step1",
@@ -141,7 +141,7 @@ def test_agent_definition_with_policy_and_observability() -> None:
             "created_at": "2023-10-27T10:00:00Z",
         },
         "interface": {"inputs": {}, "outputs": {}},
-        "topology": {
+        "config": {
             "nodes": [],
             "edges": [],
             "entry_point": "start",

--- a/tests/test_polish_edge_cases.py
+++ b/tests/test_polish_edge_cases.py
@@ -1,0 +1,117 @@
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.definitions.agent import (
+    AgentConfig,
+    AgentDefinition,
+)
+from coreason_manifest.definitions.audit import AuditEventType, AuditLog, GenAIOperation
+from coreason_manifest.recipes import RecipeManifest
+
+
+def test_audit_log_legacy_key_rejection() -> None:
+    """Test that instantiating AuditLog with legacy 'id' field fails."""
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValidationError) as exc:
+        AuditLog(
+            id=uuid.uuid4(),  # Legacy key  # type: ignore[call-arg]
+            trace_id="trace-123",
+            timestamp=now,
+            actor="user",
+            event_type=AuditEventType.SYSTEM_CHANGE,
+            safety_metadata={},
+            previous_hash="abc",
+            integrity_hash="def",
+        )  # type: ignore[call-arg]
+    # Pydantic v2 error for extra fields (if extra="forbid" which is default for these models usually)
+    # or missing required field 'audit_id'
+    error_str = str(exc.value)
+    assert "audit_id" in error_str and "Field required" in error_str
+
+
+def test_audit_log_trace_id_requirement() -> None:
+    """Test that trace_id is mandatory for AuditLog."""
+    now = datetime.now(timezone.utc)
+    with pytest.raises(ValidationError) as exc:
+        AuditLog(
+            audit_id=uuid.uuid4(),
+            # trace_id missing
+            timestamp=now,
+            actor="user",
+            event_type=AuditEventType.SYSTEM_CHANGE,
+            safety_metadata={},
+            previous_hash="abc",
+            integrity_hash="def",
+        )  # type: ignore[call-arg]
+    assert "trace_id" in str(exc.value)
+
+
+def test_gen_ai_operation_legacy_key_rejection() -> None:
+    """Test that instantiating GenAIOperation with legacy 'id' field fails."""
+    with pytest.raises(ValidationError) as exc:
+        GenAIOperation(
+            id="span-123",  # Legacy  # type: ignore[call-arg]
+            trace_id="trace-123",
+            operation_name="test",
+            provider="openai",
+            model="gpt-4",
+        )  # type: ignore[call-arg]
+    error_str = str(exc.value)
+    assert "span_id" in error_str and "Field required" in error_str
+
+
+def test_agent_definition_legacy_key_rejection() -> None:
+    """Test that AgentDefinition rejects 'topology' key in favor of 'config'."""
+    data = {
+        "metadata": {
+            "id": str(uuid.uuid4()),
+            "version": "1.0.0",
+            "name": "Test",
+            "author": "Me",
+            "created_at": "2023-01-01T00:00:00Z",
+        },
+        "interface": {"inputs": {}, "outputs": {}},
+        "topology": {  # Legacy key
+            "nodes": [],
+            "edges": [],
+            "entry_point": "start",
+            "model_config": {"model": "gpt-4", "temperature": 0.1},
+        },
+        "dependencies": {},
+        "integrity_hash": "a" * 64,
+    }
+    with pytest.raises(ValidationError) as exc:
+        AgentDefinition(**data)
+
+    error_str = str(exc.value)
+    assert "config" in error_str and "Field required" in error_str
+    assert "topology" in error_str and "Extra inputs are not permitted" in error_str
+
+
+def test_recipe_manifest_legacy_key_rejection() -> None:
+    """Test that RecipeManifest rejects 'graph' key in favor of 'topology'."""
+    data = {
+        "id": "recipe-1",
+        "version": "1.0.0",
+        "name": "Test Recipe",
+        "interface": {"inputs": {}, "outputs": {}},
+        "state": {"schema": {}, "persistence": "ephemeral"},
+        "parameters": {},
+        "graph": {"nodes": [], "edges": []},  # Legacy key
+    }
+    with pytest.raises(ValidationError) as exc:
+        RecipeManifest(**data)
+
+    error_str = str(exc.value)
+    assert "topology" in error_str and "Field required" in error_str
+    assert "graph" in error_str and "Extra inputs are not permitted" in error_str
+
+
+def test_agent_config_validation() -> None:
+    """Test that AgentConfig (new name) works correctly."""
+    config = AgentConfig(nodes=[], edges=[], entry_point="start", model_config={"model": "gpt-4", "temperature": 0.5})
+    assert config.model_config.get("extra") == "forbid"
+    assert hasattr(config, "nodes")

--- a/tests/test_recipe_v2.py
+++ b/tests/test_recipe_v2.py
@@ -44,7 +44,7 @@ def test_full_recipe_v2_creation() -> None:
         interface=interface,
         state=state,
         parameters=parameters,
-        graph=Topology(nodes=[], edges=[]),
+        topology=Topology(nodes=[], edges=[]),
     )
 
     assert manifest.interface.inputs["properties"]["topic"]["type"] == "string"
@@ -62,7 +62,7 @@ def test_recipe_v2_serialization() -> None:
         interface=RecipeInterface(inputs={}, outputs={}),
         state=StateDefinition(schema={"foo": "bar"}, persistence="ephemeral"),
         parameters={},
-        graph=Topology(nodes=[], edges=[]),
+        topology=Topology(nodes=[], edges=[]),
     )
 
     # Must use by_alias=True to get "schema" instead of "schema_"
@@ -90,7 +90,7 @@ def test_recipe_v2_validation_error() -> None:
             # interface missing
             state=StateDefinition(schema={}, persistence="ephemeral"),
             parameters={},
-            graph=Topology(nodes=[], edges=[]),
+            topology=Topology(nodes=[], edges=[]),
         )  # type: ignore[call-arg]
     assert "interface" in str(excinfo.value)
     assert "Field required" in str(excinfo.value)
@@ -104,7 +104,7 @@ def test_recipe_v2_validation_error() -> None:
             interface=RecipeInterface(inputs={}, outputs={}),
             # state missing
             parameters={},
-            graph=Topology(nodes=[], edges=[]),
+            topology=Topology(nodes=[], edges=[]),
         )  # type: ignore[call-arg]
     assert "state" in str(excinfo.value)
     assert "Field required" in str(excinfo.value)
@@ -120,7 +120,7 @@ def test_recipe_v2_extra_fields() -> None:
             interface=RecipeInterface(inputs={}, outputs={}),
             state=StateDefinition(schema={}, persistence="ephemeral"),
             parameters={},
-            graph=Topology(nodes=[], edges=[]),
+            topology=Topology(nodes=[], edges=[]),
             extra_field="fail",  # type: ignore[call-arg]
         )
     assert "Extra inputs are not permitted" in str(excinfo.value)

--- a/tests/test_recipe_v2_extras.py
+++ b/tests/test_recipe_v2_extras.py
@@ -31,7 +31,7 @@ def test_state_schema_aliasing_roundtrip() -> None:
         interface=RecipeInterface(inputs={}, outputs={}),
         state=state,
         parameters={},
-        graph=Topology(nodes=[], edges=[]),
+        topology=Topology(nodes=[], edges=[]),
     )
     json_str = manifest.model_dump_json(by_alias=True)
     reloaded = RecipeManifest.model_validate_json(json_str)
@@ -47,7 +47,7 @@ def test_empty_interface_and_state() -> None:
         interface=RecipeInterface(inputs={}, outputs={}),
         state=StateDefinition(schema={}, persistence="ephemeral"),
         parameters={},
-        graph=Topology(nodes=[], edges=[]),
+        topology=Topology(nodes=[], edges=[]),
     )
     assert manifest.interface.inputs == {}
     assert manifest.state.schema_ == {}
@@ -68,7 +68,7 @@ def test_complex_parameters() -> None:
         interface=RecipeInterface(inputs={}, outputs={}),
         state=StateDefinition(schema={}, persistence="ephemeral"),
         parameters=params,
-        graph=Topology(nodes=[], edges=[]),
+        topology=Topology(nodes=[], edges=[]),
     )
 
     assert manifest.parameters["llm_config"]["model"] == "gpt-4"

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -23,14 +23,14 @@ def test_recipe_manifest_creation() -> None:
         interface=RecipeInterface(inputs={"param1": "value1"}, outputs={}),
         state=StateDefinition(schema={}, persistence="ephemeral"),
         parameters={},
-        graph=topology,
+        topology=topology,
     )
 
     assert manifest.id == "recipe1"
     assert manifest.version == "1.0.0"
-    assert len(manifest.graph.nodes) == 2
-    assert isinstance(manifest.graph.nodes[0], AgentNode)
-    assert isinstance(manifest.graph.nodes[1], HumanNode)
+    assert len(manifest.topology.nodes) == 2
+    assert isinstance(manifest.topology.nodes[0], AgentNode)
+    assert isinstance(manifest.topology.nodes[1], HumanNode)
 
 
 def test_version_validation() -> None:
@@ -47,7 +47,7 @@ def test_version_validation() -> None:
         interface=interface,
         state=state,
         parameters=params,
-        graph=GraphTopology(nodes=[], edges=[]),
+        topology=GraphTopology(nodes=[], edges=[]),
     )
     assert m.version == "1.0.0"
 
@@ -58,7 +58,7 @@ def test_version_validation() -> None:
         interface=interface,
         state=state,
         parameters=params,
-        graph=GraphTopology(nodes=[], edges=[]),
+        topology=GraphTopology(nodes=[], edges=[]),
     )
     assert m.version == "2.0.0"
 
@@ -71,7 +71,7 @@ def test_version_validation() -> None:
             interface=interface,
             state=state,
             parameters=params,
-            graph=GraphTopology(nodes=[], edges=[]),
+            topology=GraphTopology(nodes=[], edges=[]),
         )
 
 
@@ -108,7 +108,7 @@ def test_serialization() -> None:
         interface=RecipeInterface(inputs={}, outputs={}),
         state=StateDefinition(schema={}, persistence="ephemeral"),
         parameters={},
-        graph=GraphTopology(nodes=[node], edges=[]),
+        topology=GraphTopology(nodes=[node], edges=[]),
     )
 
     json_output = manifest.model_dump_json()

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -38,7 +38,7 @@ def test_strict_schema_extra_fields() -> None:
             interface=RecipeInterface(inputs={}, outputs={}),
             state=StateDefinition(schema={}, persistence="ephemeral"),
             parameters={},
-            graph=GraphTopology(nodes=[], edges=[]),
+            topology=GraphTopology(nodes=[], edges=[]),
             extra_thing="bad",  # type: ignore[call-arg]
         )
     assert "Extra inputs are not permitted" in str(excinfo.value)
@@ -62,7 +62,7 @@ def test_recursive_version_normalization() -> None:
         interface=RecipeInterface(inputs={}, outputs={}),
         state=StateDefinition(schema={}, persistence="ephemeral"),
         parameters={},
-        graph=GraphTopology(nodes=[], edges=[]),
+        topology=GraphTopology(nodes=[], edges=[]),
     )
     assert manifest.version == "1.5.0"
 
@@ -81,7 +81,7 @@ def test_complex_inputs_structure() -> None:
         interface=RecipeInterface(inputs=complex_inputs, outputs={}),
         state=StateDefinition(schema={}, persistence="ephemeral"),
         parameters={},
-        graph=GraphTopology(nodes=[], edges=[]),
+        topology=GraphTopology(nodes=[], edges=[]),
     )
 
     assert manifest.interface.inputs["user"]["name"] == "Alice"
@@ -108,7 +108,7 @@ def test_large_topology_serialization() -> None:
         interface=RecipeInterface(inputs={}, outputs={}),
         state=StateDefinition(schema={}, persistence="ephemeral"),
         parameters={},
-        graph=topology,
+        topology=topology,
     )
 
     # Dump
@@ -117,10 +117,10 @@ def test_large_topology_serialization() -> None:
     # Load back
     loaded = RecipeManifest.model_validate_json(json_str)
 
-    assert len(loaded.graph.nodes) == count
-    assert len(loaded.graph.edges) == count - 1
-    assert loaded.graph.nodes[99].id == "node_99"
-    assert isinstance(loaded.graph.nodes[0], LogicNode)
+    assert len(loaded.topology.nodes) == count
+    assert len(loaded.topology.edges) == count - 1
+    assert loaded.topology.nodes[99].id == "node_99"
+    assert isinstance(loaded.topology.nodes[0], LogicNode)
 
 
 def test_polymorphic_list_parsing() -> None:

--- a/tests/test_validation_edge_cases.py
+++ b/tests/test_validation_edge_cases.py
@@ -6,8 +6,8 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.definitions.agent import (
+    AgentConfig,
     AgentMetadata,
-    AgentTopology,
 )
 from coreason_manifest.definitions.topology import AgentNode
 
@@ -20,7 +20,7 @@ def test_unique_node_ids_validation() -> None:
     ]
 
     with pytest.raises(ValidationError) as e:
-        AgentTopology(nodes=nodes, edges=[], entry_point="node1", model_config={"model": "gpt-4", "temperature": 0.5})
+        AgentConfig(nodes=nodes, edges=[], entry_point="node1", model_config={"model": "gpt-4", "temperature": 0.5})
     assert "Duplicate node IDs found: node1" in str(e.value)
 
 
@@ -30,9 +30,7 @@ def test_unique_node_ids_valid() -> None:
         AgentNode(id="node1", agent_name="A"),
         AgentNode(id="node2", agent_name="B"),
     ]
-    topo = AgentTopology(
-        nodes=nodes, edges=[], entry_point="node1", model_config={"model": "gpt-4", "temperature": 0.5}
-    )
+    topo = AgentConfig(nodes=nodes, edges=[], entry_point="node1", model_config={"model": "gpt-4", "temperature": 0.5})
     assert len(topo.nodes) == 2
 
 


### PR DESCRIPTION
…rts (#103)

* Standardize IDs and refactor Agent topology

- Rename `AuditLog.id` to `audit_id` and add `trace_id`.
- Rename `GenAIOperation.id` to `span_id`.
- Rename `AgentTopology` to `AgentConfig` and update `AgentDefinition` to use `config` field.
- Rename `RecipeManifest.graph` to `topology` and update imports.
- Update tests and schema.