### PR TITLE
Support system_prompt and inline tools in AgentDefinition

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.9.0"
+version = "0.10.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.9.0"
+version = "0.10.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from .definitions.agent import AgentDefinition
 from .definitions.audit import AuditLog
 from .definitions.simulation import SimulationScenario, SimulationStep, SimulationTrace

--- a/src/coreason_manifest/definitions/__init__.py
+++ b/src/coreason_manifest/definitions/__init__.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from .agent import AgentDefinition, AgentRuntimeConfig
 from .events import (
     ArtifactGenerated,

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 """Pydantic models for the Coreason Manifest system.
 
 These models define the structure and validation rules for the Agent Manifest

--- a/src/coreason_manifest/definitions/audit.py
+++ b/src/coreason_manifest/definitions/audit.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import hashlib
 import json
 from datetime import datetime

--- a/src/coreason_manifest/definitions/events.py
+++ b/src/coreason_manifest/definitions/events.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from datetime import datetime, timezone
 from typing import Any, Dict, Generic, Literal, Optional, Protocol, TypeVar, runtime_checkable
 from uuid import uuid4

--- a/src/coreason_manifest/definitions/message.py
+++ b/src/coreason_manifest/definitions/message.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional, Union
 

--- a/src/coreason_manifest/definitions/simulation.py
+++ b/src/coreason_manifest/definitions/simulation.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List

--- a/src/coreason_manifest/definitions/topology.py
+++ b/src/coreason_manifest/definitions/topology.py
@@ -23,6 +23,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
 
+
 class StateSchema(BaseModel):
     """Defines the structure and persistence of the graph state.
 
@@ -38,6 +39,7 @@ class StateSchema(BaseModel):
     )
     persistence: str = Field(..., description="Configuration for how state is checkpointed (e.g., 'memory', 'redis').")
 
+
 class CouncilConfig(BaseModel):
     """Configuration for 'Architectural Triangulation'.
 
@@ -50,6 +52,7 @@ class CouncilConfig(BaseModel):
 
     strategy: str = Field(default="consensus", description="The strategy for the council, e.g., 'consensus'.")
     voters: List[str] = Field(..., description="List of agents or models that vote.")
+
 
 class VisualMetadata(BaseModel):
     """Data explicitly for the UI.
@@ -70,6 +73,7 @@ class VisualMetadata(BaseModel):
     icon: Optional[str] = Field(None, description="The icon to represent the node.")
     animation_style: Optional[str] = Field(None, description="The animation style for the node.")
 
+
 class BaseNode(BaseModel):
     """Base model for all node types.
 
@@ -87,6 +91,7 @@ class BaseNode(BaseModel):
     )
     visual: Optional[VisualMetadata] = Field(None, description="Visual metadata for the UI.")
 
+
 class AgentNode(BaseNode):
     """A node that calls a specific atomic agent.
 
@@ -97,6 +102,7 @@ class AgentNode(BaseNode):
 
     type: Literal["agent"] = Field("agent", description="Discriminator for AgentNode.")
     agent_name: str = Field(..., description="The name of the atomic agent to call.")
+
 
 class HumanNode(BaseNode):
     """A node that pauses execution for user input/approval.
@@ -109,6 +115,7 @@ class HumanNode(BaseNode):
     type: Literal["human"] = Field("human", description="Discriminator for HumanNode.")
     timeout_seconds: Optional[int] = Field(None, description="Optional timeout in seconds for the user interaction.")
 
+
 class LogicNode(BaseNode):
     """A node that executes pure Python logic.
 
@@ -120,12 +127,14 @@ class LogicNode(BaseNode):
     type: Literal["logic"] = Field("logic", description="Discriminator for LogicNode.")
     code: str = Field(..., description="The Python logic code to execute.")
 
+
 class DataMappingStrategy(str, Enum):
     """Strategy for mapping data."""
 
     DIRECT = "direct"
     JSONPATH = "jsonpath"
     LITERAL = "literal"
+
 
 class DataMapping(BaseModel):
     """Defines how to transform data between parent and child."""
@@ -134,6 +143,7 @@ class DataMapping(BaseModel):
 
     source: str = Field(..., description="The path/key source.")
     strategy: DataMappingStrategy = Field(default=DataMappingStrategy.DIRECT, description="The mapping strategy.")
+
 
 class RecipeNode(BaseNode):
     """A node that executes another Recipe as a sub-graph.
@@ -154,6 +164,7 @@ class RecipeNode(BaseNode):
         ..., description="Mapping of child output keys to parent state keys."
     )
 
+
 class MapNode(BaseNode):
     """A node that spawns multiple parallel executions of a sub-branch.
 
@@ -169,11 +180,13 @@ class MapNode(BaseNode):
     processor_node_id: str = Field(..., description="The node (or subgraph) to run for each item.")
     concurrency_limit: int = Field(..., description="Max parallel executions.")
 
+
 # Discriminated Union for polymorphism
 Node = Annotated[
     Union[AgentNode, HumanNode, LogicNode, RecipeNode, MapNode],
     Field(discriminator="type", description="Polymorphic node definition."),
 ]
+
 
 class Edge(BaseModel):
     """Represents a connection between two nodes.
@@ -190,6 +203,7 @@ class Edge(BaseModel):
     target_node_id: str = Field(..., description="The ID of the target node.")
     condition: Optional[str] = Field(None, description="Optional Python expression for conditional branching.")
 
+
 RouterRef = Annotated[
     str,
     StringConstraints(
@@ -197,6 +211,7 @@ RouterRef = Annotated[
         strip_whitespace=True,
     ),
 ]
+
 
 class RouterExpression(BaseModel):
     """A structured expression for routing logic (e.g., CEL or JSONLogic)."""
@@ -206,10 +221,12 @@ class RouterExpression(BaseModel):
     operator: str = Field(..., description="The operator (e.g., 'eq', 'gt').")
     args: List[Any] = Field(..., description="Arguments for the expression.")
 
+
 RouterDefinition = Annotated[
     Union[RouterRef, RouterExpression],
     Field(description="A reference to a python function or a logic expression."),
 ]
+
 
 class ConditionalEdge(BaseModel):
     """Represents a dynamic routing connection from one node to multiple potential targets.
@@ -228,6 +245,7 @@ class ConditionalEdge(BaseModel):
     )
     mapping: Dict[str, str] = Field(..., description="Map of router output values to target node IDs.")
 
+
 class GraphTopology(BaseModel):
     """The topology definition of the recipe.
 
@@ -242,5 +260,6 @@ class GraphTopology(BaseModel):
     nodes: List[Node] = Field(..., description="List of nodes in the graph.")
     edges: List[Union[Edge, ConditionalEdge]] = Field(..., description="List of edges connecting the nodes.")
     state_schema: Optional[StateSchema] = Field(None, description="Schema definition for the graph state.")
+
 
 Topology = GraphTopology

--- a/src/coreason_manifest/definitions/topology.py
+++ b/src/coreason_manifest/definitions/topology.py
@@ -6,13 +6,22 @@
 # For details, see the LICENSE file.
 # Commercial use beyond a 30-day trial requires a separate license.
 #
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
 # Source Code: https://github.com/CoReason-AI/coreason_maco
 
 from enum import Enum
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, StringConstraints
-
 
 class StateSchema(BaseModel):
     """Defines the structure and persistence of the graph state.
@@ -29,7 +38,6 @@ class StateSchema(BaseModel):
     )
     persistence: str = Field(..., description="Configuration for how state is checkpointed (e.g., 'memory', 'redis').")
 
-
 class CouncilConfig(BaseModel):
     """Configuration for 'Architectural Triangulation'.
 
@@ -42,7 +50,6 @@ class CouncilConfig(BaseModel):
 
     strategy: str = Field(default="consensus", description="The strategy for the council, e.g., 'consensus'.")
     voters: List[str] = Field(..., description="List of agents or models that vote.")
-
 
 class VisualMetadata(BaseModel):
     """Data explicitly for the UI.
@@ -63,7 +70,6 @@ class VisualMetadata(BaseModel):
     icon: Optional[str] = Field(None, description="The icon to represent the node.")
     animation_style: Optional[str] = Field(None, description="The animation style for the node.")
 
-
 class BaseNode(BaseModel):
     """Base model for all node types.
 
@@ -81,7 +87,6 @@ class BaseNode(BaseModel):
     )
     visual: Optional[VisualMetadata] = Field(None, description="Visual metadata for the UI.")
 
-
 class AgentNode(BaseNode):
     """A node that calls a specific atomic agent.
 
@@ -92,7 +97,6 @@ class AgentNode(BaseNode):
 
     type: Literal["agent"] = Field("agent", description="Discriminator for AgentNode.")
     agent_name: str = Field(..., description="The name of the atomic agent to call.")
-
 
 class HumanNode(BaseNode):
     """A node that pauses execution for user input/approval.
@@ -105,7 +109,6 @@ class HumanNode(BaseNode):
     type: Literal["human"] = Field("human", description="Discriminator for HumanNode.")
     timeout_seconds: Optional[int] = Field(None, description="Optional timeout in seconds for the user interaction.")
 
-
 class LogicNode(BaseNode):
     """A node that executes pure Python logic.
 
@@ -117,14 +120,12 @@ class LogicNode(BaseNode):
     type: Literal["logic"] = Field("logic", description="Discriminator for LogicNode.")
     code: str = Field(..., description="The Python logic code to execute.")
 
-
 class DataMappingStrategy(str, Enum):
     """Strategy for mapping data."""
 
     DIRECT = "direct"
     JSONPATH = "jsonpath"
     LITERAL = "literal"
-
 
 class DataMapping(BaseModel):
     """Defines how to transform data between parent and child."""
@@ -133,7 +134,6 @@ class DataMapping(BaseModel):
 
     source: str = Field(..., description="The path/key source.")
     strategy: DataMappingStrategy = Field(default=DataMappingStrategy.DIRECT, description="The mapping strategy.")
-
 
 class RecipeNode(BaseNode):
     """A node that executes another Recipe as a sub-graph.
@@ -154,7 +154,6 @@ class RecipeNode(BaseNode):
         ..., description="Mapping of child output keys to parent state keys."
     )
 
-
 class MapNode(BaseNode):
     """A node that spawns multiple parallel executions of a sub-branch.
 
@@ -170,13 +169,11 @@ class MapNode(BaseNode):
     processor_node_id: str = Field(..., description="The node (or subgraph) to run for each item.")
     concurrency_limit: int = Field(..., description="Max parallel executions.")
 
-
 # Discriminated Union for polymorphism
 Node = Annotated[
     Union[AgentNode, HumanNode, LogicNode, RecipeNode, MapNode],
     Field(discriminator="type", description="Polymorphic node definition."),
 ]
-
 
 class Edge(BaseModel):
     """Represents a connection between two nodes.
@@ -193,7 +190,6 @@ class Edge(BaseModel):
     target_node_id: str = Field(..., description="The ID of the target node.")
     condition: Optional[str] = Field(None, description="Optional Python expression for conditional branching.")
 
-
 RouterRef = Annotated[
     str,
     StringConstraints(
@@ -201,7 +197,6 @@ RouterRef = Annotated[
         strip_whitespace=True,
     ),
 ]
-
 
 class RouterExpression(BaseModel):
     """A structured expression for routing logic (e.g., CEL or JSONLogic)."""
@@ -211,12 +206,10 @@ class RouterExpression(BaseModel):
     operator: str = Field(..., description="The operator (e.g., 'eq', 'gt').")
     args: List[Any] = Field(..., description="Arguments for the expression.")
 
-
 RouterDefinition = Annotated[
     Union[RouterRef, RouterExpression],
     Field(description="A reference to a python function or a logic expression."),
 ]
-
 
 class ConditionalEdge(BaseModel):
     """Represents a dynamic routing connection from one node to multiple potential targets.
@@ -235,7 +228,6 @@ class ConditionalEdge(BaseModel):
     )
     mapping: Dict[str, str] = Field(..., description="Map of router output values to target node IDs.")
 
-
 class GraphTopology(BaseModel):
     """The topology definition of the recipe.
 
@@ -250,6 +242,5 @@ class GraphTopology(BaseModel):
     nodes: List[Node] = Field(..., description="List of nodes in the graph.")
     edges: List[Union[Edge, ConditionalEdge]] = Field(..., description="List of edges connecting the nodes.")
     state_schema: Optional[StateSchema] = Field(None, description="Schema definition for the graph state.")
-
 
 Topology = GraphTopology

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -6,6 +6,16 @@
 # For details, see the LICENSE file.
 # Commercial use beyond a 30-day trial requires a separate license.
 #
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
 # Source Code: https://github.com/CoReason-AI/coreason_maco
 
 from typing import Any, Dict, Literal, Optional
@@ -14,7 +24,6 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from .definitions.agent import VersionStr
 from .definitions.topology import GraphTopology
-
 
 class RecipeInterface(BaseModel):
     """Defines the input/output contract for a Recipe.
@@ -30,7 +39,6 @@ class RecipeInterface(BaseModel):
     outputs: Dict[str, Any] = Field(
         ..., description="JSON Schema defining the guaranteed structure of the final result."
     )
-
 
 class StateDefinition(BaseModel):
     """Defines the internal state (memory) of the Recipe.
@@ -48,7 +56,6 @@ class StateDefinition(BaseModel):
     persistence: Literal["ephemeral", "persistent"] = Field(
         default="ephemeral", description="Configuration for state durability."
     )
-
 
 class RecipeManifest(BaseModel):
     """The executable specification for the MACO engine.

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field
 from .definitions.agent import VersionStr
 from .definitions.topology import GraphTopology
 
+
 class RecipeInterface(BaseModel):
     """Defines the input/output contract for a Recipe.
 
@@ -39,6 +40,7 @@ class RecipeInterface(BaseModel):
     outputs: Dict[str, Any] = Field(
         ..., description="JSON Schema defining the guaranteed structure of the final result."
     )
+
 
 class StateDefinition(BaseModel):
     """Defines the internal state (memory) of the Recipe.
@@ -56,6 +58,7 @@ class StateDefinition(BaseModel):
     persistence: Literal["ephemeral", "persistent"] = Field(
         default="ephemeral", description="Configuration for state durability."
     )
+
 
 class RecipeManifest(BaseModel):
     """The executable specification for the MACO engine.

--- a/src/coreason_manifest/schemas/__init__.py
+++ b/src/coreason_manifest/schemas/__init__.py
@@ -1,1 +1,9 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -7,7 +7,14 @@
         "tools": {
           "description": "List of MCP tool requirements.",
           "items": {
-            "$ref": "#/$defs/ToolRequirement"
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ToolRequirement"
+              },
+              {
+                "$ref": "#/$defs/InlineToolDefinition"
+              }
+            ]
           },
           "title": "Tools",
           "type": "array"
@@ -377,6 +384,42 @@
       "title": "HumanNode",
       "type": "object"
     },
+    "InlineToolDefinition": {
+      "additionalProperties": false,
+      "description": "Definition of an inline tool.\n\nAttributes:\n    name: Name of the tool.\n    description: Description of the tool.\n    parameters: JSON Schema of parameters.\n    type: The type of the tool (must be 'function').",
+      "properties": {
+        "name": {
+          "description": "Name of the tool.",
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the tool.",
+          "title": "Description",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": true,
+          "description": "JSON Schema of parameters.",
+          "title": "Parameters",
+          "type": "object"
+        },
+        "type": {
+          "const": "function",
+          "default": "function",
+          "description": "The type of the tool (must be 'function').",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "parameters"
+      ],
+      "title": "InlineToolDefinition",
+      "type": "object"
+    },
     "LogicNode": {
       "additionalProperties": false,
       "description": "A node that executes pure Python logic.\n\nAttributes:\n    type: The type of the node (must be 'logic').\n    code: The Python logic code to execute.",
@@ -497,7 +540,7 @@
     },
     "ModelConfig": {
       "additionalProperties": false,
-      "description": "LLM Configuration parameters.\n\nAttributes:\n    model: The LLM model identifier.\n    temperature: Temperature for generation.",
+      "description": "LLM Configuration parameters.\n\nAttributes:\n    model: The LLM model identifier.\n    temperature: Temperature for generation.\n    system_prompt: The default system prompt/persona for the agent.",
       "properties": {
         "model": {
           "description": "The LLM model identifier.",
@@ -510,6 +553,19 @@
           "minimum": 0.0,
           "title": "Temperature",
           "type": "number"
+        },
+        "system_prompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The default system prompt/persona for the agent.",
+          "title": "System Prompt"
         }
       },
       "required": [

--- a/src/coreason_manifest/utils/__init__.py
+++ b/src/coreason_manifest/utils/__init__.py
@@ -6,6 +6,16 @@
 # For details, see the LICENSE file.
 # Commercial use beyond a 30-day trial requires a separate license.
 #
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
 # Source Code: https://github.com/CoReason-AI/coreason_manifest
 
 """

--- a/src/coreason_manifest/utils/logger.py
+++ b/src/coreason_manifest/utils/logger.py
@@ -6,6 +6,16 @@
 # For details, see the LICENSE file.
 # Commercial use beyond a 30-day trial requires a separate license.
 #
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
 # Source Code: https://github.com/CoReason-AI/coreason_manifest
 
 import os

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 import re
 import shutil

--- a/tests/test_audit.py
+++ b/tests/test_audit.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import uuid
 from datetime import datetime, timezone
 

--- a/tests/test_audit_edge_cases.py
+++ b/tests/test_audit_edge_cases.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import uuid
 from datetime import datetime, timezone
 

--- a/tests/test_audit_message.py
+++ b/tests/test_audit_message.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 import uuid
 from datetime import datetime

--- a/tests/test_ci_config.py
+++ b/tests/test_ci_config.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from pathlib import Path
 
 import pytest

--- a/tests/test_cloudevents.py
+++ b/tests/test_cloudevents.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 from datetime import datetime, timezone
 from typing import Any, Dict

--- a/tests/test_complex_cases.py
+++ b/tests/test_complex_cases.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import uuid
 from pathlib import Path
 

--- a/tests/test_edge_cases_policy_observability.py
+++ b/tests/test_edge_cases_policy_observability.py
@@ -1,4 +1,12 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from coreason_manifest.definitions.agent import (
     ObservabilityConfig,

--- a/tests/test_edge_cases_tooling.py
+++ b/tests/test_edge_cases_tooling.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_edge_cases_topology.py
+++ b/tests/test_edge_cases_topology.py
@@ -1,4 +1,12 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from coreason_manifest.definitions.agent import AgentRuntimeConfig
 from coreason_manifest.definitions.topology import Edge, LogicNode

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_immutability.py
+++ b/tests/test_immutability.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import uuid
 
 import pytest

--- a/tests/test_inline_tools.py
+++ b/tests/test_inline_tools.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 
@@ -31,7 +40,7 @@ def test_inline_tool_definition_invalid_type() -> None:
             name="my_tool",
             description="A helpful tool",
             parameters={},
-            type="invalid_type",  # type: ignore[arg-type]
+            type="invalid_type",
         )
 
 

--- a/tests/test_inline_tools.py
+++ b/tests/test_inline_tools.py
@@ -1,0 +1,79 @@
+# Prosperity-3.0
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.definitions.agent import (
+    AgentDependencies,
+    InlineToolDefinition,
+    ToolRequirement,
+    ToolRiskLevel,
+)
+
+
+def test_inline_tool_definition_valid() -> None:
+    """Test creating a valid InlineToolDefinition."""
+    tool = InlineToolDefinition(
+        name="my_tool",
+        description="A helpful tool",
+        parameters={"type": "object", "properties": {"arg": {"type": "string"}}},
+        type="function",
+    )
+    assert tool.name == "my_tool"
+    assert tool.description == "A helpful tool"
+    assert tool.type == "function"
+    assert tool.parameters["type"] == "object"
+
+
+def test_inline_tool_definition_invalid_type() -> None:
+    """Test that invalid tool type raises ValidationError."""
+    with pytest.raises(ValidationError):
+        InlineToolDefinition(
+            name="my_tool",
+            description="A helpful tool",
+            parameters={},
+            type="invalid_type",  # type: ignore[arg-type]
+        )
+
+
+def test_agent_dependencies_with_mixed_tools() -> None:
+    """Test AgentDependencies with both ToolRequirement and InlineToolDefinition."""
+    remote_tool = ToolRequirement(
+        uri="https://example.com/tool",
+        hash="a" * 64,
+        scopes=["read"],
+        risk_level=ToolRiskLevel.SAFE,
+    )
+
+    inline_tool = InlineToolDefinition(
+        name="inline_tool",
+        description="An inline tool",
+        parameters={"type": "object"},
+    )
+
+    deps = AgentDependencies(tools=[remote_tool, inline_tool])
+    assert len(deps.tools) == 2
+    assert isinstance(deps.tools[0], ToolRequirement)
+    assert isinstance(deps.tools[1], InlineToolDefinition)
+
+
+def test_agent_dependencies_serialization() -> None:
+    """Test serialization of AgentDependencies with mixed tools."""
+    remote_tool = ToolRequirement(
+        uri="https://example.com/tool",
+        hash="a" * 64,
+        scopes=["read"],
+        risk_level=ToolRiskLevel.SAFE,
+    )
+
+    inline_tool = InlineToolDefinition(
+        name="inline_tool",
+        description="An inline tool",
+        parameters={"type": "object"},
+    )
+
+    deps = AgentDependencies(tools=[remote_tool, inline_tool])
+    dumped = deps.model_dump()
+
+    assert len(dumped["tools"]) == 2
+    assert dumped["tools"][0]["uri"] == "https://example.com/tool"
+    assert dumped["tools"][1]["name"] == "inline_tool"

--- a/tests/test_logger_creation.py
+++ b/tests/test_logger_creation.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import os
 import subprocess
 import sys

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -158,3 +158,12 @@ def test_agent_definition_with_policy_and_observability() -> None:
     assert agent.policy.budget_caps["cost"] == 100.0
     assert agent.observability is not None
     assert agent.observability.trace_level == "full"
+
+
+def test_model_config_system_prompt() -> None:
+    """Test ModelConfig with system_prompt."""
+    config = ModelConfig(model="gpt-4", temperature=0.7, system_prompt="You are a helpful assistant.")
+    assert config.system_prompt == "You are a helpful assistant."
+
+    config_no_prompt = ModelConfig(model="gpt-4", temperature=0.7)
+    assert config_no_prompt.system_prompt is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import uuid
 
 import pytest

--- a/tests/test_models_complex.py
+++ b/tests/test_models_complex.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from uuid import uuid4
 
 import pytest

--- a/tests/test_observability_config.py
+++ b/tests/test_observability_config.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_policy_config.py
+++ b/tests/test_policy_config.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_polish_edge_cases.py
+++ b/tests/test_polish_edge_cases.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import uuid
 from datetime import datetime, timezone
 

--- a/tests/test_recipe_definitions.py
+++ b/tests/test_recipe_definitions.py
@@ -1,10 +1,19 @@
 # Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+# Copyright (c) 2025 CoReason, Inc.
 
 import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.recipes import RecipeInterface, StateDefinition
-
 
 def test_recipe_interface_valid() -> None:
     """Test creating a valid RecipeInterface."""
@@ -15,19 +24,16 @@ def test_recipe_interface_valid() -> None:
     assert interface.inputs["type"] == "object"
     assert interface.outputs["type"] == "object"
 
-
 def test_recipe_interface_invalid_missing_fields() -> None:
     """Test validation failure for missing fields in RecipeInterface."""
     with pytest.raises(ValidationError):
         RecipeInterface(inputs={})  # type: ignore[call-arg]
-
 
 def test_state_definition_valid_defaults() -> None:
     """Test creating a valid StateDefinition with defaults."""
     state = StateDefinition(schema={"type": "object", "properties": {"messages": {"type": "array"}}})
     assert state.schema_["type"] == "object"
     assert state.persistence == "ephemeral"
-
 
 def test_state_definition_valid_persistent() -> None:
     """Test creating a valid StateDefinition with persistence."""
@@ -36,7 +42,6 @@ def test_state_definition_valid_persistent() -> None:
         persistence="persistent",
     )
     assert state.persistence == "persistent"
-
 
 def test_state_definition_invalid_persistence() -> None:
     """Test validation failure for invalid persistence value."""

--- a/tests/test_recipe_definitions.py
+++ b/tests/test_recipe_definitions.py
@@ -15,6 +15,7 @@ from pydantic import ValidationError
 
 from coreason_manifest.recipes import RecipeInterface, StateDefinition
 
+
 def test_recipe_interface_valid() -> None:
     """Test creating a valid RecipeInterface."""
     interface = RecipeInterface(
@@ -24,16 +25,19 @@ def test_recipe_interface_valid() -> None:
     assert interface.inputs["type"] == "object"
     assert interface.outputs["type"] == "object"
 
+
 def test_recipe_interface_invalid_missing_fields() -> None:
     """Test validation failure for missing fields in RecipeInterface."""
     with pytest.raises(ValidationError):
         RecipeInterface(inputs={})  # type: ignore[call-arg]
+
 
 def test_state_definition_valid_defaults() -> None:
     """Test creating a valid StateDefinition with defaults."""
     state = StateDefinition(schema={"type": "object", "properties": {"messages": {"type": "array"}}})
     assert state.schema_["type"] == "object"
     assert state.persistence == "ephemeral"
+
 
 def test_state_definition_valid_persistent() -> None:
     """Test creating a valid StateDefinition with persistence."""
@@ -42,6 +46,7 @@ def test_state_definition_valid_persistent() -> None:
         persistence="persistent",
     )
     assert state.persistence == "persistent"
+
 
 def test_state_definition_invalid_persistence() -> None:
     """Test validation failure for invalid persistence value."""

--- a/tests/test_recipe_v2.py
+++ b/tests/test_recipe_v2.py
@@ -18,6 +18,7 @@ from pydantic import ValidationError
 from coreason_manifest import RecipeManifest, Topology
 from coreason_manifest.recipes import RecipeInterface, StateDefinition
 
+
 def test_full_recipe_v2_creation() -> None:
     """Test creating a fully populated V2 RecipeManifest."""
     interface = RecipeInterface(
@@ -61,6 +62,7 @@ def test_full_recipe_v2_creation() -> None:
     assert manifest.state.persistence == "persistent"
     assert manifest.parameters["model"] == "gpt-4"
 
+
 def test_recipe_v2_serialization() -> None:
     """Test that V2 RecipeManifest serializes correctly (with aliases)."""
     manifest = RecipeManifest(
@@ -85,6 +87,7 @@ def test_recipe_v2_serialization() -> None:
     assert "schema" in data["state"]
     assert "schema_" not in data["state"]
     assert data["state"]["schema"] == {"foo": "bar"}
+
 
 def test_recipe_v2_validation_error() -> None:
     """Test validation errors for missing new fields."""
@@ -115,6 +118,7 @@ def test_recipe_v2_validation_error() -> None:
         )  # type: ignore[call-arg]
     assert "state" in str(excinfo.value)
     assert "Field required" in str(excinfo.value)
+
 
 def test_recipe_v2_extra_fields() -> None:
     """Test that extra fields are forbidden in V2 manifest."""

--- a/tests/test_recipe_v2.py
+++ b/tests/test_recipe_v2.py
@@ -1,4 +1,14 @@
 # Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+# Copyright (c) 2025 CoReason, Inc.
 
 import json
 
@@ -7,7 +17,6 @@ from pydantic import ValidationError
 
 from coreason_manifest import RecipeManifest, Topology
 from coreason_manifest.recipes import RecipeInterface, StateDefinition
-
 
 def test_full_recipe_v2_creation() -> None:
     """Test creating a fully populated V2 RecipeManifest."""
@@ -52,7 +61,6 @@ def test_full_recipe_v2_creation() -> None:
     assert manifest.state.persistence == "persistent"
     assert manifest.parameters["model"] == "gpt-4"
 
-
 def test_recipe_v2_serialization() -> None:
     """Test that V2 RecipeManifest serializes correctly (with aliases)."""
     manifest = RecipeManifest(
@@ -77,7 +85,6 @@ def test_recipe_v2_serialization() -> None:
     assert "schema" in data["state"]
     assert "schema_" not in data["state"]
     assert data["state"]["schema"] == {"foo": "bar"}
-
 
 def test_recipe_v2_validation_error() -> None:
     """Test validation errors for missing new fields."""
@@ -108,7 +115,6 @@ def test_recipe_v2_validation_error() -> None:
         )  # type: ignore[call-arg]
     assert "state" in str(excinfo.value)
     assert "Field required" in str(excinfo.value)
-
 
 def test_recipe_v2_extra_fields() -> None:
     """Test that extra fields are forbidden in V2 manifest."""

--- a/tests/test_recipe_v2_extras.py
+++ b/tests/test_recipe_v2_extras.py
@@ -1,12 +1,20 @@
 # Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+# Copyright (c) 2025 CoReason, Inc.
 
 import pytest
 from pydantic import ValidationError
 
 from coreason_manifest import RecipeManifest, Topology
 from coreason_manifest.recipes import RecipeInterface, StateDefinition
-
 
 def test_state_schema_aliasing_roundtrip() -> None:
     """Test that 'schema' input maps to 'schema_' and serializes back to 'schema'."""
@@ -37,7 +45,6 @@ def test_state_schema_aliasing_roundtrip() -> None:
     reloaded = RecipeManifest.model_validate_json(json_str)
     assert reloaded.state.schema_ == {"foo": "bar"}
 
-
 def test_empty_interface_and_state() -> None:
     """Test that empty but valid objects are accepted."""
     manifest = RecipeManifest(
@@ -51,7 +58,6 @@ def test_empty_interface_and_state() -> None:
     )
     assert manifest.interface.inputs == {}
     assert manifest.state.schema_ == {}
-
 
 def test_complex_parameters() -> None:
     """Test parameters with nested complex types."""
@@ -74,7 +80,6 @@ def test_complex_parameters() -> None:
     assert manifest.parameters["llm_config"]["model"] == "gpt-4"
     assert manifest.parameters["features"][0] == "logging"
 
-
 def test_persistence_literal_strictness() -> None:
     """Test that persistence validation is case-sensitive and strict."""
     # Valid
@@ -90,7 +95,6 @@ def test_persistence_literal_strictness() -> None:
     with pytest.raises(ValidationError) as excinfo:
         StateDefinition(schema={}, persistence="in-memory")
     assert "Input should be 'ephemeral' or 'persistent'" in str(excinfo.value)
-
 
 def test_interface_schema_structure_preservation() -> None:
     """Test that nested JSON Schema structures in interface are preserved exactly."""

--- a/tests/test_recipe_v2_extras.py
+++ b/tests/test_recipe_v2_extras.py
@@ -16,6 +16,7 @@ from pydantic import ValidationError
 from coreason_manifest import RecipeManifest, Topology
 from coreason_manifest.recipes import RecipeInterface, StateDefinition
 
+
 def test_state_schema_aliasing_roundtrip() -> None:
     """Test that 'schema' input maps to 'schema_' and serializes back to 'schema'."""
     state_input = {"schema": {"foo": "bar"}, "persistence": "ephemeral"}
@@ -45,6 +46,7 @@ def test_state_schema_aliasing_roundtrip() -> None:
     reloaded = RecipeManifest.model_validate_json(json_str)
     assert reloaded.state.schema_ == {"foo": "bar"}
 
+
 def test_empty_interface_and_state() -> None:
     """Test that empty but valid objects are accepted."""
     manifest = RecipeManifest(
@@ -58,6 +60,7 @@ def test_empty_interface_and_state() -> None:
     )
     assert manifest.interface.inputs == {}
     assert manifest.state.schema_ == {}
+
 
 def test_complex_parameters() -> None:
     """Test parameters with nested complex types."""
@@ -80,6 +83,7 @@ def test_complex_parameters() -> None:
     assert manifest.parameters["llm_config"]["model"] == "gpt-4"
     assert manifest.parameters["features"][0] == "logging"
 
+
 def test_persistence_literal_strictness() -> None:
     """Test that persistence validation is case-sensitive and strict."""
     # Valid
@@ -95,6 +99,7 @@ def test_persistence_literal_strictness() -> None:
     with pytest.raises(ValidationError) as excinfo:
         StateDefinition(schema={}, persistence="in-memory")
     assert "Input should be 'ephemeral' or 'persistent'" in str(excinfo.value)
+
 
 def test_interface_schema_structure_preservation() -> None:
     """Test that nested JSON Schema structures in interface are preserved exactly."""

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_refactor_edge_cases.py
+++ b/tests/test_refactor_edge_cases.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 from datetime import datetime
 from uuid import uuid4

--- a/tests/test_refactor_v3.py
+++ b/tests/test_refactor_v3.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from datetime import datetime
 from uuid import uuid4
 

--- a/tests/test_schema_sync.py
+++ b/tests/test_schema_sync.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 from pathlib import Path
 

--- a/tests/test_simulation.py
+++ b/tests/test_simulation.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 import uuid
 from datetime import datetime, timezone

--- a/tests/test_simulation_edge_cases.py
+++ b/tests/test_simulation_edge_cases.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import uuid
 from datetime import datetime, timezone
 

--- a/tests/test_tool_requirement.py
+++ b/tests/test_tool_requirement.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_tools_validation.py
+++ b/tests/test_tools_validation.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from coreason_manifest.definitions.agent import AgentDependencies, ToolRequirement, ToolRiskLevel
 
 
@@ -10,8 +20,15 @@ def test_tools_validation_valid_requirements() -> None:
 
     deps = AgentDependencies(tools=[req1, req2])
     assert len(deps.tools) == 2
-    assert str(deps.tools[0].uri) == "https://example.com/tool"
-    assert deps.tools[1].risk_level == ToolRiskLevel.STANDARD
+
+    # Assert types to satisfy mypy union checks
+    tool0 = deps.tools[0]
+    assert isinstance(tool0, ToolRequirement)
+    assert str(tool0.uri) == "https://example.com/tool"
+
+    tool1 = deps.tools[1]
+    assert isinstance(tool1, ToolRequirement)
+    assert tool1.risk_level == ToolRiskLevel.STANDARD
 
 
 def test_tools_validation_empty_list() -> None:

--- a/tests/test_topology_edge_cases.py
+++ b/tests/test_topology_edge_cases.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_topology_features.py
+++ b/tests/test_topology_features.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import importlib
 import os
 from pathlib import Path

--- a/tests/test_validation_edge_cases.py
+++ b/tests/test_validation_edge_cases.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from datetime import datetime, timezone
 from uuid import uuid4
 

--- a/tests/test_version_normalization.py
+++ b/tests/test_version_normalization.py
@@ -1,4 +1,13 @@
-# Prosperity-3.0
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import uuid
 from typing import Any, Dict
 


### PR DESCRIPTION
Added support for `system_prompt` in `ModelConfig` and `InlineToolDefinition` in `AgentDependencies` to enable inline/embedded definitions for atomic agents. This aligns `coreason-manifest` with `coreason-foundry` requirements. Updated version to 0.10.0 and regenerated the JSON schema.

---
*PR created automatically by Jules for task [13684321743601434694](https://jules.google.com/task/13684321743601434694) started by @gowthamrao*