### PR TITLE
Restore `system_prompt` to `AgentRuntimeConfig`

### DIFF
--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -165,6 +165,7 @@ class AgentRuntimeConfig(BaseModel):
     edges: List[Edge] = Field(..., description="Directed connections defining control flow.")
     entry_point: str = Field(..., description="The ID of the starting node.")
     llm_config: ModelConfig = Field(..., alias="model_config", description="Specific LLM parameters.")
+    system_prompt: Optional[str] = Field(None, description="The global system prompt/instruction for the agent.")
 
     @field_validator("nodes")
     @classmethod

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -222,6 +222,19 @@
         "model_config": {
           "$ref": "#/$defs/ModelConfig",
           "description": "Specific LLM parameters."
+        },
+        "system_prompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The global system prompt/instruction for the agent.",
+          "title": "System Prompt"
         }
       },
       "required": [

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -184,3 +184,34 @@ def test_persona() -> None:
     persona = Persona(name="Helper", description="A helpful assistant", directives=["Be nice", "Help user"])
     assert persona.name == "Helper"
     assert len(persona.directives) == 2
+
+
+def test_agent_config_system_prompt() -> None:
+    """Test AgentRuntimeConfig with system_prompt."""
+    valid_data = {
+        "metadata": {
+            "id": str(uuid.uuid4()),
+            "version": "1.0.0",
+            "name": "Test Agent",
+            "author": "Test Author",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "interface": {"inputs": {}, "outputs": {}},
+        "config": {
+            "nodes": [],
+            "edges": [],
+            "entry_point": "start",
+            "model_config": {"model": "gpt-4", "temperature": 0.7},
+            "system_prompt": "Global instruction",
+        },
+        "dependencies": {},
+        "integrity_hash": "a" * 64,
+    }
+
+    agent = AgentDefinition(**valid_data)
+    assert agent.config.system_prompt == "Global instruction"
+
+    # Ensure optionality
+    del valid_data["config"]["system_prompt"]
+    agent = AgentDefinition(**valid_data)
+    assert agent.config.system_prompt is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import uuid
+from typing import Any, Dict
 
 import pytest
 from pydantic import ValidationError
@@ -188,7 +189,7 @@ def test_persona() -> None:
 
 def test_agent_config_system_prompt() -> None:
     """Test AgentRuntimeConfig with system_prompt."""
-    valid_data = {
+    valid_data: Dict[str, Any] = {
         "metadata": {
             "id": str(uuid.uuid4()),
             "version": "1.0.0",


### PR DESCRIPTION
Restore `system_prompt` to `AgentRuntimeConfig`

Added an optional `system_prompt` field to `AgentRuntimeConfig` to align with migration expectations and enable global instruction validation by external tools like `coreason-assay`.
Regenerated `agent.schema.json` to reflect the changes.
Added tests in `tests/test_models.py` to verify the new field.

---
*PR created automatically by Jules for task [13801718382427226996](https://jules.google.com/task/13801718382427226996) started by @gowthamrao*