### PR TITLE
feat: Update manifest schema for v0.10.0

### DIFF
--- a/src/coreason_manifest/definitions/topology.py
+++ b/src/coreason_manifest/definitions/topology.py
@@ -98,10 +98,20 @@ class AgentNode(BaseNode):
     Attributes:
         type: The type of the node (must be 'agent').
         agent_name: The name of the atomic agent to call.
+        system_prompt: Overrides the registry default prompt. Required for ad-hoc/optimized agents.
+        config: Runtime-specific configuration (e.g., model parameters, temperature). Merged with registry defaults.
     """
 
     type: Literal["agent"] = Field("agent", description="Discriminator for AgentNode.")
     agent_name: str = Field(..., description="The name of the atomic agent to call.")
+    system_prompt: Optional[str] = Field(
+        default=None,
+        description="Overrides the registry default prompt. Required for ad-hoc/optimized agents.",
+    )
+    config: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Runtime-specific configuration (e.g., model parameters, temperature). Merged with registry defaults.",
+    )
 
 
 class HumanNode(BaseNode):

--- a/src/coreason_manifest/definitions/topology.py
+++ b/src/coreason_manifest/definitions/topology.py
@@ -110,7 +110,9 @@ class AgentNode(BaseNode):
     )
     config: Optional[Dict[str, Any]] = Field(
         default=None,
-        description="Runtime-specific configuration (e.g., model parameters, temperature). Merged with registry defaults.",
+        description=(
+            "Runtime-specific configuration (e.g., model parameters, temperature). Merged with registry defaults."
+        ),
     )
 
 
@@ -269,7 +271,7 @@ class GraphTopology(BaseModel):
 
     nodes: List[Node] = Field(..., description="List of nodes in the graph.")
     edges: List[Union[Edge, ConditionalEdge]] = Field(..., description="List of edges connecting the nodes.")
-    state_schema: Optional[StateSchema] = Field(None, description="Schema definition for the graph state.")
+    state_schema: Optional[StateSchema] = Field(default=None, description="Schema definition for the graph state.")
 
 
 Topology = GraphTopology

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -72,6 +72,8 @@ class RecipeManifest(BaseModel):
         state: Defines the internal state (memory) of the Recipe.
         parameters: Dictionary of build-time constants.
         topology: The topology definition of the workflow.
+        integrity_hash: SHA256 hash of the canonical JSON representation of the topology.
+        metadata: Container for design-time data.
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -84,3 +86,11 @@ class RecipeManifest(BaseModel):
     state: StateDefinition = Field(..., description="Defines the internal state (memory) of the Recipe.")
     parameters: Dict[str, Any] = Field(..., description="Dictionary of build-time constants.")
     topology: GraphTopology = Field(..., description="The topology definition of the workflow.")
+    integrity_hash: Optional[str] = Field(
+        default=None,
+        description="SHA256 hash of the canonical JSON representation of the topology. Enforced by Builder, verified by Runtime.",
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Container for design-time data (UI coordinates, resolution logs, draft status) to support re-hydration.",
+    )

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -88,9 +88,14 @@ class RecipeManifest(BaseModel):
     topology: GraphTopology = Field(..., description="The topology definition of the workflow.")
     integrity_hash: Optional[str] = Field(
         default=None,
-        description="SHA256 hash of the canonical JSON representation of the topology. Enforced by Builder, verified by Runtime.",
+        description=(
+            "SHA256 hash of the canonical JSON representation of the topology. "
+            "Enforced by Builder, verified by Runtime."
+        ),
     )
     metadata: Dict[str, Any] = Field(
         default_factory=dict,
-        description="Container for design-time data (UI coordinates, resolution logs, draft status) to support re-hydration.",
+        description=(
+            "Container for design-time data (UI coordinates, resolution logs, draft status) to support re-hydration."
+        ),
     )

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -116,7 +116,7 @@
     },
     "AgentNode": {
       "additionalProperties": false,
-      "description": "A node that calls a specific atomic agent.\n\nAttributes:\n    type: The type of the node (must be 'agent').\n    agent_name: The name of the atomic agent to call.",
+      "description": "A node that calls a specific atomic agent.\n\nAttributes:\n    type: The type of the node (must be 'agent').\n    agent_name: The name of the atomic agent to call.\n    system_prompt: Overrides the registry default prompt. Required for ad-hoc/optimized agents.\n    config: Runtime-specific configuration (e.g., model parameters, temperature). Merged with registry defaults.",
       "properties": {
         "id": {
           "description": "Unique identifier for the node.",
@@ -158,6 +158,33 @@
           "description": "The name of the atomic agent to call.",
           "title": "Agent Name",
           "type": "string"
+        },
+        "system_prompt": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Overrides the registry default prompt. Required for ad-hoc/optimized agents.",
+          "title": "System Prompt"
+        },
+        "config": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Runtime-specific configuration (e.g., model parameters, temperature). Merged with registry defaults.",
+          "title": "Config"
         }
       },
       "required": [

--- a/tests/test_v0_10_0_features.py
+++ b/tests/test_v0_10_0_features.py
@@ -1,0 +1,106 @@
+import pytest
+from pydantic import ValidationError
+from src.coreason_manifest.definitions.topology import AgentNode, GraphTopology
+from src.coreason_manifest.recipes import RecipeManifest, RecipeInterface, StateDefinition
+from src.coreason_manifest.definitions.agent import VersionStr
+
+def test_agent_node_v0_10_0_features():
+    """Test new optional fields in AgentNode."""
+    # Test valid instantiation with new fields
+    node = AgentNode(
+        id="agent_1",
+        agent_name="optimizer_agent",
+        system_prompt="You are a helpful assistant.",
+        config={"temperature": 0.7, "model": "gpt-4"}
+    )
+    assert node.system_prompt == "You are a helpful assistant."
+    assert node.config == {"temperature": 0.7, "model": "gpt-4"}
+
+    # Test valid instantiation without new fields (defaults)
+    node_defaults = AgentNode(
+        id="agent_2",
+        agent_name="standard_agent"
+    )
+    assert node_defaults.system_prompt is None
+    assert node_defaults.config is None
+
+def test_recipe_manifest_v0_10_0_features():
+    """Test new optional fields in RecipeManifest."""
+    interface = RecipeInterface(inputs={}, outputs={})
+    state = StateDefinition(schema={}, persistence="ephemeral")
+    topology = GraphTopology(nodes=[], edges=[])
+
+    # Test valid instantiation with new fields
+    manifest = RecipeManifest(
+        id="recipe_1",
+        version=VersionStr("1.0.0"),
+        name="Test Recipe",
+        interface=interface,
+        state=state,
+        parameters={},
+        topology=topology,
+        integrity_hash="sha256:1234567890abcdef",
+        metadata={"ui_layout": {"x": 100, "y": 200}, "draft": True}
+    )
+    assert manifest.integrity_hash == "sha256:1234567890abcdef"
+    assert manifest.metadata == {"ui_layout": {"x": 100, "y": 200}, "draft": True}
+
+    # Test valid instantiation without new fields (defaults)
+    manifest_defaults = RecipeManifest(
+        id="recipe_2",
+        version=VersionStr("1.0.0"),
+        name="Default Recipe",
+        interface=interface,
+        state=state,
+        parameters={},
+        topology=topology
+    )
+    assert manifest_defaults.integrity_hash is None
+    assert manifest_defaults.metadata == {}
+
+def test_graph_topology_state_schema_optional():
+    """Test that state_schema is optional in GraphTopology."""
+    # This was already verified to be optional, but good to have a test for regression.
+    topology = GraphTopology(nodes=[], edges=[])
+    assert topology.state_schema is None
+
+    # Also verify we can provide it
+    from src.coreason_manifest.definitions.topology import StateSchema
+    schema = StateSchema(data_schema={}, persistence="memory")
+    topology_with_schema = GraphTopology(nodes=[], edges=[], state_schema=schema)
+    assert topology_with_schema.state_schema == schema
+
+def test_agent_node_serialization():
+    """Test serialization of AgentNode with new fields."""
+    node = AgentNode(
+        id="agent_1",
+        agent_name="optimizer_agent",
+        system_prompt="Prompt",
+        config={"key": "value"}
+    )
+    data = node.model_dump()
+    assert data["system_prompt"] == "Prompt"
+    assert data["config"] == {"key": "value"}
+
+def test_recipe_manifest_serialization():
+    """Test serialization of RecipeManifest with new fields."""
+    interface = RecipeInterface(inputs={}, outputs={})
+    state = StateDefinition(schema={}, persistence="ephemeral")
+    topology = GraphTopology(nodes=[], edges=[])
+
+    manifest = RecipeManifest(
+        id="recipe_1",
+        version=VersionStr("1.0.0"),
+        name="Test Recipe",
+        interface=interface,
+        state=state,
+        parameters={},
+        topology=topology,
+        integrity_hash="hash_123",
+        metadata={"key": "value"}
+    )
+
+    # Use by_alias=True because StateDefinition has an alias
+    data = manifest.model_dump(by_alias=True)
+    assert data["integrity_hash"] == "hash_123"
+    assert data["metadata"] == {"key": "value"}

--- a/tests/test_v0_10_0_features.py
+++ b/tests/test_v0_10_0_features.py
@@ -1,30 +1,27 @@
-import pytest
-from pydantic import ValidationError
-from src.coreason_manifest.definitions.topology import AgentNode, GraphTopology
-from src.coreason_manifest.recipes import RecipeManifest, RecipeInterface, StateDefinition
-from src.coreason_manifest.definitions.agent import VersionStr
+from coreason_manifest.definitions.agent import VersionStr
+from coreason_manifest.definitions.topology import AgentNode, GraphTopology
+from coreason_manifest.recipes import RecipeInterface, RecipeManifest, StateDefinition
 
-def test_agent_node_v0_10_0_features():
+
+def test_agent_node_v0_10_0_features() -> None:
     """Test new optional fields in AgentNode."""
     # Test valid instantiation with new fields
     node = AgentNode(
         id="agent_1",
         agent_name="optimizer_agent",
         system_prompt="You are a helpful assistant.",
-        config={"temperature": 0.7, "model": "gpt-4"}
+        config={"temperature": 0.7, "model": "gpt-4"},
     )
     assert node.system_prompt == "You are a helpful assistant."
     assert node.config == {"temperature": 0.7, "model": "gpt-4"}
 
     # Test valid instantiation without new fields (defaults)
-    node_defaults = AgentNode(
-        id="agent_2",
-        agent_name="standard_agent"
-    )
+    node_defaults = AgentNode(id="agent_2", agent_name="standard_agent")
     assert node_defaults.system_prompt is None
     assert node_defaults.config is None
 
-def test_recipe_manifest_v0_10_0_features():
+
+def test_recipe_manifest_v0_10_0_features() -> None:
     """Test new optional fields in RecipeManifest."""
     interface = RecipeInterface(inputs={}, outputs={})
     state = StateDefinition(schema={}, persistence="ephemeral")
@@ -40,7 +37,7 @@ def test_recipe_manifest_v0_10_0_features():
         parameters={},
         topology=topology,
         integrity_hash="sha256:1234567890abcdef",
-        metadata={"ui_layout": {"x": 100, "y": 200}, "draft": True}
+        metadata={"ui_layout": {"x": 100, "y": 200}, "draft": True},
     )
     assert manifest.integrity_hash == "sha256:1234567890abcdef"
     assert manifest.metadata == {"ui_layout": {"x": 100, "y": 200}, "draft": True}
@@ -53,36 +50,35 @@ def test_recipe_manifest_v0_10_0_features():
         interface=interface,
         state=state,
         parameters={},
-        topology=topology
+        topology=topology,
     )
     assert manifest_defaults.integrity_hash is None
     assert manifest_defaults.metadata == {}
 
-def test_graph_topology_state_schema_optional():
+
+def test_graph_topology_state_schema_optional() -> None:
     """Test that state_schema is optional in GraphTopology."""
     # This was already verified to be optional, but good to have a test for regression.
     topology = GraphTopology(nodes=[], edges=[])
     assert topology.state_schema is None
 
     # Also verify we can provide it
-    from src.coreason_manifest.definitions.topology import StateSchema
+    from coreason_manifest.definitions.topology import StateSchema
+
     schema = StateSchema(data_schema={}, persistence="memory")
     topology_with_schema = GraphTopology(nodes=[], edges=[], state_schema=schema)
     assert topology_with_schema.state_schema == schema
 
-def test_agent_node_serialization():
+
+def test_agent_node_serialization() -> None:
     """Test serialization of AgentNode with new fields."""
-    node = AgentNode(
-        id="agent_1",
-        agent_name="optimizer_agent",
-        system_prompt="Prompt",
-        config={"key": "value"}
-    )
+    node = AgentNode(id="agent_1", agent_name="optimizer_agent", system_prompt="Prompt", config={"key": "value"})
     data = node.model_dump()
     assert data["system_prompt"] == "Prompt"
     assert data["config"] == {"key": "value"}
 
-def test_recipe_manifest_serialization():
+
+def test_recipe_manifest_serialization() -> None:
     """Test serialization of RecipeManifest with new fields."""
     interface = RecipeInterface(inputs={}, outputs={})
     state = StateDefinition(schema={}, persistence="ephemeral")
@@ -97,7 +93,7 @@ def test_recipe_manifest_serialization():
         parameters={},
         topology=topology,
         integrity_hash="hash_123",
-        metadata={"key": "value"}
+        metadata={"key": "value"},
     )
 
     # Use by_alias=True because StateDefinition has an alias


### PR DESCRIPTION
This PR implements the changes required for Coreason Manifest v0.10.0.

Changes:
1.  **AgentNode Enhancements**: Added `system_prompt` and `config` fields to `AgentNode` in `src/coreason_manifest/definitions/topology.py`. This allows defining ad-hoc agents with optimized prompts and runtime configurations.
2.  **RecipeManifest Integrity & Metadata**: Added `integrity_hash` and `metadata` fields to `RecipeManifest` in `src/coreason_manifest/recipes.py`. This supports artifact integrity verification and storing design-time metadata.
3.  **GraphTopology State Schema**: Verified that `state_schema` is already optional in `GraphTopology`. Added a regression test to ensure it remains optional.

Tests:
- Added `tests/test_v0_10_0_features.py` covering all new fields and serialization.
- Verified all existing tests pass.


---
*PR created automatically by Jules for task [11832351264233535176](https://jules.google.com/task/11832351264233535176) started by @gowthamrao*