### PR TITLE
Integrate Persona into AdversaryProfile and ModelConfig

### DIFF
--- a/docs/atomic_agents.md
+++ b/docs/atomic_agents.md
@@ -39,7 +39,15 @@ For atomic agents, `nodes`, `edges`, and `entry_point` are optional. You define 
 
 ```python
 config = AgentRuntimeConfig(
-    model_config=ModelConfig(...),
+    model_config=ModelConfig(
+        model="gpt-4",
+        temperature=0.7,
+        persona=Persona(
+            name="Assistant",
+            description="A helpful assistant.",
+            directives=["Be polite.", "Be concise."]
+        )
+    ),
     system_prompt="You are a helpful assistant."
 )
 ```

--- a/docs/simulation_architecture.md
+++ b/docs/simulation_architecture.md
@@ -40,3 +40,35 @@ We define scenarios that allow for rigorous, standardized benchmarking, aligned 
 - **difficulty** (`int`): Difficulty level (1-3).
 - **expected_outcome** (`Any`): The ground truth for validation.
 - **validation_logic** (`ValidationLogic`): Logic used to validate the outcome (`exact_match`, `fuzzy`, `code_eval`).
+
+## Simulation Configuration
+
+To enable reproducible and configurable simulations, we define standard configuration objects for the Simulator service.
+
+### SimulationRequest
+
+The standard payload for triggering a simulation.
+
+- **scenario** (`SimulationScenario`): The scenario to run.
+- **profile** (`AdversaryProfile`): Configuration for the adversary (Red Team).
+- **chaos_config** (`ChaosConfig`): Configuration for infrastructure chaos injection.
+
+### AdversaryProfile
+
+Defines the strategy and identity of the adversary agent.
+
+- **name** (`str`): Name of the profile.
+- **goal** (`str`): The objective of the adversary.
+- **strategy_model** (`str`): The model used for strategic planning (e.g., "claude-3-opus").
+- **attack_model** (`str`): The model used for generating attacks (e.g., "llama-3-uncensored").
+- **persona** (`Optional[Persona]`): The full persona definition (name, description, directives) for the adversary.
+
+### ChaosConfig
+
+Defines parameters for injecting simulated infrastructure faults.
+
+- **latency_ms** (`int`): Artificial latency in milliseconds.
+- **error_rate** (`float`): Probability of random errors (0.0 to 1.0).
+- **noise_rate** (`float`): Probability of noise injection (0.0 to 1.0).
+- **token_throttle** (`bool`): Whether to simulate token rate limiting.
+- **exception_type** (`str`): The type of exception to raise (default: "RuntimeError").

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -140,6 +140,7 @@ class ModelConfig(CoReasonBaseModel):
         model: The LLM model identifier.
         temperature: Temperature for generation.
         system_prompt: The default system prompt/persona for the agent.
+        persona: The full persona definition (name, description, directives).
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -147,6 +148,7 @@ class ModelConfig(CoReasonBaseModel):
     model: str = Field(..., description="The LLM model identifier.")
     temperature: float = Field(..., ge=0.0, le=2.0, description="Temperature for generation.")
     system_prompt: Optional[str] = Field(None, description="The default system prompt/persona for the agent.")
+    persona: Optional[Persona] = Field(None, description="The full persona definition (name, description, directives).")
 
 
 class AgentRuntimeConfig(CoReasonBaseModel):

--- a/src/coreason_manifest/definitions/simulation_config.py
+++ b/src/coreason_manifest/definitions/simulation_config.py
@@ -9,8 +9,11 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 
+from typing import Optional
+
 from pydantic import BaseModel, Field
 
+from coreason_manifest.definitions.agent import Persona
 from coreason_manifest.definitions.simulation import SimulationScenario
 
 
@@ -19,6 +22,7 @@ class AdversaryProfile(BaseModel):
     goal: str
     strategy_model: str  # e.g., "claude-3-opus"
     attack_model: str  # e.g., "llama-3-uncensored"
+    persona: Optional[Persona] = Field(None, description="The full persona definition (name, description, directives).")
     # Potential future field: 'system_prompt_override'
 
 

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -623,7 +623,7 @@
     },
     "ModelConfig": {
       "additionalProperties": false,
-      "description": "LLM Configuration parameters.\n\nAttributes:\n    model: The LLM model identifier.\n    temperature: Temperature for generation.\n    system_prompt: The default system prompt/persona for the agent.",
+      "description": "LLM Configuration parameters.\n\nAttributes:\n    model: The LLM model identifier.\n    temperature: Temperature for generation.\n    system_prompt: The default system prompt/persona for the agent.\n    persona: The full persona definition (name, description, directives).",
       "properties": {
         "model": {
           "description": "The LLM model identifier.",
@@ -649,6 +649,18 @@
           "default": null,
           "description": "The default system prompt/persona for the agent.",
           "title": "System Prompt"
+        },
+        "persona": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/Persona"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The full persona definition (name, description, directives)."
         }
       },
       "required": [
@@ -687,6 +699,37 @@
         }
       },
       "title": "ObservabilityConfig",
+      "type": "object"
+    },
+    "Persona": {
+      "additionalProperties": false,
+      "description": "Definition of an Agent Persona.\n\nAttributes:\n    name: Name of the persona.\n    description: Description of the persona.\n    directives: List of specific instructions or directives.",
+      "properties": {
+        "name": {
+          "description": "Name of the persona.",
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "description": "Description of the persona.",
+          "title": "Description",
+          "type": "string"
+        },
+        "directives": {
+          "description": "List of specific instructions or directives.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Directives",
+          "type": "array"
+        }
+      },
+      "required": [
+        "name",
+        "description",
+        "directives"
+      ],
+      "title": "Persona",
       "type": "object"
     },
     "PolicyConfig": {

--- a/tests/test_gap_analysis_recommendations.py
+++ b/tests/test_gap_analysis_recommendations.py
@@ -53,3 +53,40 @@ def test_recipe_manifest_integrity_and_metadata() -> None:
 
     assert manifest.integrity_hash == "a" * 64
     assert manifest.metadata["ui_layout"]["agent-1"] == [10, 20]
+
+
+def test_adversary_profile_accepts_persona() -> None:
+    """Test that AdversaryProfile accepts a Persona object."""
+    from coreason_manifest.definitions.agent import Persona
+    from coreason_manifest.definitions.simulation_config import AdversaryProfile
+
+    persona = Persona(
+        name="Hacker",
+        description="A skilled hacker.",
+        directives=["Be stealthy.", "Exfiltrate data."],
+    )
+    profile = AdversaryProfile(
+        name="APT28",
+        goal="Steal credentials",
+        strategy_model="gpt-4",
+        attack_model="llama-3",
+        persona=persona,
+    )
+    assert profile.persona is not None
+    assert profile.persona.name == "Hacker"
+    assert profile.persona.directives[0] == "Be stealthy."
+
+
+def test_model_config_accepts_persona() -> None:
+    """Test that ModelConfig accepts a Persona object."""
+    from coreason_manifest.definitions.agent import ModelConfig, Persona
+
+    persona = Persona(
+        name="Assistant",
+        description="A helpful assistant.",
+        directives=["Be polite.", "Be concise."],
+    )
+    config = ModelConfig(model="gpt-4", temperature=0.7, persona=persona)
+    assert config.persona is not None
+    assert config.persona.name == "Assistant"
+    assert config.persona.directives[1] == "Be concise."

--- a/tests/test_persona_edge_cases.py
+++ b/tests/test_persona_edge_cases.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.definitions.agent import ModelConfig, Persona
+from coreason_manifest.definitions.simulation_config import AdversaryProfile
+
+
+def test_persona_empty_strings() -> None:
+    """Test Persona instantiation with empty strings (allowed by Pydantic but worth checking behavior)."""
+    persona = Persona(name="", description="", directives=[])
+    assert persona.name == ""
+    assert persona.description == ""
+    assert persona.directives == []
+
+
+def test_persona_missing_fields() -> None:
+    """Test Persona validation failure when required fields are missing."""
+    with pytest.raises(ValidationError):
+        Persona(name="Just Name")  # type: ignore[call-arg]
+
+
+def test_model_config_with_system_prompt_and_persona() -> None:
+    """Test that ModelConfig accepts both system_prompt and persona."""
+    persona = Persona(name="Test", description="Test Desc", directives=["Act normal"])
+    config = ModelConfig(
+        model="gpt-4",
+        temperature=0.5,
+        system_prompt="Global prompt",
+        persona=persona,
+    )
+    assert config.system_prompt == "Global prompt"
+    assert config.persona == persona
+    assert config.persona.name == "Test"
+
+
+def test_adversary_profile_optional_persona() -> None:
+    """Test backward compatibility: AdversaryProfile without persona."""
+    profile = AdversaryProfile(
+        name="Old Profile",
+        goal="Legacy goal",
+        strategy_model="gpt-3.5",
+        attack_model="gpt-3.5",
+    )
+    assert profile.persona is None
+
+
+def test_adversary_profile_with_empty_directives_persona() -> None:
+    """Test AdversaryProfile with a Persona having empty directives."""
+    persona = Persona(name="Lazy Adversary", description="Does nothing", directives=[])
+    profile = AdversaryProfile(
+        name="Lazy Profile",
+        goal="Do nothing",
+        strategy_model="gpt-4",
+        attack_model="gpt-4",
+        persona=persona,
+    )
+    assert profile.persona is not None
+    assert len(profile.persona.directives) == 0


### PR DESCRIPTION
Integrated the `Persona` class into `AdversaryProfile` and `ModelConfig` to provide a standardized way to define agent and adversary personas (name, description, directives). This addresses the gap identified in the v0.10.0 recommendations where `Persona` was defined but not fully utilized in the simulation configuration.

Changes:
- Added `persona: Optional[Persona]` field to `AdversaryProfile` in `src/coreason_manifest/definitions/simulation_config.py`.
- Added `persona: Optional[Persona]` field to `ModelConfig` in `src/coreason_manifest/definitions/agent.py`.
- Verified changes with new tests in `tests/test_gap_analysis_recommendations.py`.

---
*PR created automatically by Jules for task [2805902185347619873](https://jules.google.com/task/2805902185347619873) started by @gowthamrao*