### PR TITLE
Refactor Shared Kernel: Unify State Models & Standardize Validation

### DIFF
--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -34,7 +34,7 @@ from pydantic import (
 from typing_extensions import Annotated
 
 from coreason_manifest.definitions.base import CoReasonBaseModel
-from coreason_manifest.definitions.topology import Edge, Node
+from coreason_manifest.definitions.topology import Edge, Node, validate_edge_integrity
 
 # SemVer Regex pattern (simplified for standard SemVer)
 # Modified to accept optional 'v' or 'V' prefix (multiple allowed) for input normalization
@@ -186,6 +186,12 @@ class AgentRuntimeConfig(CoReasonBaseModel):
             if not (has_global_prompt or has_model_prompt):
                 raise ValueError("Atomic Agents require a system_prompt (global or in model_config).")
 
+        return self
+
+    @model_validator(mode="after")
+    def validate_topology_integrity(self) -> AgentRuntimeConfig:
+        """Ensure that edges connect existing nodes."""
+        validate_edge_integrity(self.nodes, self.edges)
         return self
 
     @field_validator("nodes")

--- a/src/coreason_manifest/definitions/events.py
+++ b/src/coreason_manifest/definitions/events.py
@@ -15,6 +15,7 @@ from uuid import uuid4
 from pydantic import ConfigDict, Field
 
 from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.definitions.topology import RuntimeVisualMetadata
 
 # --- CloudEvents v1.0 Implementation ---
 
@@ -290,7 +291,7 @@ class BaseGraphEvent(CoReasonBaseModel):
     sequence_id: Optional[int] = None  # Optional for internal use
 
     # Visual Metadata drives the Flutter animation engine
-    visual_metadata: Dict[str, str] = Field(
+    visual_metadata: RuntimeVisualMetadata = Field(
         ..., description="Hints for UI: color='#00FF00', animation='pulse', progress='0.5'"
     )
 
@@ -389,9 +390,10 @@ def migrate_graph_event_to_cloud_event(event: GraphEvent) -> CloudEvent[Any]:
     # UI Metadata as extension
     payload_visual_cue = getattr(event.payload, "visual_cue", None)
 
+    visual_dict = event.visual_metadata.model_dump(exclude_none=True)
     extensions = {
-        "com_coreason_ui_cue": event.visual_metadata.get("animation") or payload_visual_cue,
-        "com_coreason_ui_metadata": event.visual_metadata,
+        "com_coreason_ui_cue": event.visual_metadata.animation or payload_visual_cue,
+        "com_coreason_ui_metadata": visual_dict,
     }
 
     # Filter out None values in extensions

--- a/src/coreason_manifest/definitions/topology.py
+++ b/src/coreason_manifest/definitions/topology.py
@@ -19,7 +19,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason_maco
 
 from enum import Enum
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Dict, List, Literal, Optional, Sequence, Union
 
 from pydantic import ConfigDict, Field, StringConstraints, model_validator
 
@@ -287,8 +287,8 @@ class ConditionalEdge(CoReasonBaseModel):
 
 
 def validate_edge_integrity(
-    nodes: List[Node],
-    edges: List[Union[Edge, ConditionalEdge]],
+    nodes: Sequence[Node],
+    edges: Sequence[Union[Edge, ConditionalEdge]],
 ) -> None:
     """Ensures that all edges point to valid nodes.
 
@@ -329,9 +329,7 @@ class GraphTopology(CoReasonBaseModel):
 
     nodes: List[Node] = Field(..., description="List of nodes in the graph.")
     edges: List[Union[Edge, ConditionalEdge]] = Field(..., description="List of edges connecting the nodes.")
-    state_schema: Optional[StateDefinition] = Field(
-        default=None, description="Schema definition for the graph state."
-    )
+    state_schema: Optional[StateDefinition] = Field(default=None, description="Schema definition for the graph state.")
 
     @model_validator(mode="after")
     def validate_graph_integrity(self) -> "GraphTopology":

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -18,7 +18,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason_maco
 
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Dict, Optional
 
 from pydantic import ConfigDict, Field
 

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -24,7 +24,7 @@ from pydantic import ConfigDict, Field
 
 from .definitions.agent import VersionStr
 from .definitions.base import CoReasonBaseModel
-from .definitions.topology import GraphTopology
+from .definitions.topology import GraphTopology, StateDefinition
 
 
 class RecipeInterface(CoReasonBaseModel):
@@ -40,24 +40,6 @@ class RecipeInterface(CoReasonBaseModel):
     inputs: Dict[str, Any] = Field(..., description="JSON Schema defining valid entry arguments.")
     outputs: Dict[str, Any] = Field(
         ..., description="JSON Schema defining the guaranteed structure of the final result."
-    )
-
-
-class StateDefinition(CoReasonBaseModel):
-    """Defines the internal state (memory) of the Recipe.
-
-    Attributes:
-        schema: JSON Schema of the keys available in the shared memory.
-        persistence: Configuration for state durability.
-    """
-
-    model_config = ConfigDict(extra="forbid")
-
-    schema_: Dict[str, Any] = Field(
-        ..., alias="schema", description="JSON Schema of the keys available in the shared memory."
-    )
-    persistence: Literal["ephemeral", "persistent"] = Field(
-        default="ephemeral", description="Configuration for state durability."
     )
 
 

--- a/src/coreason_manifest/schemas/recipe.schema.json
+++ b/src/coreason_manifest/schemas/recipe.schema.json
@@ -287,7 +287,7 @@
         "state_schema": {
           "anyOf": [
             {
-              "$ref": "#/$defs/StateSchema"
+              "$ref": "#/$defs/StateDefinition"
             },
             {
               "type": "null"
@@ -663,29 +663,6 @@
         "schema"
       ],
       "title": "StateDefinition",
-      "type": "object"
-    },
-    "StateSchema": {
-      "additionalProperties": false,
-      "description": "Defines the structure and persistence of the graph state.\n\nAttributes:\n    data_schema: A JSON Schema or Pydantic definition describing the state structure.\n    persistence: Configuration for how state is checkpointed.",
-      "properties": {
-        "data_schema": {
-          "additionalProperties": true,
-          "description": "A JSON Schema or Pydantic definition describing the state structure.",
-          "title": "Data Schema",
-          "type": "object"
-        },
-        "persistence": {
-          "description": "Configuration for how state is checkpointed (e.g., 'memory', 'redis').",
-          "title": "Persistence",
-          "type": "string"
-        }
-      },
-      "required": [
-        "data_schema",
-        "persistence"
-      ],
-      "title": "StateSchema",
       "type": "object"
     },
     "VisualMetadata": {

--- a/tests/test_atomic_agent.py
+++ b/tests/test_atomic_agent.py
@@ -156,18 +156,12 @@ def test_edges_without_nodes_integrity() -> None:
         "integrity_hash": "a" * 64,
     }
 
-    # Currently, AgentRuntimeConfig does NOT seem to inherit GraphTopology's validator.
-    # It constructs lists.
-    # If this is a gap, we should probably know.
-    # But for Atomic Agents, edges should be empty.
+    # Currently, AgentRuntimeConfig DOES have the integrity check (added in Shared Kernel Review).
 
-    # The current implementation allows this because AgentRuntimeConfig doesn't have the integrity check
-    # that GraphTopology has. It probably should, but that might be out of scope for "Atomic Agents" PR
-    # unless we want to enforce "Atomic = No Nodes AND No Edges".
+    with pytest.raises(ValidationError) as exc:
+        AgentDefinition(**data)
 
-    agent = AgentDefinition(**data)
-    # If this passes, it means we allow edges without nodes in the config object itself.
-    assert len(agent.config.edges) == 1
+    assert "Edge source node 'a' not found in nodes" in str(exc.value)
 
 
 def test_atomic_agent_serialization_excludes_defaults() -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -49,7 +49,7 @@ def test_graph_event_creation() -> None:
     )
     assert event.event_type == "NODE_INIT"
     assert event.payload.type == "AGENT"
-    assert event.visual_metadata["color"] == "#FFFFFF"
+    assert event.visual_metadata.color == "#FFFFFF"
 
 
 def test_graph_event_default_trace_id() -> None:

--- a/tests/test_gap_analysis_recommendations.py
+++ b/tests/test_gap_analysis_recommendations.py
@@ -8,8 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from coreason_manifest.definitions.topology import AgentNode, GraphTopology
-from coreason_manifest.recipes import RecipeInterface, RecipeManifest, StateDefinition
+from coreason_manifest.definitions.topology import AgentNode, GraphTopology, StateDefinition
+from coreason_manifest.recipes import RecipeInterface, RecipeManifest
 
 
 def test_agent_node_enhancements() -> None:

--- a/tests/test_recipe_definitions.py
+++ b/tests/test_recipe_definitions.py
@@ -13,7 +13,8 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest.recipes import RecipeInterface, StateDefinition
+from coreason_manifest.definitions.topology import StateDefinition
+from coreason_manifest.recipes import RecipeInterface
 
 
 def test_recipe_interface_valid() -> None:

--- a/tests/test_recipe_v2.py
+++ b/tests/test_recipe_v2.py
@@ -16,7 +16,8 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest import RecipeManifest, Topology
-from coreason_manifest.recipes import RecipeInterface, StateDefinition
+from coreason_manifest.definitions.topology import StateDefinition
+from coreason_manifest.recipes import RecipeInterface
 
 
 def test_full_recipe_v2_creation() -> None:

--- a/tests/test_recipe_v2_extras.py
+++ b/tests/test_recipe_v2_extras.py
@@ -14,7 +14,8 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest import RecipeManifest, Topology
-from coreason_manifest.recipes import RecipeInterface, StateDefinition
+from coreason_manifest.definitions.topology import StateDefinition
+from coreason_manifest.recipes import RecipeInterface
 
 
 def test_state_schema_aliasing_roundtrip() -> None:

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -13,8 +13,8 @@ from pydantic import ValidationError
 
 from coreason_manifest import Edge, RecipeManifest
 from coreason_manifest import Topology as GraphTopology
-from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode
-from coreason_manifest.recipes import RecipeInterface, StateDefinition
+from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, StateDefinition
+from coreason_manifest.recipes import RecipeInterface
 
 
 def test_recipe_manifest_creation() -> None:

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -13,8 +13,8 @@ from pydantic import ValidationError
 
 from coreason_manifest import Edge, RecipeManifest
 from coreason_manifest import Topology as GraphTopology
-from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode
-from coreason_manifest.recipes import RecipeInterface, StateDefinition
+from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, StateDefinition
+from coreason_manifest.recipes import RecipeInterface
 
 
 def test_invalid_node_discriminator() -> None:

--- a/tests/test_refactor_v3.py
+++ b/tests/test_refactor_v3.py
@@ -257,7 +257,7 @@ def test_extension_filtering() -> None:
         timestamp=1234567890.0,
         payload={"type": "start", "node_id": "node1"},
         visual_metadata={
-            "empty": "",
+            "label": "",
         },
     )
     ce = migrate_graph_event_to_cloud_event(event_empty)
@@ -270,9 +270,11 @@ def test_extension_filtering() -> None:
         node_id="node1",
         timestamp=1234567890.0,
         payload={"type": "start", "node_id": "node1"},
-        visual_metadata={"valid": "value", "empty": ""},
+        visual_metadata={"label": "value", "color": ""},
     )
     ce_mixed = migrate_graph_event_to_cloud_event(event_mixed)
     dump = ce_mixed.model_dump()
     assert "com_coreason_ui_metadata" in dump
-    assert dump["com_coreason_ui_metadata"] == {"valid": "value", "empty": ""}
+    # model_dump() output depends on Pydantic serialization
+    assert dump["com_coreason_ui_metadata"]["label"] == "value"
+    assert dump["com_coreason_ui_metadata"]["color"] == ""

--- a/tests/test_topology_edge_cases.py
+++ b/tests/test_topology_edge_cases.py
@@ -42,7 +42,7 @@ def test_state_schema_invalid_persistence_type() -> None:
     """Test validation fails for non-string persistence."""
     with pytest.raises(ValidationError):
         StateDefinition(
-            schema={},
+            schema_={},
             persistence=123,
         )
 

--- a/tests/test_topology_edge_cases.py
+++ b/tests/test_topology_edge_cases.py
@@ -15,7 +15,7 @@ from coreason_manifest.definitions.topology import (
     ConditionalEdge,
     MapNode,
     RecipeNode,
-    StateSchema,
+    StateDefinition,
 )
 
 
@@ -41,8 +41,8 @@ def test_map_node_invalid_concurrency() -> None:
 def test_state_schema_invalid_persistence_type() -> None:
     """Test validation fails for non-string persistence."""
     with pytest.raises(ValidationError):
-        StateSchema(
-            data_schema={},
+        StateDefinition(
+            schema={},
             persistence=123,
         )
 

--- a/tests/test_topology_features.py
+++ b/tests/test_topology_features.py
@@ -25,7 +25,7 @@ from coreason_manifest.definitions.topology import (
 def test_state_schema_creation() -> None:
     """Test creating a valid StateDefinition."""
     schema_def = {"type": "object", "properties": {"messages": {"type": "array"}}}
-    state = StateDefinition(schema=schema_def, persistence="ephemeral")
+    state = StateDefinition(schema_=schema_def, persistence="ephemeral")
     assert state.schema_ == schema_def
     assert state.persistence == "ephemeral"
 
@@ -33,7 +33,7 @@ def test_state_schema_creation() -> None:
 def test_state_schema_validation_types() -> None:
     """Test validation fails for invalid types."""
     with pytest.raises(ValidationError):
-        StateDefinition(schema="not-a-dict", persistence="ephemeral")
+        StateDefinition(schema_="not-a-dict", persistence="ephemeral")
 
 
 def test_state_schema_missing_fields() -> None:
@@ -48,14 +48,14 @@ def test_state_schema_extra_forbid() -> None:
     """Test that extra fields are forbidden."""
     schema_def = {"type": "object"}
     with pytest.raises(ValidationError) as excinfo:
-        StateDefinition(schema=schema_def, persistence="ephemeral", extra_field="fail")  # type: ignore[call-arg]
+        StateDefinition(schema_=schema_def, persistence="ephemeral", extra_field="fail")  # type: ignore[call-arg]
     assert "Extra inputs are not permitted" in str(excinfo.value)
 
 
 def test_graph_topology_with_state_schema() -> None:
     """Test integrating StateDefinition into GraphTopology."""
     schema_def = {"type": "object", "properties": {"messages": {"type": "array"}}}
-    state = StateDefinition(schema=schema_def, persistence="ephemeral")
+    state = StateDefinition(schema_=schema_def, persistence="ephemeral")
     topology = GraphTopology(nodes=[], edges=[], state_schema=state)
     assert topology.state_schema == state
     assert topology.state_schema.persistence == "ephemeral"

--- a/tests/test_topology_features.py
+++ b/tests/test_topology_features.py
@@ -18,47 +18,47 @@ from coreason_manifest.definitions.topology import (
     LogicNode,
     MapNode,
     RecipeNode,
-    StateSchema,
+    StateDefinition,
 )
 
 
 def test_state_schema_creation() -> None:
-    """Test creating a valid StateSchema."""
+    """Test creating a valid StateDefinition."""
     schema_def = {"type": "object", "properties": {"messages": {"type": "array"}}}
-    state = StateSchema(data_schema=schema_def, persistence="memory")
-    assert state.data_schema == schema_def
-    assert state.persistence == "memory"
+    state = StateDefinition(schema=schema_def, persistence="ephemeral")
+    assert state.schema_ == schema_def
+    assert state.persistence == "ephemeral"
 
 
 def test_state_schema_validation_types() -> None:
     """Test validation fails for invalid types."""
     with pytest.raises(ValidationError):
-        StateSchema(data_schema="not-a-dict", persistence="memory")
+        StateDefinition(schema="not-a-dict", persistence="ephemeral")
 
 
 def test_state_schema_missing_fields() -> None:
     """Test validation fails for missing required fields."""
     with pytest.raises(ValidationError) as excinfo:
-        StateSchema(persistence="memory")  # type: ignore[call-arg]
+        StateDefinition(persistence="ephemeral")  # type: ignore[call-arg]
     assert "Field required" in str(excinfo.value)
-    assert "data_schema" in str(excinfo.value)
+    assert "schema" in str(excinfo.value)
 
 
 def test_state_schema_extra_forbid() -> None:
     """Test that extra fields are forbidden."""
     schema_def = {"type": "object"}
     with pytest.raises(ValidationError) as excinfo:
-        StateSchema(data_schema=schema_def, persistence="memory", extra_field="fail")  # type: ignore[call-arg]
+        StateDefinition(schema=schema_def, persistence="ephemeral", extra_field="fail")  # type: ignore[call-arg]
     assert "Extra inputs are not permitted" in str(excinfo.value)
 
 
 def test_graph_topology_with_state_schema() -> None:
-    """Test integrating StateSchema into GraphTopology."""
+    """Test integrating StateDefinition into GraphTopology."""
     schema_def = {"type": "object", "properties": {"messages": {"type": "array"}}}
-    state = StateSchema(data_schema=schema_def, persistence="memory")
+    state = StateDefinition(schema=schema_def, persistence="ephemeral")
     topology = GraphTopology(nodes=[], edges=[], state_schema=state)
     assert topology.state_schema == state
-    assert topology.state_schema.persistence == "memory"
+    assert topology.state_schema.persistence == "ephemeral"
 
 
 def test_conditional_edge_creation() -> None:

--- a/tests/test_v0_10_0_features.py
+++ b/tests/test_v0_10_0_features.py
@@ -63,9 +63,9 @@ def test_graph_topology_state_schema_optional() -> None:
     assert topology.state_schema is None
 
     # Also verify we can provide it
-    from coreason_manifest.definitions.topology import StateSchema
+    from coreason_manifest.definitions.topology import StateDefinition
 
-    schema = StateSchema(data_schema={}, persistence="memory")
+    schema = StateDefinition(schema={}, persistence="ephemeral")
     topology_with_schema = GraphTopology(nodes=[], edges=[], state_schema=schema)
     assert topology_with_schema.state_schema == schema
 

--- a/tests/test_v0_10_0_features.py
+++ b/tests/test_v0_10_0_features.py
@@ -1,6 +1,6 @@
 from coreason_manifest.definitions.agent import VersionStr
-from coreason_manifest.definitions.topology import AgentNode, GraphTopology
-from coreason_manifest.recipes import RecipeInterface, RecipeManifest, StateDefinition
+from coreason_manifest.definitions.topology import AgentNode, GraphTopology, StateDefinition
+from coreason_manifest.recipes import RecipeInterface, RecipeManifest
 
 
 def test_agent_node_v0_10_0_features() -> None:
@@ -65,7 +65,7 @@ def test_graph_topology_state_schema_optional() -> None:
     # Also verify we can provide it
     from coreason_manifest.definitions.topology import StateDefinition
 
-    schema = StateDefinition(schema={}, persistence="ephemeral")
+    schema = StateDefinition(schema_={}, persistence="ephemeral")
     topology_with_schema = GraphTopology(nodes=[], edges=[], state_schema=schema)
     assert topology_with_schema.state_schema == schema
 


### PR DESCRIPTION
Implemented recommendations from the Shared Kernel Review:
1.  **Unify State Models**: Deprecated `StateSchema` and moved `StateDefinition` to `topology.py` to be the single source of truth for state definitions. Updated `GraphTopology` and `RecipeManifest` to use `StateDefinition`.
2.  **Standardize Topology Validation**: Extracted `validate_edge_integrity` logic from `GraphTopology` and reused it in `AgentRuntimeConfig` to ensure agent topologies also validate edge integrity.
3.  **Enhance Event Metadata**: Replaced `Dict[str, str]` with `RuntimeVisualMetadata` (inheriting from `VisualMetadata`) in `GraphEvent` to provide strict typing and better runtime support for visual cues (color, progress, animation).

All tests passed with 100% coverage. JSON schemas were regenerated.

---
*PR created automatically by Jules for task [13364292042740194560](https://jules.google.com/task/13364292042740194560) started by @gowthamrao*