### PR TITLE
Support Intermediate Events in AgentInterface

### DIFF
--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -118,18 +118,31 @@ class Persona(CoReasonBaseModel):
     directives: List[str] = Field(..., description="List of specific instructions or directives.")
 
 
+class EventSchema(CoReasonBaseModel):
+    """Defines the structure of an intermediate event emitted by the agent."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(..., description="Event name (e.g., 'SEARCH_PROGRESS').")
+    data_schema: ImmutableDict = Field(..., description="JSON Schema of the event payload.")
+
+
 class AgentInterface(CoReasonBaseModel):
     """Interface definition for the Agent.
 
     Attributes:
         inputs: Typed arguments the agent accepts (JSON Schema).
         outputs: Typed structure of the result.
+        events: List of intermediate events this agent produces during execution.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     inputs: ImmutableDict = Field(..., description="Typed arguments the agent accepts (JSON Schema).")
     outputs: ImmutableDict = Field(..., description="Typed structure of the result.")
+    events: List[EventSchema] = Field(
+        default_factory=list, description="List of intermediate events this agent produces during execution."
+    )
     injected_params: List[str] = Field(default_factory=list, description="List of parameters injected by the system.")
 
 

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -33,7 +33,7 @@
     },
     "AgentInterface": {
       "additionalProperties": false,
-      "description": "Interface definition for the Agent.\n\nAttributes:\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.",
+      "description": "Interface definition for the Agent.\n\nAttributes:\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.\n    events: List of intermediate events this agent produces during execution.",
       "properties": {
         "inputs": {
           "additionalProperties": true,
@@ -46,6 +46,14 @@
           "description": "Typed structure of the result.",
           "title": "Outputs",
           "type": "object"
+        },
+        "events": {
+          "description": "List of intermediate events this agent produces during execution.",
+          "items": {
+            "$ref": "#/$defs/EventSchema"
+          },
+          "title": "Events",
+          "type": "array"
         },
         "injected_params": {
           "description": "List of parameters injected by the system.",
@@ -387,6 +395,29 @@
         "target_node_id"
       ],
       "title": "Edge",
+      "type": "object"
+    },
+    "EventSchema": {
+      "additionalProperties": false,
+      "description": "Defines the structure of an intermediate event emitted by the agent.",
+      "properties": {
+        "name": {
+          "description": "Event name (e.g., 'SEARCH_PROGRESS').",
+          "title": "Name",
+          "type": "string"
+        },
+        "data_schema": {
+          "additionalProperties": true,
+          "description": "JSON Schema of the event payload.",
+          "title": "Data Schema",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "data_schema"
+      ],
+      "title": "EventSchema",
       "type": "object"
     },
     "HumanNode": {

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -16,11 +16,11 @@ from pydantic import ValidationError
 
 from coreason_manifest.definitions.agent import (
     AgentDefinition,
+    AgentInterface,
     AgentMetadata,
+    EventSchema,
     ModelConfig,
     Persona,
-    AgentInterface,
-    EventSchema,
 )
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -19,6 +19,8 @@ from coreason_manifest.definitions.agent import (
     AgentMetadata,
     ModelConfig,
     Persona,
+    AgentInterface,
+    EventSchema,
 )
 
 
@@ -229,3 +231,28 @@ def test_agent_config_system_prompt() -> None:
     agent = AgentDefinition(**valid_data)
     assert agent.config.system_prompt is None
     assert agent.config.llm_config.system_prompt == "Model Prompt"
+
+
+def test_agent_interface_events() -> None:
+    """Test AgentInterface with EventSchema."""
+    event = EventSchema(
+        name="SEARCH_PROGRESS",
+        data_schema={"type": "object", "properties": {"query": {"type": "string"}}},
+    )
+    assert event.name == "SEARCH_PROGRESS"
+    assert event.data_schema["type"] == "object"
+
+    interface = AgentInterface(
+        inputs={"type": "object"},
+        outputs={"type": "string"},
+        events=[event],
+    )
+    assert len(interface.events) == 1
+    assert interface.events[0].name == "SEARCH_PROGRESS"
+
+    # Test default factory
+    interface_empty = AgentInterface(
+        inputs={"type": "object"},
+        outputs={"type": "string"},
+    )
+    assert interface_empty.events == []


### PR DESCRIPTION
Introduced EventSchema and added an 'events' list to AgentInterface to formalize intermediate events emitted by agents. This aligns with streaming agent frameworks like Sentient. Updates schemas and adds tests.

---
*PR created automatically by Jules for task [16869448752883780137](https://jules.google.com/task/16869448752883780137) started by @gowthamrao*