### PR TITLE
Refactor AgentDefinition to support Multi-Mode Agents (Capabilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ from datetime import datetime, timezone
 from coreason_manifest.definitions.agent import (
     AgentDefinition,
     AgentMetadata,
-    AgentInterface,
+    AgentCapability,
+    CapabilityType,
     AgentRuntimeConfig,
     ModelConfig,
     AgentDependencies,
@@ -74,10 +75,15 @@ metadata = AgentMetadata(
 # 2. Instantiate Agent
 agent = AgentDefinition(
     metadata=metadata,
-    interface=AgentInterface(
-        inputs={"topic": {"type": "string"}},
-        outputs={"summary": {"type": "string"}}
-    ),
+    capabilities=[
+        AgentCapability(
+            name="research",
+            type=CapabilityType.ATOMIC,
+            description="Deep research on a topic.",
+            inputs={"topic": {"type": "string"}},
+            outputs={"summary": {"type": "string"}}
+        )
+    ],
     config=AgentRuntimeConfig(
         model_config=ModelConfig(
             model="gpt-4",

--- a/docs/open_agent_specification.md
+++ b/docs/open_agent_specification.md
@@ -24,8 +24,9 @@ An `AgentDefinition` consists of the following sections:
     *   **Timestamps**: `created_at`.
     *   **Auth**: `requires_auth` flag for user context injection.
 
-2.  **Interface (`AgentInterface`)**:
-    *   Defines the "contract" of the agent.
+2.  **Capabilities (`List[AgentCapability]`)**:
+    *   Defines the modes of interaction for the agent (e.g., "Atomic", "Streaming").
+    *   Each capability has a unique `name`, `type`, and `description`.
     *   `inputs` and `outputs` are defined using immutable dictionaries (representing JSON Schemas).
     *   `injected_params` lists system-injected values (e.g., `user_context`).
 
@@ -105,7 +106,8 @@ from datetime import datetime, timezone
 from coreason_manifest.definitions.agent import (
     AgentDefinition,
     AgentMetadata,
-    AgentInterface,
+    AgentCapability,
+    CapabilityType,
     AgentRuntimeConfig,
     ModelConfig,
     AgentDependencies,
@@ -124,11 +126,16 @@ agent = AgentDefinition(
         created_at=datetime.now(timezone.utc)
     ),
 
-    # 2. Interface
-    interface=AgentInterface(
-        inputs={"location": {"type": "string"}},
-        outputs={"forecast": {"type": "string"}}
-    ),
+    # 2. Capabilities
+    capabilities=[
+        AgentCapability(
+            name="forecast",
+            type=CapabilityType.ATOMIC,
+            description="Get the weather forecast.",
+            inputs={"location": {"type": "string"}},
+            outputs={"forecast": {"type": "string"}}
+        )
+    ],
 
     # 3. Configuration (Atomic)
     config=AgentRuntimeConfig(

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -9,7 +9,7 @@ It is designed to be a pure data library, meaning it contains **no execution log
 ### 1. Agent Definition
 The `AgentDefinition` is the source of truth for an AI Agent. It includes:
 - **Metadata**: Identity, versioning (Strict SemVer), and authorship.
-- **Interface**: Strictly typed inputs and outputs (JSON Schema).
+- **Capabilities**: Strictly typed modes of interaction (`inputs`, `outputs` as JSON Schema).
 - **Topology**: A graph-based execution flow (`GraphTopology`) supporting cyclic loops (e.g., for reflection).
 - **Dependencies**: MCP Tooling requirements (`ToolRequirement`) and Python libraries.
 - **Policy**: Governance rules for budget and human-in-the-loop triggers (`PolicyConfig`).
@@ -19,11 +19,11 @@ The `AgentDefinition` is the source of truth for an AI Agent. It includes:
 To ensure reliability and auditability, the library enforces three strict constraints:
 
 #### A. Immutability
-All dictionary and list fields in the interface are converted to immutable types (`MappingProxyType`, `tuple`) upon validation. You cannot modify them in place.
+All dictionary and list fields in the capabilities are converted to immutable types (`MappingProxyType`, `tuple`) upon validation. You cannot modify them in place.
 
 **Incorrect:**
 ```python
-agent.interface.inputs["new_param"] = "value"  # Raises TypeError
+agent.capabilities[0].inputs["new_param"] = "value"  # Raises TypeError
 ```
 
 **Correct:**
@@ -80,10 +80,15 @@ edges = [
 # 3. Instantiate Agent
 agent = AgentDefinition(
     metadata=metadata,
-    interface={
-        "inputs": {"topic": {"type": "string"}},
-        "outputs": {"summary": {"type": "string"}}
-    },
+    capabilities=[
+        {
+            "name": "default",
+            "type": "atomic",
+            "description": "Default mode",
+            "inputs": {"topic": {"type": "string"}},
+            "outputs": {"summary": {"type": "string"}}
+        }
+    ],
     config={
         "nodes": nodes,
         "edges": edges,
@@ -120,11 +125,11 @@ print(f"Agent '{agent.metadata.name}' created successfully.")
 
 ```python
 # Reading is allowed
-print(agent.interface.inputs["topic"])
+print(agent.capabilities[0].inputs["topic"])
 
 # Writing raises TypeError
 try:
-    agent.interface.inputs["topic"] = "int"
+    agent.capabilities[0].inputs["topic"] = "int"
 except TypeError as e:
     print("Caught expected error:", e)
 ```

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -1,40 +1,23 @@
 {
   "$defs": {
-    "AgentDependencies": {
+    "AgentCapability": {
       "additionalProperties": false,
-      "description": "External dependencies for the Agent.\n\nAttributes:\n    tools: List of MCP tool requirements.\n    libraries: List of Python packages required (if code execution is allowed).",
+      "description": "Defines a specific mode of interaction for the agent.\n\nAttributes:\n    name: Unique name for this capability.\n    type: Interaction mode.\n    description: What this mode does.\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.\n    events: List of intermediate events this agent produces during execution.\n    injected_params: List of parameters injected by the system.",
       "properties": {
-        "tools": {
-          "description": "List of MCP tool requirements.",
-          "items": {
-            "anyOf": [
-              {
-                "$ref": "#/$defs/ToolRequirement"
-              },
-              {
-                "$ref": "#/$defs/InlineToolDefinition"
-              }
-            ]
-          },
-          "title": "Tools",
-          "type": "array"
+        "name": {
+          "description": "Unique name for this capability.",
+          "title": "Name",
+          "type": "string"
         },
-        "libraries": {
-          "description": "List of Python packages required (if code execution is allowed).",
-          "items": {
-            "type": "string"
-          },
-          "title": "Libraries",
-          "type": "array"
-        }
-      },
-      "title": "AgentDependencies",
-      "type": "object"
-    },
-    "AgentInterface": {
-      "additionalProperties": false,
-      "description": "Interface definition for the Agent.\n\nAttributes:\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.\n    events: List of intermediate events this agent produces during execution.",
-      "properties": {
+        "type": {
+          "$ref": "#/$defs/CapabilityType",
+          "description": "Interaction mode."
+        },
+        "description": {
+          "description": "What this mode does.",
+          "title": "Description",
+          "type": "string"
+        },
         "inputs": {
           "additionalProperties": true,
           "description": "Typed arguments the agent accepts (JSON Schema).",
@@ -65,10 +48,44 @@
         }
       },
       "required": [
+        "name",
+        "type",
+        "description",
         "inputs",
         "outputs"
       ],
-      "title": "AgentInterface",
+      "title": "AgentCapability",
+      "type": "object"
+    },
+    "AgentDependencies": {
+      "additionalProperties": false,
+      "description": "External dependencies for the Agent.\n\nAttributes:\n    tools: List of MCP tool requirements.\n    libraries: List of Python packages required (if code execution is allowed).",
+      "properties": {
+        "tools": {
+          "description": "List of MCP tool requirements.",
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/$defs/ToolRequirement"
+              },
+              {
+                "$ref": "#/$defs/InlineToolDefinition"
+              }
+            ]
+          },
+          "title": "Tools",
+          "type": "array"
+        },
+        "libraries": {
+          "description": "List of Python packages required (if code execution is allowed).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Libraries",
+          "type": "array"
+        }
+      },
+      "title": "AgentDependencies",
       "type": "object"
     },
     "AgentMetadata": {
@@ -305,6 +322,15 @@
       ],
       "title": "AgentRuntimeConfig",
       "type": "object"
+    },
+    "CapabilityType": {
+      "description": "The interaction mode for the capability.",
+      "enum": [
+        "atomic",
+        "streaming"
+      ],
+      "title": "CapabilityType",
+      "type": "string"
     },
     "CouncilConfig": {
       "additionalProperties": false,
@@ -1016,8 +1042,13 @@
     "metadata": {
       "$ref": "#/$defs/AgentMetadata"
     },
-    "interface": {
-      "$ref": "#/$defs/AgentInterface"
+    "capabilities": {
+      "description": "List of supported capabilities.",
+      "items": {
+        "$ref": "#/$defs/AgentCapability"
+      },
+      "title": "Capabilities",
+      "type": "array"
     },
     "config": {
       "$ref": "#/$defs/AgentRuntimeConfig"
@@ -1072,7 +1103,7 @@
   },
   "required": [
     "metadata",
-    "interface",
+    "capabilities",
     "config",
     "dependencies",
     "integrity_hash"

--- a/tests/test_atomic_agent.py
+++ b/tests/test_atomic_agent.py
@@ -19,7 +19,7 @@ def test_atomic_agent_without_topology_succeeds() -> None:
             "author": "Me",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
         "config": {
             # No nodes, edges, entry_point
             "model_config": {"model": "gpt-4", "temperature": 0.7},
@@ -48,7 +48,7 @@ def test_atomic_agent_with_skeleton_topology_succeeds() -> None:
             "author": "Me",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
         "config": {
             # Skeleton Topology
             "nodes": [{"id": "main", "type": "agent", "agent_name": "self"}],  # minimal node
@@ -78,7 +78,7 @@ def test_nodes_without_entry_point_fails() -> None:
             "author": "Me",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
         "config": {
             "nodes": [{"id": "main", "type": "agent", "agent_name": "self"}],
             "edges": [],
@@ -106,7 +106,7 @@ def test_atomic_agent_with_explicit_empty_nodes() -> None:
             "author": "Me",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
         "config": {
             "nodes": [],  # Explicit empty
             "edges": [],
@@ -144,7 +144,7 @@ def test_edges_without_nodes_integrity() -> None:
             "author": "Me",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
         "config": {
             "nodes": [],
             "edges": [{"source_node_id": "a", "target_node_id": "b"}],
@@ -176,7 +176,7 @@ def test_atomic_agent_serialization_excludes_defaults() -> None:
             "author": "Me",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
         "config": {
             "model_config": {"model": "gpt-4", "temperature": 0.7},
             "system_prompt": "Atomic",

--- a/tests/test_complex_cases.py
+++ b/tests/test_complex_cases.py
@@ -27,7 +27,15 @@ def test_deep_immutability_mapping_proxy() -> None:
             "author": "Tester",
             "created_at": "2023-01-01T00:00:00Z",
         },
-        "interface": {"inputs": {"param": 1}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {"param": 1},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],
@@ -52,10 +60,10 @@ def test_deep_immutability_mapping_proxy() -> None:
 
     # inputs should be read-only
     with pytest.raises(TypeError, match="'mappingproxy' object does not support item assignment"):
-        agent.interface.inputs["param"] = 2  # type: ignore[index]
+        agent.capabilities[0].inputs["param"] = 2  # type: ignore[index]
 
     with pytest.raises(TypeError, match="'mappingproxy' object does not support item assignment"):
-        agent.interface.inputs["new"] = 3  # type: ignore[index]
+        agent.capabilities[0].inputs["new"] = 3  # type: ignore[index]
 
 
 def test_deep_immutability_tuples() -> None:
@@ -68,7 +76,15 @@ def test_deep_immutability_tuples() -> None:
             "author": "Tester",
             "created_at": "2023-01-01T00:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],
@@ -122,7 +138,15 @@ def test_unicode_handling() -> None:
             "author": author_unicode,
             "created_at": "2023-01-01T00:00:00Z",
         },
-        "interface": {"inputs": {"key_Ω": "val_🤖"}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {"key_Ω": "val_🤖"},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],
@@ -137,7 +161,7 @@ def test_unicode_handling() -> None:
 
     assert agent.metadata.name == name_unicode
     assert agent.metadata.author == author_unicode
-    assert agent.interface.inputs["key_Ω"] == "val_🤖"
+    assert agent.capabilities[0].inputs["key_Ω"] == "val_🤖"
 
 
 def test_hash_validation_edge_cases() -> None:
@@ -150,7 +174,15 @@ def test_hash_validation_edge_cases() -> None:
             "author": "Tester",
             "created_at": "2023-01-01T00:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],

--- a/tests/test_immutability.py
+++ b/tests/test_immutability.py
@@ -41,7 +41,15 @@ def test_agent_definition_immutability() -> None:
             "author": "Tester",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],
@@ -74,7 +82,15 @@ def test_nested_model_immutability() -> None:
             "author": "Tester",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -299,6 +299,7 @@ def test_agent_capability_events() -> None:
     )
     assert capability_empty.events == []
 
+
 def test_agent_capabilities_validation() -> None:
     """Test validation of capabilities list."""
     valid_data = {
@@ -326,13 +327,7 @@ def test_agent_capabilities_validation() -> None:
     assert "Agent must have at least one capability" in str(exc.value)
 
     # Test duplicate names
-    cap = AgentCapability(
-        name="dup",
-        type=CapabilityType.ATOMIC,
-        description="D",
-        inputs={},
-        outputs={}
-    )
+    cap = AgentCapability(name="dup", type=CapabilityType.ATOMIC, description="D", inputs={}, outputs={})
     with pytest.raises(ValidationError) as exc:
         AgentDefinition(capabilities=[cap, cap], **valid_data)
     assert "Duplicate capability names found" in str(exc.value)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,9 +15,10 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.definitions.agent import (
+    AgentCapability,
     AgentDefinition,
-    AgentInterface,
     AgentMetadata,
+    CapabilityType,
     EventSchema,
     ModelConfig,
     Persona,
@@ -34,10 +35,16 @@ def test_agent_definition_valid() -> None:
             "author": "Test Author",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {
-            "inputs": {"type": "object", "properties": {"query": {"type": "string"}}},
-            "outputs": {"type": "string"},
-        },
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {"type": "object", "properties": {"query": {"type": "string"}}},
+                "outputs": {"type": "string"},
+                "injected_params": [],  # Missing user_context
+            }
+        ],
         "config": {
             "nodes": [{"id": "step1", "type": "logic", "code": "pass"}],
             "edges": [],
@@ -98,7 +105,15 @@ def test_validation_error_on_missing_fields() -> None:
             "author": "Test Author",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],
@@ -123,11 +138,16 @@ def test_auth_validation_failure() -> None:
             "created_at": "2023-10-27T10:00:00Z",
             "requires_auth": True,
         },
-        "interface": {
-            "inputs": {"type": "object", "properties": {"query": {"type": "string"}}},
-            "outputs": {"type": "string"},
-            "injected_params": [],  # Missing user_context
-        },
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {"type": "object", "properties": {"query": {"type": "string"}}},
+                "outputs": {"type": "string"},
+                "injected_params": [],  # Missing user_context
+            }
+        ],
         "config": {
             "nodes": [{"id": "step1", "type": "logic", "code": "pass"}],
             "edges": [],
@@ -138,7 +158,7 @@ def test_auth_validation_failure() -> None:
         "integrity_hash": "a" * 64,
     }
     with pytest.raises(
-        ValueError, match="Agent requires authentication but 'user_context' is not an injected parameter"
+        ValueError, match="Agent requires authentication but capability 'default' does not inject 'user_context'."
     ):
         AgentDefinition(**data)
 
@@ -153,7 +173,15 @@ def test_agent_definition_with_policy_and_observability() -> None:
             "author": "Test Author",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],
@@ -200,7 +228,15 @@ def test_agent_config_system_prompt() -> None:
             "author": "Test Author",
             "created_at": "2023-10-27T10:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {},
+                "outputs": {},
+            }
+        ],
         "config": {
             "nodes": [],
             "edges": [],
@@ -233,8 +269,8 @@ def test_agent_config_system_prompt() -> None:
     assert agent.config.llm_config.system_prompt == "Model Prompt"
 
 
-def test_agent_interface_events() -> None:
-    """Test AgentInterface with EventSchema."""
+def test_agent_capability_events() -> None:
+    """Test AgentCapability with EventSchema."""
     event = EventSchema(
         name="SEARCH_PROGRESS",
         data_schema={"type": "object", "properties": {"query": {"type": "string"}}},
@@ -242,17 +278,61 @@ def test_agent_interface_events() -> None:
     assert event.name == "SEARCH_PROGRESS"
     assert event.data_schema["type"] == "object"
 
-    interface = AgentInterface(
+    capability = AgentCapability(
+        name="test",
+        type=CapabilityType.ATOMIC,
+        description="Test capability",
         inputs={"type": "object"},
         outputs={"type": "string"},
         events=[event],
     )
-    assert len(interface.events) == 1
-    assert interface.events[0].name == "SEARCH_PROGRESS"
+    assert len(capability.events) == 1
+    assert capability.events[0].name == "SEARCH_PROGRESS"
 
     # Test default factory
-    interface_empty = AgentInterface(
+    capability_empty = AgentCapability(
+        name="test",
+        type=CapabilityType.ATOMIC,
+        description="Test capability",
         inputs={"type": "object"},
         outputs={"type": "string"},
     )
-    assert interface_empty.events == []
+    assert capability_empty.events == []
+
+def test_agent_capabilities_validation() -> None:
+    """Test validation of capabilities list."""
+    valid_data = {
+        "metadata": {
+            "id": str(uuid.uuid4()),
+            "version": "1.0.0",
+            "name": "Test Agent",
+            "author": "Test Author",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "config": {
+            "nodes": [],
+            "edges": [],
+            "entry_point": "start",
+            "model_config": {"model": "gpt-4", "temperature": 0.7},
+            "system_prompt": "Prompt",
+        },
+        "dependencies": {},
+        "integrity_hash": "a" * 64,
+    }
+
+    # Test empty capabilities
+    with pytest.raises(ValidationError) as exc:
+        AgentDefinition(capabilities=[], **valid_data)
+    assert "Agent must have at least one capability" in str(exc.value)
+
+    # Test duplicate names
+    cap = AgentCapability(
+        name="dup",
+        type=CapabilityType.ATOMIC,
+        description="D",
+        inputs={},
+        outputs={}
+    )
+    with pytest.raises(ValidationError) as exc:
+        AgentDefinition(capabilities=[cap, cap], **valid_data)
+    assert "Duplicate capability names found" in str(exc.value)

--- a/tests/test_polish_edge_cases.py
+++ b/tests/test_polish_edge_cases.py
@@ -83,7 +83,15 @@ def test_agent_definition_legacy_key_rejection() -> None:
             "author": "Me",
             "created_at": "2023-01-01T00:00:00Z",
         },
-        "interface": {"inputs": {}, "outputs": {}},
+        "capabilities": [
+            {
+                "name": "default",
+                "type": "atomic",
+                "description": "Default",
+                "inputs": {},
+                "outputs": {},
+            }
+        ],
         "topology": {  # Legacy key
             "nodes": [],
             "edges": [],


### PR DESCRIPTION
This PR refactors `AgentDefinition` to support Multi-Mode Agents by replacing the single `interface` field with a list of `capabilities`. This allows an agent to expose multiple distinct entry points (e.g., "Fast Chat", "Deep Research").

Changes:
- Defined `CapabilityType` Enum.
- Renamed `AgentInterface` to `AgentCapability`, adding `name`, `type`, and `description`.
- Updated `AgentDefinition` to include `capabilities: List[AgentCapability]`.
- Added validators for capabilities.
- Updated all tests to use the new structure.
- Regenerated `agent.schema.json` and `recipe.schema.json`.


---
*PR created automatically by Jules for task [7700704740173450581](https://jules.google.com/task/7700704740173450581) started by @gowthamrao*