### PR TITLE
Add AgentRequest envelope for distributed tracing

### DIFF
--- a/docs/agent_request_envelope.md
+++ b/docs/agent_request_envelope.md
@@ -1,0 +1,94 @@
+# AgentRequest Envelope
+
+The `AgentRequest` model is the standardized envelope for all agent invocations within the Coreason Framework. It ensures that every request—whether originating from a user, another agent, or an external system—carries the necessary context for **Distributed Tracing**, **Session Management**, and **Causal Tracking**.
+
+## Purpose
+
+By wrapping every invocation in an `AgentRequest`, the Engine automatically propagates trace context across complex multi-agent workflows. This enables:
+
+1.  **Distributed Tracing:** Visualization of request chains (Root -> Parent -> Child) in tools like Jaeger or Arize.
+2.  **Causal Integrity:** Strict validation ensures that no child request exists without a clear lineage back to a root cause.
+3.  **Standardization:** A uniform interface for all agents, regardless of their internal logic (Atomic vs. Graph-based).
+
+## Structure
+
+The `AgentRequest` model is defined in `src/coreason_manifest/definitions/request.py`.
+
+```python
+from coreason_manifest.definitions import AgentRequest
+
+request = AgentRequest(
+    request_id=uuid4(),      # Unique ID for this specific invocation
+    session_id=uuid4(),      # The conversation/session ID
+    root_request_id=uuid4(), # The ID of the very first request in the chain
+    parent_request_id=uuid4(),# The ID of the request that triggered this one
+    payload={"input": "Hello"}, # The actual arguments for the agent
+    metadata={"user_locale": "en-US"} # Contextual headers
+)
+```
+
+### Fields
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `request_id` | `UUID` | Unique identifier for this specific request. Defaults to `uuid4()`. |
+| `session_id` | `UUID` | The conversation/session ID this request belongs to. **Required.** |
+| `root_request_id` | `UUID` | The ID of the first request in the causal chain. |
+| `parent_request_id` | `UUID` | The ID of the request that triggered this one (optional). |
+| `timestamp` | `datetime` | Creation time (UTC). Defaults to `now()`. |
+| `payload` | `Dict[str, Any]` | The actual input arguments for the agent. **Required.** |
+| `metadata` | `Dict[str, Any]` | Arbitrary headers or context. Defaults to `{}`. |
+
+## Tracing Logic & Validation
+
+The `AgentRequest` model enforces strict validation rules to maintain trace integrity.
+
+### 1. Auto-Rooting (New Traces)
+If `root_request_id` is not provided, the system assumes this is a **new trace**.
+*   **Logic:** `root_request_id` defaults to the current `request_id`.
+
+```python
+# A new external request
+req = AgentRequest(
+    session_id=session_id,
+    payload={"query": "Start task"}
+)
+# Result:
+# req.request_id = <UUID-A>
+# req.root_request_id = <UUID-A> (Self-rooted)
+# req.parent_request_id = None
+```
+
+### 2. Trace Continuity (Child Requests)
+If you provide a `parent_request_id`, you **must** also provide a `root_request_id`. The system raises a `ValueError` if lineage is broken.
+
+*   **Rule:** If `parent_request_id` is set, `root_request_id` cannot be inferred; it must be explicit.
+
+```python
+# VALID Child Request
+child = AgentRequest(
+    session_id=session_id,
+    root_request_id=root_req.request_id,
+    parent_request_id=parent_req.request_id,
+    payload=...
+)
+
+# INVALID (Raises ValueError)
+invalid = AgentRequest(
+    session_id=session_id,
+    parent_request_id=parent_req.request_id,
+    # Missing root_request_id!
+    payload=...
+)
+```
+
+## Integration
+
+The `AgentRequest` is the primary input for the `AgentRuntime` and is expected to be passed into the `Interaction` model.
+
+### Serialization
+Inheriting from `CoReasonBaseModel`, it supports standardized JSON serialization:
+
+```python
+json_payload = request.to_json()
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,4 +7,5 @@ This is the documentation for the coreason_manifest project.
 *   [Atomic Agents](atomic_agents.md): Understand how to define simple, prompt-based agents without complex topologies.
 *   [Recipe Manifests](recipes.md): Learn about defining executable workflows and graphs.
 *   [Session Management](session_management.md): Decoupling execution from memory with standardized Session and Interaction models.
+*   [Agent Request Envelope](agent_request_envelope.md): The standard envelope for agent invocations and distributed tracing.
 *   [Observability](observability.md): Details on tracing, logging, and metrics.

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -29,6 +29,16 @@ Every event emitted by the Coreason Engine is wrapped in a standard `CloudEvent`
 - **source**: The producer of the event (e.g., the Node ID).
 - **traceparent**: W3C Trace Context header for distributed tracing.
 
+## Distributed Tracing with AgentRequest
+
+Distributed tracing starts at the edge. The `AgentRequest` envelope standardizes the propagation of trace IDs (Root -> Parent -> Child) into the system.
+
+*   **Ingestion:** When an `AgentRequest` is received, the Engine extracts the `root_request_id` and `parent_request_id`.
+*   **Propagation:** These IDs are mapped to the W3C `traceparent` header in all subsequent `CloudEvent` emissions.
+*   **Visualization:** This lineage allows tools like **Jaeger** or **Arize** to reconstruct the full execution tree, even across asynchronous distributed systems.
+
+See [Agent Request Envelope](agent_request_envelope.md) for implementation details.
+
 ## OpenTelemetry GenAI Semantic Conventions
 
 Payloads (`data`) now strictly follow [OpenTelemetry GenAI Semantic Conventions](https://opentelemetry.io/docs/specs/semconv/gen-ai/).

--- a/docs/session_management.md
+++ b/docs/session_management.md
@@ -4,6 +4,10 @@ The `coreason-manifest` library defines a standardized protocol for managing age
 
 ## Core Concepts
 
+### AgentRequest
+
+The entry point for any interaction is the [AgentRequest](agent_request_envelope.md). This envelope carries the `session_id` and the input `payload` that triggers the runtime. The runtime uses this ID to hydrate the correct `SessionState` before execution begins.
+
 ### Interaction
 
 An `Interaction` represents a single "turn" or request/response cycle in a conversation or workflow. It captures:

--- a/src/coreason_manifest/definitions/__init__.py
+++ b/src/coreason_manifest/definitions/__init__.py
@@ -33,9 +33,11 @@ from .events import (
     WorkflowError,
     WorkflowErrorPayload,
 )
+from .request import AgentRequest
 from .session import Interaction, SessionState
 
 __all__ = [
+    "AgentRequest",
     "AgentRuntimeConfig",
     "AgentDefinition",
     "Persona",

--- a/src/coreason_manifest/definitions/request.py
+++ b/src/coreason_manifest/definitions/request.py
@@ -1,0 +1,55 @@
+from uuid import UUID, uuid4
+from datetime import datetime, timezone
+from typing import Dict, Any, Optional
+
+from pydantic import Field, model_validator, ConfigDict
+
+from coreason_manifest.definitions.base import CoReasonBaseModel
+
+
+class AgentRequest(CoReasonBaseModel):
+    """Standard envelope for Agent invocations with distributed tracing support.
+
+    Wraps every agent invocation to automatically propagate trace context
+    (Root ID -> Parent ID -> Child ID), enabling visualization in tools like Jaeger.
+    """
+    model_config = ConfigDict(frozen=True)
+
+    request_id: UUID = Field(
+        default_factory=uuid4,
+        description="Unique identifier for this specific request"
+    )
+    session_id: UUID = Field(
+        ...,
+        description="The conversation/session ID this request belongs to"
+    )
+    root_request_id: Optional[UUID] = Field(
+        default=None,
+        description="The ID of the first request in the causal chain"
+    )
+    parent_request_id: Optional[UUID] = Field(
+        default=None,
+        description="The ID of the request that triggered this one"
+    )
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    payload: Dict[str, Any] = Field(
+        ...,
+        description="The actual input arguments for the agent"
+    )
+    metadata: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arbitrary headers or context (e.g., user locale)"
+    )
+
+    @model_validator(mode="after")
+    def validate_tracing_ids(self) -> "AgentRequest":
+        # Logic to ensure root_request_id is populated
+        if self.root_request_id is None:
+             # If no parent, I am the root.
+             if self.parent_request_id is None:
+                 self.__dict__['root_request_id'] = self.request_id
+             else:
+                 raise ValueError("Root ID missing while Parent ID is present.")
+        return self

--- a/src/coreason_manifest/definitions/request.py
+++ b/src/coreason_manifest/definitions/request.py
@@ -1,8 +1,8 @@
-from uuid import UUID, uuid4
 from datetime import datetime, timezone
-from typing import Dict, Any, Optional
+from typing import Any, Dict, Optional
+from uuid import UUID, uuid4
 
-from pydantic import Field, model_validator, ConfigDict
+from pydantic import ConfigDict, Field, model_validator
 
 from coreason_manifest.definitions.base import CoReasonBaseModel
 
@@ -13,43 +13,26 @@ class AgentRequest(CoReasonBaseModel):
     Wraps every agent invocation to automatically propagate trace context
     (Root ID -> Parent ID -> Child ID), enabling visualization in tools like Jaeger.
     """
+
     model_config = ConfigDict(frozen=True)
 
-    request_id: UUID = Field(
-        default_factory=uuid4,
-        description="Unique identifier for this specific request"
-    )
-    session_id: UUID = Field(
-        ...,
-        description="The conversation/session ID this request belongs to"
-    )
-    root_request_id: Optional[UUID] = Field(
-        default=None,
-        description="The ID of the first request in the causal chain"
-    )
-    parent_request_id: Optional[UUID] = Field(
-        default=None,
-        description="The ID of the request that triggered this one"
-    )
-    timestamp: datetime = Field(
-        default_factory=lambda: datetime.now(timezone.utc)
-    )
-    payload: Dict[str, Any] = Field(
-        ...,
-        description="The actual input arguments for the agent"
-    )
+    request_id: UUID = Field(default_factory=uuid4, description="Unique identifier for this specific request")
+    session_id: UUID = Field(..., description="The conversation/session ID this request belongs to")
+    root_request_id: Optional[UUID] = Field(default=None, description="The ID of the first request in the causal chain")
+    parent_request_id: Optional[UUID] = Field(default=None, description="The ID of the request that triggered this one")
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    payload: Dict[str, Any] = Field(..., description="The actual input arguments for the agent")
     metadata: Dict[str, Any] = Field(
-        default_factory=dict,
-        description="Arbitrary headers or context (e.g., user locale)"
+        default_factory=dict, description="Arbitrary headers or context (e.g., user locale)"
     )
 
     @model_validator(mode="after")
     def validate_tracing_ids(self) -> "AgentRequest":
         # Logic to ensure root_request_id is populated
         if self.root_request_id is None:
-             # If no parent, I am the root.
-             if self.parent_request_id is None:
-                 self.__dict__['root_request_id'] = self.request_id
-             else:
-                 raise ValueError("Root ID missing while Parent ID is present.")
+            # If no parent, I am the root.
+            if self.parent_request_id is None:
+                self.__dict__["root_request_id"] = self.request_id
+            else:
+                raise ValueError("Root ID missing while Parent ID is present.")
         return self

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -1,15 +1,15 @@
-import pytest
-from uuid import uuid4
 from datetime import datetime
-from coreason_manifest.definitions.request import AgentRequest
+from uuid import uuid4
+
+import pytest
 from pydantic import ValidationError
 
-def test_agent_request_defaults():
+from coreason_manifest.definitions.request import AgentRequest
+
+
+def test_agent_request_defaults() -> None:
     session_id = uuid4()
-    req = AgentRequest(
-        session_id=session_id,
-        payload={"input": "test"}
-    )
+    req = AgentRequest(session_id=session_id, payload={"input": "test"})
 
     assert req.request_id is not None
     assert req.session_id == session_id
@@ -20,43 +20,35 @@ def test_agent_request_defaults():
     assert req.payload == {"input": "test"}
     assert req.metadata == {}
 
-def test_agent_request_full_trace():
+
+def test_agent_request_full_trace() -> None:
     request_id = uuid4()
     session_id = uuid4()
     root_id = uuid4()
     parent_id = uuid4()
 
     req = AgentRequest(
-        request_id=request_id,
-        session_id=session_id,
-        root_request_id=root_id,
-        parent_request_id=parent_id,
-        payload={}
+        request_id=request_id, session_id=session_id, root_request_id=root_id, parent_request_id=parent_id, payload={}
     )
 
     assert req.request_id == request_id
     assert req.root_request_id == root_id
     assert req.parent_request_id == parent_id
 
-def test_agent_request_missing_root_with_parent_error_wrapped():
+
+def test_agent_request_missing_root_with_parent_error_wrapped() -> None:
     session_id = uuid4()
     parent_id = uuid4()
 
     with pytest.raises(ValidationError) as excinfo:
-        AgentRequest(
-            session_id=session_id,
-            parent_request_id=parent_id,
-            payload={}
-        )
+        AgentRequest(session_id=session_id, parent_request_id=parent_id, payload={})
 
     assert "Root ID missing while Parent ID is present" in str(excinfo.value)
 
-def test_agent_request_json_serialization():
+
+def test_agent_request_json_serialization() -> None:
     session_id = uuid4()
-    req = AgentRequest(
-        session_id=session_id,
-        payload={"foo": "bar"}
-    )
+    req = AgentRequest(session_id=session_id, payload={"foo": "bar"})
 
     json_str = req.to_json()
     assert str(session_id) in json_str
@@ -68,10 +60,11 @@ def test_agent_request_json_serialization():
     assert req2.request_id == req.request_id
     assert req2.root_request_id == req.root_request_id
 
-def test_immutability():
+
+def test_immutability() -> None:
     session_id = uuid4()
     req = AgentRequest(session_id=session_id, payload={})
 
     # Pydantic v2 frozen models raise ValidationError on assignment
     with pytest.raises(ValidationError):
-        req.payload = {"new": "val"}
+        req.payload = {"new": "val"}  # type: ignore[misc]


### PR DESCRIPTION
Implemented `AgentRequest` envelope to standardize agent invocations and enable distributed tracing. This new model ensures trace integrity by strictly validating `root_request_id` and `parent_request_id` relationships. It serves as the canonical entry point for all agent executions in the Coreason framework.

---
*PR created automatically by Jules for task [16555545909229566860](https://jules.google.com/task/16555545909229566860) started by @gowthamrao*