### PR TITLE
Implement UI-First Presentation Schemas

### DIFF
--- a/docs/frontend_integration.md
+++ b/docs/frontend_integration.md
@@ -68,6 +68,20 @@ The `visual_metadata` field allows the backend graph logic to drive frontend ani
 
 ---
 
+## Presentation Schemas ("UI-First" Artifacts)
+
+In addition to workflow events, agents can emit standardized "Presentation Blocks" to render rich UI elements directly. These are defined in `coreason_manifest.definitions.presentation`.
+
+These blocks are particularly useful for:
+*   **Thinking Processes**: Showing the user what the agent is planning (`ThinkingBlock`).
+*   **Structured Data**: Rendering tables or JSON views (`DataBlock`).
+*   **Rich Text**: Displaying formatted answers (`MarkdownBlock`).
+*   **Errors**: showing user-friendly error messages (`UserErrorBlock`).
+
+See [Presentation Schemas](./presentation_schemas.md) for detailed documentation on these types.
+
+---
+
 ## Event Types & Payloads
 
 ### 1. `NODE_INIT`

--- a/docs/presentation_schemas.md
+++ b/docs/presentation_schemas.md
@@ -1,0 +1,104 @@
+# Presentation Schemas: UI-First Artifacts
+
+## Overview
+
+The `coreason_manifest.definitions.presentation` module defines a set of standardized "Presentation Blocks." These blocks serve as interim artifacts that allow agents to emit UI-specific events—such as thinking processes, structured data visualizations, rich text, or user-facing errors—independently of the final response.
+
+These schemas are designed to be "UI-First," meaning they provide hints and structures that frontend applications can directly render without complex parsing logic.
+
+## Core Concepts
+
+All presentation blocks inherit from `PresentationBlock`, which provides the following common fields:
+
+*   **`block_type`**: A discriminator field (`THOUGHT`, `DATA`, `MARKDOWN`, `ERROR`).
+*   **`id`**: A unique identifier for the block (UUID).
+*   **`title`**: An optional title for the block (e.g., "Analyzing Data").
+
+### 1. ThinkingBlock
+
+Represents the agent's internal monologue or planning process. This is useful for showing "work in progress" to the user, increasing transparency and trust.
+
+*   **`block_type`**: `THOUGHT`
+*   **`content`**: The chain-of-thought text.
+*   **`status`**: The current status of the thought process (`IN_PROGRESS` or `COMPLETE`).
+
+**Example:**
+```python
+from coreason_manifest.definitions.presentation import ThinkingBlock
+
+block = ThinkingBlock(
+    content="Querying the database for recent orders...",
+    status="IN_PROGRESS"
+)
+```
+
+### 2. DataBlock
+
+Represents structured data that should be rendered in a specific way (e.g., a table, a list, or a JSON view).
+
+*   **`block_type`**: `DATA`
+*   **`data`**: A dictionary containing the structured data.
+*   **`view_hint`**: A hint to the UI on how to render the data (`TABLE`, `JSON`, `LIST`, `KEY_VALUE`).
+    *   **`TABLE`**: Expects a list of objects with similar keys.
+    *   **`JSON`**: Renders a code block with syntax highlighting.
+    *   **`LIST`**: Renders a bulleted or numbered list.
+    *   **`KEY_VALUE`**: Renders a property list or definition list.
+
+**Example:**
+```python
+from coreason_manifest.definitions.presentation import DataBlock
+
+data = {
+    "columns": ["ID", "Name", "Role"],
+    "rows": [
+        {"ID": 1, "Name": "Alice", "Role": "Admin"},
+        {"ID": 2, "Name": "Bob", "Role": "User"}
+    ]
+}
+
+block = DataBlock(
+    title="User Directory",
+    data=data,
+    view_hint="TABLE"
+)
+```
+
+### 3. MarkdownBlock
+
+Represents rich text content formatted using Markdown. This is the standard block for general text responses.
+
+*   **`block_type`**: `MARKDOWN`
+*   **`content`**: The Markdown string.
+
+**Example:**
+```python
+from coreason_manifest.definitions.presentation import MarkdownBlock
+
+content = """
+# Summary
+
+Based on the analysis, we found **3 critical issues**.
+"""
+
+block = MarkdownBlock(content=content)
+```
+
+### 4. UserErrorBlock
+
+Represents a user-facing error message. Unlike internal exceptions, these are designed to be shown to the end-user with helpful context.
+
+*   **`block_type`**: `ERROR`
+*   **`user_message`**: A friendly, human-readable error message.
+*   **`technical_details`**: Optional dictionary containing error codes or stack traces for debugging (hidden by default in most UIs).
+*   **`recoverable`**: Boolean indicating if the user can retry the action.
+
+**Example:**
+```python
+from coreason_manifest.definitions.presentation import UserErrorBlock
+
+block = UserErrorBlock(
+    user_message="Unable to connect to the weather service. Please try again later.",
+    technical_details={"status_code": 503, "service": "weather-api"},
+    recoverable=True
+)
+```

--- a/src/coreason_manifest/definitions/__init__.py
+++ b/src/coreason_manifest/definitions/__init__.py
@@ -33,6 +33,13 @@ from .events import (
     WorkflowError,
     WorkflowErrorPayload,
 )
+from .presentation import (
+    DataBlock,
+    MarkdownBlock,
+    PresentationBlockType,
+    ThinkingBlock,
+    UserErrorBlock,
+)
 from .request import AgentRequest
 from .session import Interaction, SessionState
 
@@ -65,4 +72,9 @@ __all__ = [
     "WorkflowErrorPayload",
     "Interaction",
     "SessionState",
+    "PresentationBlockType",
+    "ThinkingBlock",
+    "DataBlock",
+    "MarkdownBlock",
+    "UserErrorBlock",
 ]

--- a/src/coreason_manifest/definitions/presentation.py
+++ b/src/coreason_manifest/definitions/presentation.py
@@ -19,6 +19,7 @@ from coreason_manifest.definitions.base import CoReasonBaseModel
 
 class PresentationBlockType(str, Enum):
     """Enumeration of presentation block types."""
+
     THOUGHT = "THOUGHT"
     DATA = "DATA"
     MARKDOWN = "MARKDOWN"
@@ -31,6 +32,7 @@ def _generate_uuid() -> str:
 
 class PresentationBlock(CoReasonBaseModel):
     """Base model for all presentation blocks."""
+
     block_type: PresentationBlockType
     id: str = Field(default_factory=_generate_uuid)
     title: Optional[str] = None
@@ -38,6 +40,7 @@ class PresentationBlock(CoReasonBaseModel):
 
 class ThinkingBlock(PresentationBlock):
     """Presentation block for internal monologue and planning."""
+
     block_type: Literal[PresentationBlockType.THOUGHT] = PresentationBlockType.THOUGHT
     content: str
     status: Literal["IN_PROGRESS", "COMPLETE"] = "IN_PROGRESS"
@@ -45,6 +48,7 @@ class ThinkingBlock(PresentationBlock):
 
 class DataBlock(PresentationBlock):
     """Presentation block for structured data."""
+
     block_type: Literal[PresentationBlockType.DATA] = PresentationBlockType.DATA
     data: Dict[str, Any]
     view_hint: Literal["TABLE", "JSON", "LIST", "KEY_VALUE"] = "JSON"
@@ -52,12 +56,14 @@ class DataBlock(PresentationBlock):
 
 class MarkdownBlock(PresentationBlock):
     """Presentation block for rich text content."""
+
     block_type: Literal[PresentationBlockType.MARKDOWN] = PresentationBlockType.MARKDOWN
     content: str
 
 
 class UserErrorBlock(PresentationBlock):
     """Presentation block for user-facing errors."""
+
     block_type: Literal[PresentationBlockType.ERROR] = PresentationBlockType.ERROR
     user_message: str
     technical_details: Optional[Dict[str, Any]] = None

--- a/src/coreason_manifest/definitions/presentation.py
+++ b/src/coreason_manifest/definitions/presentation.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import Enum
+from typing import Any, Dict, Literal, Optional
+from uuid import uuid4
+
+from pydantic import Field
+
+from coreason_manifest.definitions.base import CoReasonBaseModel
+
+
+class PresentationBlockType(str, Enum):
+    """Enumeration of presentation block types."""
+    THOUGHT = "THOUGHT"
+    DATA = "DATA"
+    MARKDOWN = "MARKDOWN"
+    ERROR = "ERROR"
+
+
+def _generate_uuid() -> str:
+    return str(uuid4())
+
+
+class PresentationBlock(CoReasonBaseModel):
+    """Base model for all presentation blocks."""
+    block_type: PresentationBlockType
+    id: str = Field(default_factory=_generate_uuid)
+    title: Optional[str] = None
+
+
+class ThinkingBlock(PresentationBlock):
+    """Presentation block for internal monologue and planning."""
+    block_type: Literal[PresentationBlockType.THOUGHT] = PresentationBlockType.THOUGHT
+    content: str
+    status: Literal["IN_PROGRESS", "COMPLETE"] = "IN_PROGRESS"
+
+
+class DataBlock(PresentationBlock):
+    """Presentation block for structured data."""
+    block_type: Literal[PresentationBlockType.DATA] = PresentationBlockType.DATA
+    data: Dict[str, Any]
+    view_hint: Literal["TABLE", "JSON", "LIST", "KEY_VALUE"] = "JSON"
+
+
+class MarkdownBlock(PresentationBlock):
+    """Presentation block for rich text content."""
+    block_type: Literal[PresentationBlockType.MARKDOWN] = PresentationBlockType.MARKDOWN
+    content: str
+
+
+class UserErrorBlock(PresentationBlock):
+    """Presentation block for user-facing errors."""
+    block_type: Literal[PresentationBlockType.ERROR] = PresentationBlockType.ERROR
+    user_message: str
+    technical_details: Optional[Dict[str, Any]] = None
+    recoverable: bool = False

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.definitions.presentation import (
+    DataBlock,
+    MarkdownBlock,
+    PresentationBlockType,
+    ThinkingBlock,
+    UserErrorBlock,
+)
+
+
+def test_thinking_block_serialization() -> None:
+    """Test serialization of ThinkingBlock."""
+    block = ThinkingBlock(content="Thinking about the problem...")
+    dumped = block.dump()
+    assert dumped["block_type"] == "THOUGHT"
+    assert dumped["content"] == "Thinking about the problem..."
+    assert dumped["status"] == "IN_PROGRESS"
+    assert isinstance(dumped["id"], str)
+
+    json_str = block.to_json()
+    # Check for presence of key fields in JSON
+    assert '"block_type":"THOUGHT"' in json_str or '"block_type": "THOUGHT"' in json_str
+
+
+def test_data_block_structure() -> None:
+    """Test DataBlock structure preservation."""
+    data = {"users": [{"name": "Alice", "age": 30}, {"name": "Bob", "age": 25}]}
+    block = DataBlock(data=data, view_hint="TABLE", title="User List")
+    dumped = block.dump()
+
+    assert dumped["block_type"] == "DATA"
+    assert dumped["data"] == data
+    assert dumped["view_hint"] == "TABLE"
+    assert dumped["title"] == "User List"
+
+
+def test_data_block_validation() -> None:
+    """Test validation of DataBlock fields."""
+    # Test invalid view_hint
+    with pytest.raises(ValidationError):
+        DataBlock(data={}, view_hint="SCATTER_PLOT")  # type: ignore
+
+
+def test_markdown_block() -> None:
+    """Test MarkdownBlock."""
+    content = "# Heading\n\n- Item 1\n- Item 2"
+    block = MarkdownBlock(content=content)
+    dumped = block.dump()
+    assert dumped["block_type"] == "MARKDOWN"
+    assert dumped["content"] == content
+
+
+def test_user_error_block() -> None:
+    """Test UserErrorBlock."""
+    block = UserErrorBlock(
+        user_message="Something went wrong",
+        technical_details={"code": 500},
+        recoverable=True
+    )
+    dumped = block.dump()
+    assert dumped["block_type"] == "ERROR"
+    assert dumped["user_message"] == "Something went wrong"
+    assert dumped["technical_details"] == {"code": 500}
+    assert dumped["recoverable"] is True
+
+
+def test_inheritance() -> None:
+    """Verify inheritance from CoReasonBaseModel."""
+    from coreason_manifest.definitions.base import CoReasonBaseModel
+    assert issubclass(ThinkingBlock, CoReasonBaseModel)
+    assert issubclass(DataBlock, CoReasonBaseModel)

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -14,7 +14,6 @@ from pydantic import ValidationError
 from coreason_manifest.definitions.presentation import (
     DataBlock,
     MarkdownBlock,
-    PresentationBlockType,
     ThinkingBlock,
     UserErrorBlock,
 )
@@ -50,7 +49,7 @@ def test_data_block_validation() -> None:
     """Test validation of DataBlock fields."""
     # Test invalid view_hint
     with pytest.raises(ValidationError):
-        DataBlock(data={}, view_hint="SCATTER_PLOT")  # type: ignore
+        DataBlock(data={}, view_hint="SCATTER_PLOT")
 
 
 def test_markdown_block() -> None:
@@ -64,11 +63,7 @@ def test_markdown_block() -> None:
 
 def test_user_error_block() -> None:
     """Test UserErrorBlock."""
-    block = UserErrorBlock(
-        user_message="Something went wrong",
-        technical_details={"code": 500},
-        recoverable=True
-    )
+    block = UserErrorBlock(user_message="Something went wrong", technical_details={"code": 500}, recoverable=True)
     dumped = block.dump()
     assert dumped["block_type"] == "ERROR"
     assert dumped["user_message"] == "Something went wrong"
@@ -79,5 +74,6 @@ def test_user_error_block() -> None:
 def test_inheritance() -> None:
     """Verify inheritance from CoReasonBaseModel."""
     from coreason_manifest.definitions.base import CoReasonBaseModel
+
     assert issubclass(ThinkingBlock, CoReasonBaseModel)
     assert issubclass(DataBlock, CoReasonBaseModel)


### PR DESCRIPTION
Implemented "UI-First" Presentation Schemas to allow agents to emit standardized interim artifacts like thinking processes, structured data, markdown content, and user-facing errors.

Changes:
- Created `src/coreason_manifest/definitions/presentation.py` defining `PresentationBlock` and its subclasses.
- Updated `src/coreason_manifest/definitions/__init__.py` to export the new types.
- Created `tests/test_presentation.py` to verify serialization and validation.
- Created `docs/presentation_schemas.md` detailing the usage of the new schemas.
- Updated `docs/frontend_integration.md` to reference the new presentation schemas.


---
*PR created automatically by Jules for task [18434520157369798187](https://jules.google.com/task/18434520157369798187) started by @gowthamrao*