### PR TITLE
Implement Builder SDK for Coreason Manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ It provides the **"Blueprint"** that all other services (Builder, Engine, Simula
 *   **Token Arithmetic:** Support for `+` and `+=` operators on `GenAITokenUsage`.
 *   **Flexible Tooling:** `ToolCallRequestPart` accepts JSON strings with automatic parsing.
 *   **Enhanced Tracing:** `ReasoningTrace` includes flexible metadata for execution state.
+*   **Builder SDK:** A fluent, strictly-typed Python SDK for defining Agents using Pydantic models.
 
 ## Serialization & Base Model
 
@@ -119,8 +120,30 @@ print(f"Agent '{agent.metadata.name}' definition created and validated.")
 
 For full details, see the [Usage Documentation](docs/usage.md).
 
+## Builder SDK
+
+The **Builder SDK** offers a developer-friendly way to define agents using standard Python classes instead of raw schemas.
+
+```python
+from coreason_manifest.builder import AgentBuilder, TypedCapability
+from pydantic import BaseModel
+
+class MyInput(BaseModel):
+    query: str
+
+class MyOutput(BaseModel):
+    answer: str
+
+cap = TypedCapability("search", "Search tool", MyInput, MyOutput)
+
+agent = AgentBuilder("MyAgent").with_capability(cap).build()
+```
+
+See [docs/builder_sdk.md](docs/builder_sdk.md) for details.
+
 ## Documentation
 
+*   [Builder SDK](docs/builder_sdk.md): Fluent Python API for defining Agents.
 *   [Agent Behavior Protocols](docs/agent_behavior_protocols.md): The standard interfaces for agent implementation.
 *   [Transport-Layer Specification](docs/transport_layer_specification.md): The HTTP/SSE contract for serving agents.
 *   [Frontend Integration](docs/frontend_integration.md): Communicating with the Coreason Engine.

--- a/docs/builder_sdk.md
+++ b/docs/builder_sdk.md
@@ -1,0 +1,116 @@
+# Builder SDK
+
+The **Builder SDK** (`coreason_manifest.builder`) provides a fluent, Pythonic interface for defining Agents. Instead of manually constructing complex dictionary schemas and strictly typed `AgentDefinition` objects, developers can use Pydantic models and a builder pattern to "compile" their agents into the standard Coreason Manifest format.
+
+## Overview
+
+The Builder SDK bridges the gap between Python's strong typing system and Coreason's language-agnostic "Schema-as-Data" architecture.
+
+*   **Typed Capabilities:** Define Inputs/Outputs using standard Pydantic models.
+*   **Fluent Interface:** Chainable methods for configuring the agent.
+*   **Auto-Compilation:** Automatically converts Pydantic models into the required JSON Schemas (`ImmutableDict`).
+*   **Validation:** Ensures the final object satisfies all `AgentDefinition` invariants.
+
+## Usage
+
+### 1. Define Input/Output Models
+
+Use Pydantic `BaseModel` to define the structure of your capability's data.
+
+```python
+from pydantic import BaseModel, Field
+from typing import List
+
+class SearchInput(BaseModel):
+    query: str = Field(..., description="The search query.")
+    max_results: int = Field(5, description="Maximum number of results to return.")
+
+class SearchOutput(BaseModel):
+    results: List[str] = Field(..., description="List of URLs found.")
+```
+
+### 2. Create a Typed Capability
+
+Wrap your models in a `TypedCapability`.
+
+```python
+from coreason_manifest.builder import TypedCapability
+from coreason_manifest.definitions.agent import CapabilityType
+
+search_capability = TypedCapability(
+    name="search",
+    description="Executes a web search.",
+    input_model=SearchInput,
+    output_model=SearchOutput,
+    type=CapabilityType.ATOMIC
+)
+```
+
+### 3. Build the Agent
+
+Use `AgentBuilder` to assemble the agent and compile it into an `AgentDefinition`.
+
+```python
+from coreason_manifest.builder import AgentBuilder
+
+builder = AgentBuilder(
+    name="ResearchAssistant",
+    version="1.0.0",
+    author="Coreason Team"
+)
+
+agent_definition = (
+    builder
+    .with_capability(search_capability)
+    .with_system_prompt("You are a helpful research assistant.")
+    .with_model("gpt-4-turbo")
+    .build()
+)
+
+# agent_definition is now a valid, immutable AgentDefinition object
+# ready for serialization or usage by the Engine.
+print(agent_definition.to_json(indent=2))
+```
+
+## Key Components
+
+### `TypedCapability[InputT, OutputT]`
+
+A generic wrapper that takes two Pydantic model types (`input_model`, `output_model`).
+
+*   **`to_definition()`**: Converts the Pydantic models into JSON Schemas and returns a standard `AgentCapability` object.
+
+### `AgentBuilder`
+
+The main entry point for creating agents.
+
+*   **`with_capability(cap)`**: Adds a capability.
+*   **`with_system_prompt(prompt)`**: Sets the global system instruction.
+*   **`with_model(model, temperature)`**: Configures the LLM settings.
+*   **`build()`**: Validates configuration, generates integrity hashes, and returns the `AgentDefinition`.
+
+## Why use the Builder?
+
+Directly instantiating `AgentDefinition` requires manually writing JSON Schemas in dictionaries:
+
+```python
+# The HARD way (Manual Schema)
+AgentCapability(
+    inputs={
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"}
+        },
+        "required": ["query"]
+    },
+    ...
+)
+```
+
+The Builder allows you to use idiomatic Python:
+
+```python
+# The EASY way (Builder SDK)
+class SearchInput(BaseModel):
+    query: str
+```

--- a/docs/open_agent_specification.md
+++ b/docs/open_agent_specification.md
@@ -2,6 +2,8 @@
 
 The **Open Agent Specification (OAS)** is the core standard used by the Coreason ecosystem to define, configure, and validate AI Agents. It serves as the "Source of Truth," ensuring that agents are portable, strictly typed, and secure.
 
+**Note:** While the OAS is the "machine code" for agents, developers are encouraged to use the **[Builder SDK](builder_sdk.md)** to generate these definitions using Python classes and Pydantic models.
+
 In this repository (`coreason-manifest`), the OAS is implemented as a set of strict **Pydantic v2 models**. These models define the schema for Agents, their relationships (Topology), and their execution requirements.
 
 ## Architecture: The Shared Kernel

--- a/src/coreason_manifest/builder/__init__.py
+++ b/src/coreason_manifest/builder/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from coreason_manifest.builder.agent import AgentBuilder
+from coreason_manifest.builder.capability import TypedCapability
+
+__all__ = ["AgentBuilder", "TypedCapability"]

--- a/src/coreason_manifest/builder/agent.py
+++ b/src/coreason_manifest/builder/agent.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import hashlib
+from datetime import datetime, timezone
+from typing import Optional, Self
+from uuid import uuid4
+
+from coreason_manifest.builder.capability import TypedCapability
+from coreason_manifest.definitions.agent import (
+    AgentDefinition,
+    AgentDependencies,
+    AgentMetadata,
+    AgentRuntimeConfig,
+    ModelConfig,
+)
+
+
+class AgentBuilder:
+    """A fluent builder for constructing valid AgentDefinition objects.
+
+    This builder simplifies the creation of Agent manifests by allowing developers
+    to use Python objects and methods instead of constructing raw dictionaries and
+    schema structures manually.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        version: str = "0.1.0",
+        author: str = "Unknown",
+    ) -> None:
+        """Initialize the AgentBuilder.
+
+        Args:
+            name: Name of the Agent.
+            version: Semantic Version of the Agent.
+            author: Author of the Agent.
+        """
+        self.name = name
+        self.version = version
+        self.author = author
+
+        self._capabilities: list[TypedCapability] = []
+        self._system_prompt: Optional[str] = None
+        self._model_name: str = "gpt-4o"  # Default model
+        self._temperature: float = 0.0
+
+    def with_capability(self, cap: TypedCapability) -> Self:
+        """Add a typed capability to the agent.
+
+        Args:
+            cap: The TypedCapability instance to add.
+
+        Returns:
+            The builder instance (for chaining).
+        """
+        self._capabilities.append(cap)
+        return self
+
+    def with_system_prompt(self, prompt: str) -> Self:
+        """Set the global system prompt for the agent.
+
+        Args:
+            prompt: The system prompt text.
+
+        Returns:
+            The builder instance (for chaining).
+        """
+        self._system_prompt = prompt
+        return self
+
+    def with_model(self, model: str, temperature: float = 0.0) -> Self:
+        """Configure the LLM model for the agent.
+
+        Args:
+            model: The model identifier (e.g., 'gpt-4').
+            temperature: Generation temperature.
+
+        Returns:
+            The builder instance (for chaining).
+        """
+        self._model_name = model
+        self._temperature = temperature
+        return self
+
+    def build(self) -> AgentDefinition:
+        """Construct the final immutable AgentDefinition.
+
+        Compiles all typed capabilities into schemas and assembles the full manifest.
+
+        Returns:
+            A validated AgentDefinition object.
+        """
+        # Generate dummy integrity hash based on name as per instructions
+        integrity_hash = hashlib.sha256(self.name.encode("utf-8")).hexdigest()
+
+        metadata = AgentMetadata(
+            id=uuid4(),
+            version=self.version,
+            name=self.name,
+            author=self.author,
+            created_at=datetime.now(timezone.utc),
+            requires_auth=False,
+        )
+
+        model_config = ModelConfig(
+            model=self._model_name,
+            temperature=self._temperature,
+            system_prompt=self._system_prompt,
+        )
+
+        # Atomic Agent configuration (no nodes/edges)
+        config = AgentRuntimeConfig(
+            nodes=[],
+            edges=[],
+            entry_point=None,
+            model_config=model_config,
+            system_prompt=self._system_prompt,
+        )
+
+        return AgentDefinition(
+            metadata=metadata,
+            capabilities=[cap.to_definition() for cap in self._capabilities],
+            config=config,
+            dependencies=AgentDependencies(),
+            integrity_hash=integrity_hash,
+        )

--- a/src/coreason_manifest/builder/agent.py
+++ b/src/coreason_manifest/builder/agent.py
@@ -10,7 +10,7 @@
 
 import hashlib
 from datetime import datetime, timezone
-from typing import Optional, Self
+from typing import Any, Optional, Self
 from uuid import uuid4
 
 from coreason_manifest.builder.capability import TypedCapability
@@ -48,12 +48,12 @@ class AgentBuilder:
         self.version = version
         self.author = author
 
-        self._capabilities: list[TypedCapability] = []
+        self._capabilities: list[TypedCapability[Any, Any]] = []
         self._system_prompt: Optional[str] = None
         self._model_name: str = "gpt-4o"  # Default model
         self._temperature: float = 0.0
 
-    def with_capability(self, cap: TypedCapability) -> Self:
+    def with_capability(self, cap: TypedCapability[Any, Any]) -> Self:
         """Add a typed capability to the agent.
 
         Args:
@@ -122,7 +122,7 @@ class AgentBuilder:
             nodes=[],
             edges=[],
             entry_point=None,
-            model_config=model_config,
+            llm_config=model_config,
             system_prompt=self._system_prompt,
         )
 

--- a/src/coreason_manifest/builder/capability.py
+++ b/src/coreason_manifest/builder/capability.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Generic, Optional, TypeVar
+
+from pydantic import BaseModel
+
+from coreason_manifest.definitions.agent import AgentCapability, CapabilityType
+
+InputT = TypeVar("InputT", bound=BaseModel)
+OutputT = TypeVar("OutputT", bound=BaseModel)
+
+
+class TypedCapability(Generic[InputT, OutputT]):
+    """A build-time capability wrapper that uses Pydantic models for I/O definitions.
+
+    This class allows developers to define capabilities using strong types (Pydantic models),
+    which are then compiled down to the required JSON Schema format for the Agent Manifest.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        input_model: type[InputT],
+        output_model: type[OutputT],
+        type: CapabilityType = CapabilityType.ATOMIC,
+        injected_params: Optional[list[str]] = None,
+    ) -> None:
+        """Initialize a TypedCapability.
+
+        Args:
+            name: Unique name for this capability.
+            description: What this mode does.
+            input_model: The Pydantic model defining the input structure.
+            output_model: The Pydantic model defining the output structure.
+            type: Interaction mode (default: ATOMIC).
+            injected_params: List of parameters injected by the system (optional).
+        """
+        self.name = name
+        self.description = description
+        self.input_model = input_model
+        self.output_model = output_model
+        self.type = type
+        self.injected_params = injected_params or []
+
+    def to_definition(self) -> AgentCapability:
+        """Compile the typed capability into a strict AgentCapability definition.
+
+        Returns:
+            An instance of AgentCapability with inputs/outputs converted to JSON Schema.
+        """
+        return AgentCapability(
+            name=self.name,
+            type=self.type,
+            description=self.description,
+            inputs=self.input_model.model_json_schema(),
+            outputs=self.output_model.model_json_schema(),
+            injected_params=self.injected_params,
+        )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -59,13 +59,7 @@ def test_full_agent_build() -> None:
     )
 
     builder = AgentBuilder(name="SearchAgent", author="Tester")
-    agent = (
-        builder
-        .with_capability(cap)
-        .with_system_prompt("You are a search agent.")
-        .with_model("gpt-4-turbo")
-        .build()
-    )
+    agent = builder.with_capability(cap).with_system_prompt("You are a search agent.").with_model("gpt-4-turbo").build()
 
     assert isinstance(agent, AgentDefinition)
     assert agent.metadata.name == "SearchAgent"

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import List
+
+from pydantic import BaseModel
+
+from coreason_manifest.builder import AgentBuilder, TypedCapability
+from coreason_manifest.definitions.agent import AgentDefinition
+
+
+class SearchInput(BaseModel):
+    query: str
+
+
+class SearchOutput(BaseModel):
+    results: List[str]
+
+
+def test_capability_compilation() -> None:
+    """Test that TypedCapability correctly compiles Pydantic models to JSON Schema."""
+    cap = TypedCapability(
+        name="search",
+        description="Search the web",
+        input_model=SearchInput,
+        output_model=SearchOutput,
+    )
+
+    definition = cap.to_definition()
+
+    assert definition.name == "search"
+    assert definition.description == "Search the web"
+
+    # Check inputs schema
+    assert "properties" in definition.inputs
+    assert "query" in definition.inputs["properties"]
+    assert definition.inputs["properties"]["query"]["type"] == "string"
+
+    # Check outputs schema
+    assert "properties" in definition.outputs
+    assert "results" in definition.outputs["properties"]
+    assert definition.outputs["properties"]["results"]["type"] == "array"
+
+
+def test_full_agent_build() -> None:
+    """Test that AgentBuilder constructs a valid AgentDefinition."""
+    cap = TypedCapability(
+        name="search",
+        description="Search the web",
+        input_model=SearchInput,
+        output_model=SearchOutput,
+    )
+
+    builder = AgentBuilder(name="SearchAgent", author="Tester")
+    agent = (
+        builder
+        .with_capability(cap)
+        .with_system_prompt("You are a search agent.")
+        .with_model("gpt-4-turbo")
+        .build()
+    )
+
+    assert isinstance(agent, AgentDefinition)
+    assert agent.metadata.name == "SearchAgent"
+    assert agent.metadata.author == "Tester"
+    assert len(agent.capabilities) == 1
+
+    # Verify capability is compiled
+    compiled_cap = agent.capabilities[0]
+    assert compiled_cap.name == "search"
+    assert compiled_cap.inputs["properties"]["query"]["type"] == "string"
+
+    # Verify config
+    assert agent.config.system_prompt == "You are a search agent."
+    assert agent.config.llm_config.model == "gpt-4-turbo"
+    assert agent.config.llm_config.system_prompt == "You are a search agent."
+    assert agent.integrity_hash is not None


### PR DESCRIPTION
Implemented the Builder SDK to allow developers to define agents using Pydantic models and Python classes, improving the developer experience by abstracting away raw JSON Schema construction. The SDK compiles these Python definitions into the strict `AgentDefinition` required by the Coreason Engine.

---
*PR created automatically by Jules for task [13461726760959106588](https://jules.google.com/task/13461726760959106588) started by @gowthamrao*