### PR TITLE
feat: Add topology and tool support to AgentBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ cap = TypedCapability("search", "Search tool", MyInput, MyOutput)
 agent = AgentBuilder("MyAgent").with_capability(cap).build()
 ```
 
+The Builder also supports **Graph Topologies** (`with_node`, `with_edge`) and **External Tools** (`with_tool_requirement`).
+
 See [docs/builder_sdk.md](docs/builder_sdk.md) for details.
 
 ## Documentation

--- a/docs/builder_sdk.md
+++ b/docs/builder_sdk.md
@@ -72,6 +72,37 @@ agent_definition = (
 print(agent_definition.to_json(indent=2))
 ```
 
+### 4. Define Graph Topology (Optional)
+
+You can define complex workflows using Nodes and Edges.
+
+```python
+from coreason_manifest.definitions.topology import LogicNode
+
+node_a = LogicNode(id="start", type="logic", code="print('Start')")
+node_b = LogicNode(id="end", type="logic", code="print('End')")
+
+builder.with_node(node_a)
+builder.with_node(node_b)
+builder.with_edge("start", "end")
+builder.set_entry_point("start")
+```
+
+### 5. Add External Tools (Optional)
+
+You can declare dependencies on external MCP tools.
+
+```python
+from coreason_manifest.definitions.agent import ToolRiskLevel
+
+builder.with_tool_requirement(
+    uri="mcp://google/search",
+    hash="a" * 64,  # Valid SHA256
+    scopes=["read"],
+    risk_level=ToolRiskLevel.STANDARD
+)
+```
+
 ## Key Components
 
 ### `TypedCapability[InputT, OutputT]`
@@ -87,6 +118,10 @@ The main entry point for creating agents.
 *   **`with_capability(cap)`**: Adds a capability.
 *   **`with_system_prompt(prompt)`**: Sets the global system instruction.
 *   **`with_model(model, temperature)`**: Configures the LLM settings.
+*   **`with_node(node)`**: Adds a processing node to the graph.
+*   **`with_edge(source, target, condition)`**: Adds a control flow edge.
+*   **`set_entry_point(node_id)`**: Sets the starting node for graph execution.
+*   **`with_tool_requirement(...)`**: Adds a dependency on an external MCP tool.
 *   **`build()`**: Validates configuration, generates integrity hashes, and returns the `AgentDefinition`.
 
 ## Why use the Builder?

--- a/tests/test_builder_topology.py
+++ b/tests/test_builder_topology.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ValidationError
 
 from coreason_manifest.builder.agent import AgentBuilder
 from coreason_manifest.builder.capability import TypedCapability
-from coreason_manifest.definitions.agent import CapabilityType
+from coreason_manifest.definitions.agent import CapabilityType, ToolRequirement
 from coreason_manifest.definitions.topology import LogicNode
 
 
@@ -37,7 +37,9 @@ def test_builder_with_tools() -> None:
         .build()
     )
     assert len(agent.dependencies.tools) == 1
-    assert str(agent.dependencies.tools[0].uri) == "mcp://google/search"
+    tool = agent.dependencies.tools[0]
+    assert isinstance(tool, ToolRequirement)
+    assert str(tool.uri) == "mcp://google/search"
 
 
 def test_builder_topology() -> None:

--- a/tests/test_builder_topology.py
+++ b/tests/test_builder_topology.py
@@ -1,0 +1,68 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from coreason_manifest.builder.agent import AgentBuilder
+from coreason_manifest.builder.capability import TypedCapability
+from coreason_manifest.definitions.agent import CapabilityType, ToolRiskLevel
+from coreason_manifest.definitions.topology import LogicNode
+
+class SimpleInput(BaseModel):
+    query: str
+
+class SimpleOutput(BaseModel):
+    result: str
+
+def get_valid_agent_builder(name="TestAgent"):
+    cap = TypedCapability(
+        name="test_cap",
+        description="A test capability",
+        input_model=SimpleInput,
+        output_model=SimpleOutput,
+        type=CapabilityType.ATOMIC
+    )
+    return AgentBuilder(name=name).with_capability(cap).with_system_prompt("System Prompt").with_model("gpt-4o")
+
+def test_builder_with_tools():
+    agent = (
+        get_valid_agent_builder(name="ToolAgent")
+        .with_tool_requirement(
+            uri="mcp://google/search",
+            hash="a" * 64, # Valid SHA256 length
+            scopes=["read"]
+        )
+        .build()
+    )
+    assert len(agent.dependencies.tools) == 1
+    assert str(agent.dependencies.tools[0].uri) == "mcp://google/search"
+
+def test_builder_topology():
+    node_a = LogicNode(id="start", type="logic", code="print('start')")
+    node_b = LogicNode(id="end", type="logic", code="print('end')")
+
+    agent = (
+        get_valid_agent_builder(name="GraphAgent")
+        .with_node(node_a)
+        .with_node(node_b)
+        .with_edge("start", "end")
+        .set_entry_point("start")
+        .build()
+    )
+
+    assert len(agent.config.nodes) == 2
+    assert len(agent.config.edges) == 1
+    assert agent.config.entry_point == "start"
+
+def test_builder_validation_failure():
+    """Attempt to build a graph with nodes but without setting an entry point."""
+    node_a = LogicNode(id="start", type="logic", code="print('start')")
+
+    builder = (
+        get_valid_agent_builder(name="InvalidGraphAgent")
+        .with_node(node_a)
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        builder.build()
+
+    # Check that the error message contains the expected validation error
+    assert "Graph execution requires an 'entry_point'" in str(excinfo.value)


### PR DESCRIPTION
Extend AgentBuilder to support Graph Execution (Nodes/Edges) and External Tools (MCP) configuration.

---
*PR created automatically by Jules for task [9109663804415321193](https://jules.google.com/task/9109663804415321193) started by @gowthamrao*