### PR TITLE
docs: fix inconsistencies with code

### DIFF
--- a/docs/maco_recipe_specification.md
+++ b/docs/maco_recipe_specification.md
@@ -123,8 +123,22 @@ Represents dynamic routing where one source can lead to multiple possible target
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `source_node_id` | `str` | The ID of the source node. |
-| `router_logic` | `RouterDefinition` | Python function or expression that returns the next node ID key. |
+| `router_logic` | `RouterDefinition` | A reference to a python function or a logic expression that determines the path. |
 | `mapping` | `Dict[str, str]` | Map of router output values to target node IDs. |
+
+### RouterDefinition
+
+The `router_logic` field accepts a `RouterDefinition`, which is a union of:
+
+1.  **`RouterRef` (String):** A dotted-path reference to a Python function (e.g., `my_module.routers.my_function`).
+2.  **`RouterExpression` (Object):** A structured logic expression.
+
+#### `RouterExpression`
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `operator` | `str` | The operator (e.g., 'eq', 'gt'). |
+| `args` | `List[Any]` | Arguments for the expression. |
 
 ---
 

--- a/docs/open_agent_specification.md
+++ b/docs/open_agent_specification.md
@@ -62,7 +62,10 @@ An `AgentDefinition` consists of the following sections:
     *   `retention_policy`: How long logs are kept.
     *   `encryption_key_id`: Optional ID of the key used for log encryption.
 
-8.  **Integrity**:
+8.  **Custom Metadata (`custom_metadata`)**:
+    *   Container for arbitrary metadata extensions without breaking validation.
+
+9.  **Integrity**:
     *   `integrity_hash`: SHA256 hash of the source code (top-level field).
 
 ## Agent Types: Atomic vs. Graph


### PR DESCRIPTION
Updated documentation files to align with the actual code implementation in `src/coreason_manifest`.

1.  `docs/maco_recipe_specification.md`: Corrected the description of `RouterDefinition` in `ConditionalEdge`. It now accurately reflects that it can be a `RouterRef` (string) or a `RouterExpression` (object), rather than just "Python function or expression".
2.  `docs/open_agent_specification.md`: Added the `custom_metadata` field to the `AgentDefinition` component list, which was present in the Pydantic model but missing from the docs.

---
*PR created automatically by Jules for task [17468707678641323772](https://jules.google.com/task/17468707678641323772) started by @gowthamrao*