### PR TITLE
Refactor: Rename OAS to Coreason Agent Manifest (CAM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,12 @@ The definitive source of truth for CoReason-AI Asset definitions. "The Blueprint
 
 It provides the **"Blueprint"** that all other services (Builder, Engine, Simulator) rely on. It focuses on strict typing, schema validation, and serialization, ensuring that if it isn't in the manifest, it doesn't exist.
 
+### Standards Clarification
+*Note: The "Coreason Agent Manifest" (CAM) is a proprietary, strict governance schema designed for the CoReason Platform. It is distinct from the Oracle/Linux Foundation "Open Agent Specification," though we aim for future interoperability via adapters.*
+
 ## Features
 
-*   **Open Agent Specification (OAS):** Strict Pydantic models for Agent definitions (`AgentDefinition`).
+*   **Coreason Agent Manifest (CAM):** Strict Pydantic models for Agent definitions (`AgentDefinition`).
 *   **Behavioral Protocols:** Standard `AgentInterface` and `LifecycleInterface` protocols for runtime interoperability.
 *   **Strict Typing:** Enforces type safety and immutable structures for critical interfaces.
 *   **Enhanced Serialization:** Includes `CoReasonBaseModel` to ensure consistent JSON serialization of complex types like `UUID` and `datetime`.

--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -1,16 +1,16 @@
-# Open Agent Specification (OAS)
+# Coreason Agent Manifest (CAM)
 
-The **Open Agent Specification (OAS)** is the core standard used by the Coreason ecosystem to define, configure, and validate AI Agents. It serves as the "Source of Truth," ensuring that agents are portable, strictly typed, and secure.
+The **Coreason Agent Manifest (CAM)** is the core standard used by the Coreason ecosystem to define, configure, and validate AI Agents. It serves as the "Source of Truth," ensuring that agents are portable, strictly typed, and secure.
 
-**Note:** While the OAS is the "machine code" for agents, developers are encouraged to use the **[Builder SDK](builder_sdk.md)** to generate these definitions using Python classes and Pydantic models.
+**Note:** While the CAM is the "machine code" for agents, developers are encouraged to use the **[Builder SDK](builder_sdk.md)** to generate these definitions using Python classes and Pydantic models.
 
-In this repository (`coreason-manifest`), the OAS is implemented as a set of strict **Pydantic v2 models**. These models define the schema for Agents, their relationships (Topology), and their execution requirements.
+In this repository (`coreason-manifest`), the CAM is implemented as a set of strict **Pydantic v2 models**. These models define the schema for Agents, their relationships (Topology), and their execution requirements.
 
 ## Architecture: The Shared Kernel
 
 The `coreason-manifest` package acts as a **Shared Kernel**. It contains *only* data structures, schemas, and validation logic. It does not contain execution engines, server logic, or database drivers.
 
-By centralizing the definitions here, all downstream services (Builder, Engine/MACO, Simulator) interact with a single, unified language. If a field or concept does not exist in the OAS, it does not exist in the platform.
+By centralizing the definitions here, all downstream services (Builder, Engine/MACO, Simulator) interact with a single, unified language. If a field or concept does not exist in the CAM, it does not exist in the platform.
 
 ## The Agent Manifest
 
@@ -70,7 +70,7 @@ An `AgentDefinition` consists of the following sections:
 
 ## Agent Types: Atomic vs. Graph
 
-The OAS supports two distinct architectural patterns via `AgentRuntimeConfig`:
+The CAM supports two distinct architectural patterns via `AgentRuntimeConfig`:
 
 ### 1. Atomic Agents
 An Atomic Agent is a single-step execution unit. It relies on a System Prompt and an LLM to process inputs and generate outputs.
@@ -100,7 +100,7 @@ Both share the `GraphTopology` structure (from `src/coreason_manifest/definition
 ## Key Value Propositions
 
 ### 1. Strict Typing & Validation
-Built on Pydantic v2, the OAS enforces types at runtime. Invalid UUIDs, malformed semantic versions, or missing required fields cause immediate validation errors, preventing invalid states from entering the system.
+Built on Pydantic v2, the CAM enforces types at runtime. Invalid UUIDs, malformed semantic versions, or missing required fields cause immediate validation errors, preventing invalid states from entering the system.
 
 ### 2. Integrity & Security
 *   **Integrity Hashing**: The `integrity_hash` field (SHA256) ensures that the agent definition has not been tampered with since creation.
@@ -111,7 +111,7 @@ All models inherit from `CoReasonBaseModel`, which solves common serialization i
 
 ## Example Usage
 
-Here is how to programmatically define an Agent using the OAS:
+Here is how to programmatically define an Agent using the CAM:
 
 ```python
 import uuid

--- a/docs/product_requirements.md
+++ b/docs/product_requirements.md
@@ -12,9 +12,12 @@
 **Mission:** The definitive source of truth for Asset definitions and Schemas.
 
 **Responsibilities (Shared Kernel):**
-*   **Defines** the Open Agent Specifications (OAS) and strict Pydantic models.
+*   **Defines** the Coreason Agent Manifest (CAM) and strict Pydantic models.
 *   **Provides** the data structures required for compliance enforcement and integrity verification.
 *   **Ensures** strict typing and consistent serialization across the ecosystem.
+
+### Standards Clarification
+*Note: The "Coreason Agent Manifest" (CAM) is a proprietary, strict governance schema designed for the CoReason Platform. It is distinct from the Oracle/Linux Foundation "Open Agent Specification," though we aim for future interoperability via adapters.*
 
 **Note:** Active policy enforcement (e.g., OPA Rego checks) and artifact integrity verification (hashing source files) are performed by consumer services (e.g., Builder, Engine) *using* the schemas defined in this package.
 
@@ -38,7 +41,7 @@ You are strictly forbidden from embedding execution logic or side effects within
 ### 2. Business Logic Specifications (The Source of Truth)
 The package acts as the validator for the "Agent Development Lifecycle" (ADLC). It ensures that every "Agent" produced by the factory meets strict GxP and security standards.
 
-#### 2.1 The Open Agent Specification (OAS)
+#### 2.1 The Coreason Agent Manifest (CAM)
 You must define the strict schema for a CoReason Agent. A valid Agent Manifest (`agent.yaml`) contains:
 *   **Metadata:** `id` (UUID), `version` (SemVer), `name`, `author`, `created_at`.
 *   **Interface:**

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -10,8 +10,8 @@
 
 """Pydantic models for the Coreason Manifest system.
 
-These models define the structure and validation rules for the Agent Manifest
-(OAS). They represent the source of truth for Agent definitions.
+These models define the structure and validation rules for the Coreason Agent Manifest
+(CAM). They represent the source of truth for Agent definitions.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Renames internal standard from OAS to CAM to avoid confusion with the Linux Foundation OAS.
Updates documentation and docstrings.
Adds clarification note in README and requirements docs.

---
*PR created automatically by Jules for task [12700634493527598017](https://jules.google.com/task/12700634493527598017) started by @gowthamrao*