### PR TITLE
feat: Support strict Multi-Modal Inputs in Interaction model

### DIFF
--- a/docs/multimodal_inputs.md
+++ b/docs/multimodal_inputs.md
@@ -1,0 +1,73 @@
+# Multi-Modal Inputs
+
+As of version `0.12.0`, `coreason-manifest` supports a strictly typed structure for handling multi-modal inputs (text mixed with files). This replaces the loose `Dict[str, Any]` previously used in interactions, although the dictionary format remains supported for backward compatibility.
+
+## The `MultiModalInput` Model
+
+The `MultiModalInput` model serves as the standard container for user inputs. It wraps a list of `ContentPart` objects.
+
+```python
+from coreason_manifest.definitions.message import MultiModalInput, ContentPart
+
+# Example: A user asking to analyze a PDF
+input_payload = MultiModalInput(
+    parts=[
+        ContentPart(
+            text="Please analyze this financial report for risks.",
+            file_ids=["file-uuid-1234-5678"],
+            mime_type="application/pdf"
+        )
+    ]
+)
+```
+
+### `ContentPart`
+
+A `ContentPart` represents a discrete unit of input. It allows associating text with specific files.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `text` | `Optional[str]` | The text content (e.g., instructions, questions). |
+| `file_ids` | `List[str]` | A list of string IDs referencing uploaded files/assets. |
+| `mime_type` | `Optional[str]` | The MIME type of the content (e.g., `image/png`, `application/pdf`). |
+
+## Usage in Sessions
+
+The `Interaction` model in `coreason_manifest.definitions.session` now accepts `MultiModalInput` in its `input` field.
+
+```python
+from coreason_manifest.definitions.session import Interaction
+
+interaction = Interaction(
+    input=input_payload,  # Strictly typed MultiModalInput
+    output={"role": "assistant", "content": "Analysis complete."},
+)
+```
+
+## JSON Serialization
+
+Like all `CoReasonBaseModel`s, `MultiModalInput` serializes to standard JSON:
+
+```json
+{
+  "parts": [
+    {
+      "text": "Please analyze this financial report for risks.",
+      "file_ids": ["file-uuid-1234-5678"],
+      "mime_type": "application/pdf"
+    }
+  ]
+}
+```
+
+## Backward Compatibility
+
+The `Interaction` input field is defined as `Union[MultiModalInput, Dict[str, Any]]`. This means existing agents that rely on unstructured dictionaries will continue to work without modification.
+
+```python
+# Legacy style (still valid)
+interaction = Interaction(
+    input={"text": "Hello world"},
+    output=...
+)
+```

--- a/docs/session_management.md
+++ b/docs/session_management.md
@@ -20,11 +20,16 @@ The `Interaction` model is immutable (`frozen=True`) to ensure history integrity
 
 ```python
 from coreason_manifest.definitions.session import Interaction
+from coreason_manifest.definitions.message import MultiModalInput, ContentPart
 from coreason_manifest.definitions.events import GraphEventNodeInit, NodeInit
 
-# Example: Creating an interaction
+# Example: Creating an interaction with strictly typed input
+input_payload = MultiModalInput(
+    parts=[ContentPart(text="Hello, world!")]
+)
+
 interaction = Interaction(
-    input={"role": "user", "content": "Hello, world!"},
+    input=input_payload,
     output={"role": "assistant", "content": "Hi there!"},
     events=[
         GraphEventNodeInit(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.10.0"
+version = "0.12.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.10.0"
+version = "0.12.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/definitions/message.py
+++ b/src/coreason_manifest/definitions/message.py
@@ -186,3 +186,26 @@ class ToolCall(CoReasonBaseModel):
 
 
 Message = ChatMessage
+
+
+# --- Multi-Modal Inputs ---
+
+
+class ContentPart(CoReasonBaseModel):
+    """Represents a part of a multi-modal input prompt."""
+
+    model_config = ConfigDict(frozen=True)
+
+    text: Optional[str] = None
+    file_ids: List[str] = Field(
+        default_factory=list, description="List of strings, referencing uploaded assets"
+    )
+    mime_type: Optional[str] = Field(None, description="MIME type of the content (e.g., application/pdf)")
+
+
+class MultiModalInput(CoReasonBaseModel):
+    """Acts as a wrapper for a list of ContentParts, effectively replacing the need for unstructured dictionaries."""
+
+    model_config = ConfigDict(frozen=True)
+
+    parts: List[ContentPart]

--- a/src/coreason_manifest/definitions/message.py
+++ b/src/coreason_manifest/definitions/message.py
@@ -197,9 +197,7 @@ class ContentPart(CoReasonBaseModel):
     model_config = ConfigDict(frozen=True)
 
     text: Optional[str] = None
-    file_ids: List[str] = Field(
-        default_factory=list, description="List of strings, referencing uploaded assets"
-    )
+    file_ids: List[str] = Field(default_factory=list, description="List of strings, referencing uploaded assets")
     mime_type: Optional[str] = Field(None, description="MIME type of the content (e.g., application/pdf)")
 
 

--- a/src/coreason_manifest/definitions/session.py
+++ b/src/coreason_manifest/definitions/session.py
@@ -9,13 +9,14 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID, uuid4
 
 from pydantic import ConfigDict, Field
 
 from coreason_manifest.definitions.base import CoReasonBaseModel
 from coreason_manifest.definitions.events import GraphEvent
+from coreason_manifest.definitions.message import MultiModalInput
 
 
 class Interaction(CoReasonBaseModel):
@@ -27,7 +28,7 @@ class Interaction(CoReasonBaseModel):
     timestamp: datetime = Field(
         default_factory=lambda: datetime.now(timezone.utc), description="Timestamp of the interaction (UTC)"
     )
-    input: Dict[str, Any] = Field(..., description="The raw input payload")
+    input: Union[MultiModalInput, Dict[str, Any]] = Field(..., description="The raw input payload")
     output: Dict[str, Any] = Field(..., description="The final output payload")
     events: List[GraphEvent] = Field(
         default_factory=list, description="A log of intermediate events emitted during this turn"

--- a/tests/test_multimodal_input.py
+++ b/tests/test_multimodal_input.py
@@ -1,7 +1,9 @@
 import pytest
+from pydantic import ValidationError
+
 from coreason_manifest.definitions.message import ContentPart, MultiModalInput
 from coreason_manifest.definitions.session import Interaction
-from uuid import uuid4
+
 
 def test_content_part_instantiation() -> None:
     # Test strict instantiation
@@ -17,8 +19,9 @@ def test_content_part_instantiation() -> None:
     assert part.mime_type is None
 
     # Test immutability
-    with pytest.raises(Exception): # ValidationError or FrozenInstanceError
-        part.text = "New Text" # type: ignore
+    with pytest.raises(ValidationError):
+        part.text = "New Text"  # type: ignore
+
 
 def test_multimodal_input_instantiation() -> None:
     part = ContentPart(text="Check this file", file_ids=["file-1"])
@@ -27,8 +30,9 @@ def test_multimodal_input_instantiation() -> None:
     assert input_obj.parts[0].text == "Check this file"
 
     # Test immutability
-    with pytest.raises(Exception):
-        input_obj.parts = [] # type: ignore
+    with pytest.raises(ValidationError):
+        input_obj.parts = []  # type: ignore
+
 
 def test_interaction_with_multimodal_input() -> None:
     part = ContentPart(text="Here is the report", file_ids=["f-999"])
@@ -46,6 +50,7 @@ def test_interaction_with_multimodal_input() -> None:
     json_str = interaction.to_json()
     assert "f-999" in json_str
     assert "Here is the report" in json_str
+
 
 def test_interaction_backward_compatibility() -> None:
     # Test with Dict

--- a/tests/test_multimodal_input.py
+++ b/tests/test_multimodal_input.py
@@ -1,0 +1,61 @@
+import pytest
+from coreason_manifest.definitions.message import ContentPart, MultiModalInput
+from coreason_manifest.definitions.session import Interaction
+from uuid import uuid4
+
+def test_content_part_instantiation() -> None:
+    # Test strict instantiation
+    part = ContentPart(text="Hello", file_ids=["file-123"], mime_type="text/plain")
+    assert part.text == "Hello"
+    assert part.file_ids == ["file-123"]
+    assert part.mime_type == "text/plain"
+
+    # Test defaults
+    part = ContentPart()
+    assert part.text is None
+    assert part.file_ids == []
+    assert part.mime_type is None
+
+    # Test immutability
+    with pytest.raises(Exception): # ValidationError or FrozenInstanceError
+        part.text = "New Text" # type: ignore
+
+def test_multimodal_input_instantiation() -> None:
+    part = ContentPart(text="Check this file", file_ids=["file-1"])
+    input_obj = MultiModalInput(parts=[part])
+    assert len(input_obj.parts) == 1
+    assert input_obj.parts[0].text == "Check this file"
+
+    # Test immutability
+    with pytest.raises(Exception):
+        input_obj.parts = [] # type: ignore
+
+def test_interaction_with_multimodal_input() -> None:
+    part = ContentPart(text="Here is the report", file_ids=["f-999"])
+    mm_input = MultiModalInput(parts=[part])
+
+    interaction = Interaction(
+        input=mm_input,
+        output={"response": "Acknowledged"},
+    )
+
+    assert isinstance(interaction.input, MultiModalInput)
+    assert interaction.input.parts[0].file_ids == ["f-999"]
+
+    # Verify JSON serialization
+    json_str = interaction.to_json()
+    assert "f-999" in json_str
+    assert "Here is the report" in json_str
+
+def test_interaction_backward_compatibility() -> None:
+    # Test with Dict
+    interaction = Interaction(
+        input={"text": "legacy input"},
+        output={"response": "ok"},
+    )
+
+    assert isinstance(interaction.input, dict)
+    assert interaction.input["text"] == "legacy input"
+
+    json_str = interaction.to_json()
+    assert "legacy input" in json_str

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -26,6 +26,7 @@ def test_interaction_creation() -> None:
     )
     assert interaction.interaction_id is not None
     assert interaction.timestamp is not None
+    assert isinstance(interaction.input, dict)
     assert interaction.input["content"] == "hello"
     assert interaction.output["content"] == "hi"
     assert interaction.events == []


### PR DESCRIPTION
This PR introduces strict Pydantic models for handling multi-modal inputs (text mixed with files), fulfilling the requirement to modernize the library's input definitions. 
 
**Changes:** 
*   **`src/coreason_manifest/definitions/message.py`**: Added `ContentPart` (supporting text, file_ids, mime_type) and `MultiModalInput` (wrapper). 
*   **`src/coreason_manifest/definitions/session.py`**: Updated `Interaction` model to accept `MultiModalInput` in the `input` field, while maintaining backward compatibility for `Dict`. 
*   **Documentation**: Created `docs/multimodal_inputs.md` detailing usage and updated `docs/session_management.md` with new examples. 
*   **Version**: Bumped to 0.12.0. 
 
**Verification:** 
*   New tests in `tests/test_multimodal_input.py` verify instantiation, immutability, JSON serialization, and backward compatibility. All tests passed.

---
*PR created automatically by Jules for task [17278638746782770642](https://jules.google.com/task/17278638746782770642) started by @gowthamrao*