### PR TITLE
Refactor ContentPart to use strict AttachedFile list

### DIFF
--- a/docs/multimodal_inputs.md
+++ b/docs/multimodal_inputs.md
@@ -7,15 +7,16 @@ As of version `0.12.0`, `coreason-manifest` supports a strictly typed structure 
 The `MultiModalInput` model serves as the standard container for user inputs. It wraps a list of `ContentPart` objects.
 
 ```python
-from coreason_manifest.definitions.message import MultiModalInput, ContentPart
+from coreason_manifest.definitions.message import MultiModalInput, ContentPart, AttachedFile
 
 # Example: A user asking to analyze a PDF
 input_payload = MultiModalInput(
     parts=[
         ContentPart(
             text="Please analyze this financial report for risks.",
-            file_ids=["file-uuid-1234-5678"],
-            mime_type="application/pdf"
+            attachments=[
+                AttachedFile(id="file-uuid-1234-5678", mime_type="application/pdf")
+            ]
         )
     ]
 )
@@ -28,8 +29,7 @@ A `ContentPart` represents a discrete unit of input. It allows associating text 
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `text` | `Optional[str]` | The text content (e.g., instructions, questions). |
-| `file_ids` | `List[str]` | A list of string IDs referencing uploaded files/assets. |
-| `mime_type` | `Optional[str]` | The MIME type of the content (e.g., `image/png`, `application/pdf`). |
+| `attachments` | `List[AttachedFile]` | A list of attached files, where each file has an `id` and optional `mime_type`. |
 
 ## Usage in Sessions
 
@@ -53,8 +53,12 @@ Like all `CoReasonBaseModel`s, `MultiModalInput` serializes to standard JSON:
   "parts": [
     {
       "text": "Please analyze this financial report for risks.",
-      "file_ids": ["file-uuid-1234-5678"],
-      "mime_type": "application/pdf"
+      "attachments": [
+        {
+          "id": "file-uuid-1234-5678",
+          "mime_type": "application/pdf"
+        }
+      ]
     }
   ]
 }

--- a/src/coreason_manifest/definitions/message.py
+++ b/src/coreason_manifest/definitions/message.py
@@ -191,14 +191,26 @@ Message = ChatMessage
 # --- Multi-Modal Inputs ---
 
 
+class AttachedFile(CoReasonBaseModel):
+    """Represents a file attached to a user input message."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(..., description="The unique identifier of the uploaded file")
+    mime_type: Optional[str] = Field(None, description="MIME type of the file (e.g., application/pdf)")
+
+
 class ContentPart(CoReasonBaseModel):
-    """Represents a part of a multi-modal input prompt."""
+    """Represents a part of a multi-modal input prompt (User -> System).
+
+    Distinction: This is for Ingress (User Input), whereas 'Part' and 'ChatMessage'
+    are for the Internal Flow (System <-> LLM).
+    """
 
     model_config = ConfigDict(frozen=True)
 
     text: Optional[str] = None
-    file_ids: List[str] = Field(default_factory=list, description="List of strings, referencing uploaded assets")
-    mime_type: Optional[str] = Field(None, description="MIME type of the content (e.g., application/pdf)")
+    attachments: List[AttachedFile] = Field(default_factory=list, description="List of attached files")
 
 
 class MultiModalInput(CoReasonBaseModel):

--- a/tests/test_multimodal_input.py
+++ b/tests/test_multimodal_input.py
@@ -1,8 +1,9 @@
-import pytest
 import json
+
+import pytest
 from pydantic import ValidationError
 
-from coreason_manifest.definitions.message import ContentPart, MultiModalInput, AttachedFile
+from coreason_manifest.definitions.message import AttachedFile, ContentPart, MultiModalInput
 from coreason_manifest.definitions.session import Interaction
 
 


### PR DESCRIPTION
This PR refactors the `ContentPart` model in `src/coreason_manifest/definitions/message.py` to address a data modeling ambiguity. Previously, `ContentPart` used a list of `file_ids` and a single `mime_type` field, which was problematic when multiple files of different types were attached. The new implementation replaces these fields with a list of `AttachedFile` objects, each containing its own `id` and `mime_type`.

This change ensures that every attached file is correctly associated with its specific MIME type, improving robustness and clarity for consuming systems.

**Changes:**
- Added `AttachedFile` model in `src/coreason_manifest/definitions/message.py`.
- Updated `ContentPart` to replace `file_ids` and `mime_type` with `attachments`.
- Updated tests in `tests/test_multimodal_input.py`.
- Updated documentation in `docs/multimodal_inputs.md`.
- Added docstrings to `ContentPart` and related classes to clarify usage context (Ingress vs Internal).

---
*PR created automatically by Jules for task [5934242736852312940](https://jules.google.com/task/5934242736852312940) started by @gowthamrao*