### PR TITLE
Explicit Streaming Contracts

### DIFF
--- a/docs/builder_sdk.md
+++ b/docs/builder_sdk.md
@@ -35,14 +35,16 @@ Wrap your models in a `TypedCapability`.
 
 ```python
 from coreason_manifest.builder import TypedCapability
-from coreason_manifest.definitions.agent import CapabilityType
+from coreason_manifest.definitions.agent import CapabilityType, DeliveryMode
 
 search_capability = TypedCapability(
     name="search",
     description="Executes a web search.",
     input_model=SearchInput,
     output_model=SearchOutput,
-    type=CapabilityType.ATOMIC
+    type=CapabilityType.ATOMIC,
+    # Optional: Explicitly set delivery mode (Defaults to REQUEST_RESPONSE)
+    delivery_mode=DeliveryMode.REQUEST_RESPONSE
 )
 ```
 
@@ -109,6 +111,11 @@ builder.with_tool_requirement(
 
 A generic wrapper that takes two Pydantic model types (`input_model`, `output_model`).
 
+*   **Arguments**:
+    *   `name`, `description`: Metadata.
+    *   `input_model`, `output_model`: Pydantic classes.
+    *   `type`: `ATOMIC` or `GRAPH`.
+    *   `delivery_mode`: `REQUEST_RESPONSE` (default) or `SERVER_SENT_EVENTS`.
 *   **`to_definition()`**: Converts the Pydantic models into JSON Schemas and returns a standard `AgentCapability` object.
 
 ### `AgentBuilder`

--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -29,6 +29,7 @@ An `AgentDefinition` consists of the following sections:
 2.  **Capabilities (`List[AgentCapability]`)**:
     *   Defines the modes of interaction for the agent (e.g., "Atomic", "Streaming").
     *   Each capability has a unique `name`, `type`, and `description`.
+    *   **Delivery Mode**: `delivery_mode` explicitly declares whether the client should expect a single `REQUEST_RESPONSE` or a stream of `SERVER_SENT_EVENTS`.
     *   `inputs` and `outputs` are defined using immutable dictionaries (representing JSON Schemas).
     *   `injected_params` lists system-injected values (e.g., `user_context`).
 
@@ -146,7 +147,8 @@ agent = AgentDefinition(
             type=CapabilityType.ATOMIC,
             description="Get the weather forecast.",
             inputs={"location": {"type": "string"}},
-            outputs={"forecast": {"type": "string"}}
+            outputs={"forecast": {"type": "string"}},
+            # delivery_mode defaults to REQUEST_RESPONSE
         )
     ],
 

--- a/docs/explicit_streaming_contracts.md
+++ b/docs/explicit_streaming_contracts.md
@@ -1,0 +1,68 @@
+# Explicit Streaming Contracts
+
+**Explicit Streaming Contracts** eliminate the ambiguity between *what* an agent does (its internal architecture) and *how* it delivers results to the client (the transport protocol).
+
+## The Problem: Implicit Behavior
+
+Previously, the `AgentCapability` model relied on the `type` field (`ATOMIC` vs `GRAPH`) to imply the delivery mechanism.
+*   **Assumption:** "Atomic agents are fast, so they return JSON. Graph agents are slow, so they stream SSE."
+
+This assumption is flawed:
+1.  **Long-running Atomic Agents:** An atomic agent might generate a long report (LLM streaming) or call a slow tool. The client needs to know to keep the connection open and render partial tokens.
+2.  **Fast Graph Agents:** A simple graph might just categorize an email and return a label instantly. Using SSE for this is overkill.
+
+## The Solution: Decoupling Type and Delivery
+
+We have introduced the `delivery_mode` field to the `AgentCapability` model. This creates a matrix of possibilities:
+
+| Capability Type | Delivery Mode | Behavior | Use Case |
+| :--- | :--- | :--- | :--- |
+| `ATOMIC` | `REQUEST_RESPONSE` (Default) | Client awaits a single JSON response. | Simple QA, classification, data extraction. |
+| `ATOMIC` | `SERVER_SENT_EVENTS` | Client listens for `CloudEvent` stream. | LLM token streaming, long tool execution updates. |
+| `GRAPH` | `SERVER_SENT_EVENTS` | Client listens for `GraphEvent` stream. | Complex workflows, visual debugging, human-in-the-loop. |
+| `GRAPH` | `REQUEST_RESPONSE` | Client awaits final workflow state. | "Black box" automation where intermediate steps don't matter. |
+
+## Implementation
+
+### Manifest Definition
+
+The `AgentCapability` now includes:
+
+```python
+class DeliveryMode(str, Enum):
+    REQUEST_RESPONSE = "request_response"
+    SERVER_SENT_EVENTS = "server_sent_events"
+
+class AgentCapability(CoReasonBaseModel):
+    # ... other fields
+    delivery_mode: DeliveryMode = Field(
+        default=DeliveryMode.REQUEST_RESPONSE,
+        description="The mechanism used to deliver the response."
+    )
+```
+
+### Builder SDK
+
+You can define this explicitly when building agents:
+
+```python
+from coreason_manifest.definitions.agent import DeliveryMode, CapabilityType
+
+# Atomic agent that streams tokens
+cap = TypedCapability(
+    name="write_essay",
+    input_model=TopicInput,
+    output_model=EssayOutput,
+    type=CapabilityType.ATOMIC,
+    delivery_mode=DeliveryMode.SERVER_SENT_EVENTS  # <--- Explicit
+)
+```
+
+## Client Impact
+
+Frontend clients (React, Flutter) can now inspect the `delivery_mode` *before* making a request.
+
+*   **If `REQUEST_RESPONSE`:** Use standard `fetch` or `axios.post`. Await the promise.
+*   **If `SERVER_SENT_EVENTS`:** Use `EventSource` or a fetch-based stream reader. Hook up event listeners.
+
+This eliminates "guesswork" and prevents connection timeouts on long requests that were mistakenly treated as standard HTTP calls.

--- a/src/coreason_manifest/builder/capability.py
+++ b/src/coreason_manifest/builder/capability.py
@@ -12,7 +12,7 @@ from typing import Generic, Optional, TypeVar
 
 from pydantic import BaseModel
 
-from coreason_manifest.definitions.agent import AgentCapability, CapabilityType
+from coreason_manifest.definitions.agent import AgentCapability, CapabilityType, DeliveryMode
 
 InputT = TypeVar("InputT", bound=BaseModel)
 OutputT = TypeVar("OutputT", bound=BaseModel)
@@ -33,6 +33,7 @@ class TypedCapability(Generic[InputT, OutputT]):
         output_model: type[OutputT],
         type: CapabilityType = CapabilityType.ATOMIC,
         injected_params: Optional[list[str]] = None,
+        delivery_mode: DeliveryMode = DeliveryMode.REQUEST_RESPONSE,
     ) -> None:
         """Initialize a TypedCapability.
 
@@ -43,6 +44,7 @@ class TypedCapability(Generic[InputT, OutputT]):
             output_model: The Pydantic model defining the output structure.
             type: Interaction mode (default: ATOMIC).
             injected_params: List of parameters injected by the system (optional).
+            delivery_mode: The mechanism used to deliver the response.
         """
         self.name = name
         self.description = description
@@ -50,6 +52,7 @@ class TypedCapability(Generic[InputT, OutputT]):
         self.output_model = output_model
         self.type = type
         self.injected_params = injected_params or []
+        self.delivery_mode = delivery_mode
 
     def to_definition(self) -> AgentCapability:
         """Compile the typed capability into a strict AgentCapability definition.
@@ -64,4 +67,5 @@ class TypedCapability(Generic[InputT, OutputT]):
             inputs=self.input_model.model_json_schema(),
             outputs=self.output_model.model_json_schema(),
             injected_params=self.injected_params,
+            delivery_mode=self.delivery_mode,
         )

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -135,6 +135,13 @@ class CapabilityType(str, Enum):
     STREAMING = "streaming"
 
 
+class DeliveryMode(str, Enum):
+    """The delivery mechanism for the capability response."""
+
+    REQUEST_RESPONSE = "request_response"
+    SERVER_SENT_EVENTS = "server_sent_events"
+
+
 class AgentCapability(CoReasonBaseModel):
     """Defines a specific mode of interaction for the agent.
 
@@ -146,6 +153,7 @@ class AgentCapability(CoReasonBaseModel):
         outputs: Typed structure of the result.
         events: List of intermediate events this agent produces during execution.
         injected_params: List of parameters injected by the system.
+        delivery_mode: The mechanism used to deliver the response.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -156,6 +164,9 @@ class AgentCapability(CoReasonBaseModel):
 
     inputs: ImmutableDict = Field(..., description="Typed arguments the agent accepts (JSON Schema).")
     outputs: ImmutableDict = Field(..., description="Typed structure of the result.")
+    delivery_mode: DeliveryMode = Field(
+        default=DeliveryMode.REQUEST_RESPONSE, description="The mechanism used to deliver the response."
+    )
     events: List[EventSchema] = Field(
         default_factory=list, description="List of intermediate events this agent produces during execution."
     )

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -2,7 +2,7 @@
   "$defs": {
     "AgentCapability": {
       "additionalProperties": false,
-      "description": "Defines a specific mode of interaction for the agent.\n\nAttributes:\n    name: Unique name for this capability.\n    type: Interaction mode.\n    description: What this mode does.\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.\n    events: List of intermediate events this agent produces during execution.\n    injected_params: List of parameters injected by the system.",
+      "description": "Defines a specific mode of interaction for the agent.\n\nAttributes:\n    name: Unique name for this capability.\n    type: Interaction mode.\n    description: What this mode does.\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.\n    events: List of intermediate events this agent produces during execution.\n    injected_params: List of parameters injected by the system.\n    delivery_mode: The mechanism used to deliver the response.",
       "properties": {
         "name": {
           "description": "Unique name for this capability.",
@@ -29,6 +29,11 @@
           "description": "Typed structure of the result.",
           "title": "Outputs",
           "type": "object"
+        },
+        "delivery_mode": {
+          "$ref": "#/$defs/DeliveryMode",
+          "default": "request_response",
+          "description": "The mechanism used to deliver the response."
         },
         "events": {
           "description": "List of intermediate events this agent produces during execution.",
@@ -386,6 +391,15 @@
         "literal"
       ],
       "title": "DataMappingStrategy",
+      "type": "string"
+    },
+    "DeliveryMode": {
+      "description": "The delivery mechanism for the capability response.",
+      "enum": [
+        "request_response",
+        "server_sent_events"
+      ],
+      "title": "DeliveryMode",
       "type": "string"
     },
     "DeploymentConfig": {


### PR DESCRIPTION
Implemented Explicit Streaming Contracts by adding `delivery_mode` to `AgentCapability` and updating the Builder SDK.
This addresses the ambiguity between "what" an agent does (Atomic/Graph) and "how" it delivers results (Req/Res vs SSE).
Regenerated JSON schemas to stay in sync.

---
*PR created automatically by Jules for task [7889748866516756194](https://jules.google.com/task/7889748866516756194) started by @gowthamrao*