### PR TITLE
Implement Draft Mode for AgentDefinition

### DIFF
--- a/docs/builder_sdk.md
+++ b/docs/builder_sdk.md
@@ -52,11 +52,13 @@ Use `AgentBuilder` to assemble the agent and compile it into an `AgentDefinition
 
 ```python
 from coreason_manifest.builder import AgentBuilder
+from coreason_manifest.definitions.agent import AgentStatus
 
 builder = AgentBuilder(
     name="ResearchAssistant",
     version="1.0.0",
-    author="Coreason Team"
+    author="Coreason Team",
+    status=AgentStatus.DRAFT  # Optional: defaults to DRAFT
 )
 
 agent_definition = (
@@ -115,6 +117,7 @@ A generic wrapper that takes two Pydantic model types (`input_model`, `output_mo
 
 The main entry point for creating agents.
 
+*   **`set_status(status)`**: Sets the lifecycle status (`DRAFT` or `PUBLISHED`).
 *   **`with_capability(cap)`**: Adds a capability.
 *   **`with_system_prompt(prompt)`**: Sets the global system instruction.
 *   **`with_model(model, temperature)`**: Configures the LLM settings.

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -423,9 +423,7 @@ class AgentDefinition(CoReasonBaseModel):
             if self.integrity_hash is None:
                 raise ValueError("Field 'integrity_hash' is required when status is 'published'.")
             if not re.match(r"^[a-fA-F0-9]{64}$", self.integrity_hash):
-                raise ValueError(
-                    f"String should match pattern '^[a-fA-F0-9]{{64}}$' (got '{self.integrity_hash}')"
-                )
+                raise ValueError(f"String should match pattern '^[a-fA-F0-9]{{64}}$' (got '{self.integrity_hash}')")
         return self
 
     @model_validator(mode="after")

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -323,6 +323,15 @@
       "title": "AgentRuntimeConfig",
       "type": "object"
     },
+    "AgentStatus": {
+      "description": "The lifecycle status of the agent.",
+      "enum": [
+        "draft",
+        "published"
+      ],
+      "title": "AgentStatus",
+      "type": "string"
+    },
     "CapabilityType": {
       "description": "The interaction mode for the capability.",
       "enum": [
@@ -1166,19 +1175,29 @@
       "description": "Container for arbitrary metadata extensions without breaking validation.",
       "title": "Custom Metadata"
     },
+    "status": {
+      "$ref": "#/$defs/AgentStatus",
+      "default": "draft"
+    },
     "integrity_hash": {
-      "description": "SHA256 hash of the source code.",
-      "pattern": "^[a-fA-F0-9]{64}$",
-      "title": "Integrity Hash",
-      "type": "string"
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "SHA256 hash of the source code. Required if status is 'published'.",
+      "title": "Integrity Hash"
     }
   },
   "required": [
     "metadata",
     "capabilities",
     "config",
-    "dependencies",
-    "integrity_hash"
+    "dependencies"
   ],
   "title": "CoReason Agent Manifest",
   "type": "object"

--- a/tests/test_atomic_agent.py
+++ b/tests/test_atomic_agent.py
@@ -153,6 +153,7 @@ def test_edges_without_nodes_integrity() -> None:
             "system_prompt": "Dummy prompt",
         },
         "dependencies": {},
+        "status": "published",
         "integrity_hash": "a" * 64,
     }
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -77,3 +77,15 @@ def test_full_agent_build() -> None:
     assert agent.config.llm_config.model == "gpt-4-turbo"
     assert agent.config.llm_config.system_prompt == "You are a search agent."
     assert agent.integrity_hash is not None
+
+
+def test_builder_set_status() -> None:
+    """Test that set_status correctly updates the builder status."""
+    builder = AgentBuilder(name="StatusAgent")
+    assert builder._status == AgentStatus.DRAFT
+
+    builder.set_status(AgentStatus.PUBLISHED)
+    assert builder._status == AgentStatus.PUBLISHED
+
+    builder.set_status(AgentStatus.DRAFT)
+    assert builder._status == AgentStatus.DRAFT

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -13,7 +13,7 @@ from typing import List
 from pydantic import BaseModel
 
 from coreason_manifest.builder import AgentBuilder, TypedCapability
-from coreason_manifest.definitions.agent import AgentDefinition
+from coreason_manifest.definitions.agent import AgentDefinition, AgentStatus
 
 
 class SearchInput(BaseModel):
@@ -58,7 +58,7 @@ def test_full_agent_build() -> None:
         output_model=SearchOutput,
     )
 
-    builder = AgentBuilder(name="SearchAgent", author="Tester")
+    builder = AgentBuilder(name="SearchAgent", author="Tester", status=AgentStatus.PUBLISHED)
     agent = builder.with_capability(cap).with_system_prompt("You are a search agent.").with_model("gpt-4-turbo").build()
 
     assert isinstance(agent, AgentDefinition)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -85,7 +85,7 @@ def test_builder_set_status() -> None:
     assert builder._status == AgentStatus.DRAFT
 
     builder.set_status(AgentStatus.PUBLISHED)
-    assert builder._status == AgentStatus.PUBLISHED
+    assert builder._status == AgentStatus.PUBLISHED  # type: ignore[comparison-overlap]
 
     builder.set_status(AgentStatus.DRAFT)
     assert builder._status == AgentStatus.DRAFT

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -58,6 +58,7 @@ def test_full_agent_build() -> None:
         output_model=SearchOutput,
     )
 
+    # Use status=PUBLISHED to ensure integrity_hash is generated
     builder = AgentBuilder(name="SearchAgent", author="Tester", status=AgentStatus.PUBLISHED)
     agent = builder.with_capability(cap).with_system_prompt("You are a search agent.").with_model("gpt-4-turbo").build()
 

--- a/tests/test_complex_cases.py
+++ b/tests/test_complex_cases.py
@@ -191,22 +191,23 @@ def test_hash_validation_edge_cases() -> None:
             "system_prompt": "Dummy",
         },
         "dependencies": {"tools": [], "libraries": []},
+        "status": "published",  # Explicitly set to published to enforce hash check
     }
 
     # Too short
     with pytest.raises(ValidationError) as exc:
         AgentDefinition(**{**base_data, "integrity_hash": "a" * 63})
-    assert "integrity_hash" in str(exc.value)
+    assert "String should match pattern" in str(exc.value)
 
     # Too long
     with pytest.raises(ValidationError) as exc:
         AgentDefinition(**{**base_data, "integrity_hash": "a" * 65})
-    assert "integrity_hash" in str(exc.value)
+    assert "String should match pattern" in str(exc.value)
 
     # Invalid chars
     with pytest.raises(ValidationError) as exc:
         AgentDefinition(**{**base_data, "integrity_hash": "z" * 64})  # z is not hex
-    assert "integrity_hash" in str(exc.value)
+    assert "String should match pattern" in str(exc.value)
 
     # Uppercase valid
     valid_upper = "A" * 64

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -119,8 +119,10 @@ def test_validation_error_on_missing_fields() -> None:
             "edges": [],
             "entry_point": "start",
             "model_config": {"model": "gpt-4", "temperature": 0.5},
+            "system_prompt": "Prompt",  # Added to satisfy Atomic Agent requirement
         },
         "dependencies": {},
+        "status": "published",  # Added to trigger integrity_hash check
     }
     with pytest.raises(ValidationError) as excinfo:
         AgentDefinition(**valid_data)


### PR DESCRIPTION
Implemented "Draft Mode" for the Coreason Agent Manifest to allow saving work-in-progress agents with incomplete topology or missing hashes.

Changes:
1.  **`src/coreason_manifest/definitions/agent.py`**:
    *   Defined `AgentStatus` Enum.
    *   Added `status` field to `AgentDefinition`, defaulting to `DRAFT`.
    *   Made `integrity_hash` optional.
    *   Implemented conditional validators `validate_integrity_hash_if_published` and `validate_topology_if_published`.
    *   Removed unconditional `validate_topology_integrity` from `AgentRuntimeConfig`.

2.  **`src/coreason_manifest/builder/agent.py`**:
    *   Updated `AgentBuilder` to initialize with `status=DRAFT`.
    *   Added `set_status()` method.
    *   Updated `build()` to handle `integrity_hash` generation based on status.

3.  **Documentation**:
    *   Updated `docs/coreason_agent_manifest.md` and `docs/builder_sdk.md` to document the new lifecycle and builder usage.

4.  **Tests & Schemas**:
    *   Updated existing tests (`tests/test_atomic_agent.py`, `tests/test_complex_cases.py`, `tests/test_models.py`, `tests/test_builder.py`) to explicitly set `status="published"` where strict validation was expected.
    *   Regenerated JSON schemas using `scripts/generate_schemas.py`.

---
*PR created automatically by Jules for task [11306583638285887856](https://jules.google.com/task/11306583638285887856) started by @gowthamrao*