### PR TITLE
feat: semantic error codes and domains

### DIFF
--- a/docs/error_handling_standards.md
+++ b/docs/error_handling_standards.md
@@ -1,0 +1,87 @@
+# Error Handling Standards
+
+This document defines the standardized approach for handling and reporting errors within the Coreason ecosystem. By adhering to these standards, agents, engines, and frontends can provide a consistent, robust, and user-friendly experience.
+
+## Overview
+
+Coreason distinguishes between two types of errors:
+1.  **Workflow Errors (`WorkflowError`)**: System-level or logic-level failures that occur during execution (e.g., "LLM API Timeout", "Database Connection Failed"). These are typically emitted as events.
+2.  **User Errors (`UserErrorBlock`)**: UI-first artifacts designed to be shown to the end-user (e.g., "I couldn't find that file. Please upload it again.").
+
+To support programmatic handling of these errors (e.g., auto-retries, specific UI icons), we enforce **Semantic Error Codes** and **Error Domains**.
+
+## Semantic Error Codes
+
+We utilize integer status codes inspired by standard HTTP response codes to convey the *nature* of the error.
+
+| Range | Category | Description |
+| :--- | :--- | :--- |
+| **400-499** | Client/Input Errors | Issues caused by the user's input or request (e.g., Invalid Format, Missing Field). |
+| **500-599** | System/Server Errors | Issues caused by the backend, LLM provider, or infrastructure (e.g., Timeout, Crash). |
+
+### Common Codes
+
+*   `400`: Bad Request / Validation Error
+*   `401`: Unauthorized
+*   `403`: Forbidden / Security Policy Violation
+*   `404`: Not Found (Resource, Tool, or Knowledge)
+*   `429`: Rate Limit Exceeded (Retryable)
+*   `500`: Internal System Error (Generic)
+*   `503`: Service Unavailable / Upstream API Failure (Retryable)
+*   `504`: Timeout
+
+## Error Domains
+
+The `ErrorDomain` enum categorizes the *source* of the error. This helps frontends decide how to present the error (e.g., color-coding).
+
+| Domain | Enum Value | Description |
+| :--- | :--- | :--- |
+| **System** | `SYSTEM` | Infrastructure, networking, or runtime engine failures. |
+| **LLM** | `LLM` | Errors originating from the Large Language Model provider (e.g., refusal, context length exceeded). |
+| **Tool** | `TOOL` | Errors occurring during the execution of an external tool or API. |
+| **Logic** | `LOGIC` | Errors within the agent's reasoning or workflow graph (e.g., invalid state transition). |
+| **Security** | `SECURITY` | Errors triggered by safety guardrails or policy enforcement. |
+
+## WorkflowError Schema
+
+The `WorkflowError` event payload (defined in `src/coreason_manifest/definitions/events.py`) includes these semantic fields:
+
+```python
+class WorkflowError(BaseNodePayload):
+    # ... existing fields (error_message, stack_trace) ...
+
+    # Semantic Fields
+    code: int = 500
+    domain: ErrorDomain = ErrorDomain.SYSTEM
+    retryable: bool = False
+```
+
+*   **`code`**: The integer status code.
+*   **`domain`**: The semantic source of the error.
+*   **`retryable`**: A definitive flag indicating if the client (or engine) should attempt to retry the operation.
+
+## UserErrorBlock Schema
+
+The `UserErrorBlock` presentation artifact (defined in `src/coreason_manifest/definitions/presentation.py`) allows the UI to render semantic errors.
+
+```python
+class UserErrorBlock(PresentationBlock):
+    # ... existing fields (user_message, etc.) ...
+
+    code: Optional[int] = None
+```
+
+*   **`code`**: If provided, the UI can use this to select an appropriate icon (e.g., a "Disconnect" icon for `503`, a "Lock" icon for `403`).
+
+## Usage Guidelines
+
+### For Agent Developers
+*   **Catch and Categorize:** When catching exceptions, try to map them to a specific `ErrorDomain` and `code`.
+*   **Set Retryable:** Explicitly mark transient errors (like Rate Limits or Network Flakes) as `retryable=True`.
+
+### For Frontend Developers
+*   **Visual Cues:**
+    *   `SYSTEM` / `SECURITY` errors might be red.
+    *   `LLM` / `TOOL` errors might be amber/yellow.
+*   **Auto-Retry:** If `retryable` is true (in a `WorkflowError`), consider showing a "Retry" button or automatically retrying the request after a backoff.
+*   **Icons:** Map common codes (403, 404, 429, 500) to standard icon sets.

--- a/docs/presentation_schemas.md
+++ b/docs/presentation_schemas.md
@@ -91,6 +91,7 @@ Represents a user-facing error message. Unlike internal exceptions, these are de
 *   **`user_message`**: A friendly, human-readable error message.
 *   **`technical_details`**: Optional dictionary containing error codes or stack traces for debugging (hidden by default in most UIs).
 *   **`recoverable`**: Boolean indicating if the user can retry the action.
+*   **`code`**: Optional integer error code (e.g., 404, 429) to allow the UI to show specific icons or help text.
 
 **Example:**
 ```python
@@ -98,7 +99,8 @@ from coreason_manifest.definitions.presentation import UserErrorBlock
 
 block = UserErrorBlock(
     user_message="Unable to connect to the weather service. Please try again later.",
-    technical_details={"status_code": 503, "service": "weather-api"},
-    recoverable=True
+    technical_details={"service": "weather-api"},
+    recoverable=True,
+    code=503
 )
 ```

--- a/src/coreason_manifest/definitions/events.py
+++ b/src/coreason_manifest/definitions/events.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from datetime import datetime, timezone
+from enum import Enum
 from typing import Annotated, Any, Dict, Generic, Literal, Optional, Protocol, TypeVar, Union, runtime_checkable
 from uuid import uuid4
 
@@ -222,6 +223,16 @@ class CouncilVote(BaseNodePayload):
     votes: Dict[str, str]
 
 
+class ErrorDomain(str, Enum):
+    """Domain of the error."""
+
+    SYSTEM = "SYSTEM"
+    LLM = "LLM"
+    TOOL = "TOOL"
+    LOGIC = "LOGIC"
+    SECURITY = "SECURITY"
+
+
 class WorkflowError(BaseNodePayload):
     """Payload for ERROR event."""
 
@@ -230,6 +241,11 @@ class WorkflowError(BaseNodePayload):
     input_snapshot: Dict[str, Any]
     status: Literal["ERROR"] = "ERROR"
     visual_cue: str = "RED_FLASH"
+
+    # Semantic Error Fields
+    code: int = 500
+    domain: ErrorDomain = ErrorDomain.SYSTEM
+    retryable: bool = False
 
 
 # --- Standardized Payloads ---

--- a/src/coreason_manifest/definitions/presentation.py
+++ b/src/coreason_manifest/definitions/presentation.py
@@ -68,3 +68,4 @@ class UserErrorBlock(PresentationBlock):
     user_message: str
     technical_details: Optional[Dict[str, Any]] = None
     recoverable: bool = False
+    code: Optional[int] = None

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -32,6 +32,7 @@ from coreason_manifest.definitions.events import (
     NodeStreamPayload,
     WorkflowError,
     WorkflowErrorPayload,
+    ErrorDomain,
 )
 
 
@@ -161,6 +162,26 @@ def test_workflow_error_payload() -> None:
     )
     assert payload.status == "ERROR"
     assert payload.visual_cue == "RED_FLASH"
+    # Defaults
+    assert payload.code == 500
+    assert payload.domain == ErrorDomain.SYSTEM
+    assert payload.retryable is False
+
+
+def test_workflow_error_payload_semantic_fields() -> None:
+    """Test WorkflowError payload with semantic fields."""
+    payload = WorkflowError(
+        node_id="node-1",
+        error_message="Rate Limit",
+        stack_trace="...",
+        input_snapshot={},
+        code=429,
+        domain=ErrorDomain.LLM,
+        retryable=True,
+    )
+    assert payload.code == 429
+    assert payload.domain == ErrorDomain.LLM
+    assert payload.retryable is True
 
 
 def test_aliases() -> None:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -18,6 +18,7 @@ from coreason_manifest.definitions.events import (
     CouncilVotePayload,
     EdgeTraversed,
     EdgeTraversedPayload,
+    ErrorDomain,
     GraphEventNodeInit,
     NodeCompleted,
     NodeCompletedPayload,
@@ -32,7 +33,6 @@ from coreason_manifest.definitions.events import (
     NodeStreamPayload,
     WorkflowError,
     WorkflowErrorPayload,
-    ErrorDomain,
 )
 
 

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -63,12 +63,19 @@ def test_markdown_block() -> None:
 
 def test_user_error_block() -> None:
     """Test UserErrorBlock."""
+    # Test with default code
     block = UserErrorBlock(user_message="Something went wrong", technical_details={"code": 500}, recoverable=True)
     dumped = block.dump()
     assert dumped["block_type"] == "ERROR"
     assert dumped["user_message"] == "Something went wrong"
     assert dumped["technical_details"] == {"code": 500}
     assert dumped["recoverable"] is True
+    assert "code" not in dumped  # exclude_none=True by default
+
+    # Test with explicit code
+    block_with_code = UserErrorBlock(user_message="Not Found", code=404)
+    dumped_code = block_with_code.dump()
+    assert dumped_code["code"] == 404
 
 
 def test_inheritance() -> None:


### PR DESCRIPTION
This PR updates `WorkflowError` and `UserErrorBlock` to include semantic error information, allowing frontend clients to programmatically handle errors. It introduces `ErrorDomain` and standard HTTP-like status codes.

---
*PR created automatically by Jules for task [14526425342469609957](https://jules.google.com/task/14526425342469609957) started by @gowthamrao*