### PR TITLE
feat(session): add Explicit Request Lineage to Interaction model

### DIFF
--- a/docs/request_lineage.md
+++ b/docs/request_lineage.md
@@ -54,6 +54,17 @@ The `AuditLog` provides a tamper-evident record. To ensure that an audit entry c
 
 By including these UUIDs in the `integrity_hash`, we ensure that the causal link cannot be altered without breaking the cryptographic chain of custody.
 
+## 4. Interaction Lineage
+
+The `Interaction` model captures a single turn in a session. While `AgentRequest` drives the execution, the `Interaction` stores the *persistent history* of that execution in the `SessionState`.
+
+### Fields
+The `Interaction` uses a dedicated `LineageMetadata` object:
+-   `root_request_id`: The ID of the original request that started the entire chain.
+-   `parent_interaction_id`: The ID of the specific interaction that triggered this one.
+
+**Note:** Unlike `AgentRequest` which strictly enforces `UUID`s, the `Interaction` lineage uses `str` to ensure interoperability with external systems (e.g., AWS Request IDs, Sentient ULIDs) that may not conform to the UUID standard.
+
 ## Summary
 
 | Model | Role | Lineage Enforcement |
@@ -61,3 +72,4 @@ By including these UUIDs in the `integrity_hash`, we ensure that the causal link
 | `AgentRequest` | **Input** Envelope | Auto-roots; Forbids Parent without Root. |
 | `ReasoningTrace` | **Process** Record | Auto-roots; Forbids Parent without Root. |
 | `AuditLog` | **Output** Record | Mandatory fields; Hashed for integrity. |
+| `Interaction` | **Session** History | Optional `LineageMetadata`; Uses `str` for compatibility. |

--- a/docs/session_management.md
+++ b/docs/session_management.md
@@ -15,11 +15,12 @@ An `Interaction` represents a single "turn" or request/response cycle in a conve
 *   **Input/Output:** The raw payloads passed to and from the agent.
 *   **Events:** A strictly typed log of `GraphEvent`s emitted during execution (e.g., node start, stream, completion).
 *   **Metadata:** Operational data like latency, cost, and model details.
+*   **Lineage:** Chain of Custody metadata linking this interaction to its trigger.
 
 The `Interaction` model is immutable (`frozen=True`) to ensure history integrity.
 
 ```python
-from coreason_manifest.definitions.session import Interaction
+from coreason_manifest.definitions.session import Interaction, LineageMetadata
 from coreason_manifest.definitions.message import MultiModalInput, ContentPart
 from coreason_manifest.definitions.events import GraphEventNodeInit, NodeInit
 
@@ -40,7 +41,11 @@ interaction = Interaction(
             visual_metadata={"color": "blue"}
         )
     ],
-    meta={"latency_ms": 150}
+    meta={"latency_ms": 150},
+    lineage=LineageMetadata(
+        root_request_id="req-123",
+        parent_interaction_id="int-456"
+    )
 )
 ```
 

--- a/src/coreason_manifest/definitions/session.py
+++ b/src/coreason_manifest/definitions/session.py
@@ -19,6 +19,19 @@ from coreason_manifest.definitions.events import GraphEvent
 from coreason_manifest.definitions.message import MultiModalInput
 
 
+class LineageMetadata(CoReasonBaseModel):
+    """Metadata tracking the Chain of Custody for this interaction."""
+
+    model_config = ConfigDict(frozen=True)
+
+    root_request_id: Optional[str] = Field(
+        None, description="The ID of the original request that started the entire chain"
+    )
+    parent_interaction_id: Optional[str] = Field(
+        None, description="The ID of the specific interaction that triggered this one"
+    )
+
+
 class Interaction(CoReasonBaseModel):
     """Represents a single 'turn' or request/response cycle in a session."""
 
@@ -34,6 +47,7 @@ class Interaction(CoReasonBaseModel):
         default_factory=list, description="A log of intermediate events emitted during this turn"
     )
     meta: Dict[str, Any] = Field(default_factory=dict, description="Metadata (Latency, cost, model used, etc.)")
+    lineage: Optional[LineageMetadata] = Field(None, description="Chain of Custody metadata")
 
 
 class SessionState(CoReasonBaseModel):

--- a/tests/test_session_lineage.py
+++ b/tests/test_session_lineage.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.definitions.session import Interaction, LineageMetadata
+
+
+def test_lineage_metadata_creation() -> None:
+    """Test successful creation of LineageMetadata."""
+    lineage = LineageMetadata(
+        root_request_id="req-123",
+        parent_interaction_id="int-456",
+    )
+    assert lineage.root_request_id == "req-123"
+    assert lineage.parent_interaction_id == "int-456"
+
+
+def test_lineage_metadata_optional_fields() -> None:
+    """Test LineageMetadata optional fields."""
+    lineage = LineageMetadata()
+    assert lineage.root_request_id is None
+    assert lineage.parent_interaction_id is None
+
+
+def test_lineage_metadata_immutability() -> None:
+    """Test that LineageMetadata is immutable."""
+    lineage = LineageMetadata(root_request_id="req-1")
+    with pytest.raises(ValidationError):
+        lineage.root_request_id = "req-2"  # type: ignore
+
+
+def test_interaction_with_lineage() -> None:
+    """Test Interaction with lineage metadata."""
+    lineage = LineageMetadata(root_request_id="root-1", parent_interaction_id="parent-1")
+    interaction = Interaction(
+        input={"content": "hello"},
+        output={"content": "world"},
+        lineage=lineage,
+    )
+    assert interaction.lineage is not None
+    assert interaction.lineage.root_request_id == "root-1"
+    assert interaction.lineage.parent_interaction_id == "parent-1"
+
+
+def test_interaction_default_lineage() -> None:
+    """Test Interaction default lineage is None (backward compatibility)."""
+    interaction = Interaction(
+        input={"content": "hello"},
+        output={"content": "world"},
+    )
+    assert interaction.lineage is None


### PR DESCRIPTION
Implemented Explicit Request Lineage by adding `LineageMetadata` and updating `Interaction` in `session.py`. This includes tracking `root_request_id` and `parent_interaction_id`. Ensured backward compatibility and immutability.

---
*PR created automatically by Jules for task [10821938052943209162](https://jules.google.com/task/10821938052943209162) started by @gowthamrao*