### PR TITLE
Refactor Agent validation logic for Draft mode support

### DIFF
--- a/tests/test_builder_topology.py
+++ b/tests/test_builder_topology.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel, ValidationError
 
 from coreason_manifest.builder.agent import AgentBuilder
 from coreason_manifest.builder.capability import TypedCapability
-from coreason_manifest.definitions.agent import CapabilityType, ToolRequirement
+from coreason_manifest.definitions.agent import AgentStatus, CapabilityType, ToolRequirement
 from coreason_manifest.definitions.topology import LogicNode
 
 
@@ -64,7 +64,7 @@ def test_builder_validation_failure() -> None:
     """Attempt to build a graph with nodes but without setting an entry point."""
     node_a = LogicNode(id="start", type="logic", code="print('start')")
 
-    builder = get_valid_agent_builder(name="InvalidGraphAgent").with_node(node_a)
+    builder = get_valid_agent_builder(name="InvalidGraphAgent").with_node(node_a).set_status(AgentStatus.PUBLISHED)
 
     with pytest.raises(ValidationError) as excinfo:
         builder.build()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -259,12 +259,14 @@ def test_agent_config_system_prompt() -> None:
 
     # In the valid_data setup above, nodes=[], so it is an Atomic Agent.
     # llm_config doesn't have system_prompt set.
-    # So this should fail now.
+    # So this should fail now IF published.
+    valid_data["status"] = "published"
     with pytest.raises(ValidationError) as exc:
         AgentDefinition(**valid_data)
     assert "Atomic Agents require a system_prompt" in str(exc.value)
 
     # But if we add it to model_config, it should pass
+    del valid_data["status"]
     valid_data["config"]["model_config"]["system_prompt"] = "Model Prompt"
     agent = AgentDefinition(**valid_data)
     assert agent.config.system_prompt is None


### PR DESCRIPTION
Refactored validation logic to allow incomplete `AgentRuntimeConfig` objects when `AgentDefinition` status is `DRAFT`.
*   Removed `validate_topology_or_atomic` from `AgentRuntimeConfig`.
*   Added `validate_config_completeness_if_published` to `AgentDefinition`.
*   Updated tests to verify new behavior.

---
*PR created automatically by Jules for task [6568261156801656671](https://jules.google.com/task/6568261156801656671) started by @gowthamrao*