### PR TITLE
Fix missing AgentStatus export in __init__.py

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from .definitions.agent import AgentDefinition, Persona
+from .definitions.agent import AgentDefinition, AgentStatus, Persona
 from .definitions.audit import AuditLog
 from .definitions.events import (
     ArtifactGenerated,
@@ -55,6 +55,7 @@ from .recipes import RecipeManifest
 
 __all__ = [
     "AgentDefinition",
+    "AgentStatus",
     "Persona",
     "Topology",
     "GraphTopology",

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import coreason_manifest
+from coreason_manifest.definitions.agent import AgentDefinition, AgentStatus
+
+
+def test_top_level_exports() -> None:
+    """Verify that key components are exported from the top-level package."""
+    # Verify AgentStatus export
+    assert hasattr(coreason_manifest, "AgentStatus")
+    assert coreason_manifest.AgentStatus is AgentStatus
+
+    # Verify AgentDefinition export
+    assert hasattr(coreason_manifest, "AgentDefinition")
+    assert coreason_manifest.AgentDefinition is AgentDefinition
+
+    # Check __all__ contains AgentStatus
+    assert "AgentStatus" in coreason_manifest.__all__


### PR DESCRIPTION
This PR addresses the missing export of `AgentStatus` from the top-level `coreason_manifest` package. 
It also includes a new test file `tests/test_exports.py` to ensure `AgentStatus` and other key components are correctly exported.
Verified that the `DeliveryMode` addition (part of a previous change) is intentional and retained.

---
*PR created automatically by Jules for task [9682897485224214092](https://jules.google.com/task/9682897485224214092) started by @gowthamrao*