### PR TITLE
Fix domain check for URIs without hostname

### DIFF
--- a/src/coreason_manifest/governance.py
+++ b/src/coreason_manifest/governance.py
@@ -124,7 +124,8 @@ def check_compliance(agent: AgentDefinition, config: GovernanceConfig) -> Compli
                 try:
                     parsed_uri = urlparse(str(tool.uri))
                     hostname = parsed_uri.hostname
-                    if hostname not in config.allowed_domains:
+                    # Guard against None (e.g. mailto:)
+                    if hostname and hostname not in config.allowed_domains:
                         violations.append(
                             ComplianceViolation(
                                 rule="domain_restriction",

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -166,3 +166,13 @@ def test_governance_malformed_uri_handling() -> None:
     assert len(report.violations) == 1
     assert report.violations[0].rule == "domain_restriction"
     assert "Failed to parse tool URI" in report.violations[0].message
+
+
+def test_governance_no_hostname_allowed() -> None:
+    # Tools with no hostname (e.g. mailto:) should be allowed if they don't violate domain rules
+    tool = ToolRequirement(uri="mailto:user@example.com", hash="a" * 64, scopes=[], risk_level=ToolRiskLevel.SAFE)
+    agent = create_agent(tools=[tool])
+    # Even if we restrict domains, "mailto:" has no domain, so it should be skipped/allowed per user request
+    config = GovernanceConfig(allowed_domains=["trusted.com"])
+    report = check_compliance(agent, config)
+    assert report.passed


### PR DESCRIPTION
Updated `check_compliance` in `src/coreason_manifest/governance.py` to skip domain restriction checks for URIs without a hostname (e.g. `mailto:`). Added a regression test case. Verified with existing tests and coverage checks.

---
*PR created automatically by Jules for task [17330211359111410815](https://jules.google.com/task/17330211359111410815) started by @gowthamrao*