### PR TITLE
Feature: Simplified YAML DSL for Agent Definitions

### DIFF
--- a/docs/simplified_dsl.md
+++ b/docs/simplified_dsl.md
@@ -1,0 +1,105 @@
+# Simplified YAML DSL
+
+The Simplified YAML DSL allows developers to define Coreason Agents using a concise, human-readable syntax. It serves as an alternative to the verbose Python Builder SDK or raw JSON Schemas.
+
+## Overview
+
+Instead of writing complex JSON Schema dictionaries for inputs and outputs, you can use **Shorthand Types** (e.g., `city: string`, `tags: list[string]`). The DSL loader compiles this YAML into the strict `AgentDefinition` required by the Coreason Kernel.
+
+## Syntax Guide
+
+### Basic Structure
+
+```yaml
+name: "MyAgent"
+version: "0.1.0"
+author: "Team Coreason"
+status: "draft"  # or "published"
+
+system_prompt: "You are a helpful assistant."
+
+model:
+  name: "gpt-4o"
+  temperature: 0.5
+
+capabilities:
+  - name: "my_capability"
+    description: "Does something useful."
+    type: "atomic"  # default
+    inputs:
+      field_name: type_shorthand
+    outputs:
+      result: type_shorthand
+```
+
+### Type Shorthands
+
+The DSL supports the following shorthand types:
+
+| Shorthand | JSON Schema Equivalent |
+| :--- | :--- |
+| `string` | `{"type": "string"}` |
+| `int`, `integer` | `{"type": "integer"}` |
+| `float`, `number` | `{"type": "number"}` |
+| `bool`, `boolean` | `{"type": "boolean"}` |
+| `any` | `{}` (Any type allowed) |
+| `list[T]`, `array[T]` | `{"type": "array", "items": ...}` |
+
+**Examples:**
+- `age: int`
+- `tags: list[string]`
+- `scores: array[float]`
+- `matrix: list[list[int]]`
+
+### Implicit Rules
+
+1.  **Required Fields**: All fields defined in `inputs` or `outputs` are treated as **Required**.
+2.  **No Additional Properties**: The generated schema sets `additionalProperties: false`.
+
+## Usage in Python
+
+To use the DSL, import `load_from_yaml` from `coreason_manifest`.
+
+```python
+from coreason_manifest import load_from_yaml
+
+yaml_content = """
+name: "WeatherBot"
+capabilities:
+  - name: "get_weather"
+    inputs:
+      city: string
+    outputs:
+      temp: int
+"""
+
+# Compile into a strict AgentDefinition
+agent = load_from_yaml(yaml_content)
+
+print(agent.metadata.name)
+# Output: WeatherBot
+```
+
+## Complete Example
+
+```yaml
+name: "WeatherBot"
+version: "1.0.0"
+status: "draft"
+system_prompt: "You are a meteorological expert."
+
+model:
+  name: "gpt-4-turbo"
+  temperature: 0.0
+
+capabilities:
+  - name: "get_forecast"
+    description: "Retrieves the weather forecast for a city."
+    inputs:
+      city: string
+      days: int
+      include_rain: bool
+    outputs:
+      description: string
+      temps: list[float]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,6 +5,7 @@ nav:
   - Home: index.md
   - Requirements: requirements.md
   - Usage: usage.md
+  - Simplified DSL: simplified_dsl.md
   - Session Management: session_management.md
   - Observability: observability.md
   - Recipes: recipes.md

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -51,6 +51,7 @@ from .definitions.topology import (
     StateDefinition,
     Topology,
 )
+from .dsl import load_from_yaml
 from .governance import ComplianceReport, GovernanceConfig, check_compliance
 from .recipes import RecipeManifest
 
@@ -99,4 +100,5 @@ __all__ = [
     "GovernanceConfig",
     "ComplianceReport",
     "check_compliance",
+    "load_from_yaml",
 ]

--- a/src/coreason_manifest/dsl.py
+++ b/src/coreason_manifest/dsl.py
@@ -1,0 +1,192 @@
+import re
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from coreason_manifest.builder.agent import AgentBuilder
+from coreason_manifest.definitions.agent import (
+    AgentCapability,
+    AgentDefinition,
+    AgentStatus,
+    CapabilityType,
+    DeliveryMode,
+)
+
+
+class SchemaCapability:
+    """A capability builder that uses raw JSON schemas instead of Pydantic models.
+
+    This class is used by the DSL loader to bridge the gap between simplified YAML
+    definitions and the AgentBuilder, which typically expects typed Pydantic models.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        inputs: Dict[str, Any],
+        outputs: Dict[str, Any],
+        type: CapabilityType = CapabilityType.ATOMIC,
+        delivery_mode: DeliveryMode = DeliveryMode.REQUEST_RESPONSE,
+        injected_params: Optional[List[str]] = None,
+    ) -> None:
+        self.name = name
+        self.description = description
+        self.inputs = inputs
+        self.outputs = outputs
+        self.type = type
+        self.delivery_mode = delivery_mode
+        self.injected_params = injected_params or []
+
+    def to_definition(self) -> AgentCapability:
+        """Convert to strict AgentCapability definition."""
+        return AgentCapability(
+            name=self.name,
+            type=self.type,
+            description=self.description,
+            inputs=self.inputs,
+            outputs=self.outputs,
+            injected_params=self.injected_params,
+            delivery_mode=self.delivery_mode,
+        )
+
+
+def _expand_shorthand_type(shorthand: str) -> Dict[str, Any]:
+    """Expand a shorthand type string into a JSON Schema dictionary.
+
+    Args:
+        shorthand: Type string like 'string', 'int', 'list[string]'.
+
+    Returns:
+        JSON Schema dictionary.
+    """
+    shorthand = shorthand.strip()
+
+    # Handle array/list types
+    array_match = re.match(r"^(?:list|array)\[(.+)\]$", shorthand, re.IGNORECASE)
+    if array_match:
+        inner_type = array_match.group(1)
+        return {
+            "type": "array",
+            "items": _expand_shorthand_type(inner_type)
+        }
+
+    # Handle basic types
+    start = shorthand.lower()
+    if start == "string":
+        return {"type": "string"}
+    elif start in ("int", "integer"):
+        return {"type": "integer"}
+    elif start in ("float", "number"):
+        return {"type": "number"}
+    elif start in ("bool", "boolean"):
+        return {"type": "boolean"}
+    elif start == "any":
+        return {}
+
+    # Fallback/Default (treat as string or maybe error? treating as string seems safe for now or raise)
+    # The prompt implies specific mappings. If unknown, we might want to raise error.
+    # But for robustness let's assume it's a string if we don't know it, or raise.
+    # Let's raise ValueError to be safe.
+    raise ValueError(f"Unknown shorthand type: {shorthand}")
+
+
+def _expand_properties(props: Dict[str, str]) -> Dict[str, Any]:
+    """Convert a dictionary of name:shorthand to a JSON Schema Object.
+
+    Args:
+        props: Dictionary mapping field names to shorthand types.
+
+    Returns:
+        Full JSON Schema Object definition.
+    """
+    properties = {}
+    required = []
+
+    for name, shorthand in props.items():
+        properties[name] = _expand_shorthand_type(shorthand)
+        required.append(name)
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False
+    }
+
+
+def load_from_yaml(content: str) -> AgentDefinition:
+    """Parse a simplified YAML string into a valid AgentDefinition.
+
+    Args:
+        content: The YAML string.
+
+    Returns:
+        A compiled AgentDefinition.
+    """
+    data = yaml.safe_load(content)
+    if not isinstance(data, dict):
+        raise ValueError("YAML content must resolve to a dictionary.")
+
+    # Extract metadata
+    name = data.get("name")
+    if not name:
+        raise ValueError("Field 'name' is required.")
+
+    version = data.get("version", "0.1.0")
+    author = data.get("author", "Unknown")
+
+    status_str = data.get("status", "draft").lower()
+    status = AgentStatus.PUBLISHED if status_str == "published" else AgentStatus.DRAFT
+
+    builder = AgentBuilder(name=name, version=str(version), author=author, status=status)
+
+    # Process Capabilities
+    capabilities = data.get("capabilities", [])
+    for cap_data in capabilities:
+        cap_name = cap_data.get("name")
+        if not cap_name:
+            raise ValueError("Capability must have a 'name'.")
+
+        description = cap_data.get("description", "")
+        cap_type_str = cap_data.get("type", "atomic")
+        cap_type = CapabilityType(cap_type_str)
+
+        # Delivery mode defaults to request_response, but let's check if it's in YAML
+        # The prompt didn't explicitly mention delivery_mode in YAML example, but good to support.
+        # We'll use default from AgentCapability if not present.
+        delivery_mode_str = cap_data.get("delivery_mode", DeliveryMode.REQUEST_RESPONSE.value)
+        delivery_mode = DeliveryMode(delivery_mode_str)
+
+        inputs_shorthand = cap_data.get("inputs", {})
+        outputs_shorthand = cap_data.get("outputs", {})
+
+        inputs_schema = _expand_properties(inputs_shorthand)
+        outputs_schema = _expand_properties(outputs_shorthand)
+
+        # Create schema capability
+        cap = SchemaCapability(
+            name=cap_name,
+            description=description,
+            inputs=inputs_schema,
+            outputs=outputs_schema,
+            type=cap_type,
+            delivery_mode=delivery_mode
+        )
+
+        # Add to builder - ignore type check because AgentBuilder expects TypedCapability
+        builder.with_capability(cap) # type: ignore
+
+    # Process Model Config
+    model_data = data.get("model")
+    if model_data:
+        model_name = model_data.get("name", "gpt-4o")
+        temperature = model_data.get("temperature", 0.0)
+        builder.with_model(model=model_name, temperature=temperature)
+
+    # Process System Prompt
+    system_prompt = data.get("system_prompt")
+    if system_prompt:
+        builder.with_system_prompt(system_prompt)
+
+    return builder.build()

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -1,0 +1,161 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from coreason_manifest.dsl import load_from_yaml
+from coreason_manifest.definitions.agent import AgentStatus, CapabilityType
+
+def test_load_basic_agent() -> None:
+    yaml_content = """
+name: "WeatherBot"
+version: "0.1.0"
+status: "draft"
+system_prompt: "You are a weather bot."
+model:
+  name: "gpt-4o"
+  temperature: 0.2
+capabilities:
+  - name: "get_weather"
+    description: "Fetches weather."
+    inputs:
+      city: string
+      days: int
+    outputs:
+      report: string
+"""
+    agent = load_from_yaml(yaml_content)
+
+    # Metadata assertions
+    assert agent.metadata.name == "WeatherBot"
+    assert agent.metadata.version == "0.1.0"
+    assert agent.status == AgentStatus.DRAFT
+
+    # Config assertions
+    assert agent.config.system_prompt == "You are a weather bot."
+    assert agent.config.llm_config.model == "gpt-4o"
+    assert agent.config.llm_config.temperature == 0.2
+
+    # Capability assertions
+    assert len(agent.capabilities) == 1
+    cap = agent.capabilities[0]
+    assert cap.name == "get_weather"
+    assert cap.description == "Fetches weather."
+    assert cap.type == CapabilityType.ATOMIC
+
+    # Schema assertions
+    # Inputs
+    assert cap.inputs["type"] == "object"
+    assert cap.inputs["required"] == ["city", "days"]
+    assert cap.inputs["properties"]["city"] == {"type": "string"}
+    assert cap.inputs["properties"]["days"] == {"type": "integer"}
+
+    # Outputs
+    assert cap.outputs["type"] == "object"
+    assert cap.outputs["properties"]["report"] == {"type": "string"}
+
+def test_load_complex_types() -> None:
+    yaml_content = """
+name: "ComplexBot"
+capabilities:
+  - name: "process_data"
+    inputs:
+      tags: list[string]
+      scores: array[float]
+    outputs:
+      summary: any
+"""
+    agent = load_from_yaml(yaml_content)
+    cap = agent.capabilities[0]
+
+    # List[string] -> {"type": "array", "items": {"type": "string"}}
+    tags_schema = cap.inputs["properties"]["tags"]
+    assert tags_schema["type"] == "array"
+    assert tags_schema["items"] == {"type": "string"}
+
+    # Array[float] -> {"type": "array", "items": {"type": "number"}}
+    scores_schema = cap.inputs["properties"]["scores"]
+    assert scores_schema["type"] == "array"
+    assert scores_schema["items"] == {"type": "number"}
+
+    # Any -> {}
+    summary_schema = cap.outputs["properties"]["summary"]
+    assert summary_schema == {}
+
+def test_load_published_status() -> None:
+    # Note: Published status requires integrity_hash usually, but AgentBuilder generates a dummy one if published.
+    yaml_content = """
+name: "PublishedBot"
+status: "published"
+capabilities:
+  - name: "test"
+    inputs: {}
+    outputs: {}
+"""
+    # Just checking if it parses status correctly.
+    # However, AgentDefinition validation might fail if integrity_hash is missing?
+    # AgentBuilder.build() handles generating integrity_hash if status is published.
+    # But wait, AgentBuilder.build() says:
+    # if self._status == AgentStatus.PUBLISHED:
+    #     integrity_hash = hashlib.sha256(self.name.encode("utf-8")).hexdigest()
+    # So it should pass.
+
+    # Also need system prompt for atomic agent if published?
+    # validate_config_completeness_if_published: Atomic Agents require a system_prompt when published.
+    # So I need to add system_prompt.
+
+    yaml_content = """
+name: "PublishedBot"
+status: "published"
+system_prompt: "Sys prompt"
+capabilities:
+  - name: "test"
+    inputs: {}
+    outputs: {}
+"""
+    agent = load_from_yaml(yaml_content)
+    assert agent.status == AgentStatus.PUBLISHED
+    assert agent.integrity_hash is not None
+
+def test_load_error_cases() -> None:
+    # Test unknown shorthand
+    with pytest.raises(ValueError, match="Unknown shorthand type"):
+        load_from_yaml("""
+name: "ErrorBot"
+capabilities:
+  - name: "test"
+    inputs:
+      x: invalid_type
+""")
+
+    # Test boolean shorthand (missing coverage)
+    agent = load_from_yaml("""
+name: "BoolBot"
+capabilities:
+  - name: "test"
+    inputs:
+      flag: bool
+""")
+    assert agent.capabilities[0].inputs["properties"]["flag"]["type"] == "boolean"
+
+    # Test invalid YAML structure (list instead of dict)
+    with pytest.raises(ValueError, match="must resolve to a dictionary"):
+        load_from_yaml("- item")
+
+    # Test missing name
+    with pytest.raises(ValueError, match="Field 'name' is required"):
+        load_from_yaml("version: '1.0'")
+
+    # Test missing capability name
+    with pytest.raises(ValueError, match="Capability must have a 'name'"):
+        load_from_yaml("""
+name: "NoCapName"
+capabilities:
+  - description: "missing name"
+""")


### PR DESCRIPTION
Implemented a new DSL module to allow defining Agents using simplified YAML syntax.
- Added `src/coreason_manifest/dsl.py`: Implements `load_from_yaml`, `SchemaCapability`, and shorthand type expansion (e.g., `list[int]`).
- Updated `src/coreason_manifest/__init__.py`: Exposed `load_from_yaml`.
- Added `tests/test_dsl.py`: Verified happy paths, complex types, error handling, and published status.
- Added `docs/simplified_dsl.md`: Documentation for the new DSL.
- Updated `mkdocs.yml`: Added Simplified DSL to navigation.
- Verified `PyYAML` dependency exists in `pyproject.toml`.

---
*PR created automatically by Jules for task [5336389765234075258](https://jules.google.com/task/5336389765234075258) started by @gowthamrao*