### PR TITLE
Add Mermaid.js Visualization Support to AgentDefinition

### DIFF
--- a/docs/builder_sdk.md
+++ b/docs/builder_sdk.md
@@ -73,7 +73,10 @@ agent_definition = (
 
 # agent_definition is now a valid, immutable AgentDefinition object
 # ready for serialization or usage by the Engine.
-print(agent_definition.to_json(indent=2))
+print(agent_definition.model_dump_json(indent=2))
+
+# Visualize the topology
+print(agent_definition.to_mermaid())
 ```
 
 ### 4. Define Graph Topology (Optional)

--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -202,3 +202,30 @@ agent = AgentDefinition(
 json_output = agent.model_dump_json(indent=2)
 print(json_output)
 ```
+
+## Visualization and Topology Export
+
+Complex graph-based agents can be difficult to understand by reading JSON. The `AgentDefinition` includes a built-in method to export the topology to **Mermaid.js** format.
+
+### `to_mermaid()`
+
+Generates a string compatible with Mermaid's Live Editor or any Mermaid renderer.
+
+*   **Atomic Agents**: Renders as a single node.
+*   **Graph Agents**: Renders the full flow, including:
+    *   **Start Node**: Synthetic entry point indicator.
+    *   **Shapes**: Distinct shapes for `AgentNode` (Rectangle), `LogicNode` (Rhombus), `HumanNode` (Rounded), etc.
+    *   **Styles**: Color-coded classes for visual distinction.
+    *   **Edges**: Directional arrows, with labels for conditional logic.
+
+**Example Usage:**
+
+```python
+mermaid_graph = agent.to_mermaid()
+print(mermaid_graph)
+# Output:
+# graph TD
+# classDef agent ...
+# Start((Start)) --> node1
+# node1["Search"]:::agent --> node2{"Check"}:::logic
+```

--- a/src/coreason_manifest/dsl.py
+++ b/src/coreason_manifest/dsl.py
@@ -66,10 +66,7 @@ def _expand_shorthand_type(shorthand: str) -> Dict[str, Any]:
     array_match = re.match(r"^(?:list|array)\[(.+)\]$", shorthand, re.IGNORECASE)
     if array_match:
         inner_type = array_match.group(1)
-        return {
-            "type": "array",
-            "items": _expand_shorthand_type(inner_type)
-        }
+        return {"type": "array", "items": _expand_shorthand_type(inner_type)}
 
     # Handle basic types
     start = shorthand.lower()
@@ -107,12 +104,7 @@ def _expand_properties(props: Dict[str, str]) -> Dict[str, Any]:
         properties[name] = _expand_shorthand_type(shorthand)
         required.append(name)
 
-    return {
-        "type": "object",
-        "properties": properties,
-        "required": required,
-        "additionalProperties": False
-    }
+    return {"type": "object", "properties": properties, "required": required, "additionalProperties": False}
 
 
 def load_from_yaml(content: str) -> AgentDefinition:
@@ -171,11 +163,11 @@ def load_from_yaml(content: str) -> AgentDefinition:
             inputs=inputs_schema,
             outputs=outputs_schema,
             type=cap_type,
-            delivery_mode=delivery_mode
+            delivery_mode=delivery_mode,
         )
 
         # Add to builder - ignore type check because AgentBuilder expects TypedCapability
-        builder.with_capability(cap) # type: ignore
+        builder.with_capability(cap)  # type: ignore
 
     # Process Model Config
     model_data = data.get("model")

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -9,8 +9,10 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import pytest
-from coreason_manifest.dsl import load_from_yaml
+
 from coreason_manifest.definitions.agent import AgentStatus, CapabilityType
+from coreason_manifest.dsl import load_from_yaml
+
 
 def test_load_basic_agent() -> None:
     yaml_content = """

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -62,6 +62,7 @@ capabilities:
     assert cap.outputs["type"] == "object"
     assert cap.outputs["properties"]["report"] == {"type": "string"}
 
+
 def test_load_complex_types() -> None:
     yaml_content = """
 name: "ComplexBot"
@@ -89,6 +90,7 @@ capabilities:
     # Any -> {}
     summary_schema = cap.outputs["properties"]["summary"]
     assert summary_schema == {}
+
 
 def test_load_published_status() -> None:
     # Note: Published status requires integrity_hash usually, but AgentBuilder generates a dummy one if published.
@@ -124,6 +126,7 @@ capabilities:
     agent = load_from_yaml(yaml_content)
     assert agent.status == AgentStatus.PUBLISHED
     assert agent.integrity_hash is not None
+
 
 def test_load_error_cases() -> None:
     # Test unknown shorthand

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -8,18 +8,15 @@ from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNo
 class DummyInput(BaseModel):
     query: str
 
+
 class DummyOutput(BaseModel):
     result: str
+
 
 def test_atomic_agent_mermaid() -> None:
     # Create an atomic agent (no nodes)
     builder = AgentBuilder(name="AtomicAgent")
-    cap = TypedCapability(
-        name="chat",
-        description="Chat capability",
-        input_model=DummyInput,
-        output_model=DummyOutput
-    )
+    cap = TypedCapability(name="chat", description="Chat capability", input_model=DummyInput, output_model=DummyOutput)
     builder.with_capability(cap)
 
     agent = builder.build()
@@ -28,42 +25,27 @@ def test_atomic_agent_mermaid() -> None:
     assert "graph TD" in mermaid
     assert 'Start((Start)) --> Agent["AtomicAgent"]' in mermaid
 
+
 def test_graph_agent_mermaid() -> None:
     # Create a graph agent
     builder = AgentBuilder(name="GraphAgent")
-    cap = TypedCapability(
-        name="chat",
-        description="Chat capability",
-        input_model=DummyInput,
-        output_model=DummyOutput
-    )
+    cap = TypedCapability(name="chat", description="Chat capability", input_model=DummyInput, output_model=DummyOutput)
     builder.with_capability(cap)
 
     # Add nodes
     # AgentNode
-    node1 = AgentNode(
-        id="node1",
-        agent_name="SearchAgent",
-        visual=VisualMetadata(label="Search Web")
-    )
+    node1 = AgentNode(id="node1", agent_name="SearchAgent", visual=VisualMetadata(label="Search Web"))
     # LogicNode
-    node2 = LogicNode(
-        id="node2",
-        code="return True",
-        visual=VisualMetadata(label="Check Result")
-    )
+    node2 = LogicNode(id="node2", code="return True", visual=VisualMetadata(label="Check Result"))
     # HumanNode
-    node3 = HumanNode(
-        id="node3",
-        visual=VisualMetadata(label="User Approval")
-    )
+    node3 = HumanNode(id="node3", visual=VisualMetadata(label="User Approval"))
     # RecipeNode (Default Case)
     node4 = RecipeNode(
         id="node4",
         recipe_id="some_recipe",
         input_mapping={},
         output_mapping={},
-        visual=VisualMetadata(label="Sub Recipe")
+        visual=VisualMetadata(label="Sub Recipe"),
     )
 
     builder.with_node(node1)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,115 @@
+import pytest
+from pydantic import BaseModel
+from coreason_manifest.builder.agent import AgentBuilder
+from coreason_manifest.builder.capability import TypedCapability
+from coreason_manifest.definitions.topology import AgentNode, LogicNode, HumanNode, RecipeNode, VisualMetadata
+
+class DummyInput(BaseModel):
+    query: str
+
+class DummyOutput(BaseModel):
+    result: str
+
+def test_atomic_agent_mermaid() -> None:
+    # Create an atomic agent (no nodes)
+    builder = AgentBuilder(name="AtomicAgent")
+    cap = TypedCapability(
+        name="chat",
+        description="Chat capability",
+        input_model=DummyInput,
+        output_model=DummyOutput
+    )
+    builder.with_capability(cap)
+
+    agent = builder.build()
+    mermaid = agent.to_mermaid()
+
+    assert "graph TD" in mermaid
+    assert 'Start((Start)) --> Agent["AtomicAgent"]' in mermaid
+
+def test_graph_agent_mermaid() -> None:
+    # Create a graph agent
+    builder = AgentBuilder(name="GraphAgent")
+    cap = TypedCapability(
+        name="chat",
+        description="Chat capability",
+        input_model=DummyInput,
+        output_model=DummyOutput
+    )
+    builder.with_capability(cap)
+
+    # Add nodes
+    # AgentNode
+    node1 = AgentNode(
+        id="node1",
+        agent_name="SearchAgent",
+        visual=VisualMetadata(label="Search Web")
+    )
+    # LogicNode
+    node2 = LogicNode(
+        id="node2",
+        code="return True",
+        visual=VisualMetadata(label="Check Result")
+    )
+    # HumanNode
+    node3 = HumanNode(
+        id="node3",
+        visual=VisualMetadata(label="User Approval")
+    )
+    # RecipeNode (Default Case)
+    node4 = RecipeNode(
+        id="node4",
+        recipe_id="some_recipe",
+        input_mapping={},
+        output_mapping={},
+        visual=VisualMetadata(label="Sub Recipe")
+    )
+
+    builder.with_node(node1)
+    builder.with_node(node2)
+    builder.with_node(node3)
+    builder.with_node(node4)
+
+    # Add edges
+    builder.with_edge("node1", "node2")
+    builder.with_edge("node2", "node3", condition="is_valid")
+    builder.with_edge("node3", "node4")
+
+    builder.set_entry_point("node1")
+
+    agent = builder.build()
+    mermaid = agent.to_mermaid()
+
+    # Check Header and Classes
+    assert "graph TD" in mermaid
+    assert "classDef agent" in mermaid
+    assert "classDef logic" in mermaid
+    assert "classDef human" in mermaid
+
+    # Check Nodes
+    # node1: agent, label "Search Web"
+    # Expected: node1["Search Web"]:::agent
+    assert 'node1["Search Web"]:::agent' in mermaid
+
+    # node2: logic, label "Check Result"
+    # Expected: node2{"Check Result"}:::logic
+    assert 'node2{"Check Result"}:::logic' in mermaid
+
+    # node3: human, label "User Approval"
+    # Expected: node3("User Approval"):::human
+    assert 'node3("User Approval"):::human' in mermaid
+
+    # node4: recipe, label "Sub Recipe" (Default)
+    # Expected: node4["Sub Recipe"]:::default
+    assert 'node4["Sub Recipe"]:::default' in mermaid
+
+    # Check Edges
+    # node1 --> node2
+    assert "node1 --> node2" in mermaid
+    # node2 -- "is_valid" --> node3
+    assert 'node2 -- "is_valid" --> node3' in mermaid
+    # node3 --> node4
+    assert "node3 --> node4" in mermaid
+
+    # Check Entry Point
+    assert "Start((Start)) --> node1" in mermaid

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,8 +1,9 @@
-import pytest
 from pydantic import BaseModel
+
 from coreason_manifest.builder.agent import AgentBuilder
 from coreason_manifest.builder.capability import TypedCapability
-from coreason_manifest.definitions.topology import AgentNode, LogicNode, HumanNode, RecipeNode, VisualMetadata
+from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, RecipeNode, VisualMetadata
+
 
 class DummyInput(BaseModel):
     query: str


### PR DESCRIPTION
This PR adds a `to_mermaid()` method to the `AgentDefinition` class, enabling the generation of Mermaid.js graph syntax strings for visualizing agent topologies. It handles both Atomic Agents and Graph Agents, applying specific styles and shapes to different node types (`AgentNode`, `LogicNode`, `HumanNode`). A new test file `tests/test_visualization.py` ensures correct output generation.

---
*PR created automatically by Jules for task [17633642993309673606](https://jules.google.com/task/17633642993309673606) started by @gowthamrao*