### PR TITLE
feat: Event Content-Type Discriminators

### DIFF
--- a/docs/event_content_types.md
+++ b/docs/event_content_types.md
@@ -1,0 +1,72 @@
+# Event Content-Type Discriminators
+
+To enable robust and generic consumption of Coreason events, the platform utilizes strict **MIME-type discriminators**. This allows consumers (such as React frontends, Event Routers, or other services) to route and render events based on standard HTTP-like headers, without needing to parse the internal payload or inspect specific event types.
+
+## EventContentType
+
+The `EventContentType` enumeration defines the supported Vendor-Specific MIME types:
+
+*   **JSON (`application/json`)**: The default content type for standard events (e.g., `NODE_STARTED`, `NODE_COMPLETED`).
+*   **STREAM (`application/vnd.coreason.stream+json`)**: Specifically for streaming token generation (`NODE_STREAM`). Clients can route these directly to a "Stream Renderer" or text buffer.
+*   **ERROR (`application/vnd.coreason.error+json`)**: For semantic error events (`ERROR`). Clients can trigger error boundaries or toaster notifications based on this type.
+*   **ARTIFACT (`application/vnd.coreason.artifact+json`)**: For generated files or artifacts (`ARTIFACT_GENERATED`). Clients can trigger file download handlers or previewers.
+
+## CloudEvent Integration
+
+The Coreason Agent Manifest utilizes the standard [CloudEvents v1.0](https://cloudevents.io/) envelope. The `datacontenttype` field of the CloudEvent carries the discriminator.
+
+### Schema
+
+```python
+class CloudEvent(CoReasonBaseModel, Generic[T]):
+    # ...
+    datacontenttype: Union[EventContentType, str] = Field(
+        default=EventContentType.JSON,
+        description="MIME content type of data"
+    )
+    # ...
+```
+
+## Usage in Streaming (SSE)
+
+When using `SERVER_SENT_EVENTS` delivery mode, each event in the stream is a JSON-serialized CloudEvent. The consumer should inspect `datacontenttype` to determine how to handle the `data` payload.
+
+### Example: Stream Event
+
+```json
+{
+  "specversion": "1.0",
+  "type": "ai.coreason.node.stream",
+  "source": "urn:node:123",
+  "datacontenttype": "application/vnd.coreason.stream+json",
+  "data": {
+    "chunk": "Hello "
+  }
+}
+```
+
+### Example: Error Event
+
+```json
+{
+  "specversion": "1.0",
+  "type": "ai.coreason.legacy.error",
+  "source": "urn:node:123",
+  "datacontenttype": "application/vnd.coreason.error+json",
+  "data": {
+    "error_message": "Rate limit exceeded",
+    "code": 429,
+    "domain": "LLM",
+    "retryable": true
+  }
+}
+```
+
+## Migration
+
+The `migrate_graph_event_to_cloud_event` utility function automatically maps legacy `GraphEvent` types to the appropriate `datacontenttype`:
+
+*   `NODE_STREAM` -> `application/vnd.coreason.stream+json`
+*   `ERROR` -> `application/vnd.coreason.error+json`
+*   `ARTIFACT_GENERATED` -> `application/vnd.coreason.artifact+json`
+*   All others -> `application/json`

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,7 @@ This is the documentation for the coreason_manifest project.
 *   [Atomic Agents](atomic_agents.md): Understand how to define simple, prompt-based agents without complex topologies.
 *   [Agent Behavior Protocols](agent_behavior_protocols.md): The standard interfaces (`AgentInterface`) for agent implementation.
 *   [Transport-Layer Specification](transport_layer_specification.md): The HTTP/SSE contract for serving agents.
+*   [Event Content-Types](event_content_types.md): Standard MIME types for Coreason events.
 *   [Recipe Manifests](recipes.md): Learn about defining executable workflows and graphs.
 *   [Session Management](session_management.md): Decoupling execution from memory with standardized Session and Interaction models.
 *   [Agent Request Envelope](agent_request_envelope.md): The standard envelope for agent invocations and distributed tracing.

--- a/docs/transport_layer_specification.md
+++ b/docs/transport_layer_specification.md
@@ -64,6 +64,8 @@ Each event in the stream corresponds to a `ServerSentEvent` object, which wraps 
 
 The `ServerSentEvent` model defines the strict structure of each chunk in the stream.
 
+**Content-Type Discriminators:** The payload within `data` (the CloudEvent) includes a `datacontenttype` field. Consumers should use this MIME type to determine how to parse or render the event (e.g., `application/vnd.coreason.stream+json` for token streams). See [Event Content-Type Discriminators](event_content_types.md) for details.
+
 ```python
 class ServerSentEvent(CoReasonBaseModel):
     event: str          # The event type (e.g., 'ai.coreason.node.started')
@@ -78,15 +80,15 @@ class ServerSentEvent(CoReasonBaseModel):
 ```
 event: ai.coreason.node.started
 id: evt-001
-data: {"specversion": "1.0", "type": "ai.coreason.node.started", "source": "urn:node:1", "data": {"node_id": "1", "status": "RUNNING"}}
+data: {"specversion": "1.0", "type": "ai.coreason.node.started", "source": "urn:node:1", "datacontenttype": "application/json", "data": {"node_id": "1", "status": "RUNNING"}}
 
 event: ai.coreason.node.stream
 id: evt-002
-data: {"specversion": "1.0", "type": "ai.coreason.node.stream", "source": "urn:node:1", "data": {"chunk": "Hello"}}
+data: {"specversion": "1.0", "type": "ai.coreason.node.stream", "source": "urn:node:1", "datacontenttype": "application/vnd.coreason.stream+json", "data": {"chunk": "Hello"}}
 
 event: ai.coreason.node.completed
 id: evt-003
-data: {"specversion": "1.0", "type": "ai.coreason.node.completed", "source": "urn:node:1", "data": {"output_summary": "Hello"}}
+data: {"specversion": "1.0", "type": "ai.coreason.node.completed", "source": "urn:node:1", "datacontenttype": "application/json", "data": {"output_summary": "Hello"}}
 ```
 
 ## Service Contract & OpenAPI

--- a/src/coreason_manifest/dsl.py
+++ b/src/coreason_manifest/dsl.py
@@ -66,10 +66,7 @@ def _expand_shorthand_type(shorthand: str) -> Dict[str, Any]:
     array_match = re.match(r"^(?:list|array)\[(.+)\]$", shorthand, re.IGNORECASE)
     if array_match:
         inner_type = array_match.group(1)
-        return {
-            "type": "array",
-            "items": _expand_shorthand_type(inner_type)
-        }
+        return {"type": "array", "items": _expand_shorthand_type(inner_type)}
 
     # Handle basic types
     start = shorthand.lower()
@@ -107,12 +104,7 @@ def _expand_properties(props: Dict[str, str]) -> Dict[str, Any]:
         properties[name] = _expand_shorthand_type(shorthand)
         required.append(name)
 
-    return {
-        "type": "object",
-        "properties": properties,
-        "required": required,
-        "additionalProperties": False
-    }
+    return {"type": "object", "properties": properties, "required": required, "additionalProperties": False}
 
 
 def load_from_yaml(content: str) -> AgentDefinition:
@@ -171,11 +163,11 @@ def load_from_yaml(content: str) -> AgentDefinition:
             inputs=inputs_schema,
             outputs=outputs_schema,
             type=cap_type,
-            delivery_mode=delivery_mode
+            delivery_mode=delivery_mode,
         )
 
         # Add to builder - ignore type check because AgentBuilder expects TypedCapability
-        builder.with_capability(cap) # type: ignore
+        builder.with_capability(cap)  # type: ignore
 
     # Process Model Config
     model_data = data.get("model")

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -9,8 +9,10 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import pytest
-from coreason_manifest.dsl import load_from_yaml
+
 from coreason_manifest.definitions.agent import AgentStatus, CapabilityType
+from coreason_manifest.dsl import load_from_yaml
+
 
 def test_load_basic_agent() -> None:
     yaml_content = """

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -62,6 +62,7 @@ capabilities:
     assert cap.outputs["type"] == "object"
     assert cap.outputs["properties"]["report"] == {"type": "string"}
 
+
 def test_load_complex_types() -> None:
     yaml_content = """
 name: "ComplexBot"
@@ -89,6 +90,7 @@ capabilities:
     # Any -> {}
     summary_schema = cap.outputs["properties"]["summary"]
     assert summary_schema == {}
+
 
 def test_load_published_status() -> None:
     # Note: Published status requires integrity_hash usually, but AgentBuilder generates a dummy one if published.
@@ -124,6 +126,7 @@ capabilities:
     agent = load_from_yaml(yaml_content)
     assert agent.status == AgentStatus.PUBLISHED
     assert agent.integrity_hash is not None
+
 
 def test_load_error_cases() -> None:
     # Test unknown shorthand


### PR DESCRIPTION
Implemented Content-Type Discriminators for Coreason events to allow generic consumers to route and render events based on standard HTTP headers.

Key changes:
1.  **`src/coreason_manifest/definitions/events.py`**:
    *   Added `EventContentType` enum with `JSON`, `STREAM`, `ERROR`, `ARTIFACT`.
    *   Updated `CloudEvent` to use `Union[EventContentType, str]` for `datacontenttype` (defaulting to JSON).
    *   Updated `migrate_graph_event_to_cloud_event` to automatically set the correct MIME type based on the event type.

2.  **Documentation**:
    *   Added `docs/event_content_types.md` explaining the feature.
    *   Updated `docs/transport_layer_specification.md` with examples using the new MIME types.
    *   Updated `docs/index.md`.

3.  **Testing**:
    *   Updated `tests/test_cloudevents.py` to verify that `migrate_graph_event_to_cloud_event` correctly assigns MIME types for `NODE_STREAM`, `ERROR`, and `ARTIFACT_GENERATED` events.
    *   Added specific test for `ARTIFACT_GENERATED` migration.


---
*PR created automatically by Jules for task [8353480591972205807](https://jules.google.com/task/8353480591972205807) started by @gowthamrao*