### PR TITLE
Visual Topology Editor Support (Mermaid Export)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ It provides the **"Blueprint"** that all other services (Builder, Engine, Simula
 *   **Flexible Tooling:** `ToolCallRequestPart` accepts JSON strings with automatic parsing.
 *   **Enhanced Tracing:** `ReasoningTrace` includes flexible metadata for execution state.
 *   **Builder SDK:** A fluent, strictly-typed Python SDK for defining Agents using Pydantic models.
+*   **Topology Visualization:** Export agent execution flows to Mermaid.js graph syntax (`.to_mermaid()`).
 
 ## Serialization & Base Model
 

--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -108,6 +108,26 @@ A Graph Agent orchestrates a complex workflow involving multiple steps, loops, o
     *   `entry_point`: The ID of the starting node.
     *   **Topology Validation**: The specification validates that all edges connect to existing nodes (preventing "dangling pointers"). *Note: This check is skipped if the agent is in `draft` status.*
 
+## Visualization & Export
+
+To assist with debugging and documentation, the `AgentDefinition` class includes a `to_mermaid()` method. This generates a [Mermaid.js](https://mermaid.js.org/) graph definition string representing the agent's topology.
+
+*   **Atomic Agents**: Rendered as a simple flow from Start to the Agent.
+*   **Graph Agents**: Rendered as a `graph TD` flow diagram, including:
+    *   Visual distinction between Node Types (Agents, Logic, Human).
+    *   Conditional Edges.
+    *   Entry Point indication.
+
+```python
+mermaid_graph = agent.to_mermaid()
+print(mermaid_graph)
+# Output:
+# graph TD
+# Start((Start)) --> node1
+# node1["Search"]:::agent
+# ...
+```
+
 ## Recipes and Topology
 
 While `AgentDefinition` defines an autonomous entity, the **Recipe Manifest** (`RecipeManifest`) defines a reusable workflow or "Standard Operating Procedure" (SOP).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -121,6 +121,19 @@ agent = AgentDefinition(
 print(f"Agent '{agent.metadata.name}' created successfully.")
 ```
 
+### Visualizing the Topology
+You can export the agent's execution flow as a Mermaid.js graph string for documentation or debugging.
+
+```python
+mermaid_str = agent.to_mermaid()
+print(mermaid_str)
+# Output:
+# graph TD
+# ...
+# start["start"]:::logic
+# ...
+```
+
 ### Accessing Immutable Fields
 
 ```python

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,8 +1,9 @@
 import uuid
-import pytest
+
 from coreason_manifest.definitions.agent import AgentDefinition
 
-def test_atomic_agent_mermaid():
+
+def test_atomic_agent_mermaid() -> None:
     """Test Mermaid export for an atomic agent."""
     data = {
         "metadata": {
@@ -29,7 +30,8 @@ def test_atomic_agent_mermaid():
     assert "graph TD" in mermaid
     assert 'Start((Start)) --> Agent["My Atomic Agent (Atomic)"]' in mermaid
 
-def test_graph_agent_mermaid():
+
+def test_graph_agent_mermaid() -> None:
     """Test Mermaid export for a graph agent."""
     data = {
         "metadata": {
@@ -42,27 +44,13 @@ def test_graph_agent_mermaid():
         "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
         "config": {
             "nodes": [
-                {
-                    "id": "node1",
-                    "type": "agent",
-                    "agent_name": "search_agent",
-                    "visual": {"label": "Search Web"}
-                },
-                {
-                    "id": "node2",
-                    "type": "logic",
-                    "code": "pass",
-                    "visual": {"label": "Process"}
-                },
-                {
-                    "id": "node3",
-                    "type": "human",
-                    "visual": {"label": "Approve"}
-                }
+                {"id": "node1", "type": "agent", "agent_name": "search_agent", "visual": {"label": "Search Web"}},
+                {"id": "node2", "type": "logic", "code": "pass", "visual": {"label": "Process"}},
+                {"id": "node3", "type": "human", "visual": {"label": "Approve"}},
             ],
             "edges": [
                 {"source_node_id": "node1", "target_node_id": "node2", "condition": "success"},
-                {"source_node_id": "node2", "target_node_id": "node3"}
+                {"source_node_id": "node2", "target_node_id": "node3"},
             ],
             "entry_point": "node1",
             "model_config": {"model": "gpt-4", "temperature": 0.7},
@@ -87,7 +75,7 @@ def test_graph_agent_mermaid():
 
     # Check Edges
     assert 'node1 -- "success" --> node2' in mermaid
-    assert 'node2 --> node3' in mermaid
+    assert "node2 --> node3" in mermaid
 
     # Check Entry Point
-    assert 'Start((Start)) --> node1' in mermaid
+    assert "Start((Start)) --> node1" in mermaid

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -79,3 +79,40 @@ def test_graph_agent_mermaid() -> None:
 
     # Check Entry Point
     assert "Start((Start)) --> node1" in mermaid
+
+
+def test_mermaid_coverage_defaults() -> None:
+    """Test Mermaid export for node types that fall into default styling (e.g. RecipeNode)."""
+    data = {
+        "metadata": {
+            "id": str(uuid.uuid4()),
+            "version": "1.0.0",
+            "name": "Coverage Agent",
+            "author": "Me",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
+        "config": {
+            "nodes": [
+                {
+                    "id": "node_r",
+                    "type": "recipe",
+                    "recipe_id": "other_recipe",
+                    "input_mapping": {},
+                    "output_mapping": {},
+                    "visual": {"label": "Sub Recipe"},
+                }
+            ],
+            "edges": [],
+            "entry_point": "node_r",
+            "model_config": {"model": "gpt-4", "temperature": 0.7},
+        },
+        "dependencies": {},
+    }
+
+    agent = AgentDefinition(**data)
+    mermaid = agent.to_mermaid()
+
+    # Should use default styling
+    # default shape is [ ] and class is default
+    assert 'node_r["Sub Recipe"]:::default' in mermaid

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,93 @@
+import uuid
+import pytest
+from coreason_manifest.definitions.agent import AgentDefinition
+
+def test_atomic_agent_mermaid():
+    """Test Mermaid export for an atomic agent."""
+    data = {
+        "metadata": {
+            "id": str(uuid.uuid4()),
+            "version": "1.0.0",
+            "name": "My Atomic Agent",
+            "author": "Me",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
+        "config": {
+            "nodes": [],
+            "edges": [],
+            "entry_point": None,
+            "model_config": {"model": "gpt-4", "temperature": 0.7},
+            "system_prompt": "You are an atomic agent.",
+        },
+        "dependencies": {},
+    }
+
+    agent = AgentDefinition(**data)
+    mermaid = agent.to_mermaid()
+
+    assert "graph TD" in mermaid
+    assert 'Start((Start)) --> Agent["My Atomic Agent (Atomic)"]' in mermaid
+
+def test_graph_agent_mermaid():
+    """Test Mermaid export for a graph agent."""
+    data = {
+        "metadata": {
+            "id": str(uuid.uuid4()),
+            "version": "1.0.0",
+            "name": "My Graph Agent",
+            "author": "Me",
+            "created_at": "2023-10-27T10:00:00Z",
+        },
+        "capabilities": [{"name": "default", "type": "atomic", "description": "Default", "inputs": {}, "outputs": {}}],
+        "config": {
+            "nodes": [
+                {
+                    "id": "node1",
+                    "type": "agent",
+                    "agent_name": "search_agent",
+                    "visual": {"label": "Search Web"}
+                },
+                {
+                    "id": "node2",
+                    "type": "logic",
+                    "code": "pass",
+                    "visual": {"label": "Process"}
+                },
+                {
+                    "id": "node3",
+                    "type": "human",
+                    "visual": {"label": "Approve"}
+                }
+            ],
+            "edges": [
+                {"source_node_id": "node1", "target_node_id": "node2", "condition": "success"},
+                {"source_node_id": "node2", "target_node_id": "node3"}
+            ],
+            "entry_point": "node1",
+            "model_config": {"model": "gpt-4", "temperature": 0.7},
+        },
+        "dependencies": {},
+    }
+
+    agent = AgentDefinition(**data)
+    mermaid = agent.to_mermaid()
+
+    assert "graph TD" in mermaid
+
+    # Check Styling Definitions
+    assert "classDef agent" in mermaid
+    assert "classDef logic" in mermaid
+    assert "classDef human" in mermaid
+
+    # Check Nodes
+    assert 'node1["Search Web"]:::agent' in mermaid
+    assert 'node2{"Process"}:::logic' in mermaid
+    assert 'node3("Approve"):::human' in mermaid
+
+    # Check Edges
+    assert 'node1 -- "success" --> node2' in mermaid
+    assert 'node2 --> node3' in mermaid
+
+    # Check Entry Point
+    assert 'Start((Start)) --> node1' in mermaid


### PR DESCRIPTION
Implemented `to_mermaid()` method on `AgentDefinition` to export agent topology as a Mermaid.js graph string. 
This supports both Atomic Agents (simplified view) and Graph Agents (full topology with styling).
Added comprehensive tests in `tests/test_visualization.py`.

---
*PR created automatically by Jules for task [14599305044084710351](https://jules.google.com/task/14599305044084710351) started by @gowthamrao*