### PR TITLE
Security Hardening: Fix Builder Auth, DSL DoS, and Risk Logic

### DIFF
--- a/src/coreason_manifest/builder/agent.py
+++ b/src/coreason_manifest/builder/agent.py
@@ -74,6 +74,7 @@ class AgentBuilder:
         self._edges: list[Edge] = []
         self._entry_point: Optional[str] = None
         self._tools: list[ToolRequirement] = []
+        self._requires_auth: bool = False
 
     def set_status(self, status: AgentStatus) -> Self:
         """Set the lifecycle status of the agent.
@@ -155,6 +156,18 @@ class AgentBuilder:
         self._entry_point = node_id
         return self
 
+    def with_auth_requirement(self, required: bool) -> Self:
+        """Set whether the agent requires user authentication.
+
+        Args:
+            required: True if authentication is required.
+
+        Returns:
+            The builder instance (for chaining).
+        """
+        self._requires_auth = required
+        return self
+
     def build(self) -> AgentDefinition:
         """Construct the final immutable AgentDefinition.
 
@@ -171,7 +184,7 @@ class AgentBuilder:
             name=self.name,
             author=self.author,
             created_at=datetime.now(timezone.utc),
-            requires_auth=False,
+            requires_auth=self._requires_auth,
         )
 
         model_config = ModelConfig(

--- a/src/coreason_manifest/dsl.py
+++ b/src/coreason_manifest/dsl.py
@@ -51,22 +51,26 @@ class SchemaCapability:
         )
 
 
-def _expand_shorthand_type(shorthand: str) -> Dict[str, Any]:
+def _expand_shorthand_type(shorthand: str, depth: int = 0) -> Dict[str, Any]:
     """Expand a shorthand type string into a JSON Schema dictionary.
 
     Args:
         shorthand: Type string like 'string', 'int', 'list[string]'.
+        depth: Current recursion depth.
 
     Returns:
         JSON Schema dictionary.
     """
+    if depth > 20:
+        raise ValueError("Type definition too deeply nested.")
+
     shorthand = shorthand.strip()
 
     # Handle array/list types
     array_match = re.match(r"^(?:list|array)\[(.+)\]$", shorthand, re.IGNORECASE)
     if array_match:
         inner_type = array_match.group(1)
-        return {"type": "array", "items": _expand_shorthand_type(inner_type)}
+        return {"type": "array", "items": _expand_shorthand_type(inner_type, depth + 1)}
 
     # Handle basic types
     start = shorthand.lower()

--- a/src/coreason_manifest/governance.py
+++ b/src/coreason_manifest/governance.py
@@ -98,7 +98,7 @@ def _risk_score(level: ToolRiskLevel) -> int:
         return 1
     if level == ToolRiskLevel.CRITICAL:
         return 2
-    return 0  # pragma: no cover
+    raise ValueError(f"Unknown risk level: {level}")
 
 
 def check_compliance(agent: AgentDefinition, config: GovernanceConfig) -> ComplianceReport:

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -118,3 +118,18 @@ def test_integrity_hash_sensitivity() -> None:
     agent3 = builder3.build()
 
     assert agent1.integrity_hash == agent3.integrity_hash
+
+def test_builder_with_auth_requirement() -> None:
+    """Test setting auth requirement."""
+    cap = TypedCapability(
+        name="search",
+        description="Search",
+        input_model=SearchInput,
+        output_model=SearchOutput,
+        injected_params=["user_context"]
+    )
+    builder = AgentBuilder(name="AuthAgent")
+    builder.with_capability(cap).with_auth_requirement(True)
+    agent = builder.build()
+
+    assert agent.metadata.requires_auth is True

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -119,6 +119,7 @@ def test_integrity_hash_sensitivity() -> None:
 
     assert agent1.integrity_hash == agent3.integrity_hash
 
+
 def test_builder_with_auth_requirement() -> None:
     """Test setting auth requirement."""
     cap = TypedCapability(
@@ -126,7 +127,7 @@ def test_builder_with_auth_requirement() -> None:
         description="Search",
         input_model=SearchInput,
         output_model=SearchOutput,
-        injected_params=["user_context"]
+        injected_params=["user_context"],
     )
     builder = AgentBuilder(name="AuthAgent")
     builder.with_capability(cap).with_auth_requirement(True)

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -164,3 +164,16 @@ name: "NoCapName"
 capabilities:
   - description: "missing name"
 """)
+
+def test_recursion_limit() -> None:
+    """Test that deeply nested types raise ValueError."""
+    nested_type = "list[" * 21 + "int" + "]" * 21
+    yaml_content = f"""
+name: DosBot
+capabilities:
+  - name: test
+    inputs:
+      x: {nested_type}
+"""
+    with pytest.raises(ValueError, match="Type definition too deeply nested"):
+        load_from_yaml(yaml_content)

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -165,6 +165,7 @@ capabilities:
   - description: "missing name"
 """)
 
+
 def test_recursion_limit() -> None:
     """Test that deeply nested types raise ValueError."""
     nested_type = "list[" * 21 + "int" + "]" * 21

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import List, Optional, Union
 from unittest.mock import patch
 from uuid import uuid4
+import pytest
 
 from coreason_manifest.definitions.agent import (
     AgentCapability,
@@ -25,7 +26,7 @@ from coreason_manifest.definitions.agent import (
     ToolRequirement,
     ToolRiskLevel,
 )
-from coreason_manifest.governance import GovernanceConfig, check_compliance
+from coreason_manifest.governance import GovernanceConfig, check_compliance, _risk_score
 
 ToolType = Union[ToolRequirement, InlineToolDefinition]
 
@@ -186,3 +187,8 @@ def test_governance_no_hostname_violation() -> None:
     report = check_compliance(agent, config)
     assert not report.passed
     assert report.violations[0].rule == "domain_restriction"
+
+def test_risk_score_unknown_error() -> None:
+    # Use a fake enum value or cast string
+    with pytest.raises(ValueError, match="Unknown risk level"):
+        _risk_score("UNKNOWN_LEVEL") # type: ignore

--- a/tests/test_governance.py
+++ b/tests/test_governance.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import List, Optional, Union
 from unittest.mock import patch
 from uuid import uuid4
+
 import pytest
 
 from coreason_manifest.definitions.agent import (
@@ -26,7 +27,7 @@ from coreason_manifest.definitions.agent import (
     ToolRequirement,
     ToolRiskLevel,
 )
-from coreason_manifest.governance import GovernanceConfig, check_compliance, _risk_score
+from coreason_manifest.governance import GovernanceConfig, _risk_score, check_compliance
 
 ToolType = Union[ToolRequirement, InlineToolDefinition]
 
@@ -188,7 +189,8 @@ def test_governance_no_hostname_violation() -> None:
     assert not report.passed
     assert report.violations[0].rule == "domain_restriction"
 
+
 def test_risk_score_unknown_error() -> None:
     # Use a fake enum value or cast string
     with pytest.raises(ValueError, match="Unknown risk level"):
-        _risk_score("UNKNOWN_LEVEL") # type: ignore
+        _risk_score("UNKNOWN_LEVEL")  # type: ignore


### PR DESCRIPTION
Addressed three critical security findings from red team review:
1. **Functional/Governance Bug**: `AgentBuilder` hardcoded `requires_auth=False`, making it impossible to build compliant agents using CRITICAL tools (which require `requires_auth=True`). Added `with_auth_requirement` method.
2. **DoS Vulnerability**: `dsl.py` used greedy regex with unbounded recursion for parsing shorthand types. Added depth check to prevent stack overflow.
3. **Fail-Open Logic**: `governance.py` treated unknown risk levels as SAFE (0). Changed to raise exception for unknown inputs.

Verified with reproduction script and full test suite (100% coverage).

---
*PR created automatically by Jules for task [9745809134592428588](https://jules.google.com/task/9745809134592428588) started by @gowthamrao*