### PR TITLE
Refactor AgentInterface to use ResponseHandler Protocol

### DIFF
--- a/src/coreason_manifest/definitions/interfaces.py
+++ b/src/coreason_manifest/definitions/interfaces.py
@@ -11,11 +11,60 @@
 """Defines the behavioral contract (Protocol) for a Coreason Agent."""
 
 from abc import abstractmethod
-from typing import Any, AsyncIterator, Protocol, Union, runtime_checkable
+from typing import Any, Awaitable, Dict, Optional, Protocol, Union, runtime_checkable
 
 from coreason_manifest.definitions.agent import AgentDefinition
 from coreason_manifest.definitions.events import CloudEvent, GraphEvent
+from coreason_manifest.definitions.presentation import (
+    DataBlock,
+    MarkdownBlock,
+    PresentationBlock,
+    ThinkingBlock,
+    UserErrorBlock,
+)
 from coreason_manifest.definitions.request import AgentRequest
+
+
+class ResponseHandler(Protocol):
+    """Protocol for handling agent responses, decoupling logic from event transport.
+
+    This interface allows agents to emit events and presentation blocks without
+    being tied to a specific transport mechanism (e.g., HTTP, WebSocket).
+    """
+
+    def emit(self, event: Union[CloudEvent[Any], GraphEvent]) -> Awaitable[None]:
+        """Emit a raw CloudEvent or GraphEvent."""
+        ...
+
+    def thought(self, content: str, status: str = "IN_PROGRESS") -> Awaitable[None]:
+        """Emit a thinking block."""
+        ...
+
+    def markdown(self, content: str) -> Awaitable[None]:
+        """Emit a markdown block."""
+        ...
+
+    def data(
+        self,
+        data: Dict[str, Any],
+        title: Optional[str] = None,
+        view_hint: str = "JSON",
+    ) -> Awaitable[None]:
+        """Emit a data block."""
+        ...
+
+    def error(
+        self,
+        message: str,
+        details: Optional[Dict[str, Any]] = None,
+        recoverable: bool = False,
+    ) -> Awaitable[None]:
+        """Emit an error block."""
+        ...
+
+    def stream_token(self, token: str) -> Awaitable[None]:
+        """Emit a token for streaming responses."""
+        ...
 
 
 @runtime_checkable
@@ -29,19 +78,12 @@ class AgentInterface(Protocol):
         ...
 
     @abstractmethod
-    def assist(self, request: AgentRequest) -> AsyncIterator[Union[CloudEvent[Any], GraphEvent]]:
-        """Process a request and yield a stream of events (thoughts, data, artifacts, or final answers).
-
-        Note:
-            This method is defined as a synchronous function returning an AsyncIterator
-            to correctly type-hint async generators in Protocols. Implementations should
-            use `async def` and `yield` (which produces an AsyncGenerator, satisfying AsyncIterator).
+    async def assist(self, request: AgentRequest, response: ResponseHandler) -> None:
+        """Process a request and use the response handler to emit events.
 
         Args:
             request: The strictly typed input envelope.
-
-        Returns:
-            An async iterator yielding thoughts, data, artifacts, or final answers.
+            response: The handler for emitting results.
         """
         ...
 

--- a/src/coreason_manifest/definitions/interfaces.py
+++ b/src/coreason_manifest/definitions/interfaces.py
@@ -15,13 +15,6 @@ from typing import Any, Awaitable, Dict, Optional, Protocol, Union, runtime_chec
 
 from coreason_manifest.definitions.agent import AgentDefinition
 from coreason_manifest.definitions.events import CloudEvent, GraphEvent
-from coreason_manifest.definitions.presentation import (
-    DataBlock,
-    MarkdownBlock,
-    PresentationBlock,
-    ThinkingBlock,
-    UserErrorBlock,
-)
 from coreason_manifest.definitions.request import AgentRequest
 
 

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -8,12 +8,10 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, AsyncIterator, Union
 from unittest.mock import MagicMock
 
 from coreason_manifest.definitions.agent import AgentDefinition
-from coreason_manifest.definitions.events import CloudEvent, GraphEvent
-from coreason_manifest.definitions.interfaces import AgentInterface
+from coreason_manifest.definitions.interfaces import AgentInterface, ResponseHandler
 from coreason_manifest.definitions.request import AgentRequest
 
 
@@ -22,8 +20,8 @@ class ValidAgent:
     def manifest(self) -> AgentDefinition:
         return MagicMock(spec=AgentDefinition)
 
-    async def assist(self, request: AgentRequest) -> AsyncIterator[Union[CloudEvent[Any], GraphEvent]]:
-        yield MagicMock(spec=GraphEvent)
+    async def assist(self, request: AgentRequest, response: ResponseHandler) -> None:
+        pass
 
 
 class InvalidAgent:


### PR DESCRIPTION
Refactored `AgentInterface` to use `ResponseHandler` Protocol instead of returning an `AsyncIterator`. This adopts an Inversion-of-Control pattern inspired by the Sentient Framework, strictly adapted to Coreason's typing and Presentation Blocks.

Changes:
- Modified `src/coreason_manifest/definitions/interfaces.py`:
  - Defined `ResponseHandler` Protocol.
  - Updated `AgentInterface` to use `ResponseHandler`.
- Updated `tests/test_interfaces.py`:
  - Updated `ValidAgent` to match new `assist` signature.
  - Added `ResponseHandler` import.

Verified with `mypy` and `pytest`.

---
*PR created automatically by Jules for task [7189715280021955775](https://jules.google.com/task/7189715280021955775) started by @gowthamrao*