### PR TITLE
Formalize Stream Identity and Lifecycle

### DIFF
--- a/docs/stream_lifecycle.md
+++ b/docs/stream_lifecycle.md
@@ -1,0 +1,90 @@
+# Stream Identity and Lifecycle
+
+This document formalizes the concept of **Stream Identity** and the **Stream Lifecycle** within the Coreason Agent Framework.
+
+## The Problem: Implicit Streams
+
+Historically, "streaming" in many agent frameworks (including earlier versions of Coreason) was implicit. An agent would simply `yield` a series of tokens or events.
+
+This led to several issues:
+1.  **Ambiguity:** If an agent yields a token, which logical "message bubble" does it belong to?
+2.  **Zombie Streams:** If an agent crashes or the client disconnects, there was no explicit "Close" signal for a specific stream, leading to hanging resources.
+3.  **Multiplexing:** It was difficult to interleave multiple streams (e.g., generating code in one block and explaining it in another) simultaneously.
+
+## The Solution: Streams as First-Class Citizens
+
+We now treat a "Stream" as an explicit object with a unique identity and a strict lifecycle.
+
+### The `StreamHandle` Protocol
+
+The `StreamHandle` is an object returned by the `ResponseHandler`. It encapsulates the state of a single stream.
+
+```python
+class StreamHandle(Protocol):
+    @property
+    def stream_id(self) -> str:
+        """Unique UUID for this stream instance."""
+        ...
+
+    @property
+    def is_active(self) -> bool:
+        """True if the stream is open and accepting data."""
+        ...
+
+    async def write(self, chunk: str) -> None:
+        """Emit a chunk of text."""
+        ...
+
+    async def close(self) -> None:
+        """Seal the stream successfully."""
+        ...
+
+    async def abort(self, reason: str) -> None:
+        """Kill the stream with an error."""
+        ...
+```
+
+## Lifecycle States
+
+A stream transitions through a strict state machine:
+
+1.  **OPEN**: Created via `response.create_stream()`. A unique `stream_id` is assigned.
+2.  **ACTIVE**: The agent calls `stream.write()`. Data flows to the client.
+3.  **CLOSED**: The agent calls `stream.close()`. The stream is sealed. No further writes are allowed.
+4.  **ABORTED**: The agent calls `stream.abort()`. The stream is terminated with an error.
+
+**Rule:** Calling `write()` on a `CLOSED` or `ABORTED` stream MUST raise a `RuntimeError`.
+
+## Usage Pattern
+
+This pattern allows the agent to pass the `StreamHandle` to helper functions, decoupling the "streaming logic" from the main "response logic".
+
+```python
+async def generate_poem(stream: StreamHandle, topic: str):
+    """Helper function that just knows how to write to a stream."""
+    # ... expensive LLM generation ...
+    for token in llm.generate(topic):
+        await stream.write(token)
+    await stream.close()
+
+async def assist(request, response):
+    # Main logic decides TO stream
+    stream = await response.create_stream(title="Poem")
+
+    # And delegates the writing
+    await generate_poem(stream, "Nature")
+```
+
+## UI Routing
+
+On the frontend, the `stream_id` allows the UI to route tokens to the correct component.
+
+*   **Event:** `ai.coreason.stream.start` (contains `stream_id`, `title`) -> **UI:** Create new message bubble.
+*   **Event:** `ai.coreason.stream.chunk` (contains `stream_id`, `chunk`) -> **UI:** Append text to bubble with matching ID.
+*   **Event:** `ai.coreason.stream.end` (contains `stream_id`) -> **UI:** Mark bubble as complete (stop loading spinner).
+
+## Error Handling
+
+Separation of concerns is key:
+*   **Stream Errors:** `stream.abort("LLM Timeout")` affects *only* that stream content (e.g., shows a red "Error" badge on that specific bubble).
+*   **Agent Errors:** `response.error("Database Down")` affects the entire request.

--- a/src/coreason_manifest/definitions/interfaces.py
+++ b/src/coreason_manifest/definitions/interfaces.py
@@ -18,6 +18,46 @@ from coreason_manifest.definitions.events import CloudEvent, GraphEvent
 from coreason_manifest.definitions.request import AgentRequest
 
 
+@runtime_checkable
+class StreamHandle(Protocol):
+    """Protocol encapsulating the lifecycle of a stream.
+
+    A stream is a first-class citizen with a unique ID, distinct lifecycle,
+    and strict state management.
+    """
+
+    @property
+    @abstractmethod
+    def stream_id(self) -> str:
+        """The unique identifier for this specific stream instance (UUID)."""
+        ...
+
+    @property
+    @abstractmethod
+    def is_active(self) -> bool:
+        """Strictly typed boolean indicating if the stream allows new data."""
+        ...
+
+    @abstractmethod
+    def write(self, chunk: str) -> Awaitable[None]:
+        """Async method to emit a token/chunk.
+
+        Raises:
+            RuntimeError: If the stream is closed.
+        """
+        ...
+
+    @abstractmethod
+    def close(self) -> Awaitable[None]:
+        """Async method to finalize the stream (seal it)."""
+        ...
+
+    @abstractmethod
+    def abort(self, reason: str) -> Awaitable[None]:
+        """Async method to kill the stream with an error."""
+        ...
+
+
 class ResponseHandler(Protocol):
     """Protocol for handling agent responses, decoupling logic from event transport.
 
@@ -55,8 +95,18 @@ class ResponseHandler(Protocol):
         """Emit an error block."""
         ...
 
-    def stream_token(self, token: str) -> Awaitable[None]:
-        """Emit a token for streaming responses."""
+    def create_stream(
+        self, title: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None
+    ) -> Awaitable[StreamHandle]:
+        """Create a new stream and return its handle.
+
+        Args:
+            title: Optional title for the stream.
+            metadata: Optional metadata for the stream.
+
+        Returns:
+            A StreamHandle instance to write content to.
+        """
         ...
 
 

--- a/tests/test_stream_protocol.py
+++ b/tests/test_stream_protocol.py
@@ -1,10 +1,13 @@
-import pytest
 from typing import Any, Dict, Optional, Union
-from coreason_manifest.definitions.interfaces import ResponseHandler, StreamHandle
+
+import pytest
+
 from coreason_manifest.definitions.events import CloudEvent, GraphEvent
+from coreason_manifest.definitions.interfaces import StreamHandle
+
 
 class MockStreamHandle:
-    def __init__(self, stream_id: str):
+    def __init__(self, stream_id: str) -> None:
         self._stream_id = stream_id
         self._active = True
 
@@ -25,6 +28,7 @@ class MockStreamHandle:
 
     async def abort(self, reason: str) -> None:
         self._active = False
+
 
 class MockResponseHandler:
     async def emit(self, event: Union[CloudEvent[Any], GraphEvent]) -> None:
@@ -57,8 +61,9 @@ class MockResponseHandler:
     ) -> StreamHandle:
         return MockStreamHandle("test-stream-id")
 
+
 @pytest.mark.asyncio
-async def test_stream_handle_protocol():
+async def test_stream_handle_protocol() -> None:
     handle = MockStreamHandle("id")
     # Runtime checkable
     assert isinstance(handle, StreamHandle)
@@ -70,8 +75,9 @@ async def test_stream_handle_protocol():
     with pytest.raises(RuntimeError):
         await handle.write("chunk")
 
+
 @pytest.mark.asyncio
-async def test_response_handler_protocol():
+async def test_response_handler_protocol() -> None:
     handler = MockResponseHandler()
     # Not runtime checkable, so we just test method invocation
     stream = await handler.create_stream()

--- a/tests/test_stream_protocol.py
+++ b/tests/test_stream_protocol.py
@@ -1,0 +1,80 @@
+import pytest
+from typing import Any, Dict, Optional, Union
+from coreason_manifest.definitions.interfaces import ResponseHandler, StreamHandle
+from coreason_manifest.definitions.events import CloudEvent, GraphEvent
+
+class MockStreamHandle:
+    def __init__(self, stream_id: str):
+        self._stream_id = stream_id
+        self._active = True
+
+    @property
+    def stream_id(self) -> str:
+        return self._stream_id
+
+    @property
+    def is_active(self) -> bool:
+        return self._active
+
+    async def write(self, chunk: str) -> None:
+        if not self._active:
+            raise RuntimeError("Stream is closed")
+
+    async def close(self) -> None:
+        self._active = False
+
+    async def abort(self, reason: str) -> None:
+        self._active = False
+
+class MockResponseHandler:
+    async def emit(self, event: Union[CloudEvent[Any], GraphEvent]) -> None:
+        pass
+
+    async def thought(self, content: str, status: str = "IN_PROGRESS") -> None:
+        pass
+
+    async def markdown(self, content: str) -> None:
+        pass
+
+    async def data(
+        self,
+        data: Dict[str, Any],
+        title: Optional[str] = None,
+        view_hint: str = "JSON",
+    ) -> None:
+        pass
+
+    async def error(
+        self,
+        message: str,
+        details: Optional[Dict[str, Any]] = None,
+        recoverable: bool = False,
+    ) -> None:
+        pass
+
+    async def create_stream(
+        self, title: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None
+    ) -> StreamHandle:
+        return MockStreamHandle("test-stream-id")
+
+@pytest.mark.asyncio
+async def test_stream_handle_protocol():
+    handle = MockStreamHandle("id")
+    # Runtime checkable
+    assert isinstance(handle, StreamHandle)
+    assert handle.stream_id == "id"
+    assert handle.is_active
+    await handle.write("chunk")
+    await handle.close()
+    assert not handle.is_active
+    with pytest.raises(RuntimeError):
+        await handle.write("chunk")
+
+@pytest.mark.asyncio
+async def test_response_handler_protocol():
+    handler = MockResponseHandler()
+    # Not runtime checkable, so we just test method invocation
+    stream = await handler.create_stream()
+    assert isinstance(stream, StreamHandle)
+    await stream.write("hello")
+    await stream.close()


### PR DESCRIPTION
This PR formalizes the concept of "Stream Identity" and "Stream Lifecycle" within the `coreason-manifest`.

**Key Changes:**
1.  **`StreamHandle` Protocol:** Defined in `src/coreason_manifest/definitions/interfaces.py`. This protocol encapsulates a stream with a unique ID (`stream_id`), active state (`is_active`), and strict methods for writing (`write`), closing (`close`), and aborting (`abort`).
2.  **`ResponseHandler` Update:** Replaced the implicit `stream_token` method with an explicit `create_stream(title=..., metadata=...)` factory method that returns a `StreamHandle`.
3.  **Documentation:**
    *   Updated `docs/agent_behavior_protocols.md` to remove outdated `AsyncIterator` references and document the new `ResponseHandler` and `StreamHandle` usage.
    *   Created `docs/stream_lifecycle.md` to explain the problem (implicit streams), the solution (first-class streams), the state machine, and usage patterns.
4.  **Testing:** Added `tests/test_stream_protocol.py` to ensure the protocols are runtime-checkable and strictly typed.

**Migration Guide:**
*   Agents calling `await response.stream_token("...")` must now call `stream = await response.create_stream(...)` followed by `await stream.write("...")` and `await stream.close()`.


---
*PR created automatically by Jules for task [7245369739566303983](https://jules.google.com/task/7245369739566303983) started by @gowthamrao*