### PR TITLE
Implement EventSink Protocol and update ResponseHandler

### DIFF
--- a/src/coreason_manifest/definitions/interfaces.py
+++ b/src/coreason_manifest/definitions/interfaces.py
@@ -72,16 +72,12 @@ class EventSink(Protocol):
         ...
 
     @abstractmethod
-    def log(
-        self, level: str, message: str, metadata: Optional[Dict[str, Any]] = None
-    ) -> Awaitable[None]:
+    def log(self, level: str, message: str, metadata: Optional[Dict[str, Any]] = None) -> Awaitable[None]:
         """A helper to emit a standard log event (which the implementation wraps in a CloudEvent)."""
         ...
 
     @abstractmethod
-    def audit(
-        self, actor: str, action: str, resource: str, success: bool
-    ) -> Awaitable[None]:
+    def audit(self, actor: str, action: str, resource: str, success: bool) -> Awaitable[None]:
         """A helper to emit an immutable Audit Log entry."""
         ...
 

--- a/src/coreason_manifest/definitions/interfaces.py
+++ b/src/coreason_manifest/definitions/interfaces.py
@@ -58,25 +58,53 @@ class StreamHandle(Protocol):
         ...
 
 
-class ResponseHandler(Protocol):
+@runtime_checkable
+class EventSink(Protocol):
+    """Protocol for emitting internal system events (telemetry, audit, logs).
+
+    This serves as the standard interface for emitting GraphEvents and CloudEvents
+    that are not necessarily meant for the user, but for the system.
+    """
+
+    @abstractmethod
+    def emit(self, event: Union[CloudEvent[Any], GraphEvent]) -> Awaitable[None]:
+        """The core method to ingest any strictly typed event."""
+        ...
+
+    @abstractmethod
+    def log(
+        self, level: str, message: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> Awaitable[None]:
+        """A helper to emit a standard log event (which the implementation wraps in a CloudEvent)."""
+        ...
+
+    @abstractmethod
+    def audit(
+        self, actor: str, action: str, resource: str, success: bool
+    ) -> Awaitable[None]:
+        """A helper to emit an immutable Audit Log entry."""
+        ...
+
+
+@runtime_checkable
+class ResponseHandler(EventSink, Protocol):
     """Protocol for handling agent responses, decoupling logic from event transport.
 
     This interface allows agents to emit events and presentation blocks without
     being tied to a specific transport mechanism (e.g., HTTP, WebSocket).
     """
 
-    def emit(self, event: Union[CloudEvent[Any], GraphEvent]) -> Awaitable[None]:
-        """Emit a raw CloudEvent or GraphEvent."""
-        ...
-
+    @abstractmethod
     def thought(self, content: str, status: str = "IN_PROGRESS") -> Awaitable[None]:
         """Emit a thinking block."""
         ...
 
+    @abstractmethod
     def markdown(self, content: str) -> Awaitable[None]:
         """Emit a markdown block."""
         ...
 
+    @abstractmethod
     def data(
         self,
         data: Dict[str, Any],
@@ -86,6 +114,7 @@ class ResponseHandler(Protocol):
         """Emit a data block."""
         ...
 
+    @abstractmethod
     def error(
         self,
         message: str,
@@ -95,6 +124,7 @@ class ResponseHandler(Protocol):
         """Emit an error block."""
         ...
 
+    @abstractmethod
     def create_stream(
         self, title: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None
     ) -> Awaitable[StreamHandle]:

--- a/tests/test_stream_protocol.py
+++ b/tests/test_stream_protocol.py
@@ -34,14 +34,10 @@ class MockResponseHandler:
     async def emit(self, event: Union[CloudEvent[Any], GraphEvent]) -> None:
         pass
 
-    async def log(
-        self, level: str, message: str, metadata: Optional[Dict[str, Any]] = None
-    ) -> None:
+    async def log(self, level: str, message: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         pass
 
-    async def audit(
-        self, actor: str, action: str, resource: str, success: bool
-    ) -> None:
+    async def audit(self, actor: str, action: str, resource: str, success: bool) -> None:
         pass
 
     async def thought(self, content: str, status: str = "IN_PROGRESS") -> None:

--- a/tests/test_stream_protocol.py
+++ b/tests/test_stream_protocol.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, Optional, Union
 import pytest
 
 from coreason_manifest.definitions.events import CloudEvent, GraphEvent
-from coreason_manifest.definitions.interfaces import StreamHandle
+from coreason_manifest.definitions.interfaces import ResponseHandler, StreamHandle
 
 
 class MockStreamHandle:
@@ -32,6 +32,16 @@ class MockStreamHandle:
 
 class MockResponseHandler:
     async def emit(self, event: Union[CloudEvent[Any], GraphEvent]) -> None:
+        pass
+
+    async def log(
+        self, level: str, message: str, metadata: Optional[Dict[str, Any]] = None
+    ) -> None:
+        pass
+
+    async def audit(
+        self, actor: str, action: str, resource: str, success: bool
+    ) -> None:
         pass
 
     async def thought(self, content: str, status: str = "IN_PROGRESS") -> None:
@@ -79,7 +89,9 @@ async def test_stream_handle_protocol() -> None:
 @pytest.mark.asyncio
 async def test_response_handler_protocol() -> None:
     handler = MockResponseHandler()
-    # Not runtime checkable, so we just test method invocation
+    # Runtime checkable
+    assert isinstance(handler, ResponseHandler)
+
     stream = await handler.create_stream()
     assert isinstance(stream, StreamHandle)
     await stream.write("hello")


### PR DESCRIPTION
Implemented the EventSink Protocol as per Step 3 of the coreason-manifest refactor.
This introduces a standard interface for emitting internal system events like telemetry and audit logs.
ResponseHandler now inherits from EventSink, allowing agents to use the response handler for system logging.

---
*PR created automatically by Jules for task [1304880291877845089](https://jules.google.com/task/1304880291877845089) started by @gowthamrao*