### PR TITLE
Refactor SessionState to use Identity model

### DIFF
--- a/docs/identity_model.md
+++ b/docs/identity_model.md
@@ -1,0 +1,68 @@
+# Identity Model
+
+The `Identity` model serves as the canonical representation of an actor within the Coreason ecosystem. It addresses the limitation of using raw strings for identification by combining a unique identifier with human-readable context.
+
+## Overview
+
+In previous iterations, actors (users, agents, tools) were identified solely by ID strings (e.g., `user_id="123"`). This forced downstream systems (UIs, logs) to perform additional lookups just to display a name. The `Identity` object solves this by carrying the display name alongside the ID.
+
+## Schema
+
+`Identity` is a frozen Pydantic model inheriting from `CoReasonBaseModel`.
+
+```python
+class Identity(CoReasonBaseModel):
+    id: str           # Unique identifier (UUID string or similar)
+    name: str         # Display name for UI/Logs
+    role: Optional[str] # Contextual role (e.g., "user", "assistant", "system")
+```
+
+## Usage
+
+### Instantiation
+
+```python
+from coreason_manifest.definitions.identity import Identity
+
+# Fully specified
+agent = Identity(
+    id="agent-007",
+    name="Bond",
+    role="assistant"
+)
+
+# Minimal
+user = Identity(
+    id="u-123",
+    name="Alice"
+)
+```
+
+### String Representation
+
+The `__str__` method provides a consistent format for logging:
+
+```python
+print(str(agent))
+# Output: "Bond (agent-007)"
+```
+
+### Anonymous Identity
+
+For unauthenticated or public sessions, use the factory method:
+
+```python
+anon = Identity.anonymous()
+# id="anonymous", name="Anonymous User", role="user"
+```
+
+## Integration
+
+The `Identity` model is primarily used in `SessionState` to identify the `processor` (the agent) and the `user`.
+
+```python
+class SessionState(CoReasonBaseModel):
+    processor: Identity
+    user: Optional[Identity]
+    # ...
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -12,4 +12,5 @@ This is the documentation for the coreason_manifest project.
 *   [Session Management](session_management.md): Decoupling execution from memory with standardized Session and Interaction models.
 *   [Agent Request Envelope](agent_request_envelope.md): The standard envelope for agent invocations and distributed tracing.
 *   [Request Lineage](request_lineage.md): The unified approach to lineage across requests, traces, and audit logs.
+*   [Identity Model](identity_model.md): The canonical representation of actors (`Identity`) within the ecosystem.
 *   [Observability](observability.md): Details on tracing, logging, and metrics.

--- a/docs/session_management.md
+++ b/docs/session_management.md
@@ -57,18 +57,19 @@ Key features:
 
 *   **Immutable Updates:** State changes via functional updates (e.g., `add_interaction` returns a *new* instance), preventing side effects.
 *   **Context Variables:** A "scratchpad" dictionary (`context_variables`) for long-term memory that persists across turns, separate from the message history.
-*   **Identification:** Strictly typed UUIDs for sessions and strings for processor/user IDs.
+*   **Identification:** Strictly typed UUIDs for sessions and `Identity` objects for processor/user (carrying both ID and display name).
 
 ```python
 from uuid import uuid4
 from datetime import datetime, timezone
 from coreason_manifest.definitions.session import SessionState
+from coreason_manifest.definitions.identity import Identity
 
 # 1. Create a new session
 session = SessionState(
     session_id=uuid4(),
-    processor_id="agent-v1",
-    user_id="user-123",
+    processor=Identity(id="agent-v1", name="Support Agent", role="assistant"),
+    user=Identity(id="user-123", name="Alice Smith", role="user"),
     created_at=datetime.now(timezone.utc),
     last_updated_at=datetime.now(timezone.utc),
 )

--- a/src/coreason_manifest/definitions/__init__.py
+++ b/src/coreason_manifest/definitions/__init__.py
@@ -33,6 +33,7 @@ from .events import (
     WorkflowError,
     WorkflowErrorPayload,
 )
+from .identity import Identity
 from .interfaces import AgentInterface, LifecycleInterface
 from .presentation import (
     DataBlock,
@@ -46,6 +47,7 @@ from .service import DEFAULT_ENDPOINT_PATH, ServerSentEvent, ServiceContract
 from .session import Interaction, SessionState
 
 __all__ = [
+    "Identity",
     "AgentRequest",
     "ServerSentEvent",
     "ServiceContract",

--- a/src/coreason_manifest/definitions/identity.py
+++ b/src/coreason_manifest/definitions/identity.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Optional
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.definitions.base import CoReasonBaseModel
+
+
+class Identity(CoReasonBaseModel):
+    """Canonical representation of an actor in the Coreason ecosystem.
+
+    Identifies entities (users, agents, tools) participating in a session
+    with both a unique ID and a human-readable display name.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(..., description="Unique identifier for the entity.")
+    name: str = Field(..., description="Display name for UI/Logs.")
+    role: Optional[str] = Field(None, description="Role of the entity (e.g., 'assistant', 'user', 'system').")
+
+    def __str__(self) -> str:
+        """Return the string representation 'name (id)'."""
+        return f"{self.name} ({self.id})"
+
+    @classmethod
+    def anonymous(cls) -> "Identity":
+        """Return a default anonymous identity."""
+        return cls(id="anonymous", name="Anonymous User", role="user")

--- a/src/coreason_manifest/definitions/session.py
+++ b/src/coreason_manifest/definitions/session.py
@@ -16,6 +16,7 @@ from pydantic import ConfigDict, Field
 
 from coreason_manifest.definitions.base import CoReasonBaseModel
 from coreason_manifest.definitions.events import GraphEvent
+from coreason_manifest.definitions.identity import Identity
 from coreason_manifest.definitions.message import MultiModalInput
 
 
@@ -56,8 +57,8 @@ class SessionState(CoReasonBaseModel):
     model_config = ConfigDict(frozen=True)
 
     session_id: UUID = Field(..., description="Global identifier for the conversation thread")
-    processor_id: str = Field(..., description="ID of the agent/graph handling this session")
-    user_id: Optional[str] = Field(None, description="The user identifying string")
+    processor: Identity = Field(..., description="The agent/graph handling this session")
+    user: Optional[Identity] = Field(None, description="The user participating in the session")
     created_at: datetime = Field(..., description="When the session was created")
     last_updated_at: datetime = Field(..., description="When the session was last updated")
     history: List[Interaction] = Field(default_factory=list, description="Chronological list of interactions")

--- a/tests/test_identity.py
+++ b/tests/test_identity.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from coreason_manifest.definitions.identity import Identity
+
+
+def test_identity_creation() -> None:
+    """Test successful creation of an Identity."""
+    identity = Identity(id="user-1", name="User One", role="user")
+    assert identity.id == "user-1"
+    assert identity.name == "User One"
+    assert identity.role == "user"
+
+
+def test_identity_str_representation() -> None:
+    """Test the string representation of Identity."""
+    identity = Identity(id="agent-007", name="Bond")
+    assert str(identity) == "Bond (agent-007)"
+
+
+def test_identity_anonymous() -> None:
+    """Test the anonymous factory method."""
+    anon = Identity.anonymous()
+    assert anon.id == "anonymous"
+    assert anon.name == "Anonymous User"
+    assert anon.role == "user"
+
+
+def test_identity_dump() -> None:
+    """Test the dump method inherited from CoReasonBaseModel."""
+    identity = Identity(id="test", name="Test")
+    data = identity.dump()
+    assert data["id"] == "test"
+    assert data["name"] == "Test"

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -94,17 +94,17 @@ def test_session_state_immutability() -> None:
     )
 
     with pytest.raises(ValidationError):  # Pydantic v2 raises ValidationError or TypeError depending on config
-        session.processor = Identity(id="agent-2", name="Agent 2")
+        session.processor = Identity(id="agent-2", name="Agent 2")  # type: ignore[misc]
 
     # Note: session.history is a list, so append() works at runtime even if frozen=True.
     # frozen=True only prevents field reassignment.
     # To test frozen properly, we check field reassignment.
     with pytest.raises(ValidationError):
-        session.history = []
+        session.history = []  # type: ignore[misc]
 
     # Better test for frozen:
     with pytest.raises(ValidationError):
-        session.user = Identity.anonymous()
+        session.user = Identity.anonymous()  # type: ignore[misc]
 
 
 def test_add_interaction() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -15,6 +15,7 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.definitions.events import GraphEventNodeInit, NodeInit
+from coreason_manifest.definitions.identity import Identity
 from coreason_manifest.definitions.session import Interaction, SessionState
 
 
@@ -56,17 +57,22 @@ def test_session_state_creation() -> None:
     session_id = uuid4()
     now = datetime.now(timezone.utc)
 
+    processor = Identity(id="agent-1", name="Agent 1", role="assistant")
+    user = Identity(id="user-1", name="User 1", role="user")
+
     session = SessionState(
         session_id=session_id,
-        processor_id="agent-1",
-        user_id="user-1",
+        processor=processor,
+        user=user,
         created_at=now,
         last_updated_at=now,
     )
 
     assert session.session_id == session_id
-    assert session.processor_id == "agent-1"
-    assert session.user_id == "user-1"
+    assert session.processor == processor
+    assert session.processor.id == "agent-1"
+    assert session.user == user
+    assert session.user.id == "user-1"  # type: ignore
     assert session.created_at == now
     assert session.last_updated_at == now
     assert session.history == []
@@ -78,15 +84,17 @@ def test_session_state_immutability() -> None:
     session_id = uuid4()
     now = datetime.now(timezone.utc)
 
+    processor = Identity(id="agent-1", name="Agent 1", role="assistant")
+
     session = SessionState(
         session_id=session_id,
-        processor_id="agent-1",
+        processor=processor,
         created_at=now,
         last_updated_at=now,
     )
 
     with pytest.raises(ValidationError):  # Pydantic v2 raises ValidationError or TypeError depending on config
-        session.processor_id = "agent-2"  # type: ignore
+        session.processor = Identity(id="agent-2", name="Agent 2")  # type: ignore
 
     # Note: session.history is a list, so append() works at runtime even if frozen=True.
     # frozen=True only prevents field reassignment.
@@ -96,7 +104,7 @@ def test_session_state_immutability() -> None:
 
     # Better test for frozen:
     with pytest.raises(ValidationError):
-        session.user_id = "new-user"  # type: ignore
+        session.user = Identity.anonymous()  # type: ignore
 
 
 def test_add_interaction() -> None:
@@ -104,9 +112,11 @@ def test_add_interaction() -> None:
     session_id = uuid4()
     now = datetime.now(timezone.utc)
 
+    processor = Identity(id="agent-1", name="Agent 1", role="assistant")
+
     session = SessionState(
         session_id=session_id,
-        processor_id="agent-1",
+        processor=processor,
         created_at=now,
         last_updated_at=now,
     )
@@ -127,7 +137,7 @@ def test_add_interaction() -> None:
 
     # Other fields should be preserved
     assert new_session.session_id == session.session_id
-    assert new_session.processor_id == session.processor_id
+    assert new_session.processor == session.processor
 
 
 def test_serialization() -> None:

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -72,7 +72,7 @@ def test_session_state_creation() -> None:
     assert session.processor == processor
     assert session.processor.id == "agent-1"
     assert session.user == user
-    assert session.user.id == "user-1"  # type: ignore
+    assert session.user.id == "user-1"
     assert session.created_at == now
     assert session.last_updated_at == now
     assert session.history == []
@@ -94,17 +94,17 @@ def test_session_state_immutability() -> None:
     )
 
     with pytest.raises(ValidationError):  # Pydantic v2 raises ValidationError or TypeError depending on config
-        session.processor = Identity(id="agent-2", name="Agent 2")  # type: ignore
+        session.processor = Identity(id="agent-2", name="Agent 2")
 
     # Note: session.history is a list, so append() works at runtime even if frozen=True.
     # frozen=True only prevents field reassignment.
     # To test frozen properly, we check field reassignment.
     with pytest.raises(ValidationError):
-        session.history = []  # type: ignore
+        session.history = []
 
     # Better test for frozen:
     with pytest.raises(ValidationError):
-        session.user = Identity.anonymous()  # type: ignore
+        session.user = Identity.anonymous()
 
 
 def test_add_interaction() -> None:


### PR DESCRIPTION
Introduced a composite `Identity` model to replace raw string identifiers in `SessionState`. This allows carrying display names and roles alongside IDs, improving downstream UI/Log integration.

Changes:
- Added `src/coreason_manifest/definitions/identity.py`.
- Updated `src/coreason_manifest/definitions/session.py`.
- Updated documentation.
- Updated tests.

---
*PR created automatically by Jules for task [10690964924293890397](https://jules.google.com/task/10690964924293890397) started by @gowthamrao*