### PR TITLE
Implement Evaluation-Ready Metadata

### DIFF
--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -63,15 +63,23 @@ An `AgentDefinition` consists of the following sections:
     *   `timeout_seconds`: Request processing limits.
     *   `env_vars`: Static environment variable injection.
 
-8.  **Observability (`ObservabilityConfig`)**:
+8.  **Evaluation (`EvaluationProfile`)**:
+    *   **Evaluation-Ready Metadata**: Defines test contracts directly in the manifest.
+    *   `expected_latency_ms`: SLA for response time.
+    *   `golden_dataset_uri`: Reference to a test dataset.
+    *   `grading_rubric`: List of `SuccessCriterion` for quality checks.
+    *   `evaluator_model`: Model to use for evaluation.
+    *   See [Evaluation-Ready Metadata](evaluation.md) for details.
+
+9.  **Observability (`ObservabilityConfig`)**:
     *   `trace_level`: Controls the granularity of logs (`FULL`, `METADATA_ONLY`, `NONE`).
     *   `retention_policy`: How long logs are kept.
     *   `encryption_key_id`: Optional ID of the key used for log encryption.
 
-9.  **Custom Metadata (`custom_metadata`)**:
+10. **Custom Metadata (`custom_metadata`)**:
     *   Container for arbitrary metadata extensions without breaking validation.
 
-10. **Integrity**:
+11. **Integrity**:
     *   `integrity_hash`: SHA256 hash of the source code (top-level field). Required only when `status` is `published`.
 
 ## Agent Lifecycle: Draft vs. Published

--- a/docs/evaluation.md
+++ b/docs/evaluation.md
@@ -1,0 +1,65 @@
+# Evaluation-Ready Metadata
+
+The **Evaluation-Ready Metadata** feature allows agents to carry their own test contracts, ensuring that every agent asset defines its own success criteria, golden datasets, and SLAs.
+
+## Overview
+
+Traditionally, evaluation logic is decoupled from the agent definition, leading to drift between the agent's behavior and its tests. By embedding evaluation metadata directly into the `AgentDefinition`, we ensure that the agent is self-describing regarding its quality and performance expectations.
+
+## The Evaluation Profile
+
+The `EvaluationProfile` class (located in `src/coreason_manifest/definitions/evaluation.py`) is the container for this metadata. It is an optional field (`evaluation`) in the `AgentDefinition`.
+
+### Components
+
+1.  **SLA (`expected_latency_ms`)**:
+    *   Defines the expected maximum response time in milliseconds.
+    *   Useful for performance testing and monitoring.
+
+2.  **Golden Dataset (`golden_dataset_uri`)**:
+    *   A URI pointing to a reference dataset used for evaluation.
+    *   This ensures that the test data is versioned alongside the agent.
+
+3.  **Grading Rubric (`grading_rubric`)**:
+    *   A list of `SuccessCriterion` objects defining specific quality checks.
+    *   Each criterion has a `name`, `description`, `threshold`, and `strict` flag.
+
+4.  **Evaluator Model (`evaluator_model`)**:
+    *   Specifies the model to be used for LLM-as-a-Judge evaluations (e.g., "gpt-4-turbo").
+
+## Success Criterion
+
+The `SuccessCriterion` model defines a single condition for success.
+
+*   `name`: The unique name of the criterion (e.g., "json_schema_validity", "semantic_similarity").
+*   `description`: A human-readable description of what is being checked.
+*   `threshold`: A numerical threshold for the check (e.g., 0.95).
+*   `strict`: A boolean indicating if this is a hard requirement (default: `True`).
+
+## Example Usage
+
+```python
+from coreason_manifest.definitions.agent import AgentDefinition
+from coreason_manifest.definitions.evaluation import EvaluationProfile, SuccessCriterion
+
+agent = AgentDefinition(
+    # ... other fields ...
+    evaluation=EvaluationProfile(
+        expected_latency_ms=2000,
+        golden_dataset_uri="s3://datasets/weather-gold-v1.json",
+        evaluator_model="gpt-4-turbo",
+        grading_rubric=[
+            SuccessCriterion(
+                name="response_conciseness",
+                description="Ensure the response is under 50 words.",
+                strict=False
+            ),
+            SuccessCriterion(
+                name="json_validity",
+                description="Ensure the output is valid JSON.",
+                strict=True
+            )
+        ]
+    )
+)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,4 +13,5 @@ This is the documentation for the coreason_manifest project.
 *   [Agent Request Envelope](agent_request_envelope.md): The standard envelope for agent invocations and distributed tracing.
 *   [Request Lineage](request_lineage.md): The unified approach to lineage across requests, traces, and audit logs.
 *   [Identity Model](identity_model.md): The canonical representation of actors (`Identity`) within the ecosystem.
+*   [Evaluation-Ready Metadata](evaluation.md): How to define test contracts and success criteria within your agents.
 *   [Observability](observability.md): Details on tracing, logging, and metrics.

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -10,6 +10,7 @@
 
 from .definitions.agent import AgentDefinition, AgentStatus, Persona
 from .definitions.audit import AuditLog
+from .definitions.evaluation import EvaluationProfile, SuccessCriterion
 from .definitions.events import (
     ArtifactGenerated,
     CloudEvent,
@@ -65,6 +66,8 @@ __all__ = [
     "AgentDefinition",
     "AgentStatus",
     "Persona",
+    "EvaluationProfile",
+    "SuccessCriterion",
     "Topology",
     "GraphTopology",
     "Node",

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -37,6 +37,7 @@ from typing_extensions import Annotated
 
 from coreason_manifest.definitions.base import CoReasonBaseModel
 from coreason_manifest.definitions.deployment import DeploymentConfig
+from coreason_manifest.definitions.evaluation import EvaluationProfile
 from coreason_manifest.definitions.topology import Edge, Node, validate_edge_integrity
 
 # SemVer Regex pattern (simplified for standard SemVer)
@@ -376,6 +377,7 @@ class AgentDefinition(CoReasonBaseModel):
     dependencies: AgentDependencies
     policy: Optional[PolicyConfig] = Field(None, description="Governance policy configuration.")
     deployment: Optional[DeploymentConfig] = Field(None, description="Runtime deployment settings")
+    evaluation: Optional[EvaluationProfile] = Field(None, description="Evaluation profile for the agent.")
     observability: Optional[ObservabilityConfig] = Field(None, description="Observability configuration.")
     custom_metadata: Optional[Dict[str, Any]] = Field(
         None, description="Container for arbitrary metadata extensions without breaking validation."

--- a/src/coreason_manifest/definitions/evaluation.py
+++ b/src/coreason_manifest/definitions/evaluation.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import List, Optional
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.definitions.base import CoReasonBaseModel
+
+
+class SuccessCriterion(CoReasonBaseModel):
+    """A model defining a single condition for success.
+
+    Attributes:
+        name: Name of the criterion (e.g., "json_schema_validity").
+        description: Description of the criterion.
+        threshold: Threshold for success (e.g., 0.95 for semantic similarity).
+        strict: Whether the criterion is strict.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(..., description="Name of the criterion (e.g., 'json_schema_validity')")
+    description: Optional[str] = Field(None, description="Description of the criterion")
+    threshold: Optional[float] = Field(None, description="Threshold for success (e.g., 0.95 for semantic similarity)")
+    strict: bool = Field(default=True, description="Whether the criterion is strict")
+
+
+class EvaluationProfile(CoReasonBaseModel):
+    """The main container for evaluation configuration.
+
+    Attributes:
+        expected_latency_ms: SLA for response time in milliseconds.
+        golden_dataset_uri: URI to a reference dataset.
+        grading_rubric: List of criteria for grading.
+        evaluator_model: Model to use for evaluation (e.g., "gpt-4-turbo").
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    expected_latency_ms: Optional[int] = Field(None, description="SLA for response time in milliseconds")
+    golden_dataset_uri: Optional[str] = Field(None, description="URI to a reference dataset")
+    grading_rubric: Optional[List[SuccessCriterion]] = Field(None, description="List of criteria for grading")
+    evaluator_model: Optional[str] = Field(None, description="Model to use for evaluation (e.g., 'gpt-4-turbo')")

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -496,6 +496,69 @@
       "title": "Edge",
       "type": "object"
     },
+    "EvaluationProfile": {
+      "additionalProperties": false,
+      "description": "The main container for evaluation configuration.\n\nAttributes:\n    expected_latency_ms: SLA for response time in milliseconds.\n    golden_dataset_uri: URI to a reference dataset.\n    grading_rubric: List of criteria for grading.\n    evaluator_model: Model to use for evaluation (e.g., \"gpt-4-turbo\").",
+      "properties": {
+        "expected_latency_ms": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "SLA for response time in milliseconds",
+          "title": "Expected Latency Ms"
+        },
+        "golden_dataset_uri": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "URI to a reference dataset",
+          "title": "Golden Dataset Uri"
+        },
+        "grading_rubric": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/SuccessCriterion"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "List of criteria for grading",
+          "title": "Grading Rubric"
+        },
+        "evaluator_model": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Model to use for evaluation (e.g., 'gpt-4-turbo')",
+          "title": "Evaluator Model"
+        }
+      },
+      "title": "EvaluationProfile",
+      "type": "object"
+    },
     "EventSchema": {
       "additionalProperties": false,
       "description": "Defines the structure of an intermediate event emitted by the agent.",
@@ -995,6 +1058,54 @@
       "title": "RecipeNode",
       "type": "object"
     },
+    "SuccessCriterion": {
+      "additionalProperties": false,
+      "description": "A model defining a single condition for success.\n\nAttributes:\n    name: Name of the criterion (e.g., \"json_schema_validity\").\n    description: Description of the criterion.\n    threshold: Threshold for success (e.g., 0.95 for semantic similarity).\n    strict: Whether the criterion is strict.",
+      "properties": {
+        "name": {
+          "description": "Name of the criterion (e.g., 'json_schema_validity')",
+          "title": "Name",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Description of the criterion",
+          "title": "Description"
+        },
+        "threshold": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Threshold for success (e.g., 0.95 for semantic similarity)",
+          "title": "Threshold"
+        },
+        "strict": {
+          "default": true,
+          "description": "Whether the criterion is strict",
+          "title": "Strict",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "title": "SuccessCriterion",
+      "type": "object"
+    },
     "ToolRequirement": {
       "additionalProperties": false,
       "description": "Requirement for an MCP tool.\n\nAttributes:\n    uri: The MCP endpoint URI.\n    hash: Integrity check for the tool definition (SHA256).\n    scopes: List of permissions required.\n    risk_level: The risk level of the tool.",
@@ -1162,6 +1273,18 @@
       ],
       "default": null,
       "description": "Runtime deployment settings"
+    },
+    "evaluation": {
+      "anyOf": [
+        {
+          "$ref": "#/$defs/EvaluationProfile"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Evaluation profile for the agent."
     },
     "observability": {
       "anyOf": [


### PR DESCRIPTION
This PR introduces "Evaluation-Ready" Metadata, allowing agents to carry their own test contracts. It adds `EvaluationProfile` and `SuccessCriterion` schemas and integrates them into the `AgentDefinition`. Documentation and tests are also included.

---
*PR created automatically by Jules for task [6476272062736262847](https://jules.google.com/task/6476272062736262847) started by @gowthamrao*