### PR TITLE
Add AdapterHints for Interoperability

### DIFF
--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -37,6 +37,7 @@ An `AgentDefinition` consists of the following sections:
     *   The "brain" of the agent.
     *   **LLM Config**: Model selection, temperature, and system prompts.
     *   **Topology**: Defines whether the agent is Atomic (single prompt) or Graph-based (workflow).
+    *   **Interoperability**: `adapter_hints` allow embedding "Rosetta Stone" metadata for external frameworks (e.g., LangGraph, AutoGen).
 
 4.  **Status (`status`)**:
     *   Lifecycle state of the agent (`draft` or `published`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,3 +15,4 @@ This is the documentation for the coreason_manifest project.
 *   [Identity Model](identity_model.md): The canonical representation of actors (`Identity`) within the ecosystem.
 *   [Evaluation-Ready Metadata](evaluation.md): How to define test contracts and success criteria within your agents.
 *   [Observability](observability.md): Details on tracing, logging, and metrics.
+*   [Interoperability](interoperability.md): Using "Adapter Hints" to translate agents to frameworks like LangGraph or AutoGen.

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -1,0 +1,83 @@
+# Interoperability & The Rosetta Stone Strategy
+
+The Coreason ecosystem is designed to be the "Shared Kernel" for AI agents—a definitive source of truth that is engine-agnostic. However, we recognize that the AI landscape is diverse, with powerful frameworks like **LangGraph**, **AutoGen**, and **CrewAI** offering specialized capabilities for execution.
+
+To support this diversity without polluting our strict kernel with heavy dependencies, Coreason employs a **"Rosetta Stone"** strategy.
+
+## Adapter Hints
+
+The primary mechanism for interoperability is the `AdapterHints` schema. These hints are embedded directly into the `AgentRuntimeConfig` of your Agent Manifest. They serve as metadata instructions for external translation tools (or "Adapters") to generate high-fidelity code for target platforms.
+
+### The Concept
+
+The Coreason Manifest defines *what* the agent is (inputs, outputs, tools, policy). The `AdapterHints` define *how* it should be instantiated in a specific foreign runtime.
+
+This keeps the Coreason kernel **logic-free** (no `langchain` or `autogen` imports) while enabling seamless transpilation.
+
+### Schema Definition
+
+```python
+class AdapterHints(CoReasonBaseModel):
+    framework: str        # e.g., "langgraph", "autogen"
+    adapter_type: str     # e.g., "ReActNode", "UserProxyAgent"
+    settings: Dict[str, Any]  # Framework-specific config
+```
+
+### Example Usage
+
+Here is how you might define an agent that is intended to be run primarily by Coreason's engine but can also be exported to **LangGraph** or **AutoGen**.
+
+```python
+from coreason_manifest.definitions.agent import (
+    AgentDefinition,
+    AgentRuntimeConfig,
+    AdapterHints
+)
+
+agent = AgentDefinition(
+    # ... metadata, capabilities ...
+    config=AgentRuntimeConfig(
+        # Standard Coreason Configuration
+        model_config=...,
+
+        # Interoperability Hints
+        adapter_hints=[
+            # Hint for LangGraph Adapters
+            AdapterHints(
+                framework="langgraph",
+                adapter_type="ReActNode",
+                settings={
+                    "memory_key": "chat_history",
+                    "recursion_limit": 50
+                }
+            ),
+            # Hint for AutoGen Adapters
+            AdapterHints(
+                framework="autogen",
+                adapter_type="AssistantAgent",
+                settings={
+                    "human_input_mode": "NEVER",
+                    "max_consecutive_auto_reply": 10
+                }
+            )
+        ]
+    ),
+    # ... dependencies ...
+)
+```
+
+## How It Works
+
+1.  **Define**: You define your agent in the Coreason Manifest, adding `AdapterHints` for your target platforms.
+2.  **Export**: You use a Coreason CLI tool or SDK (separate from this kernel) to "export" the agent.
+3.  **Translate**: The exporter reads the `framework` hint.
+    *   If `framework="langgraph"`, it looks up the `LangGraphAdapter`.
+    *   It uses `adapter_type="ReActNode"` to determine which class to instantiate.
+    *   It passes `settings` directly to that class constructor.
+4.  **Generate**: The tool outputs a valid Python file (e.g., `agent.py`) containing the LangGraph code, pre-configured with the tools, prompts, and models defined in your manifest.
+
+## Benefits
+
+*   **No Vendor Lock-in**: Your agent definition is portable. You can switch execution engines by simply adding a new hint and re-exporting.
+*   **Clean Kernel**: The `coreason-manifest` package remains lightweight and secure, with zero dependencies on the rapidly changing AI framework ecosystem.
+*   **High Fidelity**: Instead of generic translations, hints allow you to leverage framework-specific features (like AutoGen's `groupchat` settings or LangGraph's `checkpoint` config) explicitly.

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from .definitions.agent import AgentDefinition, AgentStatus, Persona
+from .definitions.agent import AdapterHints, AgentDefinition, AgentStatus, Persona
 from .definitions.audit import AuditLog
 from .definitions.evaluation import EvaluationProfile, SuccessCriterion
 from .definitions.events import (
@@ -63,6 +63,7 @@ from .governance import ComplianceReport, GovernanceConfig, check_compliance
 from .recipes import RecipeManifest
 
 __all__ = [
+    "AdapterHints",
     "AgentDefinition",
     "AgentStatus",
     "Persona",

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -201,6 +201,24 @@ class ModelConfig(CoReasonBaseModel):
     persona: Optional[Persona] = Field(None, description="The full persona definition (name, description, directives).")
 
 
+class AdapterHints(CoReasonBaseModel):
+    """Hints for translating the agent to external frameworks.
+
+    Attributes:
+        framework: The target framework (e.g., "langgraph", "autogen").
+        adapter_type: The specific class or node type in that framework.
+        settings: Framework-specific configuration parameters.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    framework: str = Field(..., description="The target framework (e.g., 'langgraph', 'autogen').")
+    adapter_type: str = Field(..., description="The specific class or node type in that framework.")
+    settings: Dict[str, Any] = Field(
+        default_factory=dict, description="Framework-specific configuration parameters."
+    )
+
+
 class AgentRuntimeConfig(CoReasonBaseModel):
     """Configuration of the Agent execution.
 
@@ -209,6 +227,7 @@ class AgentRuntimeConfig(CoReasonBaseModel):
         edges: Directed connections defining control flow.
         entry_point: The ID of the starting node.
         llm_config: Specific LLM parameters.
+        adapter_hints: Optional list of adapter hints for interoperability.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -218,6 +237,9 @@ class AgentRuntimeConfig(CoReasonBaseModel):
     entry_point: Optional[str] = Field(None, description="The ID of the starting node.")
     llm_config: ModelConfig = Field(..., alias="model_config", description="Specific LLM parameters.")
     system_prompt: Optional[str] = Field(None, description="The global system prompt/instruction for the agent.")
+    adapter_hints: Optional[List[AdapterHints]] = Field(
+        None, description="Optional list of adapter hints for interoperability."
+    )
 
     @field_validator("nodes")
     @classmethod

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -214,9 +214,7 @@ class AdapterHints(CoReasonBaseModel):
 
     framework: str = Field(..., description="The target framework (e.g., 'langgraph', 'autogen').")
     adapter_type: str = Field(..., description="The specific class or node type in that framework.")
-    settings: Dict[str, Any] = Field(
-        default_factory=dict, description="Framework-specific configuration parameters."
-    )
+    settings: Dict[str, Any] = Field(default_factory=dict, description="Framework-specific configuration parameters.")
 
 
 class AgentRuntimeConfig(CoReasonBaseModel):

--- a/src/coreason_manifest/schemas/agent.schema.json
+++ b/src/coreason_manifest/schemas/agent.schema.json
@@ -1,5 +1,33 @@
 {
   "$defs": {
+    "AdapterHints": {
+      "additionalProperties": false,
+      "description": "Hints for translating the agent to external frameworks.\n\nAttributes:\n    framework: The target framework (e.g., \"langgraph\", \"autogen\").\n    adapter_type: The specific class or node type in that framework.\n    settings: Framework-specific configuration parameters.",
+      "properties": {
+        "framework": {
+          "description": "The target framework (e.g., 'langgraph', 'autogen').",
+          "title": "Framework",
+          "type": "string"
+        },
+        "adapter_type": {
+          "description": "The specific class or node type in that framework.",
+          "title": "Adapter Type",
+          "type": "string"
+        },
+        "settings": {
+          "additionalProperties": true,
+          "description": "Framework-specific configuration parameters.",
+          "title": "Settings",
+          "type": "object"
+        }
+      },
+      "required": [
+        "framework",
+        "adapter_type"
+      ],
+      "title": "AdapterHints",
+      "type": "object"
+    },
     "AgentCapability": {
       "additionalProperties": false,
       "description": "Defines a specific mode of interaction for the agent.\n\nAttributes:\n    name: Unique name for this capability.\n    type: Interaction mode.\n    description: What this mode does.\n    inputs: Typed arguments the agent accepts (JSON Schema).\n    outputs: Typed structure of the result.\n    events: List of intermediate events this agent produces during execution.\n    injected_params: List of parameters injected by the system.\n    delivery_mode: The mechanism used to deliver the response.",
@@ -246,7 +274,7 @@
     },
     "AgentRuntimeConfig": {
       "additionalProperties": false,
-      "description": "Configuration of the Agent execution.\n\nAttributes:\n    nodes: A collection of execution units (Agents, Tools, Logic).\n    edges: Directed connections defining control flow.\n    entry_point: The ID of the starting node.\n    llm_config: Specific LLM parameters.",
+      "description": "Configuration of the Agent execution.\n\nAttributes:\n    nodes: A collection of execution units (Agents, Tools, Logic).\n    edges: Directed connections defining control flow.\n    entry_point: The ID of the starting node.\n    llm_config: Specific LLM parameters.\n    adapter_hints: Optional list of adapter hints for interoperability.",
       "properties": {
         "nodes": {
           "description": "A collection of execution units.",
@@ -320,6 +348,22 @@
           "default": null,
           "description": "The global system prompt/instruction for the agent.",
           "title": "System Prompt"
+        },
+        "adapter_hints": {
+          "anyOf": [
+            {
+              "items": {
+                "$ref": "#/$defs/AdapterHints"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional list of adapter hints for interoperability.",
+          "title": "Adapter Hints"
         }
       },
       "required": [

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -8,26 +8,27 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-import pytest
 import json
-from uuid import uuid4
 from datetime import datetime, timezone
-from coreason_manifest.definitions.evaluation import EvaluationProfile, SuccessCriterion
+from uuid import uuid4
+
 from coreason_manifest.definitions.agent import (
-    AgentDefinition, AgentMetadata, AgentCapability, CapabilityType,
-    AgentRuntimeConfig, ModelConfig, AgentDependencies
+    AgentCapability,
+    AgentDefinition,
+    AgentDependencies,
+    AgentMetadata,
+    AgentRuntimeConfig,
+    CapabilityType,
+    ModelConfig,
 )
-from pydantic import ValidationError
+from coreason_manifest.definitions.evaluation import EvaluationProfile, SuccessCriterion
+
 
 def create_minimal_agent() -> AgentDefinition:
     """Helper to create a minimal valid AgentDefinition."""
     return AgentDefinition(
         metadata=AgentMetadata(
-            id=uuid4(),
-            version="1.0.0",
-            name="TestAgent",
-            author="Tester",
-            created_at=datetime.now(timezone.utc)
+            id=uuid4(), version="1.0.0", name="TestAgent", author="Tester", created_at=datetime.now(timezone.utc)
         ),
         capabilities=[
             AgentCapability(
@@ -35,29 +36,21 @@ def create_minimal_agent() -> AgentDefinition:
                 type=CapabilityType.ATOMIC,
                 description="test",
                 inputs={"x": {"type": "string"}},
-                outputs={"y": {"type": "string"}}
+                outputs={"y": {"type": "string"}},
             )
         ],
-        config=AgentRuntimeConfig(
-            model_config=ModelConfig(
-                model="gpt-4",
-                temperature=0.0
-            )
-        ),
-        dependencies=AgentDependencies()
+        config=AgentRuntimeConfig(llm_config=ModelConfig(model="gpt-4", temperature=0.0)),
+        dependencies=AgentDependencies(),
     )
+
 
 def test_success_criterion_valid() -> None:
     """Test valid SuccessCriterion creation."""
-    sc = SuccessCriterion(
-        name="test_criterion",
-        description="A test criterion",
-        threshold=0.9,
-        strict=True
-    )
+    sc = SuccessCriterion(name="test_criterion", description="A test criterion", threshold=0.9, strict=True)
     assert sc.name == "test_criterion"
     assert sc.threshold == 0.9
     assert sc.strict is True
+
 
 def test_success_criterion_defaults() -> None:
     """Test SuccessCriterion defaults."""
@@ -65,18 +58,18 @@ def test_success_criterion_defaults() -> None:
     assert sc.strict is True
     assert sc.threshold is None
 
+
 def test_evaluation_profile_valid() -> None:
     """Test valid EvaluationProfile creation."""
     sc = SuccessCriterion(name="test")
     ep = EvaluationProfile(
-        expected_latency_ms=100,
-        golden_dataset_uri="s3://test/data.json",
-        grading_rubric=[sc],
-        evaluator_model="gpt-4"
+        expected_latency_ms=100, golden_dataset_uri="s3://test/data.json", grading_rubric=[sc], evaluator_model="gpt-4"
     )
     assert ep.expected_latency_ms == 100
+    assert ep.grading_rubric is not None
     assert ep.grading_rubric[0].name == "test"
     assert ep.evaluator_model == "gpt-4"
+
 
 def test_evaluation_profile_empty() -> None:
     """Test empty EvaluationProfile."""
@@ -84,12 +77,12 @@ def test_evaluation_profile_empty() -> None:
     assert ep.expected_latency_ms is None
     assert ep.grading_rubric is None
 
+
 def test_agent_integration() -> None:
     """Test integrating EvaluationProfile into AgentDefinition."""
     # Create an evaluation profile
     eval_profile = EvaluationProfile(
-        expected_latency_ms=500,
-        grading_rubric=[SuccessCriterion(name="accuracy", threshold=0.99)]
+        expected_latency_ms=500, grading_rubric=[SuccessCriterion(name="accuracy", threshold=0.99)]
     )
 
     # Use helper to create a minimal agent
@@ -101,14 +94,13 @@ def test_agent_integration() -> None:
 
     assert agent.evaluation is not None
     assert agent.evaluation.expected_latency_ms == 500
+    assert agent.evaluation.grading_rubric is not None
     assert agent.evaluation.grading_rubric[0].name == "accuracy"
+
 
 def test_serialization() -> None:
     """Test serialization of EvaluationProfile."""
-    ep = EvaluationProfile(
-        expected_latency_ms=100,
-        grading_rubric=[SuccessCriterion(name="test")]
-    )
+    ep = EvaluationProfile(expected_latency_ms=100, grading_rubric=[SuccessCriterion(name="test")])
     json_str = ep.to_json()
     data = json.loads(json_str)
     assert data["expected_latency_ms"] == 100


### PR DESCRIPTION
This PR introduces the `AdapterHints` schema and integrates it into `AgentRuntimeConfig`. 

**Changes:**
1.  **New Model**: `AdapterHints` in `src/coreason_manifest/definitions/agent.py`.
    -   `framework`: Target framework (e.g., "langgraph").
    -   `adapter_type`: Specific node/agent type.
    -   `settings`: Arbitrary configuration dict.
2.  **Schema Update**: `AgentRuntimeConfig` now accepts `adapter_hints: Optional[List[AdapterHints]]`.
3.  **Exports**: Added `AdapterHints` to top-level `__init__.py`.
4.  **Documentation**:
    -   Updated `docs/coreason_agent_manifest.md` to mention the new field.
    -   Created `docs/interoperability.md` explaining the "Rosetta Stone" strategy.
    -   Updated `docs/index.md` to link to the new doc.

**Purpose:**
To allow agents to carry metadata that helps external tools translate the Coreason manifest into framework-specific code (like LangGraph or AutoGen) without polluting the core kernel with dependencies.

---
*PR created automatically by Jules for task [6355832117277732880](https://jules.google.com/task/6355832117277732880) started by @gowthamrao*