### PR TITLE
Decoupling Interface from Implementation

### DIFF
--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -30,7 +30,8 @@ An `AgentDefinition` consists of the following sections:
     *   Defines the modes of interaction for the agent (e.g., "Atomic", "Streaming").
     *   Each capability has a unique `name`, `type`, and `description`.
     *   **Delivery Mode**: `delivery_mode` explicitly declares whether the client should expect a single `REQUEST_RESPONSE` or a stream of `SERVER_SENT_EVENTS`.
-    *   `inputs` and `outputs` are defined using immutable dictionaries (representing JSON Schemas).
+    *   **Contracts**: Can optionally implement a reusable `InterfaceDefinition` by providing an `interface_id`.
+    *   `inputs` and `outputs` are defined using immutable dictionaries (representing JSON Schemas). *Note: These are optional if `interface_id` is provided.*
     *   `injected_params` lists system-injected values (e.g., `user_context`).
 
 3.  **Configuration (`AgentRuntimeConfig`)**:

--- a/docs/interface_contracts.md
+++ b/docs/interface_contracts.md
@@ -1,0 +1,100 @@
+# Interface Contracts
+
+The Coreason Agent Manifest (CAM) supports decoupling the **Interface** (Contract) from the **Implementation** (Capability). This allows for stricter governance, reusability, and polymorphism across agents.
+
+Instead of every agent redefining `inputs` and `outputs` inline, they can reference a shared `InterfaceDefinition` by ID.
+
+## The Interface Definition
+
+The `InterfaceDefinition` is a top-level asset that defines a strict contract for inputs and outputs.
+
+### Schema
+
+An `InterfaceDefinition` consists of:
+
+1.  **Metadata (`ContractMetadata`)**:
+    *   `id`: Unique Identifier (UUID).
+    *   `version`: Semantic Version.
+    *   `name`: Human-readable name (e.g., "Corporate Search").
+    *   `author`: The team or entity defining the contract.
+
+2.  **Inputs (`inputs`)**:
+    *   A JSON Schema defining the arguments required by the interface.
+
+3.  **Outputs (`outputs`)**:
+    *   A JSON Schema defining the expected structure of the result.
+
+4.  **Description (`description`)**:
+    *   A human-readable explanation of the contract's purpose.
+
+### Example
+
+```python
+from uuid import uuid4
+from datetime import datetime, timezone
+from coreason_manifest.definitions.contracts import InterfaceDefinition, ContractMetadata
+
+search_interface = InterfaceDefinition(
+    metadata=ContractMetadata(
+        id=uuid4(),
+        version="1.0.0",
+        name="Enterprise Search",
+        author="Platform Team",
+        created_at=datetime.now(timezone.utc)
+    ),
+    description="Standard interface for searching corporate knowledge bases.",
+    inputs={
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "The search query."}
+        },
+        "required": ["query"]
+    },
+    outputs={
+        "type": "object",
+        "properties": {
+            "results": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "title": {"type": "string"},
+                        "url": {"type": "string"}
+                    }
+                }
+            }
+        },
+        "required": ["results"]
+    }
+)
+```
+
+## Using Interfaces in Agents
+
+When defining an `AgentCapability`, you can now reference an interface instead of defining schemas inline.
+
+### `AgentCapability` Updates
+
+The `AgentCapability` class has been updated with:
+*   `interface_id` (Optional[UUID]): References a published `InterfaceDefinition`.
+*   **Validation Rule**: A capability must provide **EITHER** an `interface_id` **OR** inline `inputs`/`outputs`.
+
+### Example Agent
+
+```python
+from coreason_manifest.definitions.agent import AgentCapability, CapabilityType
+
+capability = AgentCapability(
+    name="search",
+    type=CapabilityType.ATOMIC,
+    description="Implements the Enterprise Search contract.",
+    # Instead of inputs/outputs, we reference the ID:
+    interface_id=search_interface.metadata.id
+)
+```
+
+## Benefits
+
+1.  **Standardization**: Ensure all "Search" agents accept the same arguments.
+2.  ** Governance**: Central teams can publish contracts that agents must adhere to.
+3.  **Polymorphism**: Clients can program against the *Interface* (e.g., "Find an agent that implements interface X") rather than inspecting individual schemas.

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -10,6 +10,7 @@
 
 from .definitions.agent import AdapterHints, AgentDefinition, AgentStatus, Persona
 from .definitions.audit import AuditLog
+from .definitions.contracts import InterfaceDefinition
 from .definitions.evaluation import EvaluationProfile, SuccessCriterion
 from .definitions.events import (
     ArtifactGenerated,
@@ -67,6 +68,7 @@ __all__ = [
     "AgentDefinition",
     "AgentStatus",
     "Persona",
+    "InterfaceDefinition",
     "EvaluationProfile",
     "SuccessCriterion",
     "Topology",

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -515,7 +515,8 @@ class AgentDefinition(CoReasonBaseModel):
         # 3. If found:
         if target_capability.inputs is None:
             raise ValueError(
-                f"Capability '{capability_name}' uses an external interface. Validation requires resolving the interface."
+                f"Capability '{capability_name}' uses an external interface. "
+                "Validation requires resolving the interface."
             )
 
         # Use jsonschema.validate(instance=payload, schema=target_capability.inputs)

--- a/src/coreason_manifest/definitions/contracts.py
+++ b/src/coreason_manifest/definitions/contracts.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime
+from typing import Any, Dict
+from uuid import UUID
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.definitions.agent import VersionStr
+from coreason_manifest.definitions.base import CoReasonBaseModel
+
+
+class ContractMetadata(CoReasonBaseModel):
+    """Metadata for the Interface Definition.
+
+    Attributes:
+        id: Unique Identifier for the Interface (UUID).
+        version: Semantic Version of the Interface.
+        name: Name of the Interface.
+        author: Author of the Interface.
+        created_at: Creation timestamp (ISO 8601).
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    id: UUID = Field(..., description="Unique Identifier for the Interface (UUID).")
+    version: VersionStr = Field(..., description="Semantic Version of the Interface.")
+    name: str = Field(..., min_length=1, description="Name of the Interface.")
+    author: str = Field(..., min_length=1, description="Author of the Interface.")
+    created_at: datetime = Field(..., description="Creation timestamp (ISO 8601).")
+
+
+class InterfaceDefinition(CoReasonBaseModel):
+    """A reusable definition of an Agent's inputs and outputs.
+
+    This decoupling allows multiple Agents to implement the same "Contract".
+
+    Attributes:
+        metadata: Metadata for the Interface.
+        inputs: JSON Schema for arguments.
+        outputs: JSON Schema for return values.
+        description: Human-readable docstring for this interface.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    metadata: ContractMetadata
+    inputs: Dict[str, Any] = Field(..., description="JSON Schema for arguments.")
+    outputs: Dict[str, Any] = Field(..., description="JSON Schema for return values.")
+    description: str = Field(..., description="Human-readable docstring for this interface.")

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -84,7 +84,7 @@ def test_full_agent_build() -> None:
 
 def test_builder_set_status() -> None:
     """Test that set_status correctly updates the builder status."""
-    builder = AgentBuilder(name="StatusAgent")
+    builder: AgentBuilder = AgentBuilder(name="StatusAgent")
     assert builder._status == AgentStatus.DRAFT
 
     builder.set_status(AgentStatus.PUBLISHED)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -39,11 +39,13 @@ def test_capability_compilation() -> None:
     assert definition.description == "Search the web"
 
     # Check inputs schema
+    assert definition.inputs is not None
     assert "properties" in definition.inputs
     assert "query" in definition.inputs["properties"]
     assert definition.inputs["properties"]["query"]["type"] == "string"
 
     # Check outputs schema
+    assert definition.outputs is not None
     assert "properties" in definition.outputs
     assert "results" in definition.outputs["properties"]
     assert definition.outputs["properties"]["results"]["type"] == "array"
@@ -70,6 +72,7 @@ def test_full_agent_build() -> None:
     # Verify capability is compiled
     compiled_cap = agent.capabilities[0]
     assert compiled_cap.name == "search"
+    assert compiled_cap.inputs is not None
     assert compiled_cap.inputs["properties"]["query"]["type"] == "string"
 
     # Verify config

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -85,7 +85,7 @@ def test_builder_set_status() -> None:
     assert builder._status == AgentStatus.DRAFT
 
     builder.set_status(AgentStatus.PUBLISHED)
-    assert builder._status == AgentStatus.PUBLISHED  # type: ignore[comparison-overlap]
+    assert builder._status == AgentStatus.PUBLISHED
 
     builder.set_status(AgentStatus.DRAFT)
     assert builder._status == AgentStatus.DRAFT

--- a/tests/test_complex_cases.py
+++ b/tests/test_complex_cases.py
@@ -59,11 +59,15 @@ def test_deep_immutability_mapping_proxy() -> None:
     agent = AgentDefinition(**data)
 
     # inputs should be read-only
-    with pytest.raises(TypeError, match="'mappingproxy' object does not support item assignment"):
-        agent.capabilities[0].inputs["param"] = 2  # type: ignore[index]
+    # We must assert inputs is not None for mypy, though we know it is from data
+    inputs = agent.capabilities[0].inputs
+    assert inputs is not None
 
     with pytest.raises(TypeError, match="'mappingproxy' object does not support item assignment"):
-        agent.capabilities[0].inputs["new"] = 3  # type: ignore[index]
+        inputs["param"] = 2
+
+    with pytest.raises(TypeError, match="'mappingproxy' object does not support item assignment"):
+        inputs["new"] = 3
 
 
 def test_deep_immutability_tuples() -> None:
@@ -115,11 +119,11 @@ def test_deep_immutability_tuples() -> None:
 
     # Test field immutability (model is frozen)
     with pytest.raises(ValidationError, match="Instance is frozen"):
-        agent.dependencies.libraries = ("a",)  # type: ignore[misc]
+        agent.dependencies.libraries = ("a",)
 
     # Test tools field immutability (model is frozen)
     with pytest.raises(ValidationError, match="Instance is frozen"):
-        agent.dependencies.tools = []  # type: ignore[misc]
+        agent.dependencies.tools = []
 
     # Note: agent.dependencies.tools is a list, so its CONTENTS are mutable,
     # but the field itself cannot be reassigned.
@@ -161,6 +165,7 @@ def test_unicode_handling() -> None:
 
     assert agent.metadata.name == name_unicode
     assert agent.metadata.author == author_unicode
+    assert agent.capabilities[0].inputs is not None
     assert agent.capabilities[0].inputs["key_Ω"] == "val_🤖"
 
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -7,7 +7,7 @@ from coreason_manifest.definitions.contracts import InterfaceDefinition, Contrac
 from coreason_manifest.definitions.agent import AgentCapability, CapabilityType, DeliveryMode
 
 
-def test_contract_metadata_creation():
+def test_contract_metadata_creation() -> None:
     metadata = ContractMetadata(
         id=uuid4(),
         version="1.0.0",
@@ -18,7 +18,7 @@ def test_contract_metadata_creation():
     assert metadata.name == "Test Interface"
     assert metadata.version == "1.0.0"
 
-def test_interface_definition_creation():
+def test_interface_definition_creation() -> None:
     metadata = ContractMetadata(
         id=uuid4(),
         version="1.0.0",
@@ -37,7 +37,7 @@ def test_interface_definition_creation():
     assert interface.inputs["type"] == "object"
     assert interface.description == "A standard search interface."
 
-def test_agent_capability_validation_inline_schema():
+def test_agent_capability_validation_inline_schema() -> None:
     # Test valid capability with inline schema
     cap = AgentCapability(
         name="search",
@@ -50,7 +50,7 @@ def test_agent_capability_validation_inline_schema():
     assert cap.outputs is not None
     assert cap.interface_id is None
 
-def test_agent_capability_validation_interface_id():
+def test_agent_capability_validation_interface_id() -> None:
     # Test valid capability with interface_id
     cap = AgentCapability(
         name="search",
@@ -62,7 +62,7 @@ def test_agent_capability_validation_interface_id():
     assert cap.inputs is None
     assert cap.outputs is None
 
-def test_agent_capability_validation_both():
+def test_agent_capability_validation_both() -> None:
     # Test valid capability with both (override)
     cap = AgentCapability(
         name="search",
@@ -75,7 +75,7 @@ def test_agent_capability_validation_both():
     assert cap.interface_id is not None
     assert cap.inputs is not None
 
-def test_agent_capability_validation_failure():
+def test_agent_capability_validation_failure() -> None:
     # Test invalid capability (neither)
     with pytest.raises(ValidationError) as excinfo:
         AgentCapability(
@@ -85,7 +85,7 @@ def test_agent_capability_validation_failure():
         )
     assert "AgentCapability must define either 'interface_id' or both 'inputs' and 'outputs'" in str(excinfo.value)
 
-def test_agent_capability_validation_partial_schema():
+def test_agent_capability_validation_partial_schema() -> None:
     # Test invalid capability (only inputs)
     with pytest.raises(ValidationError) as excinfo:
         AgentCapability(

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,97 @@
+import pytest
+from uuid import uuid4
+from datetime import datetime
+from pydantic import ValidationError
+
+from coreason_manifest.definitions.contracts import InterfaceDefinition, ContractMetadata
+from coreason_manifest.definitions.agent import AgentCapability, CapabilityType, DeliveryMode
+
+
+def test_contract_metadata_creation():
+    metadata = ContractMetadata(
+        id=uuid4(),
+        version="1.0.0",
+        name="Test Interface",
+        author="Tester",
+        created_at=datetime.utcnow()
+    )
+    assert metadata.name == "Test Interface"
+    assert metadata.version == "1.0.0"
+
+def test_interface_definition_creation():
+    metadata = ContractMetadata(
+        id=uuid4(),
+        version="1.0.0",
+        name="Search Interface",
+        author="Tester",
+        created_at=datetime.utcnow()
+    )
+
+    interface = InterfaceDefinition(
+        metadata=metadata,
+        inputs={"type": "object", "properties": {"query": {"type": "string"}}},
+        outputs={"type": "object", "properties": {"results": {"type": "array"}}},
+        description="A standard search interface."
+    )
+
+    assert interface.inputs["type"] == "object"
+    assert interface.description == "A standard search interface."
+
+def test_agent_capability_validation_inline_schema():
+    # Test valid capability with inline schema
+    cap = AgentCapability(
+        name="search",
+        type=CapabilityType.ATOMIC,
+        description="Search function",
+        inputs={"type": "object"},
+        outputs={"type": "object"}
+    )
+    assert cap.inputs is not None
+    assert cap.outputs is not None
+    assert cap.interface_id is None
+
+def test_agent_capability_validation_interface_id():
+    # Test valid capability with interface_id
+    cap = AgentCapability(
+        name="search",
+        type=CapabilityType.ATOMIC,
+        description="Search function",
+        interface_id=uuid4()
+    )
+    assert cap.interface_id is not None
+    assert cap.inputs is None
+    assert cap.outputs is None
+
+def test_agent_capability_validation_both():
+    # Test valid capability with both (override)
+    cap = AgentCapability(
+        name="search",
+        type=CapabilityType.ATOMIC,
+        description="Search function",
+        interface_id=uuid4(),
+        inputs={"type": "object"},
+        outputs={"type": "object"}
+    )
+    assert cap.interface_id is not None
+    assert cap.inputs is not None
+
+def test_agent_capability_validation_failure():
+    # Test invalid capability (neither)
+    with pytest.raises(ValidationError) as excinfo:
+        AgentCapability(
+            name="search",
+            type=CapabilityType.ATOMIC,
+            description="Search function"
+        )
+    assert "AgentCapability must define either 'interface_id' or both 'inputs' and 'outputs'" in str(excinfo.value)
+
+def test_agent_capability_validation_partial_schema():
+    # Test invalid capability (only inputs)
+    with pytest.raises(ValidationError) as excinfo:
+        AgentCapability(
+            name="search",
+            type=CapabilityType.ATOMIC,
+            description="Search function",
+            inputs={"type": "object"}
+        )
+    assert "AgentCapability must define either 'interface_id' or both 'inputs' and 'outputs'" in str(excinfo.value)

--- a/tests/test_dsl.py
+++ b/tests/test_dsl.py
@@ -53,12 +53,14 @@ capabilities:
 
     # Schema assertions
     # Inputs
+    assert cap.inputs is not None
     assert cap.inputs["type"] == "object"
     assert cap.inputs["required"] == ["city", "days"]
     assert cap.inputs["properties"]["city"] == {"type": "string"}
     assert cap.inputs["properties"]["days"] == {"type": "integer"}
 
     # Outputs
+    assert cap.outputs is not None
     assert cap.outputs["type"] == "object"
     assert cap.outputs["properties"]["report"] == {"type": "string"}
 
@@ -77,6 +79,7 @@ capabilities:
     agent = load_from_yaml(yaml_content)
     cap = agent.capabilities[0]
 
+    assert cap.inputs is not None
     # List[string] -> {"type": "array", "items": {"type": "string"}}
     tags_schema = cap.inputs["properties"]["tags"]
     assert tags_schema["type"] == "array"
@@ -88,6 +91,7 @@ capabilities:
     assert scores_schema["items"] == {"type": "number"}
 
     # Any -> {}
+    assert cap.outputs is not None
     summary_schema = cap.outputs["properties"]["summary"]
     assert summary_schema == {}
 
@@ -147,6 +151,7 @@ capabilities:
     inputs:
       flag: bool
 """)
+    assert agent.capabilities[0].inputs is not None
     assert agent.capabilities[0].inputs["properties"]["flag"]["type"] == "boolean"
 
     # Test invalid YAML structure (list instead of dict)


### PR DESCRIPTION
This change introduces the `InterfaceDefinition` schema (Contract) to decouple the definition of agent inputs/outputs from their implementation in `AgentCapability`. 

Changes:
- New module `src/coreason_manifest/definitions/contracts.py` defining `InterfaceDefinition` and `ContractMetadata`.
- Modification to `AgentCapability` to include an optional `interface_id` and make `inputs`/`outputs` optional.
- Validation logic to ensure `AgentCapability` has either an interface reference or inline schemas.
- Updates to `AgentDefinition.validate_input` to handle external interfaces (raising explicit error instead of crashing).
- New documentation in `docs/interface_contracts.md` and updates to the main manifest documentation.
- Comprehensive tests in `tests/test_contracts.py`.

---
*PR created automatically by Jules for task [13528817994242430347](https://jules.google.com/task/13528817994242430347) started by @gowthamrao*