### PR TITLE
Abstract Tools into Resources (Sidecars & Remote Services)

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -61,6 +61,11 @@ from .definitions.topology import (
 from .dsl import load_from_yaml
 from .governance import ComplianceReport, GovernanceConfig, check_compliance
 from .recipes import RecipeManifest
+from .definitions.resources import (
+    RemoteServiceResource,
+    ResourceRiskLevel,
+    SidecarResource,
+)
 
 __all__ = [
     "AdapterHints",
@@ -116,4 +121,7 @@ __all__ = [
     "SwarmPattern",
     "HierarchicalTeamPattern",
     "PatternDefinition",
+    "ResourceRiskLevel",
+    "SidecarResource",
+    "RemoteServiceResource",
 ]

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -42,6 +42,11 @@ from .definitions.patterns import (
     PatternType,
     SwarmPattern,
 )
+from .definitions.resources import (
+    RemoteServiceResource,
+    ResourceRiskLevel,
+    SidecarResource,
+)
 from .definitions.simulation import (
     SimulationMetrics,
     SimulationScenario,
@@ -61,11 +66,6 @@ from .definitions.topology import (
 from .dsl import load_from_yaml
 from .governance import ComplianceReport, GovernanceConfig, check_compliance
 from .recipes import RecipeManifest
-from .definitions.resources import (
-    RemoteServiceResource,
-    ResourceRiskLevel,
-    SidecarResource,
-)
 
 __all__ = [
     "AdapterHints",

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -35,9 +35,10 @@ from pydantic import (
 )
 from typing_extensions import Annotated
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.definitions.base import CoReasonBaseModel, StrictUri
 from coreason_manifest.definitions.deployment import DeploymentConfig
 from coreason_manifest.definitions.evaluation import EvaluationProfile
+from coreason_manifest.definitions.resources import RemoteServiceResource, SidecarResource
 from coreason_manifest.definitions.topology import Edge, Node, validate_edge_integrity
 
 # SemVer Regex pattern (simplified for standard SemVer)
@@ -75,13 +76,6 @@ ImmutableDict = Annotated[
     Mapping[str, Any],
     AfterValidator(lambda x: MappingProxyType(x)),
     PlainSerializer(lambda x: dict(x), return_type=Dict[str, Any]),
-]
-
-
-# Strict URI type that serializes to string
-StrictUri = Annotated[
-    AnyUrl,
-    PlainSerializer(lambda x: str(x), return_type=str),
 ]
 
 
@@ -316,14 +310,23 @@ class AgentDependencies(CoReasonBaseModel):
     """External dependencies for the Agent.
 
     Attributes:
-        tools: List of MCP tool requirements.
+        tools: List of MCP tool requirements. (Deprecated)
+        sidecars: List of Sidecar containers.
+        remote_services: List of Remote API/MCP services.
         libraries: List of Python packages required (if code execution is allowed).
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     tools: List[Union[ToolRequirement, InlineToolDefinition]] = Field(
-        default_factory=list, description="List of MCP tool requirements."
+        default_factory=list,
+        description="List of MCP tool requirements. (Deprecated: Use sidecars/remote_services instead)",
+    )
+    sidecars: List[SidecarResource] = Field(
+        default_factory=list, description="List of Sidecar containers."
+    )
+    remote_services: List[RemoteServiceResource] = Field(
+        default_factory=list, description="List of Remote API/MCP services."
     )
     libraries: Tuple[str, ...] = Field(
         default_factory=tuple, description="List of Python packages required (if code execution is allowed)."

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -321,9 +321,7 @@ class AgentDependencies(CoReasonBaseModel):
         default_factory=list,
         description="List of MCP tool requirements. (Deprecated: Use sidecars/remote_services instead)",
     )
-    sidecars: List[SidecarResource] = Field(
-        default_factory=list, description="List of Sidecar containers."
-    )
+    sidecars: List[SidecarResource] = Field(default_factory=list, description="List of Sidecar containers.")
     remote_services: List[RemoteServiceResource] = Field(
         default_factory=list, description="List of Remote API/MCP services."
     )

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -26,7 +26,6 @@ from uuid import UUID
 import jsonschema
 from pydantic import (
     AfterValidator,
-    AnyUrl,
     ConfigDict,
     Field,
     PlainSerializer,

--- a/src/coreason_manifest/definitions/base.py
+++ b/src/coreason_manifest/definitions/base.py
@@ -9,8 +9,16 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from typing import Any, Dict
+from typing_extensions import Annotated
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import AnyUrl, BaseModel, ConfigDict, PlainSerializer
+
+
+# Strict URI type that serializes to string
+StrictUri = Annotated[
+    AnyUrl,
+    PlainSerializer(lambda x: str(x), return_type=str),
+]
 
 
 class CoReasonBaseModel(BaseModel):

--- a/src/coreason_manifest/definitions/base.py
+++ b/src/coreason_manifest/definitions/base.py
@@ -9,9 +9,9 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from typing import Any, Dict
-from typing_extensions import Annotated
 
 from pydantic import AnyUrl, BaseModel, ConfigDict, PlainSerializer
+from typing_extensions import Annotated
 
 
 # Strict URI type that serializes to string

--- a/src/coreason_manifest/definitions/resources.py
+++ b/src/coreason_manifest/definitions/resources.py
@@ -39,9 +39,7 @@ class SidecarResource(CoReasonBaseModel):
 
     name: str = Field(..., description="Name of the sidecar.")
     image: str = Field(..., description="Docker image (e.g., 'redis:alpine').")
-    env_vars: Optional[Dict[str, str]] = Field(
-        default=None, description="Environment variables for the sidecar."
-    )
+    env_vars: Optional[Dict[str, str]] = Field(default=None, description="Environment variables for the sidecar.")
     ports: Optional[List[int]] = Field(default=None, description="Ports to expose.")
     command: Optional[List[str]] = Field(default=None, description="Command to run.")
 
@@ -61,9 +59,7 @@ class RemoteServiceResource(CoReasonBaseModel):
 
     name: str = Field(..., description="Name of the remote service.")
     uri: StrictUri = Field(..., description="The service URI.")
-    scopes: Optional[List[str]] = Field(
-        default=None, description="List of required scopes/permissions."
-    )
+    scopes: Optional[List[str]] = Field(default=None, description="List of required scopes/permissions.")
     connection_secret_env: Optional[str] = Field(
         default=None, description="Name of the env var holding the API key."
     )

--- a/src/coreason_manifest/definitions/resources.py
+++ b/src/coreason_manifest/definitions/resources.py
@@ -60,7 +60,5 @@ class RemoteServiceResource(CoReasonBaseModel):
     name: str = Field(..., description="Name of the remote service.")
     uri: StrictUri = Field(..., description="The service URI.")
     scopes: Optional[List[str]] = Field(default=None, description="List of required scopes/permissions.")
-    connection_secret_env: Optional[str] = Field(
-        default=None, description="Name of the env var holding the API key."
-    )
+    connection_secret_env: Optional[str] = Field(default=None, description="Name of the env var holding the API key.")
     risk_level: ResourceRiskLevel = Field(..., description="Risk level of the resource.")

--- a/src/coreason_manifest/definitions/resources.py
+++ b/src/coreason_manifest/definitions/resources.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import Enum
+from typing import Dict, List, Optional
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.definitions.base import CoReasonBaseModel, StrictUri
+
+
+class ResourceRiskLevel(str, Enum):
+    """Risk level for the resource."""
+
+    SAFE = "SAFE"
+    STANDARD = "STANDARD"
+    CRITICAL = "CRITICAL"
+
+
+class SidecarResource(CoReasonBaseModel):
+    """Represents a container that runs alongside the agent.
+
+    Attributes:
+        name: Name of the sidecar.
+        image: Docker image (e.g., 'redis:alpine').
+        env_vars: Environment variables for the sidecar.
+        ports: Ports to expose.
+        command: Command to run.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(..., description="Name of the sidecar.")
+    image: str = Field(..., description="Docker image (e.g., 'redis:alpine').")
+    env_vars: Optional[Dict[str, str]] = Field(
+        default=None, description="Environment variables for the sidecar."
+    )
+    ports: Optional[List[int]] = Field(default=None, description="Ports to expose.")
+    command: Optional[List[str]] = Field(default=None, description="Command to run.")
+
+
+class RemoteServiceResource(CoReasonBaseModel):
+    """Represents an external API or MCP server.
+
+    Attributes:
+        name: Name of the remote service.
+        uri: The service URI.
+        scopes: List of required scopes/permissions.
+        connection_secret_env: Name of the env var holding the API key.
+        risk_level: Risk level of the resource.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    name: str = Field(..., description="Name of the remote service.")
+    uri: StrictUri = Field(..., description="The service URI.")
+    scopes: Optional[List[str]] = Field(
+        default=None, description="List of required scopes/permissions."
+    )
+    connection_secret_env: Optional[str] = Field(
+        default=None, description="Name of the env var holding the API key."
+    )
+    risk_level: ResourceRiskLevel = Field(..., description="Risk level of the resource.")

--- a/tests/test_resources_integration.py
+++ b/tests/test_resources_integration.py
@@ -1,20 +1,22 @@
 import pytest
-from coreason_manifest.definitions.agent import AgentDependencies
+from pydantic import ValidationError
+
 from coreason_manifest import (
     RemoteServiceResource,
     ResourceRiskLevel,
     SidecarResource,
 )
-from pydantic import ValidationError
+from coreason_manifest.definitions.agent import AgentDependencies
 
-def test_sidecar_resource():
+
+def test_sidecar_resource() -> None:
     # Test valid sidecar
     sidecar = SidecarResource(
         name="redis-sidecar",
         image="redis:alpine",
         env_vars={"REDIS_PORT": "6379"},
         ports=[6379],
-        command=["redis-server"]
+        command=["redis-server"],
     )
     assert sidecar.name == "redis-sidecar"
     assert sidecar.image == "redis:alpine"
@@ -28,14 +30,15 @@ def test_sidecar_resource():
     assert minimal.ports is None
     assert minimal.command is None
 
-def test_remote_service_resource():
+
+def test_remote_service_resource() -> None:
     # Test valid remote service
     service = RemoteServiceResource(
         name="weather-api",
         uri="https://api.weather.com",
         scopes=["read"],
         connection_secret_env="WEATHER_API_KEY",
-        risk_level=ResourceRiskLevel.SAFE
+        risk_level=ResourceRiskLevel.SAFE,
     )
     assert service.name == "weather-api"
     # Pydantic v2 AnyUrl usually normalizes, let's check basic string match or startswith
@@ -47,21 +50,19 @@ def test_remote_service_resource():
         RemoteServiceResource(
             name="bad-uri",
             uri="not-a-uri",
-            risk_level=ResourceRiskLevel.STANDARD
+            risk_level=ResourceRiskLevel.STANDARD,
         )
 
-def test_agent_dependencies_integration():
+
+def test_agent_dependencies_integration() -> None:
     sidecar = SidecarResource(name="db", image="postgres")
     remote = RemoteServiceResource(
         name="llm",
         uri="https://api.openai.com",
-        risk_level=ResourceRiskLevel.CRITICAL
+        risk_level=ResourceRiskLevel.CRITICAL,
     )
 
-    deps = AgentDependencies(
-        sidecars=[sidecar],
-        remote_services=[remote]
-    )
+    deps = AgentDependencies(sidecars=[sidecar], remote_services=[remote])
 
     assert len(deps.sidecars) == 1
     assert deps.sidecars[0].name == "db"
@@ -70,7 +71,8 @@ def test_agent_dependencies_integration():
     # Check default for tools
     assert deps.tools == []
 
-def test_resource_risk_level_values():
+
+def test_resource_risk_level_values() -> None:
     assert ResourceRiskLevel.SAFE.value == "SAFE"
     assert ResourceRiskLevel.STANDARD.value == "STANDARD"
     assert ResourceRiskLevel.CRITICAL.value == "CRITICAL"

--- a/tests/test_resources_integration.py
+++ b/tests/test_resources_integration.py
@@ -1,0 +1,76 @@
+import pytest
+from coreason_manifest.definitions.agent import AgentDependencies
+from coreason_manifest import (
+    RemoteServiceResource,
+    ResourceRiskLevel,
+    SidecarResource,
+)
+from pydantic import ValidationError
+
+def test_sidecar_resource():
+    # Test valid sidecar
+    sidecar = SidecarResource(
+        name="redis-sidecar",
+        image="redis:alpine",
+        env_vars={"REDIS_PORT": "6379"},
+        ports=[6379],
+        command=["redis-server"]
+    )
+    assert sidecar.name == "redis-sidecar"
+    assert sidecar.image == "redis:alpine"
+    assert sidecar.env_vars == {"REDIS_PORT": "6379"}
+    assert sidecar.ports == [6379]
+    assert sidecar.command == ["redis-server"]
+
+    # Test minimal sidecar
+    minimal = SidecarResource(name="minimal", image="busybox")
+    assert minimal.env_vars is None
+    assert minimal.ports is None
+    assert minimal.command is None
+
+def test_remote_service_resource():
+    # Test valid remote service
+    service = RemoteServiceResource(
+        name="weather-api",
+        uri="https://api.weather.com",
+        scopes=["read"],
+        connection_secret_env="WEATHER_API_KEY",
+        risk_level=ResourceRiskLevel.SAFE
+    )
+    assert service.name == "weather-api"
+    # Pydantic v2 AnyUrl usually normalizes, let's check basic string match or startswith
+    assert str(service.uri).startswith("https://api.weather.com")
+    assert service.risk_level == ResourceRiskLevel.SAFE
+
+    # Test invalid uri
+    with pytest.raises(ValidationError):
+        RemoteServiceResource(
+            name="bad-uri",
+            uri="not-a-uri",
+            risk_level=ResourceRiskLevel.STANDARD
+        )
+
+def test_agent_dependencies_integration():
+    sidecar = SidecarResource(name="db", image="postgres")
+    remote = RemoteServiceResource(
+        name="llm",
+        uri="https://api.openai.com",
+        risk_level=ResourceRiskLevel.CRITICAL
+    )
+
+    deps = AgentDependencies(
+        sidecars=[sidecar],
+        remote_services=[remote]
+    )
+
+    assert len(deps.sidecars) == 1
+    assert deps.sidecars[0].name == "db"
+    assert len(deps.remote_services) == 1
+    assert deps.remote_services[0].risk_level == ResourceRiskLevel.CRITICAL
+    # Check default for tools
+    assert deps.tools == []
+
+def test_resource_risk_level_values():
+    assert ResourceRiskLevel.SAFE.value == "SAFE"
+    assert ResourceRiskLevel.STANDARD.value == "STANDARD"
+    assert ResourceRiskLevel.CRITICAL.value == "CRITICAL"


### PR DESCRIPTION
Abstracted generic "Tools" into specific "Resources" (`SidecarResource` and `RemoteServiceResource`) to distinguish between local containers and remote APIs. This enables downstream orchestrators to provision infrastructure correctly. Maintained backward compatibility for the `tools` field in `AgentDependencies` while marking it as deprecated. Moved `StrictUri` to `base.py` to resolve circular import issues.

---
*PR created automatically by Jules for task [5553391842920074650](https://jules.google.com/task/5553391842920074650) started by @gowthamrao*