### PR TITLE
Implement V2 Loader Bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,4 +160,4 @@ See [docs/builder_sdk.md](docs/builder_sdk.md) for details.
 
 ## Roadmap
 
-*   **RFC 001: Canonical YAML (v2)**: We are working on a new "Human-Centric" YAML format for manifests. See [docs/rfcs/001-v2-canonical-yaml.md](docs/rfcs/001-v2-canonical-yaml.md) for the specification.
+*   **RFC 001: Canonical YAML (v2)**: We have implemented the "Human-Centric" YAML format for manifests. See [docs/rfcs/001-v2-canonical-yaml.md](docs/rfcs/001-v2-canonical-yaml.md) for the specification and [docs/v2_bridge.md](docs/v2_bridge.md) for usage of the Loader Bridge.

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,3 +16,4 @@ This is the documentation for the coreason_manifest project.
 *   [Evaluation-Ready Metadata](evaluation.md): How to define test contracts and success criteria within your agents.
 *   [Observability](observability.md): Details on tracing, logging, and metrics.
 *   [Interoperability](interoperability.md): Using "Adapter Hints" to translate agents to frameworks like LangGraph or AutoGen.
+*   [V2 Loader Bridge](v2_bridge.md): Using the Bridge to load V2 YAML manifests into the V1 Runtime.

--- a/docs/rfcs/001-v2-canonical-yaml.md
+++ b/docs/rfcs/001-v2-canonical-yaml.md
@@ -231,6 +231,13 @@ The v2 implementation is located in `src/coreason_manifest/v2/`. It does not mod
 *   **v1** remains the stable runtime format for now.
 *   **v2** is introduced as an RFC and experimental interface.
 
+### Implementation Status
+**Status: Implemented (Loader Bridge)**
+
+As of `coreason-manifest` v0.13.0 (estimated), the **V2 Loader Bridge** is available. This bridge allows V2 YAML files to be loaded and compiled into V1 `RecipeManifest` objects at runtime.
+
+The implementation differs slightly from the initial RFC proposal in that it explicitly depends on V1 definitions to perform the translation, acting as a true "Bridge" layer.
+
 ### Upgrade Path
 We will provide a CLI utility (`coreason upgrade`) that:
 1.  Parses a v1 `AgentDefinition` or `RecipeManifest`.

--- a/docs/v2_bridge.md
+++ b/docs/v2_bridge.md
@@ -1,0 +1,60 @@
+# V2 Loader Bridge
+
+The **V2 Loader Bridge** is the mechanism that connects the human-friendly **V2 Canonical YAML** format with the strict, machine-optimized **V1 Runtime Engine**.
+
+It allows developers to write manifests in the concise V2 YAML format and immediately execute them on the existing V1 engine without waiting for a full runtime rewrite.
+
+## Components
+
+The bridge consists of three main modules located in `src/coreason_manifest/v2/`:
+
+1.  **Compiler** (`compiler.py`): Transforms the implicit "Linked List" topology of V2 into the explicit "Graph" topology of V1.
+2.  **I/O** (`io.py`): Handles loading and dumping of V2 YAML files, ensuring correct key ordering for human readability.
+3.  **Adapter** (`adapter.py`): Converts a loaded V2 `ManifestV2` object into a V1 `RecipeManifest` ready for execution.
+
+## Usage
+
+### Loading and Executing a V2 Manifest
+
+To run a V2 YAML file, you use the `load_from_yaml` function to parse the file and `v2_to_recipe` to convert it.
+
+```python
+from coreason_manifest.v2.io import load_from_yaml
+from coreason_manifest.v2.adapter import v2_to_recipe
+
+# 1. Load V2 Manifest (Human Friendly)
+v2_manifest = load_from_yaml("my_workflow.v2.yaml")
+
+# 2. Convert to V1 Recipe (Machine Optimized)
+recipe = v2_to_recipe(v2_manifest)
+
+# 3. The 'recipe' object is now a standard RecipeManifest
+# compatible with the coreason-maco engine.
+print(f"Loaded Recipe: {recipe.name} (ID: {recipe.id})")
+print(f"Topology has {len(recipe.topology.nodes)} nodes.")
+```
+
+### Compiler Logic
+
+The compiler performs several transformations:
+
+*   **Node Conversion**:
+    *   `AgentStep` -> `AgentNode`
+    *   `LogicStep` -> `LogicNode`
+    *   `CouncilStep` -> `LogicNode` (with `council_config`)
+    *   `SwitchStep` -> `LogicNode` (generates routing logic)
+*   **Edge Generation**:
+    *   `step.next` -> `Edge`
+    *   `SwitchStep.cases` -> `ConditionalEdge` (with generated keys)
+*   **Validation**: Ensures all referenced steps exist, preventing "dangling pointers".
+
+### Round-Trip Serialization
+
+You can also programmatically create V2 manifests and dump them to YAML. The dumper ensures that `apiVersion`, `kind`, and `metadata` appear at the top of the file.
+
+```python
+from coreason_manifest.v2.io import dump_to_yaml
+
+yaml_str = dump_to_yaml(v2_manifest)
+print(yaml_str)
+```

--- a/src/coreason_manifest/v2/adapter.py
+++ b/src/coreason_manifest/v2/adapter.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+"""Adapter module for backward compatibility with V1 Runtime."""
+
+from uuid import uuid4
+
+from coreason_manifest.definitions.topology import StateDefinition
+from coreason_manifest.recipes import RecipeInterface, RecipeManifest
+from coreason_manifest.v2.compiler import compile_to_topology
+from coreason_manifest.v2.spec.definitions import ManifestV2
+
+
+def v2_to_recipe(manifest: ManifestV2) -> RecipeManifest:
+    """Convert a V2 Manifest into a V1 RecipeManifest.
+
+    Args:
+        manifest: The V2 manifest to convert.
+
+    Returns:
+        The converted RecipeManifest compatible with the V1 engine.
+    """
+    # Generate a random ID as V2 manifests don't strictly require one at the root
+    # In a real system, this might be consistent or derived from name/version
+    recipe_id = str(uuid4())
+
+    # Compile the topology
+    topology = compile_to_topology(manifest)
+
+    # Convert metadata
+    # We dump to dict to handle potential Pydantic model vs dict
+    design_metadata = {}
+    if manifest.metadata.design_metadata:
+        design_metadata = manifest.metadata.design_metadata.model_dump(
+            by_alias=True, exclude_none=True
+        )
+
+    # Construct the RecipeManifest
+    # Note: State and Interface are populated with defaults as V2 is less strict currently
+    return RecipeManifest(
+        id=recipe_id,
+        version="0.1.0",  # Default version
+        name=manifest.metadata.name,
+        description=None,
+        interface=RecipeInterface(inputs={}, outputs={}),
+        state=StateDefinition(schema={}, persistence="ephemeral"),
+        parameters=manifest.definitions,
+        topology=topology,
+        metadata=design_metadata,
+    )

--- a/src/coreason_manifest/v2/adapter.py
+++ b/src/coreason_manifest/v2/adapter.py
@@ -38,9 +38,7 @@ def v2_to_recipe(manifest: ManifestV2) -> RecipeManifest:
     # We dump to dict to handle potential Pydantic model vs dict
     design_metadata = {}
     if manifest.metadata.design_metadata:
-        design_metadata = manifest.metadata.design_metadata.model_dump(
-            by_alias=True, exclude_none=True
-        )
+        design_metadata = manifest.metadata.design_metadata.model_dump(by_alias=True, exclude_none=True)
 
     # Construct the RecipeManifest
     # Note: State and Interface are populated with defaults as V2 is less strict currently
@@ -50,7 +48,7 @@ def v2_to_recipe(manifest: ManifestV2) -> RecipeManifest:
         name=manifest.metadata.name,
         description=None,
         interface=RecipeInterface(inputs={}, outputs={}),
-        state=StateDefinition(schema={}, persistence="ephemeral"),
+        state=StateDefinition(schema_={}, persistence="ephemeral"),
         parameters=manifest.definitions,
         topology=topology,
         metadata=design_metadata,

--- a/src/coreason_manifest/v2/compiler.py
+++ b/src/coreason_manifest/v2/compiler.py
@@ -31,7 +31,7 @@ from coreason_manifest.v2.spec.definitions import (
 )
 
 
-def _convert_visual_metadata(design_metadata: Union[Dict, Any, None]) -> Union[VisualMetadata, None]:
+def _convert_visual_metadata(design_metadata: Union[Dict[str, Any], Any, None]) -> Union[VisualMetadata, None]:
     """Convert V2 design metadata to V1 visual metadata.
 
     Args:
@@ -45,9 +45,7 @@ def _convert_visual_metadata(design_metadata: Union[Dict, Any, None]) -> Union[V
 
     # Handle if it's a Pydantic model (DesignMetadata) or dict
     data = (
-        design_metadata.model_dump(by_alias=True)
-        if hasattr(design_metadata, "model_dump")
-        else dict(design_metadata)
+        design_metadata.model_dump(by_alias=True) if hasattr(design_metadata, "model_dump") else dict(design_metadata)
     )
 
     return VisualMetadata(
@@ -82,6 +80,7 @@ def compile_to_topology(manifest: ManifestV2) -> GraphTopology:
 
     for step_id, step in manifest.workflow.steps.items():
         visual = _convert_visual_metadata(step.design_metadata)
+        node: Node
 
         # 1. Convert Nodes
         if isinstance(step, AgentStep):
@@ -162,10 +161,12 @@ def compile_to_topology(manifest: ManifestV2) -> GraphTopology:
             # Using a placeholder identity function because we cannot add new dependencies/libs.
             # We assume the runtime has a way to handle this or the user provides the identity util.
             # Here we use 'coreason.lib.router.identity' as the implied identity function.
-            edges.append(ConditionalEdge(
-                source_node_id=step_id,
-                router_logic="coreason.lib.router.identity",
-                mapping=mapping,
-            ))
+            edges.append(
+                ConditionalEdge(
+                    source_node_id=step_id,
+                    router_logic="coreason.lib.router.identity",
+                    mapping=mapping,
+                )
+            )
 
     return GraphTopology(nodes=nodes, edges=edges)

--- a/src/coreason_manifest/v2/compiler.py
+++ b/src/coreason_manifest/v2/compiler.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+"""Compiler module for transforming V2 Manifests to V1 Runtime Topology."""
+
+from typing import Any, Dict, List, Union
+
+from coreason_manifest.definitions.topology import (
+    AgentNode,
+    ConditionalEdge,
+    CouncilConfig,
+    Edge,
+    GraphTopology,
+    LogicNode,
+    Node,
+    VisualMetadata,
+)
+from coreason_manifest.v2.spec.definitions import (
+    AgentStep,
+    CouncilStep,
+    LogicStep,
+    ManifestV2,
+    SwitchStep,
+)
+
+
+def _convert_visual_metadata(design_metadata: Union[Dict, Any, None]) -> Union[VisualMetadata, None]:
+    """Convert V2 design metadata to V1 visual metadata.
+
+    Args:
+        design_metadata: The design metadata from V2 (DesignMetadata object or dict).
+
+    Returns:
+        The converted V1 VisualMetadata or None.
+    """
+    if not design_metadata:
+        return None
+
+    # Handle if it's a Pydantic model (DesignMetadata) or dict
+    data = (
+        design_metadata.model_dump(by_alias=True)
+        if hasattr(design_metadata, "model_dump")
+        else dict(design_metadata)
+    )
+
+    return VisualMetadata(
+        label=data.get("label"),
+        x_y_coordinates=[data.get("x", 0.0), data.get("y", 0.0)],
+        icon=data.get("icon"),
+    )
+
+
+def compile_to_topology(manifest: ManifestV2) -> GraphTopology:
+    """Transform the V2 "Linked List" manifest into the V1 "Graph" topology.
+
+    Args:
+        manifest: The V2 manifest to compile.
+
+    Returns:
+        The compiled V1 GraphTopology.
+
+    Raises:
+        ValueError: If a dangling pointer (reference to non-existent step) is found.
+    """
+    nodes: List[Node] = []
+    edges: List[Union[Edge, ConditionalEdge]] = []
+
+    # Index of all valid step IDs for validation
+    valid_step_ids = set(manifest.workflow.steps.keys())
+
+    # Helper validation function
+    def validate_target(target_id: str, source_id: str) -> None:
+        if target_id not in valid_step_ids:
+            raise ValueError(f"Step '{source_id}' references non-existent step '{target_id}'.")
+
+    for step_id, step in manifest.workflow.steps.items():
+        visual = _convert_visual_metadata(step.design_metadata)
+
+        # 1. Convert Nodes
+        if isinstance(step, AgentStep):
+            node = AgentNode(
+                id=step_id,
+                agent_name=step.agent,
+                system_prompt=step.system_prompt,
+                config=step.inputs,  # Mapping inputs to config
+                visual=visual,
+            )
+            nodes.append(node)
+
+            # Standard Edge
+            if step.next:
+                validate_target(step.next, step_id)
+                edges.append(Edge(source_node_id=step_id, target_node_id=step.next))
+
+        elif isinstance(step, LogicStep):
+            node = LogicNode(
+                id=step_id,
+                code=step.code,
+                visual=visual,
+            )
+            nodes.append(node)
+
+            # Standard Edge
+            if step.next:
+                validate_target(step.next, step_id)
+                edges.append(Edge(source_node_id=step_id, target_node_id=step.next))
+
+        elif isinstance(step, CouncilStep):
+            # Map CouncilStep to a LogicNode (noop) with CouncilConfig
+            node = LogicNode(
+                id=step_id,
+                code="pass  # Council Execution handled by Runtime via council_config",
+                council_config=CouncilConfig(
+                    strategy=step.strategy,
+                    voters=step.voters,
+                ),
+                visual=visual,
+            )
+            nodes.append(node)
+
+            # Standard Edge
+            if step.next:
+                validate_target(step.next, step_id)
+                edges.append(Edge(source_node_id=step_id, target_node_id=step.next))
+
+        elif isinstance(step, SwitchStep):
+            # Generate logic for the switch
+            lines = ["def switch_logic(inputs):"]
+            mapping: Dict[str, str] = {}
+
+            for i, (condition, target_id) in enumerate(step.cases.items()):
+                validate_target(target_id, step_id)
+                key = f"case_{i}"
+                mapping[key] = target_id
+                lines.append(f"    if {condition}:")
+                lines.append(f"        return '{key}'")
+
+            if step.default:
+                validate_target(step.default, step_id)
+                mapping["default"] = step.default
+                lines.append("    return 'default'")
+            else:
+                lines.append("    raise ValueError('No case matched and no default provided')")
+
+            generated_code = "\n".join(lines)
+
+            node = LogicNode(
+                id=step_id,
+                code=generated_code,
+                visual=visual,
+            )
+            nodes.append(node)
+
+            # Conditional Edge
+            # Using a placeholder identity function because we cannot add new dependencies/libs.
+            # We assume the runtime has a way to handle this or the user provides the identity util.
+            # Here we use 'coreason.lib.router.identity' as the implied identity function.
+            edges.append(ConditionalEdge(
+                source_node_id=step_id,
+                router_logic="coreason.lib.router.identity",
+                mapping=mapping,
+            ))
+
+    return GraphTopology(nodes=nodes, edges=edges)

--- a/src/coreason_manifest/v2/io.py
+++ b/src/coreason_manifest/v2/io.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+"""I/O module for loading and dumping V2 Manifests."""
+
+from pathlib import Path
+from typing import Union
+
+import yaml
+
+from coreason_manifest.v2.spec.definitions import ManifestV2
+
+
+def load_from_yaml(path: Union[str, Path]) -> ManifestV2:
+    """Load a V2 manifest from a YAML file.
+
+    Args:
+        path: Path to the YAML file.
+
+    Returns:
+        The validated ManifestV2 object.
+
+    Raises:
+        FileNotFoundError: If the file does not exist.
+        ValidationError: If the manifest is invalid.
+        yaml.YAMLError: If the YAML is invalid.
+    """
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"Manifest file not found: {path}")
+
+    with p.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    return ManifestV2.model_validate(data)
+
+
+def dump_to_yaml(manifest: ManifestV2) -> str:
+    """Dump a V2 manifest to a YAML string.
+
+    Ensures that apiVersion, kind, and metadata appear at the top.
+
+    Args:
+        manifest: The ManifestV2 object to dump.
+
+    Returns:
+        The YAML string representation.
+    """
+    # Serialize to dict, using aliases (e.g., x-design) and excluding None
+    data = manifest.model_dump(by_alias=True, exclude_none=True)
+
+    # Reorder keys to ensure human readability
+    # Priority keys: apiVersion, kind, metadata
+    ordered_keys = ["apiVersion", "kind", "metadata"]
+    ordered_data = {}
+
+    # 1. Add priority keys
+    for key in ordered_keys:
+        if key in data:
+            ordered_data[key] = data.pop(key)
+
+    # 2. Add remaining keys
+    ordered_data.update(data)
+
+    # Dump using PyYAML, preserving key order (sort_keys=False)
+    # allow_unicode=True ensures proper string representation
+    return yaml.dump(ordered_data, sort_keys=False, allow_unicode=True)

--- a/tests/test_v2_bridge.py
+++ b/tests/test_v2_bridge.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pathlib import Path
+
+from coreason_manifest.definitions.topology import (
+    AgentNode,
+    ConditionalEdge,
+    Edge,
+    GraphTopology,
+    LogicNode,
+)
+from coreason_manifest.recipes import RecipeManifest
+from coreason_manifest.v2.adapter import v2_to_recipe
+from coreason_manifest.v2.compiler import compile_to_topology
+from coreason_manifest.v2.io import dump_to_yaml, load_from_yaml
+from coreason_manifest.v2.spec.definitions import (
+    ManifestV2,
+    AgentStep,
+    Workflow,
+    ManifestMetadata,
+)
+
+
+SAMPLE_V2_YAML = """
+apiVersion: coreason.ai/v2
+kind: Recipe
+metadata:
+  name: "Test Recipe"
+  x-design:
+    x: 100
+    y: 200
+    icon: "test-icon"
+workflow:
+  start: "step1"
+  steps:
+    step1:
+      type: "agent"
+      id: "step1"
+      agent: "coreason.agent.v1"
+      inputs:
+        foo: "bar"
+      next: "step2"
+    step2:
+      type: "switch"
+      id: "step2"
+      cases:
+        "x > 10": "step3"
+        "x <= 10": "step4"
+      default: "step4"
+    step3:
+      type: "logic"
+      id: "step3"
+      code: "print('hello')"
+    step4:
+      type: "council"
+      id: "step4"
+      voters: ["agent1", "agent2"]
+      strategy: "consensus"
+"""
+
+
+def test_load_from_yaml(tmp_path: Path) -> None:
+    f = tmp_path / "manifest.yaml"
+    f.write_text(SAMPLE_V2_YAML, encoding="utf-8")
+
+    manifest = load_from_yaml(f)
+    assert isinstance(manifest, ManifestV2)
+    assert manifest.metadata.name == "Test Recipe"
+    assert len(manifest.workflow.steps) == 4
+
+    # Check design metadata alias
+    assert manifest.metadata.design_metadata is not None
+    assert manifest.metadata.design_metadata.icon == "test-icon"
+
+
+def test_compile_to_topology(tmp_path: Path) -> None:
+    f = tmp_path / "manifest.yaml"
+    f.write_text(SAMPLE_V2_YAML, encoding="utf-8")
+    manifest = load_from_yaml(f)
+
+    topology = compile_to_topology(manifest)
+    assert isinstance(topology, GraphTopology)
+
+    # Nodes
+    assert len(topology.nodes) == 4
+    node_map = {n.id: n for n in topology.nodes}
+
+    # Check AgentNode
+    assert isinstance(node_map["step1"], AgentNode)
+    assert node_map["step1"].agent_name == "coreason.agent.v1"
+    assert node_map["step1"].config == {"foo": "bar"}
+
+    # Check SwitchNode (LogicNode)
+    assert isinstance(node_map["step2"], LogicNode)
+    assert "def switch_logic" in node_map["step2"].code
+
+    # Check CouncilNode (LogicNode)
+    assert isinstance(node_map["step4"], LogicNode)
+    assert node_map["step4"].council_config is not None
+    assert node_map["step4"].council_config.voters == ["agent1", "agent2"]
+
+    # Edges
+    # step1 -> step2 (Edge)
+    # step2 -> step3/step4 (ConditionalEdge)
+    # step3 -> None
+    # step4 -> None
+
+    edges = topology.edges
+    assert len(edges) == 2 # 1 Edge + 1 ConditionalEdge
+
+    edge1 = next((e for e in edges if e.source_node_id == "step1"), None)
+    assert isinstance(edge1, Edge)
+    assert edge1.target_node_id == "step2"
+
+    edge2 = next((e for e in edges if e.source_node_id == "step2"), None)
+    assert isinstance(edge2, ConditionalEdge)
+    assert "case_0" in edge2.mapping
+    assert edge2.mapping["case_0"] == "step3"
+    assert edge2.mapping["default"] == "step4"
+
+
+def test_dangling_pointer() -> None:
+    manifest = ManifestV2(
+        kind="Recipe",
+        metadata=ManifestMetadata(name="Bad"),
+        workflow=Workflow(
+            start="step1",
+            steps={
+                "step1": AgentStep(
+                    id="step1",
+                    agent="a",
+                    next="step_non_existent"
+                )
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="references non-existent step"):
+        compile_to_topology(manifest)
+
+
+def test_v2_to_recipe(tmp_path: Path) -> None:
+    f = tmp_path / "manifest.yaml"
+    f.write_text(SAMPLE_V2_YAML, encoding="utf-8")
+    manifest = load_from_yaml(f)
+
+    recipe = v2_to_recipe(manifest)
+    assert isinstance(recipe, RecipeManifest)
+    assert recipe.name == "Test Recipe"
+    assert recipe.version == "0.1.0"
+    assert len(recipe.topology.nodes) == 4
+
+
+def test_dump_to_yaml() -> None:
+    manifest = ManifestV2(
+        kind="Recipe",
+        metadata=ManifestMetadata(name="Test"),
+        workflow=Workflow(start="s1", steps={})
+    )
+
+    s = dump_to_yaml(manifest)
+    # Basic check for ordering
+    # Check that apiVersion appears before workflow
+    assert s.index("apiVersion") < s.index("workflow")
+    assert s.index("kind") < s.index("workflow")

--- a/tests/test_v2_bridge.py
+++ b/tests/test_v2_bridge.py
@@ -137,9 +137,7 @@ def test_compile_chained_steps() -> None:
             start="step1",
             steps={
                 "step1": LogicStep(id="step1", code="pass", next="step2"),
-                "step2": CouncilStep(
-                    id="step2", voters=["a"], next="step3", strategy="consensus"
-                ),
+                "step2": CouncilStep(id="step2", voters=["a"], next="step3", strategy="consensus"),
                 "step3": LogicStep(id="step3", code="pass"),
             },
         ),

--- a/tests/test_v2_bridge.py
+++ b/tests/test_v2_bridge.py
@@ -1,7 +1,8 @@
 # Copyright (c) 2025 CoReason, Inc.
 
-import pytest
 from pathlib import Path
+
+import pytest
 
 from coreason_manifest.definitions.topology import (
     AgentNode,
@@ -15,12 +16,11 @@ from coreason_manifest.v2.adapter import v2_to_recipe
 from coreason_manifest.v2.compiler import compile_to_topology
 from coreason_manifest.v2.io import dump_to_yaml, load_from_yaml
 from coreason_manifest.v2.spec.definitions import (
-    ManifestV2,
     AgentStep,
-    Workflow,
     ManifestMetadata,
+    ManifestV2,
+    Workflow,
 )
-
 
 SAMPLE_V2_YAML = """
 apiVersion: coreason.ai/v2
@@ -107,7 +107,7 @@ def test_compile_to_topology(tmp_path: Path) -> None:
     # step4 -> None
 
     edges = topology.edges
-    assert len(edges) == 2 # 1 Edge + 1 ConditionalEdge
+    assert len(edges) == 2  # 1 Edge + 1 ConditionalEdge
 
     edge1 = next((e for e in edges if e.source_node_id == "step1"), None)
     assert isinstance(edge1, Edge)
@@ -126,14 +126,8 @@ def test_dangling_pointer() -> None:
         metadata=ManifestMetadata(name="Bad"),
         workflow=Workflow(
             start="step1",
-            steps={
-                "step1": AgentStep(
-                    id="step1",
-                    agent="a",
-                    next="step_non_existent"
-                )
-            }
-        )
+            steps={"step1": AgentStep(id="step1", agent="a", next="step_non_existent")},
+        ),
     )
 
     with pytest.raises(ValueError, match="references non-existent step"):
@@ -156,7 +150,7 @@ def test_dump_to_yaml() -> None:
     manifest = ManifestV2(
         kind="Recipe",
         metadata=ManifestMetadata(name="Test"),
-        workflow=Workflow(start="s1", steps={})
+        workflow=Workflow(start="s1", steps={}),
     )
 
     s = dump_to_yaml(manifest)


### PR DESCRIPTION
Implemented the Loader Bridge for Coreason Manifest V2.
This includes:
1.  **Compiler**: Transforms the linked-list style V2 steps into the graph-based V1 topology (`Node`, `Edge`, `ConditionalEdge`). Handles polymorphic steps (`AgentStep`, `LogicStep`, `CouncilStep`, `SwitchStep`).
2.  **I/O**: Provides `load_from_yaml` and `dump_to_yaml` for V2 manifests, ensuring proper key ordering for human readability.
3.  **Adapter**: Provides `v2_to_recipe` to convert a V2 manifest into a V1 `RecipeManifest` for immediate execution by the runtime engine.
4.  **Tests**: Comprehensive tests covering linear flows, branching (Switch), council steps, and I/O operations.


---
*PR created automatically by Jules for task [434213176480058149](https://jules.google.com/task/434213176480058149) started by @gowthamrao*