### PR TITLE
Implement Strict Wire Format for Streaming

### DIFF
--- a/docs/frontend_integration.md
+++ b/docs/frontend_integration.md
@@ -108,6 +108,8 @@ See [Presentation Schemas](./presentation_schemas.md) for detailed documentation
 - `chunk`: The string fragment generated.
 - `visual_cue`: "TEXT_BUBBLE".
 
+> **Note:** When using the new SSE Streaming Protocol, `NODE_STREAM` events are typically replaced by direct `DELTA` packets in the wire format. See [SSE Wire Protocol](./sse_wire_protocol.md).
+
 ### 4. `NODE_DONE`
 **When:** Execution completes successfully.
 **UI Behavior:** Mark node as complete (Green checkmark), stop animations.

--- a/docs/presentation_schemas.md
+++ b/docs/presentation_schemas.md
@@ -67,6 +67,10 @@ class CitationBlock(CoReasonBaseModel):
 }
 ```
 
+## Streaming Wire Format
+
+When sending these events over a stream (Server-Sent Events), they are wrapped in a `StreamPacket`. See [SSE Wire Protocol Specification](./sse_wire_protocol.md) for details.
+
 ### ProgressUpdate
 
 Used to report the status of a long-running operation.

--- a/docs/rfcs/002-sse-transport-v2.md
+++ b/docs/rfcs/002-sse-transport-v2.md
@@ -1,0 +1,64 @@
+# RFC 002: Coreason SSE Wire Protocol
+
+## 1. The Packet Structure
+
+The core unit of transmission is the `StreamPacket`, which wraps every chunk of data sent over Server-Sent Events (SSE). This ensures deterministic parsing on the frontend.
+
+### StreamPacket Fields
+
+*   `stream_id` (UUID): The unique identifier of the stream this packet belongs to.
+*   `seq` (int): Sequence number, strictly increasing per stream to handle out-of-order delivery or reconnection.
+*   `op` (StreamOpCode): Operation code indicating the type of payload.
+    *   `DELTA`: Raw text token (for streaming LLM output).
+    *   `EVENT`: A structured `PresentationEvent` (for UI components).
+    *   `ERROR`: Stream-level error.
+    *   `CLOSE`: Graceful termination.
+*   `t` (datetime): Timestamp of emission (UTC).
+*   `p` (Union[str, PresentationEvent, Dict[str, Any]]): The Payload. Shortened to 'p' to save bandwidth.
+
+## 2. JSON Serialization Examples
+
+### DELTA Packet
+
+```json
+{
+  "stream_id": "123e4567-e89b-12d3-a456-426614174000",
+  "seq": 1,
+  "op": "DELTA",
+  "t": "2023-10-27T10:00:00+00:00",
+  "p": "Hello"
+}
+```
+
+### EVENT Packet (Citation)
+
+```json
+{
+  "stream_id": "123e4567-e89b-12d3-a456-426614174000",
+  "seq": 2,
+  "op": "EVENT",
+  "t": "2023-10-27T10:00:01+00:00",
+  "p": {
+    "id": "987fcdeb-51a2-11e1-fad2-0242ac130003",
+    "timestamp": "2023-10-27T10:00:01+00:00",
+    "type": "CITATION_BLOCK",
+    "data": {
+      "citations": [
+        {
+          "source_id": "src_1",
+          "uri": "https://example.com",
+          "title": "Example",
+          "confidence": 0.99
+        }
+      ]
+    }
+  }
+}
+```
+
+## 3. Protocol Flow
+
+1.  **Connection:** The client initiates an HTTP GET request to the streaming endpoint.
+2.  **Handshake:** The server establishes the SSE connection.
+3.  **Transmission:** The server sends a series of `StreamPacket` objects serialized as JSON within SSE `data:` fields.
+4.  **Termination:** The server sends a packet with `op=CLOSE` to indicate the end of the stream, then closes the connection.

--- a/docs/sse_wire_protocol.md
+++ b/docs/sse_wire_protocol.md
@@ -1,0 +1,116 @@
+# SSE Wire Protocol Specification
+
+This document defines the **Strict Wire Format** for streaming data from the Coreason Engine to clients via Server-Sent Events (SSE). It supersedes previous ad-hoc streaming formats.
+
+## Overview
+
+The Coreason SSE Wire Protocol ensures deterministic parsing of streaming data by wrapping every chunk of data in a standardized `StreamPacket`. This allows a single stream to multiplex raw text deltas (for LLM generation) and complex UI events (like citations or tool calls).
+
+## The Packet Structure
+
+The core unit of transmission is the `StreamPacket`.
+
+### Schema
+
+```python
+class StreamPacket(CoReasonBaseModel):
+    stream_id: UUID
+    seq: int
+    op: StreamOpCode
+    t: datetime
+    p: Union[str, PresentationEvent, Dict[str, Any]]
+```
+
+### Fields
+
+*   **`stream_id`** (UUID): The unique identifier of the logical stream this packet belongs to.
+*   **`seq`** (int): A strictly increasing sequence number per stream. Used to detect dropped packets or handle out-of-order delivery.
+*   **`op`** (`StreamOpCode`): The operation code indicating the type of payload.
+*   **`t`** (datetime): The UTC timestamp of when the packet was emitted.
+*   **`p`** (Union): The payload. The type of this field depends on the `op`.
+
+### Operation Codes (`StreamOpCode`)
+
+| OpCode | Payload Type | Description |
+| :--- | :--- | :--- |
+| `DELTA` | `str` | A raw text token. Used for streaming prose (e.g., from an LLM). |
+| `EVENT` | `PresentationEvent` or `Dict` | A structured event for the UI (e.g., a Citation, Progress Update). |
+| `ERROR` | `str` or `Dict` | A stream-level error. |
+| `CLOSE` | `Any` (usually `str` reason) | Indicates the stream has finished. No further packets with this `stream_id` will be sent. |
+
+## JSON Serialization Examples
+
+### 1. Text Delta
+
+Used for streaming the main response text.
+
+```json
+{
+  "stream_id": "123e4567-e89b-12d3-a456-426614174000",
+  "seq": 1,
+  "op": "DELTA",
+  "t": "2023-10-27T10:00:00.000000+00:00",
+  "p": "Hello"
+}
+```
+
+### 2. UI Event (Citation)
+
+Used for inserting rich UI components into the stream.
+
+```json
+{
+  "stream_id": "123e4567-e89b-12d3-a456-426614174000",
+  "seq": 2,
+  "op": "EVENT",
+  "t": "2023-10-27T10:00:01.000000+00:00",
+  "p": {
+    "id": "987fcdeb-51a2-11e1-fad2-0242ac130003",
+    "timestamp": "2023-10-27T10:00:01.000000+00:00",
+    "type": "CITATION_BLOCK",
+    "data": {
+      "citations": [
+        {
+          "source_id": "src_1",
+          "uri": "https://example.com",
+          "title": "Example Source",
+          "confidence": 0.99
+        }
+      ]
+    }
+  }
+}
+```
+
+### 3. Stream Close
+
+Indicates the end of the stream.
+
+```json
+{
+  "stream_id": "123e4567-e89b-12d3-a456-426614174000",
+  "seq": 3,
+  "op": "CLOSE",
+  "t": "2023-10-27T10:00:02.000000+00:00",
+  "p": "Stream completed successfully"
+}
+```
+
+## Protocol Flow
+
+1.  **Connection:** The client initiates an HTTP GET request to the streaming endpoint (e.g., `/v1/assist` with `Accept: text/event-stream`).
+2.  **Handshake:** The server responds with `Content-Type: text/event-stream`.
+3.  **Transmission:** The server sends `StreamPacket` objects serialized as JSON, each within an SSE `data:` field.
+    *   `data: {"stream_id": "...", "op": "DELTA", ...}`
+    *   `data: {"stream_id": "...", "op": "EVENT", ...}`
+4.  **Termination:** The server sends a packet with `op=CLOSE`. The client should then close the connection (or expect the server to close it).
+
+## Frontend Integration
+
+The frontend should implement a parser that:
+1.  Listens for SSE `message` events.
+2.  Parses the `data` string as JSON into a `StreamPacket` object.
+3.  Checks the `op` code:
+    *   If `DELTA`: Append `packet.p` to the current text buffer.
+    *   If `EVENT`: Render the structured component (e.g., insert a citation chip).
+    *   If `CLOSE`: Finalize the UI state.

--- a/docs/stream_lifecycle.md
+++ b/docs/stream_lifecycle.md
@@ -75,6 +75,8 @@ On the frontend, the stream allows the UI to route tokens to the correct compone
 *   **Event:** `ai.coreason.stream.chunk` (contains `stream_id`, `chunk`) -> **UI:** Append text to bubble with matching ID.
 *   **Event:** `ai.coreason.stream.end` (contains `stream_id`) -> **UI:** Mark bubble as complete (stop loading spinner).
 
+> **Note:** The actual wire format for these chunks is defined in the [SSE Wire Protocol Specification](./sse_wire_protocol.md). The `StreamPacket` wraps these logical events.
+
 ## Error Handling
 
 Separation of concerns is key:

--- a/src/coreason_manifest/definitions/__init__.py
+++ b/src/coreason_manifest/definitions/__init__.py
@@ -43,6 +43,8 @@ from .presentation import (
     PresentationEvent,
     PresentationEventType,
     ProgressUpdate,
+    StreamOpCode,
+    StreamPacket,
 )
 from .request import AgentRequest
 from .service import DEFAULT_ENDPOINT_PATH, ServerSentEvent, ServiceContract
@@ -90,4 +92,6 @@ __all__ = [
     "MediaItem",
     "MediaCarousel",
     "PresentationEvent",
+    "StreamOpCode",
+    "StreamPacket",
 ]

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -178,13 +178,11 @@ def test_stream_packet_validation() -> None:
             seq=1,
             op=StreamOpCode.DELTA,
             t=now,
-            p={"foo": "bar"},  # type: ignore
+            p={"foo": "bar"},
         )
 
     # EVENT must not be string
-    with pytest.raises(
-        ValueError, match="Payload must be a PresentationEvent or Dict for EVENT op"
-    ):
+    with pytest.raises(ValueError, match="Payload must be a PresentationEvent or Dict for EVENT op"):
         StreamPacket(
             stream_id=stream_id,
             seq=1,


### PR DESCRIPTION
Implemented the Strict Wire Format for streaming as per the requirements. This includes the `StreamPacket` model, `StreamOpCode` enum, and associated validation logic. Also included is an RFC document describing the protocol and comprehensive unit tests.

---
*PR created automatically by Jules for task [2413827959698952661](https://jules.google.com/task/2413827959698952661) started by @gowthamrao*