### PR TITLE
Strict Session Context Definition

### DIFF
--- a/docs/session_context.md
+++ b/docs/session_context.md
@@ -1,0 +1,83 @@
+# Session Context
+
+In the Coreason Framework, every agent execution is accompanied by a **Session Context**. This context answers the fundamental questions of *who* initiated the request, *where* it came from, and *what* permissions are granted.
+
+Unlike the conversation history (which grows and changes), the **Session Context** is **immutable** for the duration of a request. It acts as the "source of truth" for security and observability.
+
+## The Model
+
+The `SessionContext` is a composite object containing three key pillars:
+
+1.  **User Context**: Who is the user?
+2.  **Trace Context**: Where is this request in the distributed system?
+3.  **Permissions**: What is this agent allowed to do?
+
+### Schema
+
+All context models are immutable (`frozen=True`) Pydantic models.
+
+```python
+class SessionContext(CoReasonBaseModel):
+    session_id: UUID          # Unique identifier for the session
+    agent_id: UUID            # The specific agent instance being invoked
+    user: UserContext         # Identity details of the caller
+    trace: TraceContext       # Distributed tracing headers
+    permissions: List[str]    # Scopes granted for this run (e.g., ["search:read"])
+    created_at: datetime      # When this context was minted
+```
+
+### User Context
+
+The `UserContext` provides stable identity details about the user. This is distinct from the `Identity` object used in the conversation history (which is for display). `UserContext` is for logic and enforcement.
+
+```python
+class UserContext(CoReasonBaseModel):
+    user_id: str              # Stable, unique ID (e.g., "auth0|12345")
+    email: Optional[str]      # Contact email
+    tier: str                 # Entitlement tier (e.g., "free", "pro", "enterprise")
+    locale: str               # I18n locale (e.g., "en-US")
+```
+
+### Trace Context
+
+The `TraceContext` carries standard distributed tracing identifiers, allowing the agent's execution to be correlated with upstream API calls and downstream service requests.
+
+```python
+class TraceContext(CoReasonBaseModel):
+    trace_id: UUID            # Global trace ID (W3C standard)
+    span_id: UUID             # Current span ID
+    parent_id: Optional[UUID] # Parent span ID (if any)
+```
+
+## Usage
+
+### In SessionState
+
+The `SessionContext` is a required field in `SessionState`. This ensures that no agent can execute without a valid, defined context.
+
+```python
+session = SessionState(
+    # ...
+    context=SessionContext(
+        # ...
+    )
+)
+```
+
+### In Agents
+
+Agents can access the context to make decisions. For example, a tool might check the user's tier before performing an expensive operation.
+
+```python
+def generate_report(session: SessionState, ...):
+    if session.context.user.tier == "free":
+        raise PermissionError("Reports are a Pro feature.")
+
+    # ...
+```
+
+## Design Principles
+
+1.  **Strict Separation:** We strictly separate **Context** (immutable facts about the request) from **State** (mutable history of the conversation). This prevents "context drift" where a long-running session might accidentally rely on outdated user info.
+2.  **Security First:** By baking permissions and user identity into an immutable object, we prevent tampering. The `SessionContext` should ideally be signed or verified by the platform before reaching the agent.
+3.  **Observability:** Mandatory `TraceContext` ensures that every agent execution is observable by default, preventing "black hole" processes that are hard to debug.

--- a/src/coreason_manifest/definitions/session.py
+++ b/src/coreason_manifest/definitions/session.py
@@ -20,6 +20,40 @@ from coreason_manifest.definitions.identity import Identity
 from coreason_manifest.definitions.message import MultiModalInput
 
 
+class UserContext(CoReasonBaseModel):
+    """Immutable context about the user associated with a session."""
+
+    model_config = ConfigDict(frozen=True)
+
+    user_id: str = Field(..., description="The stable ID of the user")
+    email: Optional[str] = Field(None, description="User email address")
+    tier: str = Field(..., description="User tier (e.g., free, pro)")
+    locale: str = Field(..., description="User locale (e.g., en-US)")
+
+
+class TraceContext(CoReasonBaseModel):
+    """Immutable distributed tracing context."""
+
+    model_config = ConfigDict(frozen=True)
+
+    trace_id: UUID = Field(..., description="Global distributed trace ID")
+    span_id: UUID = Field(..., description="Current span ID")
+    parent_id: Optional[UUID] = Field(None, description="Parent span ID")
+
+
+class SessionContext(CoReasonBaseModel):
+    """Immutable context accompanying a session request."""
+
+    model_config = ConfigDict(frozen=True)
+
+    session_id: UUID = Field(..., description="Unique session identifier")
+    agent_id: UUID = Field(..., description="The specific agent instance being invoked")
+    user: UserContext = Field(..., description="User context")
+    trace: TraceContext = Field(..., description="Tracing context")
+    permissions: List[str] = Field(..., description="Scopes granted for this specific run")
+    created_at: datetime = Field(..., description="When the session context was created")
+
+
 class LineageMetadata(CoReasonBaseModel):
     """Metadata tracking the Chain of Custody for this interaction."""
 
@@ -57,6 +91,7 @@ class SessionState(CoReasonBaseModel):
     model_config = ConfigDict(frozen=True)
 
     session_id: UUID = Field(..., description="Global identifier for the conversation thread")
+    context: SessionContext = Field(..., description="Immutable context for the session")
     processor: Identity = Field(..., description="The agent/graph handling this session")
     user: Optional[Identity] = Field(None, description="The user participating in the session")
     created_at: datetime = Field(..., description="When the session was created")

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -9,14 +9,46 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from datetime import datetime, timezone
-from uuid import uuid4
+from typing import Optional
+from uuid import UUID, uuid4
 
 import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.definitions.events import GraphEventNodeInit, NodeInit
 from coreason_manifest.definitions.identity import Identity
-from coreason_manifest.definitions.session import Interaction, SessionState
+from coreason_manifest.definitions.session import (
+    Interaction,
+    SessionState,
+    SessionContext,
+    UserContext,
+    TraceContext,
+)
+
+
+def create_default_context(
+    session_id: UUID, agent_id: UUID, user_id: str = "user-1", trace_id: Optional[UUID] = None
+) -> SessionContext:
+    if trace_id is None:
+        trace_id = uuid4()
+
+    return SessionContext(
+        session_id=session_id,
+        agent_id=agent_id,
+        user=UserContext(
+            user_id=user_id,
+            email="test@example.com",
+            tier="free",
+            locale="en-US"
+        ),
+        trace=TraceContext(
+            trace_id=trace_id,
+            span_id=uuid4(),
+            parent_id=None
+        ),
+        permissions=["read", "write"],
+        created_at=datetime.now(timezone.utc)
+    )
 
 
 def test_interaction_creation() -> None:
@@ -60,8 +92,11 @@ def test_session_state_creation() -> None:
     processor = Identity(id="agent-1", name="Agent 1", role="assistant")
     user = Identity(id="user-1", name="User 1", role="user")
 
+    context = create_default_context(session_id, uuid4(), user.id)
+
     session = SessionState(
         session_id=session_id,
+        context=context,
         processor=processor,
         user=user,
         created_at=now,
@@ -69,6 +104,8 @@ def test_session_state_creation() -> None:
     )
 
     assert session.session_id == session_id
+    assert session.context == context
+    assert session.context.user.user_id == "user-1"
     assert session.processor == processor
     assert session.processor.id == "agent-1"
     assert session.user == user
@@ -85,9 +122,11 @@ def test_session_state_immutability() -> None:
     now = datetime.now(timezone.utc)
 
     processor = Identity(id="agent-1", name="Agent 1", role="assistant")
+    context = create_default_context(session_id, uuid4())
 
     session = SessionState(
         session_id=session_id,
+        context=context,
         processor=processor,
         created_at=now,
         last_updated_at=now,
@@ -113,9 +152,11 @@ def test_add_interaction() -> None:
     now = datetime.now(timezone.utc)
 
     processor = Identity(id="agent-1", name="Agent 1", role="assistant")
+    context = create_default_context(session_id, uuid4())
 
     session = SessionState(
         session_id=session_id,
+        context=context,
         processor=processor,
         created_at=now,
         last_updated_at=now,
@@ -137,6 +178,7 @@ def test_add_interaction() -> None:
 
     # Other fields should be preserved
     assert new_session.session_id == session.session_id
+    assert new_session.context == session.context
     assert new_session.processor == session.processor
 
 
@@ -147,3 +189,47 @@ def test_serialization() -> None:
     # Check key presence without relying on exact whitespace
     assert '"k":"v"' in json_str.replace(" ", "")
     assert '"x":"y"' in json_str.replace(" ", "")
+
+
+def test_session_context_serialization() -> None:
+    """Test serialization of SessionContext."""
+    session_id = uuid4()
+    agent_id = uuid4()
+    trace_id = uuid4()
+    span_id = uuid4()
+
+    user_context = UserContext(
+        user_id="user-123",
+        email="test@test.com",
+        tier="pro",
+        locale="fr-FR"
+    )
+
+    trace_context = TraceContext(
+        trace_id=trace_id,
+        span_id=span_id,
+        parent_id=None
+    )
+
+    now = datetime.now(timezone.utc)
+
+    context = SessionContext(
+        session_id=session_id,
+        agent_id=agent_id,
+        user=user_context,
+        trace=trace_context,
+        permissions=["search:read"],
+        created_at=now
+    )
+
+    # Test json dump
+    json_str = context.to_json()
+
+    # Verify basic fields
+    assert str(session_id) in json_str
+    assert "user-123" in json_str
+    assert "search:read" in json_str
+    assert "fr-FR" in json_str
+
+    # Verify UUID serialization
+    assert str(trace_id) in json_str

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -19,10 +19,10 @@ from coreason_manifest.definitions.events import GraphEventNodeInit, NodeInit
 from coreason_manifest.definitions.identity import Identity
 from coreason_manifest.definitions.session import (
     Interaction,
-    SessionState,
     SessionContext,
-    UserContext,
+    SessionState,
     TraceContext,
+    UserContext,
 )
 
 
@@ -35,19 +35,10 @@ def create_default_context(
     return SessionContext(
         session_id=session_id,
         agent_id=agent_id,
-        user=UserContext(
-            user_id=user_id,
-            email="test@example.com",
-            tier="free",
-            locale="en-US"
-        ),
-        trace=TraceContext(
-            trace_id=trace_id,
-            span_id=uuid4(),
-            parent_id=None
-        ),
+        user=UserContext(user_id=user_id, email="test@example.com", tier="free", locale="en-US"),
+        trace=TraceContext(trace_id=trace_id, span_id=uuid4(), parent_id=None),
         permissions=["read", "write"],
-        created_at=datetime.now(timezone.utc)
+        created_at=datetime.now(timezone.utc),
     )
 
 
@@ -198,18 +189,9 @@ def test_session_context_serialization() -> None:
     trace_id = uuid4()
     span_id = uuid4()
 
-    user_context = UserContext(
-        user_id="user-123",
-        email="test@test.com",
-        tier="pro",
-        locale="fr-FR"
-    )
+    user_context = UserContext(user_id="user-123", email="test@test.com", tier="pro", locale="fr-FR")
 
-    trace_context = TraceContext(
-        trace_id=trace_id,
-        span_id=span_id,
-        parent_id=None
-    )
+    trace_context = TraceContext(trace_id=trace_id, span_id=span_id, parent_id=None)
 
     now = datetime.now(timezone.utc)
 
@@ -219,7 +201,7 @@ def test_session_context_serialization() -> None:
         user=user_context,
         trace=trace_context,
         permissions=["search:read"],
-        created_at=now
+        created_at=now,
     )
 
     # Test json dump


### PR DESCRIPTION
Introduces `UserContext`, `TraceContext`, and `SessionContext` models to strictly define the immutable context accompanying a session. Refactors `SessionState` to include this context. Updates tests to ensure correct serialization and initialization.

---
*PR created automatically by Jules for task [11586920670820483324](https://jules.google.com/task/11586920670820483324) started by @gowthamrao*