### PR TITLE
Refactor SessionState to use strictly defined SessionContext

### DIFF
--- a/docs/identity_model.md
+++ b/docs/identity_model.md
@@ -58,11 +58,10 @@ anon = Identity.anonymous()
 
 ## Integration
 
-The `Identity` model is primarily used in `SessionState` to identify the `processor` (the agent) and the `user`.
+The `Identity` model is primarily used in `SessionState` to identify the `processor` (the agent).
 
 ```python
 class SessionState(CoReasonBaseModel):
     processor: Identity
-    user: Optional[Identity]
     # ...
 ```

--- a/docs/session_management.md
+++ b/docs/session_management.md
@@ -58,7 +58,7 @@ Key features:
 *   **Immutable Updates:** State changes via functional updates (e.g., `add_interaction` returns a *new* instance), preventing side effects.
 *   **Session Context:** A strictly defined, immutable `SessionContext` object that carries user identity, distributed tracing info, and permissions. See [Session Context](session_context.md) for details.
 *   **Context Variables:** A "scratchpad" dictionary (`context_variables`) for long-term memory that persists across turns, separate from the message history.
-*   **Identification:** Strictly typed `Identity` objects for processor/user (carrying both ID and display name).
+*   **Identification:** Strictly typed `Identity` objects for processor (carrying both ID and display name).
 
 ```python
 from uuid import uuid4
@@ -89,11 +89,8 @@ context = SessionContext(
 
 # 2. Create a new session with context
 session = SessionState(
-    session_id=context.session_id,
     context=context,
     processor=Identity(id="agent-v1", name="Support Agent", role="assistant"),
-    user=Identity(id="user-123", name="Alice Smith", role="user"),
-    created_at=datetime.now(timezone.utc),
     last_updated_at=datetime.now(timezone.utc),
 )
 

--- a/src/coreason_manifest/definitions/session.py
+++ b/src/coreason_manifest/definitions/session.py
@@ -90,11 +90,8 @@ class SessionState(CoReasonBaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    session_id: UUID = Field(..., description="Global identifier for the conversation thread")
     context: SessionContext = Field(..., description="Immutable context for the session")
     processor: Identity = Field(..., description="The agent/graph handling this session")
-    user: Optional[Identity] = Field(None, description="The user participating in the session")
-    created_at: datetime = Field(..., description="When the session was created")
     last_updated_at: datetime = Field(..., description="When the session was last updated")
     history: List[Interaction] = Field(default_factory=list, description="Chronological list of interactions")
     context_variables: Dict[str, Any] = Field(


### PR DESCRIPTION
Refactored `SessionState` in `src/coreason_manifest/definitions/session.py` to remove redundant fields (`session_id`, `created_at`, `user`) that are now strictly managed within the `context: SessionContext` field. This ensures strict separation of mutable history and immutable identity/context. Updated `tests/test_session.py` to reflect these changes. Verified imports and tests pass.

---
*PR created automatically by Jules for task [2524774541309359294](https://jules.google.com/task/2524774541309359294) started by @gowthamrao*