### PR TITLE
feat: Implement V2 Composition and Recursive Loading

### DIFF
--- a/docs/v2_bridge.md
+++ b/docs/v2_bridge.md
@@ -9,20 +9,23 @@ It allows developers to write manifests in the concise V2 YAML format and immedi
 The bridge consists of three main modules located in `src/coreason_manifest/v2/`:
 
 1.  **Compiler** (`compiler.py`): Transforms the implicit "Linked List" topology of V2 into the explicit "Graph" topology of V1.
-2.  **I/O** (`io.py`): Handles loading and dumping of V2 YAML files, ensuring correct key ordering for human readability.
+2.  **I/O** (`io.py`): Handles loading and dumping of V2 YAML files. It supports **recursive multi-file composition** (via `$ref`) and enforces secure path resolution.
 3.  **Adapter** (`adapter.py`): Converts a loaded V2 `ManifestV2` object into a V1 `RecipeManifest` ready for execution.
+4.  **Resolver** (`resolver.py`): A helper module used by the loader to securely resolve file paths against a root "Jail" directory.
 
 ## Usage
 
 ### Loading and Executing a V2 Manifest
 
-To run a V2 YAML file, you use the `load_from_yaml` function to parse the file and `v2_to_recipe` to convert it.
+To run a V2 YAML file, you use the `load_from_yaml` function. This function automatically handles recursive imports and security checks.
 
 ```python
+from pathlib import Path
 from coreason_manifest.v2.io import load_from_yaml
 from coreason_manifest.v2.adapter import v2_to_recipe
 
 # 1. Load V2 Manifest (Human Friendly)
+# By default, this resolves imports relative to the file's directory.
 v2_manifest = load_from_yaml("my_workflow.v2.yaml")
 
 # 2. Convert to V1 Recipe (Machine Optimized)
@@ -34,7 +37,67 @@ print(f"Loaded Recipe: {recipe.name} (ID: {recipe.id})")
 print(f"Topology has {len(recipe.topology.nodes)} nodes.")
 ```
 
-### Compiler Logic
+## Multi-File Composition
+
+The V2 Loader supports composing complex manifests from multiple files using the standard `$ref` syntax within the `definitions` section.
+
+### Example
+
+**`tools.yaml`** (A fragment defining a tool):
+```yaml
+id: weather-tool
+name: Weather Tool
+uri: mcp://weather.com
+risk_level: safe
+description: Get weather info
+```
+
+**`main.yaml`** (The root manifest):
+```yaml
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: Weather Agent
+definitions:
+  # Import the tool definition from an external file
+  my_tool:
+    $ref: "./tools.yaml"
+workflow:
+  start: step1
+  steps:
+    step1:
+      type: agent
+      id: step1
+      agent: some-agent
+      # ...
+```
+
+When `load_from_yaml("main.yaml")` is called, the loader recursively resolves `./tools.yaml` and injects its content into `definitions.my_tool`.
+
+## Security & Safety
+
+To prevent security vulnerabilities and infinite loops, the loader enforces strict constraints:
+
+### 1. The Jail (Root Directory)
+To prevent **Path Traversal Attacks**, the loader enforces a "Jail" constraint. By default, the root of the jail is the parent directory of the initial file being loaded.
+
+*   All references (`$ref`) must resolve to a path **inside** this root directory.
+*   Attempts to reference files outside the root (e.g., `../sensitive_file.txt`) will raise a `ValueError`.
+
+You can explicitly set the root directory:
+
+```python
+# Enforce that all imports must be within /safe/base/dir
+manifest = load_from_yaml(
+    "project/main.yaml",
+    root_dir="/safe/base/dir"
+)
+```
+
+### 2. Cycle Detection
+The loader tracks visited paths during recursion. If a circular dependency is detected (e.g., A imports B, and B imports A), a `RecursionError` is raised immediately.
+
+## Compiler Logic
 
 The compiler performs several transformations:
 

--- a/src/coreason_manifest/v2/io.py
+++ b/src/coreason_manifest/v2/io.py
@@ -14,15 +14,12 @@ from pathlib import Path
 from typing import Any, Dict, Optional, Set, Union
 
 import yaml
-from pydantic import ValidationError
 
 from coreason_manifest.v2.resolver import ReferenceResolver
 from coreason_manifest.v2.spec.definitions import ManifestV2
 
 
-def _load_recursive(
-    path: Path, resolver: ReferenceResolver, visited_paths: Set[Path]
-) -> Dict[str, Any]:
+def _load_recursive(path: Path, resolver: ReferenceResolver, visited_paths: Set[Path]) -> Dict[str, Any]:
     """
     Recursively load YAML data, resolving $ref in definitions.
     """
@@ -35,7 +32,10 @@ def _load_recursive(
         with path.open("r", encoding="utf-8") as f:
             data = yaml.safe_load(f)
     except yaml.YAMLError as e:
-        raise ValueError(f"Invalid YAML in {path}: {e}")
+        raise ValueError(f"Invalid YAML in {path}: {e}") from e
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected a dictionary in {path}, got {type(data).__name__}")
 
     # Resolve references in definitions
     definitions = data.get("definitions", {})

--- a/src/coreason_manifest/v2/io.py
+++ b/src/coreason_manifest/v2/io.py
@@ -11,18 +11,63 @@
 """I/O module for loading and dumping V2 Manifests."""
 
 from pathlib import Path
-from typing import Union
+from typing import Any, Dict, Optional, Set, Union
 
 import yaml
+from pydantic import ValidationError
 
+from coreason_manifest.v2.resolver import ReferenceResolver
 from coreason_manifest.v2.spec.definitions import ManifestV2
 
 
-def load_from_yaml(path: Union[str, Path]) -> ManifestV2:
+def _load_recursive(
+    path: Path, resolver: ReferenceResolver, visited_paths: Set[Path]
+) -> Dict[str, Any]:
+    """
+    Recursively load YAML data, resolving $ref in definitions.
+    """
+    if path in visited_paths:
+        raise RecursionError(f"Circular dependency detected: {path}")
+
+    visited_paths.add(path)
+
+    try:
+        with path.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except yaml.YAMLError as e:
+        raise ValueError(f"Invalid YAML in {path}: {e}")
+
+    # Resolve references in definitions
+    definitions = data.get("definitions", {})
+    if definitions:
+        for key, value in definitions.items():
+            if isinstance(value, dict) and "$ref" in value:
+                ref_path_str = value["$ref"]
+                # Resolve the path
+                abs_path = resolver.resolve(path, ref_path_str)
+
+                # Recursively load
+                loaded_obj = _load_recursive(abs_path, resolver, visited_paths)
+
+                # Merge Strategy:
+                # Replace the $ref dict with the loaded data.
+                definitions[key] = loaded_obj
+
+    visited_paths.remove(path)
+    return data
+
+
+def load_from_yaml(
+    path: Union[str, Path],
+    root_dir: Optional[Union[str, Path]] = None,
+    recursive: bool = True,
+) -> ManifestV2:
     """Load a V2 manifest from a YAML file.
 
     Args:
         path: Path to the YAML file.
+        root_dir: The allowed root directory for references. Defaults to path's parent.
+        recursive: Whether to resolve $ref recursively.
 
     Returns:
         The validated ManifestV2 object.
@@ -31,13 +76,23 @@ def load_from_yaml(path: Union[str, Path]) -> ManifestV2:
         FileNotFoundError: If the file does not exist.
         ValidationError: If the manifest is invalid.
         yaml.YAMLError: If the YAML is invalid.
+        RecursionError: If a cyclic dependency is detected.
+        ValueError: If a security violation occurs or YAML is invalid.
     """
-    p = Path(path)
+    p = Path(path).resolve()
     if not p.exists():
         raise FileNotFoundError(f"Manifest file not found: {path}")
 
-    with p.open("r", encoding="utf-8") as f:
-        data = yaml.safe_load(f)
+    if root_dir is None:
+        root_dir = p.parent
+
+    if recursive:
+        resolver = ReferenceResolver(root_dir)
+        visited_paths: Set[Path] = set()
+        data = _load_recursive(p, resolver, visited_paths)
+    else:
+        with p.open("r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
 
     return ManifestV2.model_validate(data)
 

--- a/src/coreason_manifest/v2/resolver.py
+++ b/src/coreason_manifest/v2/resolver.py
@@ -52,9 +52,9 @@ class ReferenceResolver:
         try:
             target_path.relative_to(self.root_dir)
         except ValueError:
-             raise ValueError(
+            raise ValueError(
                 f"Security Error: Reference '{ref_path}' escapes the root directory '{self.root_dir}'."
-            )
+            ) from None
 
         if not target_path.exists():
             raise FileNotFoundError(f"Referenced file not found: {target_path}")

--- a/src/coreason_manifest/v2/resolver.py
+++ b/src/coreason_manifest/v2/resolver.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+"""Resolver module for secure file reference handling."""
+
+from pathlib import Path
+from typing import Union
+
+
+class ReferenceResolver:
+    """Resolves file references with security constraints (Jail)."""
+
+    def __init__(self, root_dir: Union[str, Path]):
+        """
+        Initialize the resolver with a root directory.
+
+        Args:
+            root_dir: The allowed jail directory. All resolved paths must be within this directory.
+        """
+        self.root_dir = Path(root_dir).resolve()
+
+    def resolve(self, base_file: Path, ref_path: str) -> Path:
+        """
+        Resolve a reference relative to a base file, ensuring it stays within the root directory.
+
+        Args:
+            base_file: The file containing the reference.
+            ref_path: The relative path string to resolve.
+
+        Returns:
+            The absolute resolved Path.
+
+        Raises:
+            ValueError: If the resolved path escapes the root directory.
+            FileNotFoundError: If the referenced file does not exist.
+        """
+        # Ensure base_file is absolute
+        base_file = base_file.resolve()
+
+        # Combine base_file parent with ref_path
+        # We assume ref_path is relative to the base_file's location
+        target_path = (base_file.parent / ref_path).resolve()
+
+        # Security Check: Jail
+        try:
+            target_path.relative_to(self.root_dir)
+        except ValueError:
+             raise ValueError(
+                f"Security Error: Reference '{ref_path}' escapes the root directory '{self.root_dir}'."
+            )
+
+        if not target_path.exists():
+            raise FileNotFoundError(f"Referenced file not found: {target_path}")
+
+        return target_path

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -169,10 +169,8 @@ def test_missing_file(manifest_dir: Path) -> None:
         "apiVersion": "coreason.ai/v2",
         "kind": "Agent",
         "metadata": {"name": "Missing Agent"},
-        "definitions": {
-            "missing": {"$ref": "does_not_exist.yaml"}
-        },
-        "workflow": {"start": "s", "steps": {"s": {"type": "logic", "id": "s", "code": "pass"}}}
+        "definitions": {"missing": {"$ref": "does_not_exist.yaml"}},
+        "workflow": {"start": "s", "steps": {"s": {"type": "logic", "id": "s", "code": "pass"}}},
     }
     main_path = manifest_dir / "main.yaml"
     with open(main_path, "w") as f:

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -1,0 +1,166 @@
+# tests/test_v2_composition.py
+
+import pytest
+import yaml
+from pathlib import Path
+from coreason_manifest.v2.io import load_from_yaml
+from coreason_manifest.v2.spec.definitions import ManifestV2, ToolDefinition
+from pydantic import ValidationError
+
+@pytest.fixture
+def manifest_dir(tmp_path):
+    d = tmp_path / "manifests"
+    d.mkdir()
+    return d
+
+def test_simple_import(manifest_dir):
+    """Test loading a manifest that references an external tool definition."""
+
+    # Create tool definition file
+    tool_def = {
+        "id": "weather-tool",
+        "name": "Weather Tool",
+        "uri": "mcp://weather.com",
+        "risk_level": "safe",
+        "description": "Get weather info"
+    }
+    tool_path = manifest_dir / "tool.yaml"
+    with open(tool_path, "w") as f:
+        yaml.dump(tool_def, f)
+
+    # Create main manifest
+    main_manifest = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Agent",
+        "metadata": {
+            "name": "Weather Agent"
+        },
+        "definitions": {
+            "my_tool": {"$ref": "tool.yaml"}
+        },
+        "workflow": {
+            "start": "step1",
+            "steps": {
+                "step1": {
+                    "type": "agent",
+                    "id": "step1",
+                    "agent": "some-agent"
+                }
+            }
+        }
+    }
+    main_path = manifest_dir / "main.yaml"
+    with open(main_path, "w") as f:
+        yaml.dump(main_manifest, f)
+
+    # Load
+    manifest = load_from_yaml(main_path)
+
+    assert isinstance(manifest, ManifestV2)
+    assert "my_tool" in manifest.definitions
+    tool = manifest.definitions["my_tool"]
+
+    # ManifestV2 definitions is Dict[str, Union[ToolDefinition, Any]]
+    # Pydantic might resolve it as a dict (Any) instead of ToolDefinition model.
+    if isinstance(tool, ToolDefinition):
+        assert tool.id == "weather-tool"
+        assert tool.name == "Weather Tool"
+    else:
+        assert isinstance(tool, dict)
+        assert tool["id"] == "weather-tool"
+        assert tool["name"] == "Weather Tool"
+
+def test_security_jailbreak(manifest_dir):
+    """Test that referencing a file outside the root directory raises an error."""
+
+    # Create file outside root
+    outside_dir = manifest_dir.parent / "outside"
+    outside_dir.mkdir()
+    outside_file = outside_dir / "secret.yaml"
+    with open(outside_file, "w") as f:
+        yaml.dump({"secret": "data"}, f)
+
+    # Create main manifest trying to access it
+    main_manifest = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Agent",
+        "metadata": {"name": "Hacker Agent"},
+        "definitions": {
+            "hack": {"$ref": "../outside/secret.yaml"}
+        },
+        "workflow": {
+            "start": "step1",
+            "steps": {"step1": {"type": "logic", "id": "step1", "code": "pass"}}
+        }
+    }
+    main_path = manifest_dir / "main.yaml"
+    with open(main_path, "w") as f:
+        yaml.dump(main_manifest, f)
+
+    # Load should fail
+    with pytest.raises(ValueError, match="Security Error"):
+        load_from_yaml(main_path)
+
+def test_cycles(manifest_dir):
+    """Test detection of circular dependencies."""
+
+    # a.yaml refs b.yaml
+    a_manifest = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "A"},
+        "definitions": {
+            "b": {"$ref": "b.yaml"}
+        },
+        "workflow": {
+            "start": "s", "steps": {"s": {"type": "logic", "id": "s", "code": "pass"}}
+        }
+    }
+
+    # b.yaml refs a.yaml
+    b_manifest = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "B"},
+        "definitions": {
+            "a": {"$ref": "a.yaml"}
+        },
+        "workflow": {
+             "start": "s", "steps": {"s": {"type": "logic", "id": "s", "code": "pass"}}
+        }
+    }
+
+    with open(manifest_dir / "a.yaml", "w") as f:
+        yaml.dump(a_manifest, f)
+
+    with open(manifest_dir / "b.yaml", "w") as f:
+        yaml.dump(b_manifest, f)
+
+    with pytest.raises(RecursionError, match="Circular dependency"):
+        load_from_yaml(manifest_dir / "a.yaml")
+
+def test_recursive_disabled(manifest_dir):
+    """Test that recursive=False does not resolve refs."""
+
+    tool_def = {"id": "t", "name": "T", "uri": "u", "risk_level": "safe"}
+    with open(manifest_dir / "tool.yaml", "w") as f:
+        yaml.dump(tool_def, f)
+
+    main_manifest = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Agent",
+        "metadata": {"name": "Agent"},
+        "definitions": {
+            "my_tool": {"$ref": "tool.yaml"}
+        },
+        "workflow": {
+             "start": "s", "steps": {"s": {"type": "logic", "id": "s", "code": "pass"}}
+        }
+    }
+    main_path = manifest_dir / "main.yaml"
+    with open(main_path, "w") as f:
+        yaml.dump(main_manifest, f)
+
+    # Since we are not resolving, the dict value for my_tool will be {"$ref": "tool.yaml"}
+    manifest = load_from_yaml(main_path, recursive=False)
+    assert manifest.definitions["my_tool"] == {"$ref": "tool.yaml"}

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -141,3 +141,23 @@ def test_recursive_disabled(manifest_dir: Path) -> None:
     # Since we are not resolving, the dict value for my_tool will be {"$ref": "tool.yaml"}
     manifest = load_from_yaml(main_path, recursive=False)
     assert manifest.definitions["my_tool"] == {"$ref": "tool.yaml"}
+
+
+def test_invalid_yaml_content(manifest_dir: Path) -> None:
+    """Test handling of invalid YAML content."""
+    invalid_path = manifest_dir / "invalid.yaml"
+    with open(invalid_path, "w") as f:
+        f.write(":: invalid yaml ::")
+
+    with pytest.raises(ValueError, match="Invalid YAML"):
+        load_from_yaml(invalid_path)
+
+
+def test_non_dict_content(manifest_dir: Path) -> None:
+    """Test handling of valid YAML that is not a dictionary."""
+    list_path = manifest_dir / "list.yaml"
+    with open(list_path, "w") as f:
+        yaml.dump(["item1", "item2"], f)
+
+    with pytest.raises(ValueError, match="Expected a dictionary"):
+        load_from_yaml(list_path)

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -161,3 +161,22 @@ def test_non_dict_content(manifest_dir: Path) -> None:
 
     with pytest.raises(ValueError, match="Expected a dictionary"):
         load_from_yaml(list_path)
+
+
+def test_missing_file(manifest_dir: Path) -> None:
+    """Test that referencing a non-existent file raises FileNotFoundError."""
+    main_manifest = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Agent",
+        "metadata": {"name": "Missing Agent"},
+        "definitions": {
+            "missing": {"$ref": "does_not_exist.yaml"}
+        },
+        "workflow": {"start": "s", "steps": {"s": {"type": "logic", "id": "s", "code": "pass"}}}
+    }
+    main_path = manifest_dir / "main.yaml"
+    with open(main_path, "w") as f:
+        yaml.dump(main_manifest, f)
+
+    with pytest.raises(FileNotFoundError, match="Referenced file not found"):
+        load_from_yaml(main_path)


### PR DESCRIPTION
This PR implements Phase 4 of the V2 Schema execution plan: Composition (Multi-File Support).

Key changes:
1.  **Secure Reference Resolution:** A new `ReferenceResolver` class ensures that all referenced files reside within a specified root directory (Jail), preventing path traversal attacks.
2.  **Recursive Loading:** The `load_from_yaml` function now recursively resolves `$ref` pointers within the `definitions` section of the manifest. It handles both full Manifest references and simple fragment references.
3.  **Cycle Detection:** A `visited_paths` context is maintained during recursion to detect and raise `RecursionError` for circular dependencies.
4.  **Testing:** New tests verify the loader's ability to handle imports, enforce security constraints, and detect cycles.

Note: The loader currently resolves referenced definitions into dictionaries (due to Pydantic's Union handling with `Any`), but the content is correctly loaded and validated as part of the parent manifest.

---
*PR created automatically by Jules for task [14653956364606932579](https://jules.google.com/task/14653956364606932579) started by @gowthamrao*