### PR TITLE
Support StreamPacket in ServerSentEvent

### DIFF
--- a/docs/sse_wire_protocol.md
+++ b/docs/sse_wire_protocol.md
@@ -101,14 +101,18 @@ Indicates the end of the stream.
 1.  **Connection:** The client initiates an HTTP GET request to the streaming endpoint (e.g., `/v1/assist` with `Accept: text/event-stream`).
 2.  **Handshake:** The server responds with `Content-Type: text/event-stream`.
 3.  **Transmission:** The server sends `StreamPacket` objects serialized as JSON, each within an SSE `data:` field.
-    *   `data: {"stream_id": "...", "op": "DELTA", ...}`
-    *   `data: {"stream_id": "...", "op": "EVENT", ...}`
+    *   **Event Type:** The SSE `event` field is set to `stream.packet`.
+    *   **ID:** The SSE `id` field is set to the `stream_id` to allow resumption.
+    *   **Payload:**
+        *   `event: stream.packet`
+        *   `id: 123e4567-e89b-12d3-a456-426614174000`
+        *   `data: {"stream_id": "...", "op": "DELTA", ...}`
 4.  **Termination:** The server sends a packet with `op=CLOSE`. The client should then close the connection (or expect the server to close it).
 
 ## Frontend Integration
 
 The frontend should implement a parser that:
-1.  Listens for SSE `message` events.
+1.  Listens for SSE events of type `stream.packet` (or generic `message` if using a raw reader).
 2.  Parses the `data` string as JSON into a `StreamPacket` object.
 3.  Checks the `op` code:
     *   If `DELTA`: Append `packet.p` to the current text buffer.

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -16,11 +16,13 @@ from pydantic import ConfigDict, Field
 
 from coreason_manifest.definitions.base import CoReasonBaseModel
 from coreason_manifest.definitions.events import CloudEvent
+from coreason_manifest.definitions.presentation import StreamPacket
 from coreason_manifest.definitions.request import AgentRequest
 from coreason_manifest.definitions.session import SessionContext
 
 DEFAULT_ENDPOINT_PATH = "/v1/assist"
 CONTENT_TYPE_SSE = "text/event-stream"
+STREAM_PACKET_EVENT_TYPE = "stream.packet"
 
 
 class ServerSentEvent(CoReasonBaseModel):
@@ -44,6 +46,22 @@ class ServerSentEvent(CoReasonBaseModel):
             event=event.type,
             data=event.to_json(),
             id=event.id,
+        )
+
+    @classmethod
+    def from_stream_packet(cls, packet: StreamPacket) -> "ServerSentEvent":
+        """Factory method to create a ServerSentEvent from a StreamPacket.
+
+        Args:
+            packet: The StreamPacket to wrap.
+
+        Returns:
+            A strictly formatted SSE object ready for the wire.
+        """
+        return cls(
+            event=STREAM_PACKET_EVENT_TYPE,
+            data=packet.to_json(),
+            id=str(packet.stream_id),
         )
 
 


### PR DESCRIPTION
This PR refactors `ServerSentEvent` to support direct conversion from `StreamPacket`, addressing the integration conflict identified in the Service Layer.

Key changes:
- `src/coreason_manifest/definitions/service.py`:
    - Imported `StreamPacket`.
    - Added `STREAM_PACKET_EVENT_TYPE = "stream.packet"`.
    - Implemented `ServerSentEvent.from_stream_packet(packet)`.
- `tests/test_service_contract.py`:
    - Added `test_sse_from_stream_packet` to verify the new functionality.

This change enables a lightweight path for token streaming, bypassing the overhead of wrapping every token in a `CloudEvent`.

---
*PR created automatically by Jules for task [12861265717100293286](https://jules.google.com/task/12861265717100293286) started by @gowthamrao*