### PR TITLE
Enforce CAP Naming Standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ It provides the **"Blueprint"** that all other services (Builder, Engine, Simula
 ### Standards Clarification
 *Note: The "Coreason Agent Manifest" (CAM) is a proprietary, strict governance schema designed for the CoReason Platform. It is distinct from the Oracle/Linux Foundation "Open Agent Specification," though we aim for future interoperability via adapters.*
 
+*   CAM is for **configuration**.
+*   CAP is for **communication**.
+
 ## Features
 
 *   **Coreason Agent Manifest (CAM):** Strict Pydantic models for Agent definitions (`AgentDefinition`).
+*   **Coreason Agent Protocol (CAP):** Standardized HTTP/SSE runtime contract for invoking agents and streaming results, strictly typed via `ServiceRequest` and `StreamPacket`.
 *   **Behavioral Protocols:** Standard `AgentInterface` and `LifecycleInterface` protocols for runtime interoperability.
 *   **Strict Typing:** Enforces type safety and immutable structures for critical interfaces.
 *   **Enhanced Serialization:** Includes `CoReasonBaseModel` to ensure consistent JSON serialization of complex types like `UUID` and `datetime`.

--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -65,7 +65,7 @@ An `AgentDefinition` consists of the following sections:
     *   `scaling_min_instances`, `scaling_max_instances`: Horizontal autoscaling bounds.
     *   `timeout_seconds`: Request processing limits.
     *   `env_vars`: Static environment variable injection.
-    *   **Service Contract**: All agents must expose the standard endpoints defined in the [Coreason Agent Protocol (CAP)](interface_contracts.md).
+    *   **Coreason Agent Protocol (CAP)**: All agents must expose the standard endpoints defined in the [Coreason Agent Protocol (CAP)](interface_contracts.md).
 
 8.  **Evaluation (`EvaluationProfile`)**:
     *   **Evaluation-Ready Metadata**: Defines test contracts directly in the manifest.

--- a/docs/transport_layer_specification.md
+++ b/docs/transport_layer_specification.md
@@ -1,6 +1,6 @@
-# Transport-Layer Specification
+# Transport-Layer Specification (CAP Binding)
 
-This document formalizes the **Public API Contract** that any Coreason-compatible engine must expose. It moves the `coreason-manifest` from strictly defining internal data structures to also defining *how* the outside world talks to an agent.
+This document formalizes the **Coreason Agent Protocol (CAP)** that any Coreason-compatible engine must expose. It moves the `coreason-manifest` from strictly defining internal data structures to also defining *how* the outside world talks to an agent.
 
 ## Goal
 

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -8,6 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+"""Defines the data structures for the Coreason Agent Protocol (CAP)."""
+
 from datetime import datetime
 from typing import Any, Dict, Literal, Optional
 from uuid import UUID
@@ -84,7 +86,7 @@ class HealthCheckResponse(CoReasonBaseModel):
 
 
 class ServiceContract(CoReasonBaseModel):
-    """Generates the OpenAPI specification for the Agent Service."""
+    """Defines the Coreason Agent Protocol (CAP) interface and generates its OpenAPI specification."""
 
     def generate_openapi_path(self) -> Dict[str, Any]:
         """Generates the OpenAPI Path Object for POST /v1/assist.


### PR DESCRIPTION
This PR enforces the 'Coreason Agent Protocol (CAP)' naming standard across the codebase and documentation. It updates docstrings and markdown files to clearly distinguish between CAM (Configuration) and CAP (Communication), ensuring consistent terminology for the runtime service layer.

---
*PR created automatically by Jules for task [9216235311097119915](https://jules.google.com/task/9216235311097119915) started by @gowthamrao*