### PR TITLE
Refactor: Extract shared primitives to common.py

### DIFF
--- a/docs/common_primitives_rationale.md
+++ b/docs/common_primitives_rationale.md
@@ -1,0 +1,58 @@
+# Common Primitives & Decoupling Strategy
+
+## Introduction
+
+As `coreason-manifest` evolves from its legacy V1 architecture to the new V2 **Coreason Orchestration Protocol (COP)**, we face the challenge of managing dependencies between these two distinct generations of code.
+
+This document explains the architectural decision to introduce a neutral `common.py` module, which serves as a shared foundation for both V1 and V2, enabling the eventual deprecation of legacy code.
+
+## The Problem: Circular & Legacy Dependencies
+
+Initially, foundational primitives like `CoReasonBaseModel` (the base Pydantic class) and `ToolRiskLevel` (an Enum) were defined inside V1 modules:
+*   `src/coreason_manifest/definitions/base.py`
+*   `src/coreason_manifest/definitions/agent.py`
+
+When we began building V2 (`src/coreason_manifest/v2/`), it needed these primitives to ensure type consistency and serialization behavior. Importing them directly from V1 created a hard dependency: **V2 depended on V1**.
+
+This prevented us from:
+1.  Isolating V2 for testing.
+2.  Deprecating or deleting V1 code in the future without breaking V2.
+3.  Maintaining a clean dependency graph (it created potential circular imports if V1 needed V2 features).
+
+## The Solution: `src/coreason_manifest/common.py`
+
+We extracted these shared primitives into a new, neutral module: `src/coreason_manifest/common.py`.
+
+This module acts as a **Leaf Node** in the dependency tree. It has zero internal dependencies on other `coreason_manifest` modules.
+
+### Shared Primitives
+
+The following core components reside in `common.py`:
+
+1.  **`CoReasonBaseModel`**: The base Pydantic model providing standardized JSON serialization (`dump()`, `to_json()`) for handling UUIDs and datetimes.
+2.  **`StrictUri`**: A Pydantic type alias for strict URI validation and string serialization.
+3.  **`ToolRiskLevel`**: An Enum defining the risk levels (`SAFE`, `STANDARD`, `CRITICAL`) for governance.
+
+## Architecture
+
+The dependency flow is now strictly unidirectional:
+
+```
+[V1 Legacy Code] ----> [common.py] <---- [V2 New Architecture]
+```
+
+*   **V1 (`definitions/`)**: Imports from `common.py` but **re-exports** the symbols to maintain backward compatibility for existing external consumers.
+*   **V2 (`v2/`)**: Imports directly from `common.py`, bypassing V1 entirely.
+
+## Backward Compatibility
+
+To ensure this refactor was non-breaking for existing users, we maintained the original import paths in V1:
+
+*   `coreason_manifest.definitions.base.CoReasonBaseModel` is now an import from `common.py`.
+*   `coreason_manifest.definitions.agent.ToolRiskLevel` is now an import from `common.py`.
+
+These modules include explicit `__all__` definitions to ensure static analysis tools (like `mypy`) treat these re-exports as public attributes.
+
+## Future Roadmap
+
+This structure allows us to eventually remove the `definitions/` directory (V1) entirely when the migration to V2 is complete, without requiring any changes to the V2 codebase.

--- a/src/coreason_manifest/builder/agent.py
+++ b/src/coreason_manifest/builder/agent.py
@@ -14,6 +14,7 @@ from datetime import datetime, timezone
 from typing import Optional, Protocol, Self, runtime_checkable
 from uuid import uuid4
 
+from coreason_manifest.common import ToolRiskLevel
 from coreason_manifest.definitions.agent import (
     AgentCapability,
     AgentDefinition,
@@ -23,7 +24,6 @@ from coreason_manifest.definitions.agent import (
     AgentStatus,
     ModelConfig,
     ToolRequirement,
-    ToolRiskLevel,
 )
 from coreason_manifest.definitions.topology import Edge, Node
 

--- a/src/coreason_manifest/common.py
+++ b/src/coreason_manifest/common.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import Enum
+from typing import Any, Dict
+
+from pydantic import AnyUrl, BaseModel, ConfigDict, PlainSerializer
+from typing_extensions import Annotated
+
+
+class CoReasonBaseModel(BaseModel):
+    """Base model for all CoReason Pydantic models with enhanced serialization.
+
+    This base class addresses JSON serialization challenges in Pydantic v2 (e.g., UUID, datetime)
+    by providing standardized methods (`dump`, `to_json`) with optimal configuration.
+
+    For a detailed rationale, see `docs/coreason_base_model_rationale.md`.
+    """
+
+    model_config = ConfigDict(populate_by_name=True)
+
+    def dump(self, **kwargs: Any) -> Dict[str, Any]:
+        """Serialize the model to a JSON-compatible dictionary.
+
+        Uses mode='json' to ensure types like UUID and datetime are serialized to strings.
+        Defaults to by_alias=True and exclude_none=True.
+        """
+        # Set defaults but allow overrides
+        kwargs.setdefault("mode", "json")
+        kwargs.setdefault("by_alias", True)
+        kwargs.setdefault("exclude_none", True)
+        return self.model_dump(**kwargs)
+
+    def to_json(self, **kwargs: Any) -> str:
+        """Serialize the model to a JSON string.
+
+        Defaults to by_alias=True and exclude_none=True.
+        """
+        # Set defaults but allow overrides
+        kwargs.setdefault("by_alias", True)
+        kwargs.setdefault("exclude_none", True)
+        return self.model_dump_json(**kwargs)
+
+
+# Strict URI type that serializes to string
+StrictUri = Annotated[
+    AnyUrl,
+    PlainSerializer(lambda x: str(x), return_type=str),
+]
+
+
+class ToolRiskLevel(str, Enum):
+    """Risk level for the tool."""
+
+    SAFE = "safe"
+    STANDARD = "standard"
+    CRITICAL = "critical"

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -40,6 +40,30 @@ from coreason_manifest.definitions.deployment import DeploymentConfig
 from coreason_manifest.definitions.evaluation import EvaluationProfile
 from coreason_manifest.definitions.topology import Edge, Node, validate_edge_integrity
 
+__all__ = [
+    "AdapterHints",
+    "AgentCapability",
+    "AgentDefinition",
+    "AgentDependencies",
+    "AgentMetadata",
+    "AgentRuntimeConfig",
+    "AgentStatus",
+    "CapabilityType",
+    "DeliveryMode",
+    "EventSchema",
+    "InlineToolDefinition",
+    "ModelConfig",
+    "ObservabilityConfig",
+    "Persona",
+    "PolicyConfig",
+    "StrictUri",
+    "ToolRequirement",
+    "ToolRiskLevel",
+    "TraceLevel",
+    "VersionStr",
+]
+
+
 # SemVer Regex pattern (simplified for standard SemVer)
 # Modified to accept optional 'v' or 'V' prefix (multiple allowed) for input normalization
 SEMVER_REGEX = (

--- a/src/coreason_manifest/definitions/agent.py
+++ b/src/coreason_manifest/definitions/agent.py
@@ -26,7 +26,6 @@ from uuid import UUID
 import jsonschema
 from pydantic import (
     AfterValidator,
-    AnyUrl,
     ConfigDict,
     Field,
     PlainSerializer,
@@ -35,6 +34,7 @@ from pydantic import (
 )
 from typing_extensions import Annotated
 
+from coreason_manifest.common import StrictUri, ToolRiskLevel
 from coreason_manifest.definitions.base import CoReasonBaseModel
 from coreason_manifest.definitions.deployment import DeploymentConfig
 from coreason_manifest.definitions.evaluation import EvaluationProfile
@@ -75,13 +75,6 @@ ImmutableDict = Annotated[
     Mapping[str, Any],
     AfterValidator(lambda x: MappingProxyType(x)),
     PlainSerializer(lambda x: dict(x), return_type=Dict[str, Any]),
-]
-
-
-# Strict URI type that serializes to string
-StrictUri = Annotated[
-    AnyUrl,
-    PlainSerializer(lambda x: str(x), return_type=str),
 ]
 
 
@@ -278,14 +271,6 @@ class AgentRuntimeConfig(CoReasonBaseModel):
                 seen.add(x)
             raise ValueError(f"Duplicate node IDs found: {', '.join(dupes)}")
         return v
-
-
-class ToolRiskLevel(str, Enum):
-    """Risk level for the tool."""
-
-    SAFE = "safe"
-    STANDARD = "standard"
-    CRITICAL = "critical"
 
 
 class ToolRequirement(CoReasonBaseModel):

--- a/src/coreason_manifest/definitions/audit.py
+++ b/src/coreason_manifest/definitions/audit.py
@@ -18,7 +18,7 @@ from uuid import UUID
 
 from pydantic import ConfigDict, Field, model_validator
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 from .message import ChatMessage
 

--- a/src/coreason_manifest/definitions/base.py
+++ b/src/coreason_manifest/definitions/base.py
@@ -8,40 +8,6 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, Dict
+from coreason_manifest.common import CoReasonBaseModel
 
-from pydantic import BaseModel, ConfigDict
-
-
-class CoReasonBaseModel(BaseModel):
-    """Base model for all CoReason Pydantic models with enhanced serialization.
-
-    This base class addresses JSON serialization challenges in Pydantic v2 (e.g., UUID, datetime)
-    by providing standardized methods (`dump`, `to_json`) with optimal configuration.
-
-    For a detailed rationale, see `docs/coreason_base_model_rationale.md`.
-    """
-
-    model_config = ConfigDict(populate_by_name=True)
-
-    def dump(self, **kwargs: Any) -> Dict[str, Any]:
-        """Serialize the model to a JSON-compatible dictionary.
-
-        Uses mode='json' to ensure types like UUID and datetime are serialized to strings.
-        Defaults to by_alias=True and exclude_none=True.
-        """
-        # Set defaults but allow overrides
-        kwargs.setdefault("mode", "json")
-        kwargs.setdefault("by_alias", True)
-        kwargs.setdefault("exclude_none", True)
-        return self.model_dump(**kwargs)
-
-    def to_json(self, **kwargs: Any) -> str:
-        """Serialize the model to a JSON string.
-
-        Defaults to by_alias=True and exclude_none=True.
-        """
-        # Set defaults but allow overrides
-        kwargs.setdefault("by_alias", True)
-        kwargs.setdefault("exclude_none", True)
-        return self.model_dump_json(**kwargs)
+__all__ = ["CoReasonBaseModel"]

--- a/src/coreason_manifest/definitions/contracts.py
+++ b/src/coreason_manifest/definitions/contracts.py
@@ -14,8 +14,8 @@ from uuid import UUID
 
 from pydantic import ConfigDict, Field
 
-from coreason_manifest.definitions.agent import VersionStr
 from coreason_manifest.common import CoReasonBaseModel
+from coreason_manifest.definitions.agent import VersionStr
 
 
 class ContractMetadata(CoReasonBaseModel):

--- a/src/coreason_manifest/definitions/contracts.py
+++ b/src/coreason_manifest/definitions/contracts.py
@@ -15,7 +15,7 @@ from uuid import UUID
 from pydantic import ConfigDict, Field
 
 from coreason_manifest.definitions.agent import VersionStr
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class ContractMetadata(CoReasonBaseModel):

--- a/src/coreason_manifest/definitions/deployment.py
+++ b/src/coreason_manifest/definitions/deployment.py
@@ -13,7 +13,7 @@ from typing import Dict
 
 from pydantic import ConfigDict, Field
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class Protocol(str, Enum):

--- a/src/coreason_manifest/definitions/evaluation.py
+++ b/src/coreason_manifest/definitions/evaluation.py
@@ -12,7 +12,7 @@ from typing import List, Optional
 
 from pydantic import ConfigDict, Field
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class SuccessCriterion(CoReasonBaseModel):

--- a/src/coreason_manifest/definitions/events.py
+++ b/src/coreason_manifest/definitions/events.py
@@ -15,7 +15,7 @@ from uuid import uuid4
 
 from pydantic import ConfigDict, Field
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 from coreason_manifest.definitions.topology import RuntimeVisualMetadata
 
 # --- CloudEvents v1.0 Implementation ---

--- a/src/coreason_manifest/definitions/identity.py
+++ b/src/coreason_manifest/definitions/identity.py
@@ -12,7 +12,7 @@ from typing import Optional
 
 from pydantic import ConfigDict, Field
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class Identity(CoReasonBaseModel):

--- a/src/coreason_manifest/definitions/message.py
+++ b/src/coreason_manifest/definitions/message.py
@@ -16,7 +16,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union, cast
 
 from pydantic import ConfigDict, Field, model_validator
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 # --- Enums ---
 

--- a/src/coreason_manifest/definitions/patterns.py
+++ b/src/coreason_manifest/definitions/patterns.py
@@ -14,7 +14,7 @@ from typing import List, Literal, Optional, Union
 from pydantic import ConfigDict, Field
 from typing_extensions import Annotated
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class PatternType(str, Enum):

--- a/src/coreason_manifest/definitions/presentation.py
+++ b/src/coreason_manifest/definitions/presentation.py
@@ -15,7 +15,7 @@ from uuid import UUID
 
 from pydantic import AnyUrl, ConfigDict, model_validator
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class PresentationEventType(str, Enum):

--- a/src/coreason_manifest/definitions/request.py
+++ b/src/coreason_manifest/definitions/request.py
@@ -4,7 +4,7 @@ from uuid import UUID, uuid4
 
 from pydantic import ConfigDict, Field, model_validator
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class AgentRequest(CoReasonBaseModel):

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -16,7 +16,7 @@ from uuid import UUID
 
 from pydantic import ConfigDict, Field
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 from coreason_manifest.definitions.events import CloudEvent
 from coreason_manifest.definitions.request import AgentRequest
 from coreason_manifest.definitions.session import SessionContext

--- a/src/coreason_manifest/definitions/session.py
+++ b/src/coreason_manifest/definitions/session.py
@@ -14,7 +14,7 @@ from uuid import UUID, uuid4
 
 from pydantic import ConfigDict, Field
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 from coreason_manifest.definitions.events import GraphEvent
 from coreason_manifest.definitions.identity import Identity
 from coreason_manifest.definitions.message import MultiModalInput

--- a/src/coreason_manifest/definitions/simulation.py
+++ b/src/coreason_manifest/definitions/simulation.py
@@ -15,7 +15,7 @@ from uuid import UUID
 
 from pydantic import Field
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class StepType(str, Enum):

--- a/src/coreason_manifest/definitions/simulation_config.py
+++ b/src/coreason_manifest/definitions/simulation_config.py
@@ -13,8 +13,8 @@ from typing import Optional
 
 from pydantic import Field
 
-from coreason_manifest.definitions.agent import Persona
 from coreason_manifest.common import CoReasonBaseModel
+from coreason_manifest.definitions.agent import Persona
 from coreason_manifest.definitions.simulation import SimulationScenario
 
 

--- a/src/coreason_manifest/definitions/simulation_config.py
+++ b/src/coreason_manifest/definitions/simulation_config.py
@@ -14,7 +14,7 @@ from typing import Optional
 from pydantic import Field
 
 from coreason_manifest.definitions.agent import Persona
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 from coreason_manifest.definitions.simulation import SimulationScenario
 
 

--- a/src/coreason_manifest/definitions/topology.py
+++ b/src/coreason_manifest/definitions/topology.py
@@ -23,7 +23,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Sequence, Unio
 
 from pydantic import ConfigDict, Field, StringConstraints, model_validator
 
-from coreason_manifest.definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 
 
 class StateDefinition(CoReasonBaseModel):

--- a/src/coreason_manifest/governance.py
+++ b/src/coreason_manifest/governance.py
@@ -18,13 +18,12 @@ from urllib.parse import urlparse
 
 from pydantic import ConfigDict, Field
 
+from coreason_manifest.common import CoReasonBaseModel, ToolRiskLevel
 from coreason_manifest.definitions.agent import (
     AgentDefinition,
     InlineToolDefinition,
     ToolRequirement,
-    ToolRiskLevel,
 )
-from coreason_manifest.definitions.base import CoReasonBaseModel
 from coreason_manifest.definitions.topology import LogicNode
 
 

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -22,8 +22,9 @@ from typing import Any, Dict, Optional
 
 from pydantic import ConfigDict, Field
 
-from .definitions.agent import VersionStr
 from coreason_manifest.common import CoReasonBaseModel
+
+from .definitions.agent import VersionStr
 from .definitions.topology import GraphTopology, StateDefinition
 
 

--- a/src/coreason_manifest/recipes.py
+++ b/src/coreason_manifest/recipes.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, Optional
 from pydantic import ConfigDict, Field
 
 from .definitions.agent import VersionStr
-from .definitions.base import CoReasonBaseModel
+from coreason_manifest.common import CoReasonBaseModel
 from .definitions.topology import GraphTopology, StateDefinition
 
 

--- a/src/coreason_manifest/v2/governance.py
+++ b/src/coreason_manifest/v2/governance.py
@@ -13,7 +13,7 @@
 from typing import List
 from urllib.parse import urlparse
 
-from coreason_manifest.definitions.agent import ToolRiskLevel
+from coreason_manifest.common import ToolRiskLevel
 from coreason_manifest.governance import (
     ComplianceReport,
     ComplianceViolation,

--- a/src/coreason_manifest/v2/spec/definitions.py
+++ b/src/coreason_manifest/v2/spec/definitions.py
@@ -2,7 +2,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field
 
-from coreason_manifest.definitions.agent import StrictUri, ToolRiskLevel
+from coreason_manifest.common import StrictUri, ToolRiskLevel
 
 
 class DesignMetadata(BaseModel):


### PR DESCRIPTION
Extracts `CoReasonBaseModel`, `StrictUri`, and `ToolRiskLevel` into `src/coreason_manifest/common.py` and updates the codebase to use this new module, effectively decoupling V2 from V1 legacy definitions. Validated with full test suite passing 100% coverage.

---
*PR created automatically by Jules for task [14795551081895686681](https://jules.google.com/task/14795551081895686681) started by @gowthamrao*