### PR TITLE
Implement Strict Error Protocol for CAP

### DIFF
--- a/docs/presentation_schemas.md
+++ b/docs/presentation_schemas.md
@@ -67,6 +67,37 @@ class CitationBlock(CoReasonBaseModel):
 }
 ```
 
+### StreamError
+
+Structured error payload for stream errors, ensuring clients can make intelligent retry decisions.
+
+```python
+class ErrorSeverity(str, Enum):
+    FATAL = "FATAL"         # Do not retry (e.g., Auth failed)
+    TRANSIENT = "TRANSIENT" # Retry immediately (e.g., Timeout)
+    WARNING = "WARNING"     # Minor failure, stream continues
+
+class StreamError(CoReasonBaseModel):
+    code: str               # Stable snake_case code (e.g., "rate_limit_exceeded")
+    message: str            # Human-readable message
+    severity: ErrorSeverity
+    details: Optional[Dict[str, Any]]
+```
+
+**JSON Example:**
+
+```json
+{
+  "code": "upstream_timeout",
+  "message": "The LLM provider failed to respond in time.",
+  "severity": "TRANSIENT",
+  "details": {
+    "provider": "openai",
+    "latency_ms": 15000
+  }
+}
+```
+
 ## Streaming Wire Format
 
 When sending these events over a stream (Server-Sent Events), they are wrapped in a `StreamPacket`. See [SSE Wire Protocol Specification](./sse_wire_protocol.md) for details.

--- a/docs/rfcs/005-strict-error-protocol.md
+++ b/docs/rfcs/005-strict-error-protocol.md
@@ -1,0 +1,98 @@
+# RFC 005: Strict Error Protocol for Streaming
+
+**Status:** Accepted
+**Created:** 2025-05-20
+**Target:** Coreason Agent Protocol (CAP) v1.0
+
+## Abstract
+
+This RFC defines a strict type schema for error reporting in the Coreason SSE wire protocol. It deprecates unstructured string errors and generic dictionary errors in favor of a strictly typed `StreamError` model. This ensures that clients can deterministically decide whether to retry a stream or surface a specific UI error message.
+
+## Motivation
+
+Previously, errors during streaming were sent as either:
+1.  Raw strings (e.g., `"Error: Rate limit exceeded"`)
+2.  Ad-hoc dictionaries (e.g., `{"error": "timeout", "details": ...}`)
+
+This forced client SDKs to rely on fragile string matching ("grep programming") to implement retry logic. For example, distinguishing between a transient `503 Service Unavailable` and a fatal `401 Unauthorized` required parsing arbitrary text.
+
+By enforcing a strict schema, we enable:
+1.  **Automatic Retries:** SDKs can check `severity == TRANSIENT` to retry automatically.
+2.  **Type Safety:** The wire format is validated at the boundary.
+3.  **Standardization:** All Coreason agents emit errors in the same shape.
+
+## Specification
+
+### 1. New Primitives
+
+We introduce two new primitives in `src/coreason_manifest/definitions/presentation.py`:
+
+#### `ErrorSeverity` (Enum)
+
+| Value | Description | Client Action |
+| :--- | :--- | :--- |
+| `FATAL` | The stream is dead and cannot be recovered (e.g., Auth failed, Validation error). | Raise exception, do not retry. |
+| `TRANSIENT` | The stream was interrupted by a temporary issue (e.g., Timeout, Rate Limit). | Retry immediately (with backoff). |
+| `WARNING` | The stream continues, but a minor component failed. | Log warning, continue processing stream. |
+
+#### `StreamError` (Model)
+
+```python
+class StreamError(CoReasonBaseModel):
+    code: str               # Machine-readable, snake_case (e.g., "rate_limit_exceeded")
+    message: str            # Human-readable description
+    severity: ErrorSeverity # Severity classification
+    details: Optional[Dict[str, Any]] = None # Extra context (e.g., {"retry_after": 60})
+```
+
+### 2. Wire Format Update
+
+The `StreamPacket` definition is updated to include `StreamError` in its payload union:
+
+```python
+class StreamPacket(CoReasonBaseModel):
+    # ...
+    op: StreamOpCode
+    p: Union[str, PresentationEvent, StreamError, Dict[str, Any]]
+```
+
+### 3. Strict Validation Rules
+
+To enforce this protocol, the `StreamPacket` validator implements the following logic when `op == StreamOpCode.ERROR`:
+
+1.  **Reject Strings:** Payloads of type `str` raise a `ValueError`.
+2.  **Coerce Dictionaries:** Payloads of type `dict` are strictly validated against the `StreamError` schema and converted to `StreamError` objects.
+3.  **Reject Invalid Objects:** Any other type raises a `ValueError`.
+
+## Migration Guide
+
+### For Agent Developers
+Instead of sending error strings:
+```python
+# OLD (Forbidden)
+await stream.write_error("Something went wrong")
+```
+
+Send structured errors:
+```python
+# NEW (Required)
+from coreason_manifest.definitions.presentation import StreamError, ErrorSeverity
+
+error = StreamError(
+    code="internal_error",
+    message="Database connection failed",
+    severity=ErrorSeverity.TRANSIENT
+)
+await stream.write_packet(op=StreamOpCode.ERROR, p=error)
+```
+
+### For Client SDKs
+Clients parsing the stream should switch on `op`:
+```python
+if packet.op == StreamOpCode.ERROR:
+    error: StreamError = packet.p
+    if error.severity == ErrorSeverity.TRANSIENT:
+        retry_stream()
+    else:
+        raise FatalError(error.message)
+```

--- a/docs/sse_wire_protocol.md
+++ b/docs/sse_wire_protocol.md
@@ -18,7 +18,7 @@ class StreamPacket(CoReasonBaseModel):
     seq: int
     op: StreamOpCode
     t: datetime
-    p: Union[str, PresentationEvent, Dict[str, Any]]
+    p: Union[str, PresentationEvent, StreamError, Dict[str, Any]]
 ```
 
 ### Fields
@@ -35,7 +35,7 @@ class StreamPacket(CoReasonBaseModel):
 | :--- | :--- | :--- |
 | `DELTA` | `str` | A raw text token. Used for streaming prose (e.g., from an LLM). |
 | `EVENT` | `PresentationEvent` or `Dict` | A structured event for the UI (e.g., a Citation, Progress Update). |
-| `ERROR` | `str` or `Dict` | A stream-level error. |
+| `ERROR` | `StreamError` | A strict stream-level error. |
 | `CLOSE` | `Any` (usually `str` reason) | Indicates the stream has finished. No further packets with this `stream_id` will be sent. |
 
 ## JSON Serialization Examples
@@ -82,16 +82,37 @@ Used for inserting rich UI components into the stream.
 }
 ```
 
-### 3. Stream Close
+### 3. Stream Error
+
+Indicates a stream-level error (fatal or transient).
+
+```json
+{
+  "stream_id": "123e4567-e89b-12d3-a456-426614174000",
+  "seq": 3,
+  "op": "ERROR",
+  "t": "2023-10-27T10:00:02.000000+00:00",
+  "p": {
+    "code": "rate_limit_exceeded",
+    "message": "You have exceeded your quota.",
+    "severity": "TRANSIENT",
+    "details": {
+      "retry_after": 60
+    }
+  }
+}
+```
+
+### 4. Stream Close
 
 Indicates the end of the stream.
 
 ```json
 {
   "stream_id": "123e4567-e89b-12d3-a456-426614174000",
-  "seq": 3,
+  "seq": 4,
   "op": "CLOSE",
-  "t": "2023-10-27T10:00:02.000000+00:00",
+  "t": "2023-10-27T10:00:03.000000+00:00",
   "p": "Stream completed successfully"
 }
 ```

--- a/docs/transport_layer_specification.md
+++ b/docs/transport_layer_specification.md
@@ -86,7 +86,7 @@ class StreamPacket(CoReasonBaseModel):
     seq: int
     op: StreamOpCode
     t: datetime
-    p: Union[str, PresentationEvent, Dict[str, Any]]
+    p: Union[str, PresentationEvent, StreamError, Dict[str, Any]]
 ```
 
 ##### Example Stream

--- a/tests/test_stream_protocol.py
+++ b/tests/test_stream_protocol.py
@@ -1,9 +1,21 @@
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional, Union
+from uuid import uuid4
 
 import pytest
+from pydantic import ValidationError
 
 from coreason_manifest.definitions.events import CloudEvent, GraphEvent
 from coreason_manifest.definitions.interfaces import ResponseHandler, StreamHandle
+from coreason_manifest.definitions.presentation import (
+    ErrorSeverity,
+    PresentationEvent,
+    PresentationEventType,
+    ProgressUpdate,
+    StreamError,
+    StreamOpCode,
+    StreamPacket,
+)
 
 
 class MockStreamHandle:
@@ -92,3 +104,131 @@ async def test_response_handler_protocol() -> None:
     assert isinstance(stream, StreamHandle)
     await stream.write("hello")
     await stream.close()
+
+
+def test_stream_packet_error_serialization() -> None:
+    """Test Case 1: Create a StreamPacket with op=ERROR and a valid StreamError object."""
+    stream_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    error = StreamError(
+        code="rate_limit_exceeded",
+        message="Too many requests",
+        severity=ErrorSeverity.TRANSIENT,
+        details={"limit": 100},
+    )
+
+    packet = StreamPacket(
+        stream_id=stream_id,
+        seq=1,
+        op=StreamOpCode.ERROR,
+        t=now,
+        p=error,
+    )
+
+    dump = packet.dump()
+    assert dump["op"] == "ERROR"
+    assert dump["p"]["code"] == "rate_limit_exceeded"
+    assert dump["p"]["severity"] == "TRANSIENT"
+
+
+def test_stream_packet_error_validation_string() -> None:
+    """Test Case 2 (Validation): Attempt to create a StreamPacket with op=ERROR and a raw string."""
+    stream_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    with pytest.raises(
+        ValueError, match="Payload must be a StreamError or Dict for ERROR op"
+    ):
+        StreamPacket(
+            stream_id=stream_id,
+            seq=1,
+            op=StreamOpCode.ERROR,
+            t=now,
+            p="Something went wrong",
+        )
+
+
+def test_stream_error_severity_serialization() -> None:
+    """Test Case 3 (Severity): Verify that ErrorSeverity serializes to its string value."""
+    assert ErrorSeverity.FATAL == "FATAL"
+    assert ErrorSeverity.TRANSIENT == "TRANSIENT"
+    assert ErrorSeverity.WARNING == "WARNING"
+
+    error = StreamError(
+        code="test_code",
+        message="test_msg",
+        severity=ErrorSeverity.FATAL,
+    )
+    dump = error.dump()
+    assert dump["severity"] == "FATAL"
+
+
+def test_stream_packet_error_dict_coercion() -> None:
+    """Test Case 4 (Coercion): Verify that a valid dict payload becomes a StreamError object."""
+    stream_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    error_dict = {
+        "code": "coercion_test",
+        "message": "This should be coerced",
+        "severity": "WARNING",
+    }
+
+    packet = StreamPacket(
+        stream_id=stream_id,
+        seq=1,
+        op=StreamOpCode.ERROR,
+        t=now,
+        p=error_dict,
+    )
+
+    # Assert p became a StreamError instance
+    assert isinstance(packet.p, StreamError)
+    assert packet.p.code == "coercion_test"
+    assert packet.p.severity == ErrorSeverity.WARNING
+
+
+def test_stream_packet_error_invalid_dict() -> None:
+    """Test Case 5 (Validation): Verify that an invalid dict raises ValidationError."""
+    stream_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    invalid_dict = {
+        "code": "missing_severity",
+        "message": "Oops"
+        # severity missing
+    }
+
+    # Expect ValidationError from StreamError.model_validate
+    with pytest.raises(ValidationError):
+        StreamPacket(
+            stream_id=stream_id,
+            seq=1,
+            op=StreamOpCode.ERROR,
+            t=now,
+            p=invalid_dict,
+        )
+
+
+def test_stream_packet_error_wrong_type() -> None:
+    """Test Case 6: Verify that a non-StreamError object raises ValueError for ERROR op."""
+    stream_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    update = ProgressUpdate(label="test", status="running")
+    event = PresentationEvent(
+        id=uuid4(),
+        timestamp=now,
+        type=PresentationEventType.PROGRESS_INDICATOR,
+        data=update,
+    )
+
+    with pytest.raises(ValueError, match="Payload must be a StreamError for ERROR op"):
+        StreamPacket(
+            stream_id=stream_id,
+            seq=1,
+            op=StreamOpCode.ERROR,
+            t=now,
+            p=event,
+        )

--- a/tests/test_stream_protocol.py
+++ b/tests/test_stream_protocol.py
@@ -137,9 +137,7 @@ def test_stream_packet_error_validation_string() -> None:
     stream_id = uuid4()
     now = datetime.now(timezone.utc)
 
-    with pytest.raises(
-        ValueError, match="Payload must be a StreamError or Dict for ERROR op"
-    ):
+    with pytest.raises(ValueError, match="Payload must be a StreamError or Dict for ERROR op"):
         StreamPacket(
             stream_id=stream_id,
             seq=1,
@@ -196,7 +194,7 @@ def test_stream_packet_error_invalid_dict() -> None:
 
     invalid_dict = {
         "code": "missing_severity",
-        "message": "Oops"
+        "message": "Oops",
         # severity missing
     }
 


### PR DESCRIPTION
Implements the Strict Error Protocol for Coreason Agent Protocol (CAP).
This change adds `StreamError` and `ErrorSeverity` to the presentation layer and enforces strict type checking and coercion for error payloads in `StreamPacket`. This prevents unstructured errors (strings/raw dicts) from being propagated without validation.
Tests were added in `tests/test_stream_protocol.py` covering serialization, validation, and type coercion.

---
*PR created automatically by Jules for task [14382856772044028194](https://jules.google.com/task/14382856772044028194) started by @gowthamrao*