### PR TITLE
Implement Native Agent Definitions in V2

### DIFF
--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -12,11 +12,74 @@ The `coreason-manifest` package acts as a **Shared Kernel**. It contains *only* 
 
 By centralizing the definitions here, all downstream services (Builder, Engine/MACO, Simulator) interact with a single, unified language. If a field or concept does not exist in the CAM, it does not exist in the platform.
 
-## The Agent Manifest
+## V2 Manifest Structure
 
-The root of the specification is the `AgentDefinition` class (located in `src/coreason_manifest/definitions/agent.py`). It encapsulates everything needed to instantiate and run an agent.
+The V2 Manifest (`ManifestV2`) is the authoring format for defining agents and recipes. It supports a polymorphic `definitions` block that allows defining reusable components like Tools and Agents.
 
-### Core Components
+### Definitions Section
+
+The `definitions` section is a key-value map where you can define:
+
+1.  **Tools (`ToolDefinition`)**:
+    *   `type`: `tool`
+    *   `id`: Unique identifier.
+    *   `name`: Human-readable name.
+    *   `uri`: The MCP endpoint URI.
+    *   `risk_level`: `safe`, `standard`, or `critical`.
+
+2.  **Agents (`AgentDefinition`)**:
+    *   `type`: `agent`
+    *   `id`: Unique identifier.
+    *   `name`: Agent name.
+    *   `role`: The persona/job title.
+    *   `goal`: The primary objective.
+    *   `backstory`: Detailed instructions or persona background.
+    *   `tools`: List of tool IDs (referencing other definitions).
+    *   `model`: LLM identifier (e.g., `gpt-4`).
+
+3.  **Generic Definitions**:
+    *   Fallback for loose dictionaries or references (`$ref`) that haven't been resolved yet or don't match a strict schema.
+
+#### Example V2 Agent Definition
+
+```yaml
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: Research Team
+definitions:
+  # Define a Tool
+  search_tool:
+    type: tool
+    id: search
+    name: Google Search
+    uri: mcp://google-search
+    risk_level: safe
+
+  # Define a Native Agent
+  writer_agent:
+    type: agent
+    id: writer
+    name: Content Writer
+    role: Senior Editor
+    goal: Summarize research into a blog post.
+    backstory: You are an expert editor with a focus on clarity.
+    tools: [] # No tools for this agent
+
+workflow:
+  start: step1
+  steps:
+    step1:
+      type: agent
+      id: step1
+      agent: writer_agent
+```
+
+## The V1 Runtime Agent Manifest
+
+The root of the runtime specification is the `AgentDefinition` class (located in `src/coreason_manifest/definitions/agent.py`). It encapsulates everything needed to instantiate and run an agent. The **V2 Loader Bridge** automatically converts the V2 YAML format into this runtime object.
+
+### Core Components (V1)
 
 An `AgentDefinition` consists of the following sections:
 

--- a/src/coreason_manifest/v2/adapter.py
+++ b/src/coreason_manifest/v2/adapter.py
@@ -10,12 +10,137 @@
 
 """Adapter module for backward compatibility with V1 Runtime."""
 
-from uuid import uuid4
+import hashlib
+from datetime import datetime, timezone
+from typing import Any, Dict
+from uuid import NAMESPACE_DNS, UUID, uuid4, uuid5
 
+from coreason_manifest.common import ToolRiskLevel
+from coreason_manifest.definitions.agent import (
+    AgentCapability,
+    AgentDefinition as V1AgentDefinition,
+    AgentDependencies,
+    AgentMetadata,
+    AgentRuntimeConfig,
+    AgentStatus,
+    CapabilityType,
+    DeliveryMode,
+    ModelConfig,
+    Persona,
+    ToolRequirement,
+)
 from coreason_manifest.definitions.topology import StateDefinition
 from coreason_manifest.recipes import PolicyConfig, RecipeInterface, RecipeManifest
 from coreason_manifest.v2.compiler import compile_to_topology
-from coreason_manifest.v2.spec.definitions import ManifestV2
+from coreason_manifest.v2.spec.definitions import AgentDefinition as V2AgentDefinition, ManifestV2, ToolDefinition
+
+
+def _convert_tool_ref(tool_ref: str, definitions: Dict[str, Any]) -> ToolRequirement:
+    """Convert a tool reference (ID) to a V1 ToolRequirement.
+
+    Args:
+        tool_ref: The ID of the tool in the V2 definitions.
+        definitions: The definitions dictionary from the manifest.
+
+    Returns:
+        A V1 ToolRequirement.
+    """
+    tool_def = definitions.get(tool_ref)
+
+    # Defaults
+    uri = f"mcp://{tool_ref}"
+    risk_level = ToolRiskLevel.STANDARD
+
+    if isinstance(tool_def, ToolDefinition):
+        uri = str(tool_def.uri)
+        risk_level = tool_def.risk_level
+
+    # Generate a deterministic hash for the tool requirement (required by V1)
+    # In a real system, this should be the actual hash of the tool's source/spec
+    tool_hash = hashlib.sha256(uri.encode()).hexdigest()
+
+    return ToolRequirement(
+        uri=uri,
+        hash=tool_hash,
+        scopes=[], # V2 doesn't have scopes yet
+        risk_level=risk_level
+    )
+
+def _convert_agent(agent_v2: V2AgentDefinition, definitions: Dict[str, Any]) -> V1AgentDefinition:
+    """Convert a V2 AgentDefinition to a V1 AgentDefinition.
+
+    Args:
+        agent_v2: The V2 agent definition.
+        definitions: The definitions dictionary from the manifest (for resolving tools).
+
+    Returns:
+        The converted V1 AgentDefinition.
+    """
+    # Ensure ID is a UUID
+    try:
+        agent_id = UUID(agent_v2.id)
+    except ValueError:
+        agent_id = uuid5(NAMESPACE_DNS, agent_v2.id)
+
+    # Convert Tools
+    tools = []
+    for tool_ref in agent_v2.tools:
+        tools.append(_convert_tool_ref(tool_ref, definitions))
+
+    # Construct Metadata
+    metadata = AgentMetadata(
+        id=agent_id,
+        version="0.1.0",
+        name=agent_v2.name,
+        author="system",
+        created_at=datetime.now(timezone.utc),
+        requires_auth=False
+    )
+
+    # Construct Capability (Default Chat)
+    capabilities = [
+        AgentCapability(
+            name="chat",
+            type=CapabilityType.ATOMIC,
+            description="Default chat capability",
+            inputs={"type": "object", "properties": {"message": {"type": "string"}}},
+            outputs={"type": "object", "properties": {"response": {"type": "string"}}},
+            delivery_mode=DeliveryMode.REQUEST_RESPONSE
+        )
+    ]
+
+    # Construct Config
+    persona = Persona(
+        name=agent_v2.role,
+        description=agent_v2.goal,
+        directives=[agent_v2.backstory] if agent_v2.backstory else []
+    )
+
+    model_config = ModelConfig(
+        model=agent_v2.model or "gpt-4",
+        temperature=0.7,
+        system_prompt=agent_v2.backstory,
+        persona=persona
+    )
+
+    # V1 requires atomic agents to have system_prompt in config OR llm_config
+    runtime_config = AgentRuntimeConfig(
+        model_config=model_config,
+        system_prompt=agent_v2.backstory
+    )
+
+    dependencies = AgentDependencies(
+        tools=tools,
+        libraries=()
+    )
+
+    return V1AgentDefinition(
+        metadata=metadata,
+        capabilities=capabilities,
+        config=runtime_config,
+        dependencies=dependencies,
+        status=AgentStatus.DRAFT
+    )
 
 
 def v2_to_recipe(manifest: ManifestV2) -> RecipeManifest:
@@ -45,6 +170,17 @@ def v2_to_recipe(manifest: ManifestV2) -> RecipeManifest:
     # If explicitly not ephemeral/memory, treat as persistent (e.g., redis, sql)
     persistence = "persistent" if backend not in ("ephemeral", "memory") else "ephemeral"
 
+    # Process parameters/definitions
+    # We create a new dict to store processed definitions
+    parameters = {}
+    for key, value in manifest.definitions.items():
+        if isinstance(value, V2AgentDefinition):
+            # Convert V2 Agent to V1 Agent
+            parameters[key] = _convert_agent(value, manifest.definitions)
+        else:
+            # Keep as is (ToolDefinition or Any)
+            parameters[key] = value
+
     # Construct the RecipeManifest
     return RecipeManifest(
         id=recipe_id,
@@ -59,7 +195,7 @@ def v2_to_recipe(manifest: ManifestV2) -> RecipeManifest:
             timeout=manifest.policy.timeout,
             human_in_the_loop=manifest.policy.human_in_the_loop,
         ),
-        parameters=manifest.definitions,
+        parameters=parameters,
         topology=topology,
         metadata=design_metadata,
     )

--- a/tests/test_v2_agent_complex.py
+++ b/tests/test_v2_agent_complex.py
@@ -1,9 +1,4 @@
-from typing import cast
-from uuid import UUID
-
-import pytest
 import yaml
-from pydantic import ValidationError
 
 from coreason_manifest.definitions.agent import AgentDefinition as V1AgentDefinition
 from coreason_manifest.definitions.agent import ToolRequirement
@@ -52,7 +47,7 @@ definitions:
     assert isinstance(v1_min, V1AgentDefinition)
     assert v1_min.config.llm_config.persona is not None
     assert v1_min.config.llm_config.persona.name == "MinRole"
-    assert v1_min.config.llm_config.model == "gpt-4" # Default
+    assert v1_min.config.llm_config.model == "gpt-4"  # Default
 
     # Check Maximal
     v1_max = recipe.parameters["max_agent"]
@@ -60,6 +55,7 @@ definitions:
     assert v1_max.config.llm_config.persona is not None
     assert v1_max.config.llm_config.model == "claude-3-opus"
     assert v1_max.config.system_prompt == "A long backstory."
+
 
 def test_recursive_composition() -> None:
     """Test 'Agent-as-a-Tool' scenario."""
@@ -101,6 +97,7 @@ definitions:
     assert isinstance(tool_req, ToolRequirement)
     # The adapter logic falls back to mcp://<id> for non-ToolDefinition references (like AgentDefinition)
     assert str(tool_req.uri) == "mcp://writer"
+
 
 def test_mixed_definitions_typo_tolerance() -> None:
     """Test mixing valid types and 'typo' types falling back to Generic."""
@@ -144,6 +141,7 @@ definitions:
     data = generic.model_dump()
     assert data["type"] == "unknown_type"
 
+
 def test_self_reference_circular_tools() -> None:
     """Test an agent referencing itself in tools (Circular)."""
     yaml_content = """
@@ -174,7 +172,5 @@ definitions:
     # Explicitly check/cast to ToolRequirement to satisfy strict mypy
     tool = v1_agent.dependencies.tools[0]
     assert isinstance(tool, ToolRequirement)
-    # Double safety cast for some mypy versions/configs
-    tool_req = cast(ToolRequirement, tool)
 
-    assert str(tool_req.uri) == "mcp://snake"
+    assert str(tool.uri) == "mcp://snake"

--- a/tests/test_v2_agent_complex.py
+++ b/tests/test_v2_agent_complex.py
@@ -162,4 +162,6 @@ definitions:
     assert isinstance(v1_agent, V1AgentDefinition)
     # It should just have a tool ref to mcp://snake
     assert len(v1_agent.dependencies.tools) == 1
-    assert str(v1_agent.dependencies.tools[0].uri) == "mcp://snake"
+    tool_req = v1_agent.dependencies.tools[0]
+    assert isinstance(tool_req, ToolRequirement)
+    assert str(tool_req.uri) == "mcp://snake"

--- a/tests/test_v2_agent_complex.py
+++ b/tests/test_v2_agent_complex.py
@@ -1,0 +1,165 @@
+import pytest
+import yaml
+from uuid import UUID
+from pydantic import ValidationError
+
+from coreason_manifest.v2.spec.definitions import ManifestV2, AgentDefinition, ToolDefinition, GenericDefinition
+from coreason_manifest.v2.adapter import v2_to_recipe
+from coreason_manifest.definitions.agent import AgentDefinition as V1AgentDefinition
+from coreason_manifest.definitions.agent import ToolRequirement
+
+def test_minimal_maximal_agents() -> None:
+    yaml_content = """
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: Edge Cases
+workflow:
+  start: s
+  steps: {s: {type: logic, id: s, code: pass}}
+definitions:
+  min_agent:
+    type: agent
+    id: min
+    name: Minimal
+    role: MinRole
+    goal: MinGoal
+
+  max_agent:
+    type: agent
+    id: max
+    name: Maximal
+    role: MaxRole
+    goal: MaxGoal
+    backstory: "A long backstory."
+    model: "claude-3-opus"
+    tools: []
+    knowledge: ["/docs/info.txt"]
+"""
+    manifest = ManifestV2(**yaml.safe_load(yaml_content))
+    recipe = v2_to_recipe(manifest)
+
+    # Check Minimal
+    v1_min = recipe.parameters["min_agent"]
+    assert isinstance(v1_min, V1AgentDefinition)
+    assert v1_min.config.llm_config.persona is not None
+    assert v1_min.config.llm_config.persona.name == "MinRole"
+    assert v1_min.config.llm_config.model == "gpt-4" # Default
+
+    # Check Maximal
+    v1_max = recipe.parameters["max_agent"]
+    assert isinstance(v1_max, V1AgentDefinition)
+    assert v1_max.config.llm_config.persona is not None
+    assert v1_max.config.llm_config.model == "claude-3-opus"
+    assert v1_max.config.system_prompt == "A long backstory."
+
+def test_recursive_composition() -> None:
+    """Test 'Agent-as-a-Tool' scenario."""
+    yaml_content = """
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: Recursive Team
+workflow:
+  start: s
+  steps: {s: {type: logic, id: s, code: pass}}
+definitions:
+  writer:
+    type: agent
+    id: writer-1
+    name: Writer
+    role: Writer
+    goal: Write
+
+  editor:
+    type: agent
+    id: editor-1
+    name: Editor
+    role: Editor
+    goal: Edit
+    tools: ["writer"] # Referencing another agent as a tool
+"""
+    manifest = ManifestV2(**yaml.safe_load(yaml_content))
+    recipe = v2_to_recipe(manifest)
+
+    v1_editor = recipe.parameters["editor"]
+    assert isinstance(v1_editor, V1AgentDefinition)
+
+    # Check dependencies
+    assert len(v1_editor.dependencies.tools) == 1
+    tool_req = v1_editor.dependencies.tools[0]
+
+    # It should treat the agent ref as an MCP tool
+    assert isinstance(tool_req, ToolRequirement)
+    # The adapter logic falls back to mcp://<id> for non-ToolDefinition references (like AgentDefinition)
+    assert str(tool_req.uri) == "mcp://writer"
+
+def test_mixed_definitions_typo_tolerance() -> None:
+    """Test mixing valid types and 'typo' types falling back to Generic."""
+    yaml_content = """
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: Mixed Bag
+workflow:
+  start: s
+  steps: {s: {type: logic, id: s, code: pass}}
+definitions:
+  valid_tool:
+    type: tool
+    id: t1
+    name: T1
+    uri: mcp://t1
+    risk_level: safe
+
+  valid_agent:
+    type: agent
+    id: a1
+    name: A1
+    role: R1
+    goal: G1
+
+  typo_thing:
+    type: unknown_type # This should become GenericDefinition
+    id: u1
+    name: Unknown
+"""
+    manifest = ManifestV2(**yaml.safe_load(yaml_content))
+
+    assert isinstance(manifest.definitions["valid_tool"], ToolDefinition)
+    assert isinstance(manifest.definitions["valid_agent"], AgentDefinition)
+    assert isinstance(manifest.definitions["typo_thing"], GenericDefinition)
+
+    # Check access on generic
+    generic = manifest.definitions["typo_thing"]
+    # GenericDefinition stores extra fields in __pydantic_extra__ or via model_dump
+    data = generic.model_dump()
+    assert data["type"] == "unknown_type"
+
+def test_self_reference_circular_tools() -> None:
+    """Test an agent referencing itself in tools (Circular)."""
+    yaml_content = """
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: Self Ref
+workflow:
+  start: s
+  steps: {s: {type: logic, id: s, code: pass}}
+definitions:
+  ouroboros:
+    type: agent
+    id: snake
+    name: Snake
+    role: Eater
+    goal: Eat tail
+    tools: ["snake"]
+"""
+    manifest = ManifestV2(**yaml.safe_load(yaml_content))
+    recipe = v2_to_recipe(manifest)
+
+    v1_agent = recipe.parameters["ouroboros"]
+    assert isinstance(v1_agent, V1AgentDefinition)
+    # It should just have a tool ref to mcp://snake
+    assert len(v1_agent.dependencies.tools) == 1
+    assert str(v1_agent.dependencies.tools[0].uri) == "mcp://snake"

--- a/tests/test_v2_agent_complex.py
+++ b/tests/test_v2_agent_complex.py
@@ -1,12 +1,20 @@
+from typing import cast
+from uuid import UUID
+
 import pytest
 import yaml
-from uuid import UUID
 from pydantic import ValidationError
 
-from coreason_manifest.v2.spec.definitions import ManifestV2, AgentDefinition, ToolDefinition, GenericDefinition
-from coreason_manifest.v2.adapter import v2_to_recipe
 from coreason_manifest.definitions.agent import AgentDefinition as V1AgentDefinition
 from coreason_manifest.definitions.agent import ToolRequirement
+from coreason_manifest.v2.adapter import v2_to_recipe
+from coreason_manifest.v2.spec.definitions import (
+    AgentDefinition,
+    GenericDefinition,
+    ManifestV2,
+    ToolDefinition,
+)
+
 
 def test_minimal_maximal_agents() -> None:
     yaml_content = """
@@ -162,6 +170,11 @@ definitions:
     assert isinstance(v1_agent, V1AgentDefinition)
     # It should just have a tool ref to mcp://snake
     assert len(v1_agent.dependencies.tools) == 1
-    tool_req = v1_agent.dependencies.tools[0]
-    assert isinstance(tool_req, ToolRequirement)
+
+    # Explicitly check/cast to ToolRequirement to satisfy strict mypy
+    tool = v1_agent.dependencies.tools[0]
+    assert isinstance(tool, ToolRequirement)
+    # Double safety cast for some mypy versions/configs
+    tool_req = cast(ToolRequirement, tool)
+
     assert str(tool_req.uri) == "mcp://snake"

--- a/tests/test_v2_agent_def.py
+++ b/tests/test_v2_agent_def.py
@@ -1,0 +1,136 @@
+import pytest
+import yaml
+from uuid import UUID
+from pydantic import ValidationError
+
+from coreason_manifest.v2.spec.definitions import ManifestV2, AgentDefinition, ToolDefinition, GenericDefinition
+from coreason_manifest.v2.adapter import v2_to_recipe
+from coreason_manifest.definitions.agent import AgentDefinition as V1AgentDefinition
+
+def test_polymorphic_parsing():
+    yaml_content = """
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: My Mixed Manifest
+workflow:
+  start: step1
+  steps:
+    step1:
+      id: step1
+      type: logic
+      code: "print('hello')"
+definitions:
+  my_tool:
+    type: tool
+    id: tool-1
+    name: Search
+    uri: mcp://search
+    risk_level: safe
+  my_agent:
+    type: agent
+    id: agent-1
+    name: Researcher
+    role: Research Specialist
+    goal: Find data
+    tools: [my_tool]
+"""
+    manifest_data = yaml.safe_load(yaml_content)
+    manifest = ManifestV2(**manifest_data)
+
+    assert "my_tool" in manifest.definitions
+    assert isinstance(manifest.definitions["my_tool"], ToolDefinition)
+    assert manifest.definitions["my_tool"].type == "tool"
+
+    assert "my_agent" in manifest.definitions
+    assert isinstance(manifest.definitions["my_agent"], AgentDefinition)
+    assert manifest.definitions["my_agent"].type == "agent"
+    assert manifest.definitions["my_agent"].role == "Research Specialist"
+
+def test_validation_failure():
+    # Missing 'role' for agent. Should fall back to GenericDefinition.
+    yaml_content = """
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: Invalid Manifest
+workflow:
+  start: step1
+  steps:
+    step1:
+      id: step1
+      type: logic
+      code: "pass"
+definitions:
+  bad_agent:
+    type: agent
+    id: agent-1
+    name: Researcher
+    # role is missing
+    goal: Find data
+"""
+    manifest_data = yaml.safe_load(yaml_content)
+    manifest = ManifestV2(**manifest_data)
+
+    assert "bad_agent" in manifest.definitions
+    # Should fallback to GenericDefinition because validation failed for AgentDefinition
+    assert isinstance(manifest.definitions["bad_agent"], GenericDefinition)
+    # Ensure it is NOT AgentDefinition
+    assert not isinstance(manifest.definitions["bad_agent"], AgentDefinition)
+
+def test_adapter_conversion():
+    yaml_content = """
+apiVersion: coreason.ai/v2
+kind: Agent
+metadata:
+  name: Conversion Test
+workflow:
+  start: step1
+  steps:
+    step1:
+      id: step1
+      type: logic
+      code: "pass"
+definitions:
+  my_tool:
+    type: tool
+    id: tool-1
+    name: Search
+    uri: mcp://search
+    risk_level: safe
+  my_agent:
+    type: agent
+    id: agent-1
+    name: Researcher
+    role: Research Specialist
+    goal: Find comprehensive data
+    backstory: You are an expert researcher.
+    tools: [my_tool]
+"""
+    manifest_data = yaml.safe_load(yaml_content)
+    manifest = ManifestV2(**manifest_data)
+
+    recipe = v2_to_recipe(manifest)
+
+    # Check parameters
+    assert "my_agent" in recipe.parameters
+    v1_agent = recipe.parameters["my_agent"]
+
+    # Assert it is a V1 AgentDefinition
+    assert isinstance(v1_agent, V1AgentDefinition)
+
+    # Check Mappings
+    # Role -> Persona.name
+    assert v1_agent.config.llm_config.persona.name == "Research Specialist"
+    # Goal -> Persona.description
+    assert v1_agent.config.llm_config.persona.description == "Find comprehensive data"
+    # Backstory -> Persona.directives
+    assert "You are an expert researcher." in v1_agent.config.llm_config.persona.directives
+
+    # Check Tools
+    assert len(v1_agent.dependencies.tools) == 1
+    tool_req = v1_agent.dependencies.tools[0]
+    assert str(tool_req.uri) == "mcp://search"
+    assert tool_req.risk_level == "safe"
+    # Hash should be present (SHA256 hex)
+    assert len(tool_req.hash) == 64

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -152,7 +152,7 @@ def test_recursive_disabled(manifest_dir: Path) -> None:
 
     # Explicitly annotated variable
     tool_ref_data: Dict[str, Any]
-    tool_ref_data = raw_data  # type: ignore[assignment]
+    tool_ref_data = raw_data
 
     # Avoid literal comparison to prevent bidirectional type inference issues in mypy
     assert tool_ref_data.get("$ref") == "tool.yaml"

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -149,7 +149,10 @@ def test_recursive_disabled(manifest_dir: Path) -> None:
     # Force cast to Dict[str, Any] to avoid bidirectional type inference conflict
     # where mypy thinks it must be Dict[str, str] due to the assert below.
     raw_data = tool_def.model_dump() if hasattr(tool_def, "model_dump") else tool_def
-    tool_ref_data = cast(Dict[str, Any], raw_data)
+
+    # Explicitly annotated variable
+    tool_ref_data: Dict[str, Any]
+    tool_ref_data = raw_data  # type: ignore[assignment]
 
     assert tool_ref_data == {"$ref": "tool.yaml"}
 

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -2,7 +2,7 @@
 
 
 from pathlib import Path
-from typing import Any, Dict, cast
+from typing import Any, Dict
 
 import pytest
 import yaml
@@ -154,7 +154,9 @@ def test_recursive_disabled(manifest_dir: Path) -> None:
     tool_ref_data: Dict[str, Any]
     tool_ref_data = raw_data  # type: ignore[assignment]
 
-    assert tool_ref_data == {"$ref": "tool.yaml"}
+    # Avoid literal comparison to prevent bidirectional type inference issues in mypy
+    assert tool_ref_data.get("$ref") == "tool.yaml"
+    assert len(tool_ref_data) == 1
 
 
 def test_invalid_yaml_content(manifest_dir: Path) -> None:

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -2,7 +2,7 @@
 
 
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, cast
 
 import pytest
 import yaml
@@ -145,7 +145,12 @@ def test_recursive_disabled(manifest_dir: Path) -> None:
     manifest = load_from_yaml(main_path, recursive=False)
     # It will be parsed as GenericDefinition because it has no known 'type'
     tool_def = manifest.definitions["my_tool"]
-    tool_ref_data: Dict[str, Any] = tool_def.model_dump() if hasattr(tool_def, "model_dump") else tool_def  # type: ignore[assignment]
+
+    # Force cast to Dict[str, Any] to avoid bidirectional type inference conflict
+    # where mypy thinks it must be Dict[str, str] due to the assert below.
+    raw_data = tool_def.model_dump() if hasattr(tool_def, "model_dump") else tool_def
+    tool_ref_data = cast(Dict[str, Any], raw_data)
+
     assert tool_ref_data == {"$ref": "tool.yaml"}
 
 

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -152,7 +152,7 @@ def test_recursive_disabled(manifest_dir: Path) -> None:
 
     # Explicitly annotated variable
     tool_ref_data: Dict[str, Any]
-    tool_ref_data = raw_data
+    tool_ref_data = raw_data  # type: ignore[assignment]
 
     # Avoid literal comparison to prevent bidirectional type inference issues in mypy
     assert tool_ref_data.get("$ref") == "tool.yaml"

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -2,6 +2,7 @@
 
 
 from pathlib import Path
+from typing import Any, Dict
 
 import pytest
 import yaml
@@ -144,7 +145,7 @@ def test_recursive_disabled(manifest_dir: Path) -> None:
     manifest = load_from_yaml(main_path, recursive=False)
     # It will be parsed as GenericDefinition because it has no known 'type'
     tool_def = manifest.definitions["my_tool"]
-    tool_dict = tool_def.model_dump() if hasattr(tool_def, "model_dump") else tool_def
+    tool_dict: Dict[str, Any] = tool_def.model_dump() if hasattr(tool_def, "model_dump") else tool_def  # type: ignore[assignment]
     assert tool_dict == {"$ref": "tool.yaml"}
 
 

--- a/tests/test_v2_composition.py
+++ b/tests/test_v2_composition.py
@@ -145,8 +145,8 @@ def test_recursive_disabled(manifest_dir: Path) -> None:
     manifest = load_from_yaml(main_path, recursive=False)
     # It will be parsed as GenericDefinition because it has no known 'type'
     tool_def = manifest.definitions["my_tool"]
-    tool_dict: Dict[str, Any] = tool_def.model_dump() if hasattr(tool_def, "model_dump") else tool_def  # type: ignore[assignment]
-    assert tool_dict == {"$ref": "tool.yaml"}
+    tool_ref_data: Dict[str, Any] = tool_def.model_dump() if hasattr(tool_def, "model_dump") else tool_def  # type: ignore[assignment]
+    assert tool_ref_data == {"$ref": "tool.yaml"}
 
 
 def test_invalid_yaml_content(manifest_dir: Path) -> None:

--- a/tests/test_v2_phase3.py
+++ b/tests/test_v2_phase3.py
@@ -36,7 +36,7 @@ def basic_manifest() -> ManifestV2:
                 "step2": AgentStep(id="step2", agent="my-agent"),
             },
         ),
-        definitions={"my-agent": "some-definition"},  # Mock definition for strict check
+        definitions={"my-agent": {}},  # Mock definition for strict check
     )
 
 
@@ -52,7 +52,7 @@ def test_validation_loose_vs_strict() -> None:
                 "step1": AgentStep(id="step1", agent="my-agent", next="step2"),
             },
         ),
-        definitions={"my-agent": "def"},
+        definitions={"my-agent": {}},
     )
 
     # Loose validation should be clean (or just warnings)
@@ -82,7 +82,7 @@ def test_governance_tool_risk() -> None:
         kind="Agent",
         metadata=ManifestMetadata(name="Risky Agent"),
         workflow=Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1")}),
-        definitions={"critical-tool": tool_def, "agent1": "def"},
+        definitions={"critical-tool": tool_def, "agent1": {}},
     )
 
     # Config allowing only STANDARD
@@ -107,7 +107,7 @@ def test_governance_allowed_domains() -> None:
         kind="Agent",
         metadata=ManifestMetadata(name="Domain Agent"),
         workflow=Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1")}),
-        definitions={"tool1": tool_def, "agent1": "def"},
+        definitions={"tool1": tool_def, "agent1": {}},
     )
 
     config = GovernanceConfig(allowed_domains=["good.com"])
@@ -130,7 +130,7 @@ def test_compiler_dependencies() -> None:
         kind="Agent",
         metadata=ManifestMetadata(name="Calc Agent"),
         workflow=Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1")}),
-        definitions={"tool1": tool_def, "agent1": "def"},
+        definitions={"tool1": tool_def, "agent1": {}},
     )
 
     deps = compile_dependencies(manifest)
@@ -158,7 +158,7 @@ def test_compiler_strict_validation_integration() -> None:
                 "step1": AgentStep(id="step1", agent="my-agent", next="missing_step"),
             },
         ),
-        definitions={"my-agent": "def"},
+        definitions={"my-agent": {}},
     )
 
     with pytest.raises(ValueError, match="Manifest validation failed"):


### PR DESCRIPTION
This commit introduces native support for defining Agents in the V2 Manifest using a discriminated union. It defines the `AgentDefinition` schema in V2 and implements the logic to bridge these definitions to the V1 Runtime `AgentDefinition` format via the adapter. This allows recursive composition of agents in recipes. It also introduces `GenericDefinition` as a robust fallback for definitions that do not match the strict schemas, ensuring backward compatibility and flexibility.

---
*PR created automatically by Jules for task [1076713369153253313](https://jules.google.com/task/1076713369153253313) started by @gowthamrao*