### PR TITLE
feat!: make V2 Manifest the default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,30 @@ pip install coreason-manifest
 
 ## Usage
 
-This library is used to define and validate Agent configurations programmatically.
+### V2 (Default)
+The library now defaults to the **V2 Manifest** (CAM) format.
+
+```python
+import coreason_manifest as cm
+
+# Load a V2 YAML
+manifest = cm.load("my_agent.yaml")
+
+# Access V2 fields
+print(f"Loaded {manifest.kind}: {manifest.metadata.name}")
+
+# Dump back to YAML
+print(cm.dump(manifest))
+```
+
+### V1 (Legacy)
+Legacy V1 objects (`AgentDefinition`, `RecipeManifest`) are available under the `v1` namespace.
 
 ```python
 import uuid
 from datetime import datetime, timezone
+from coreason_manifest.v1 import AgentDefinition
 from coreason_manifest.definitions.agent import (
-    AgentDefinition,
     AgentMetadata,
     AgentCapability,
     CapabilityType,

--- a/docs/builder_sdk.md
+++ b/docs/builder_sdk.md
@@ -54,7 +54,7 @@ Use `AgentBuilder` to assemble the agent and compile it into an `AgentDefinition
 
 ```python
 from coreason_manifest.builder import AgentBuilder
-from coreason_manifest.definitions.agent import AgentStatus
+from coreason_manifest.v1 import AgentStatus
 
 builder = AgentBuilder(
     name="ResearchAssistant",
@@ -81,7 +81,7 @@ print(agent_definition.to_json(indent=2))
 You can define complex workflows using Nodes and Edges.
 
 ```python
-from coreason_manifest.definitions.topology import LogicNode
+from coreason_manifest.v1 import LogicNode
 
 node_a = LogicNode(id="start", type="logic", code="print('Start')")
 node_b = LogicNode(id="end", type="logic", code="print('End')")

--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -235,8 +235,8 @@ Here is how to programmatically define an Agent using the CAM:
 ```python
 import uuid
 from datetime import datetime, timezone
+from coreason_manifest.v1 import AgentDefinition
 from coreason_manifest.definitions.agent import (
-    AgentDefinition,
     AgentMetadata,
     AgentCapability,
     CapabilityType,

--- a/docs/migration_guide_v2.md
+++ b/docs/migration_guide_v2.md
@@ -1,0 +1,83 @@
+# Migration Guide: V1 to V2
+
+Coreason Manifest v0.12.0 introduces a **Breaking Change** to the default import behavior. The root `coreason_manifest` package now exports **V2** objects by default, while legacy **V1** objects have been moved to the `coreason_manifest.v1` namespace.
+
+This guide details the changes and how to migrate your existing code.
+
+## Summary of Changes
+
+| Feature | Legacy (V1) | Modern (V2) |
+| :--- | :--- | :--- |
+| **Default Export** | `RecipeManifest` | `Manifest` (V2) |
+| **Serialization** | `.model_dump()` | `dump()` / `load()` |
+| **File Format** | Pydantic / JSON | Canonical YAML (CAM) |
+| **Topology** | GraphTopology (Pydantic) | V2 Workflow Topology |
+
+## 1. Import Changes
+
+### The "Quick Fix" (Legacy Mode)
+If you are not ready to upgrade to V2, you can keep your existing V1 code working by updating your imports.
+
+**Before:**
+```python
+from coreason_manifest import RecipeManifest, AgentDefinition, Topology
+```
+
+**After:**
+```python
+from coreason_manifest.v1 import RecipeManifest, AgentDefinition, Topology
+# OR
+from coreason_manifest.recipes import RecipeManifest
+from coreason_manifest.definitions.agent import AgentDefinition
+```
+
+### Adopting V2 (Recommended)
+The new default `Manifest` is the entry point for the V2 ecosystem.
+
+```python
+import coreason_manifest as cm
+
+# Load a V2 YAML file
+manifest = cm.load("path/to/manifest.yaml")
+
+# Work with the V2 object
+print(manifest.metadata.name)
+```
+
+## 2. Using the V2 API
+
+The V2 API is designed around the **Canonical Agent Manifest (CAM)** YAML format.
+
+### Loading
+```python
+from coreason_manifest import load
+
+manifest = load("agent.yaml", recursive=True)
+```
+
+### Dumping
+```python
+from coreason_manifest import dump
+
+yaml_str = dump(manifest)
+print(yaml_str)
+```
+
+## 3. Backward Compatibility
+
+While the root exports have changed, the underlying V1 definitions (`coreason_manifest.definitions.*`) remain in place. The V2 adapter layer is available to translate V2 manifests into V1 runtime objects if needed.
+
+```python
+from coreason_manifest.v2.adapter import v2_to_recipe
+
+# Convert V2 Manifest to V1 Recipe
+recipe = v2_to_recipe(manifest_v2)
+```
+
+## Troubleshooting
+
+**Error:** `AttributeError: module 'coreason_manifest' has no attribute 'RecipeManifest'`
+**Solution:** Change your import to `from coreason_manifest.v1 import RecipeManifest`.
+
+**Error:** `ImportError: cannot import name 'AgentDefinition' from 'coreason_manifest'`
+**Solution:** Change your import to `from coreason_manifest.v1 import AgentDefinition`.

--- a/docs/recipes.md
+++ b/docs/recipes.md
@@ -120,8 +120,12 @@ The schema enforces strict validation to prevent runtime errors. Common edge cas
 
 ## Example Usage
 
+### Legacy V1 Usage
+
+> **Note:** As of v0.12.0, `RecipeManifest` must be imported from `coreason_manifest.v1`.
+
 ```python
-from coreason_manifest import (
+from coreason_manifest.v1 import (
     RecipeManifest, GraphTopology, AgentNode, HumanNode, Edge,
     ConditionalEdge, StateDefinition
 )

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,12 +44,14 @@ The `integrity_hash` field is mandatory. It must be a valid 64-character SHA256 
 
 ## Examples
 
-### Creating an Agent Definition
+### Creating an Agent Definition (Legacy V1)
+
+> **Note:** For V2 (YAML), see `docs/coreason_agent_manifest.md`. For V1 code, import `AgentDefinition` from `coreason_manifest.v1`.
 
 ```python
 import uuid
+from coreason_manifest.v1 import AgentDefinition
 from coreason_manifest.definitions.agent import (
-    AgentDefinition,
     ToolRequirement,
     ToolRiskLevel,
     TraceLevel,

--- a/docs/v2_bridge.md
+++ b/docs/v2_bridge.md
@@ -21,12 +21,12 @@ To run a V2 YAML file, you use the `load_from_yaml` function. This function auto
 
 ```python
 from pathlib import Path
-from coreason_manifest.v2.io import load_from_yaml
+from coreason_manifest import load
 from coreason_manifest.v2.adapter import v2_to_recipe
 
 # 1. Load V2 Manifest (Human Friendly)
 # By default, this resolves imports relative to the file's directory.
-v2_manifest = load_from_yaml("my_workflow.v2.yaml")
+v2_manifest = load("my_workflow.v2.yaml")
 
 # 2. Convert to V1 Recipe (Machine Optimized)
 recipe = v2_to_recipe(v2_manifest)
@@ -104,8 +104,10 @@ To prevent **Path Traversal Attacks**, the loader enforces a "Jail" constraint. 
 You can explicitly set the root directory:
 
 ```python
+from coreason_manifest import load
+
 # Enforce that all imports must be within /safe/base/dir
-manifest = load_from_yaml(
+manifest = load(
     "project/main.yaml",
     root_dir="/safe/base/dir"
 )
@@ -133,8 +135,8 @@ The compiler performs several transformations:
 You can also programmatically create V2 manifests and dump them to YAML. The dumper ensures that `apiVersion`, `kind`, and `metadata` appear at the top of the file.
 
 ```python
-from coreason_manifest.v2.io import dump_to_yaml
+from coreason_manifest import dump
 
-yaml_str = dump_to_yaml(v2_manifest)
+yaml_str = dump(v2_manifest)
 print(yaml_str)
 ```

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -8,114 +8,14 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from .definitions.agent import AdapterHints, AgentDefinition, AgentStatus, Persona
-from .definitions.audit import AuditLog
-from .definitions.contracts import InterfaceDefinition
-from .definitions.evaluation import EvaluationProfile, SuccessCriterion
-from .definitions.events import (
-    ArtifactGenerated,
-    CloudEvent,
-    CouncilVote,
-    EdgeTraversed,
-    GraphEvent,
-    GraphEventArtifactGenerated,
-    GraphEventCouncilVote,
-    GraphEventEdgeActive,
-    GraphEventError,
-    GraphEventNodeDone,
-    GraphEventNodeInit,
-    GraphEventNodeRestored,
-    GraphEventNodeSkipped,
-    GraphEventNodeStart,
-    GraphEventNodeStream,
-    NodeCompleted,
-    NodeInit,
-    NodeRestored,
-    NodeSkipped,
-    NodeStarted,
-    NodeStream,
-    WorkflowError,
-    migrate_graph_event_to_cloud_event,
-)
-from .definitions.patterns import (
-    HierarchicalTeamPattern,
-    PatternDefinition,
-    PatternType,
-    SwarmPattern,
-)
-from .definitions.simulation import (
-    SimulationMetrics,
-    SimulationScenario,
-    SimulationStep,
-    SimulationTrace,
-    StepType,
-)
-from .definitions.simulation_config import AdversaryProfile, ChaosConfig, SimulationRequest
-from .definitions.topology import (
-    AgentNode,
-    Edge,
-    GraphTopology,
-    Node,
-    StateDefinition,
-    Topology,
-)
-from .dsl import load_from_yaml
-from .governance import ComplianceReport, GovernanceConfig, check_compliance
-from .recipes import RecipeManifest
+from coreason_manifest.v2.io import dump_to_yaml, load_from_yaml
+from coreason_manifest.v2.spec.definitions import ManifestV2
 
-__all__ = [
-    "AdapterHints",
-    "AgentDefinition",
-    "AgentStatus",
-    "Persona",
-    "InterfaceDefinition",
-    "EvaluationProfile",
-    "SuccessCriterion",
-    "Topology",
-    "GraphTopology",
-    "Node",
-    "AgentNode",
-    "Edge",
-    "StateDefinition",
-    "GraphEvent",
-    "CloudEvent",
-    "GraphEventNodeInit",
-    "GraphEventNodeStart",
-    "GraphEventNodeDone",
-    "GraphEventNodeStream",
-    "GraphEventNodeSkipped",
-    "GraphEventNodeRestored",
-    "GraphEventEdgeActive",
-    "GraphEventCouncilVote",
-    "GraphEventError",
-    "GraphEventArtifactGenerated",
-    "NodeInit",
-    "NodeStarted",
-    "NodeCompleted",
-    "NodeStream",
-    "NodeSkipped",
-    "NodeRestored",
-    "WorkflowError",
-    "CouncilVote",
-    "ArtifactGenerated",
-    "EdgeTraversed",
-    "migrate_graph_event_to_cloud_event",
-    "SimulationScenario",
-    "SimulationTrace",
-    "SimulationStep",
-    "SimulationMetrics",
-    "StepType",
-    "AdversaryProfile",
-    "ChaosConfig",
-    "SimulationRequest",
-    "AuditLog",
-    "RecipeManifest",
-    "GovernanceConfig",
-    "ComplianceReport",
-    "check_compliance",
-    "load_from_yaml",
-    "PatternType",
-    "SwarmPattern",
-    "HierarchicalTeamPattern",
-    "PatternDefinition",
-]
+__version__ = "0.12.0"
+
+Manifest = ManifestV2
+Recipe = ManifestV2
+load = load_from_yaml
+dump = dump_to_yaml
+
+__all__ = ["Manifest", "Recipe", "load", "dump", "__version__"]

--- a/src/coreason_manifest/v1/__init__.py
+++ b/src/coreason_manifest/v1/__init__.py
@@ -8,9 +8,32 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from coreason_manifest.definitions.agent import AgentDefinition
 from coreason_manifest.definitions.agent import AgentDefinition as Agent
+from coreason_manifest.definitions.topology import (
+    AgentNode,
+    ConditionalEdge,
+    Edge,
+    GraphTopology,
+)
 from coreason_manifest.definitions.topology import GraphTopology as Topology
+from coreason_manifest.definitions.topology import HumanNode, LogicNode, MapNode, RecipeNode, StateDefinition
 from coreason_manifest.recipes import RecipeManifest
 from coreason_manifest.recipes import RecipeManifest as Recipe
 
-__all__ = ["Agent", "Recipe", "RecipeManifest", "Topology"]
+__all__ = [
+    "Agent",
+    "AgentDefinition",
+    "AgentNode",
+    "ConditionalEdge",
+    "Edge",
+    "GraphTopology",
+    "HumanNode",
+    "LogicNode",
+    "MapNode",
+    "Recipe",
+    "RecipeManifest",
+    "RecipeNode",
+    "StateDefinition",
+    "Topology",
+]

--- a/src/coreason_manifest/v1/__init__.py
+++ b/src/coreason_manifest/v1/__init__.py
@@ -15,9 +15,13 @@ from coreason_manifest.definitions.topology import (
     ConditionalEdge,
     Edge,
     GraphTopology,
+    HumanNode,
+    LogicNode,
+    MapNode,
+    RecipeNode,
+    StateDefinition,
 )
 from coreason_manifest.definitions.topology import GraphTopology as Topology
-from coreason_manifest.definitions.topology import HumanNode, LogicNode, MapNode, RecipeNode, StateDefinition
 from coreason_manifest.recipes import RecipeManifest
 from coreason_manifest.recipes import RecipeManifest as Recipe
 

--- a/src/coreason_manifest/v1/__init__.py
+++ b/src/coreason_manifest/v1/__init__.py
@@ -10,6 +10,7 @@
 
 from coreason_manifest.definitions.agent import AgentDefinition as Agent
 from coreason_manifest.definitions.topology import GraphTopology as Topology
+from coreason_manifest.recipes import RecipeManifest
 from coreason_manifest.recipes import RecipeManifest as Recipe
 
-__all__ = ["Agent", "Recipe", "Topology"]
+__all__ = ["Agent", "Recipe", "RecipeManifest", "Topology"]

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -9,8 +9,8 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import coreason_manifest
+from coreason_manifest.v2.io import dump_to_yaml, load_from_yaml
 from coreason_manifest.v2.spec.definitions import ManifestV2
-from coreason_manifest.v2.io import load_from_yaml, dump_to_yaml
 
 
 def test_top_level_exports() -> None:
@@ -36,6 +36,7 @@ def test_top_level_exports() -> None:
     expected = ["Manifest", "Recipe", "load", "dump", "__version__"]
     for item in expected:
         assert item in coreason_manifest.__all__
+
 
 def test_legacy_exports_removed() -> None:
     """Verify that legacy V1 components are NOT exported from root."""

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -9,18 +9,36 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import coreason_manifest
-from coreason_manifest.definitions.agent import AgentDefinition, AgentStatus
+from coreason_manifest.v2.spec.definitions import ManifestV2
+from coreason_manifest.v2.io import load_from_yaml, dump_to_yaml
 
 
 def test_top_level_exports() -> None:
-    """Verify that key components are exported from the top-level package."""
-    # Verify AgentStatus export
-    assert hasattr(coreason_manifest, "AgentStatus")
-    assert coreason_manifest.AgentStatus is AgentStatus
+    """Verify that key components are exported from the top-level package (V2)."""
+    # Verify Manifest export
+    assert hasattr(coreason_manifest, "Manifest")
+    assert coreason_manifest.Manifest is ManifestV2
 
-    # Verify AgentDefinition export
-    assert hasattr(coreason_manifest, "AgentDefinition")
-    assert coreason_manifest.AgentDefinition is AgentDefinition
+    # Verify Recipe export (alias)
+    assert hasattr(coreason_manifest, "Recipe")
+    assert coreason_manifest.Recipe is ManifestV2
 
-    # Check __all__ contains AgentStatus
-    assert "AgentStatus" in coreason_manifest.__all__
+    # Verify load/dump
+    assert hasattr(coreason_manifest, "load")
+    assert coreason_manifest.load is load_from_yaml
+    assert hasattr(coreason_manifest, "dump")
+    assert coreason_manifest.dump is dump_to_yaml
+
+    # Verify version
+    assert hasattr(coreason_manifest, "__version__")
+
+    # Check __all__
+    expected = ["Manifest", "Recipe", "load", "dump", "__version__"]
+    for item in expected:
+        assert item in coreason_manifest.__all__
+
+def test_legacy_exports_removed() -> None:
+    """Verify that legacy V1 components are NOT exported from root."""
+    assert not hasattr(coreason_manifest, "AgentStatus")
+    assert not hasattr(coreason_manifest, "AgentDefinition")
+    assert not hasattr(coreason_manifest, "RecipeManifest")

--- a/tests/test_migration_complex.py
+++ b/tests/test_migration_complex.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2025 CoReason, Inc.
 
 import importlib
+from typing import Any, cast
 
 import coreason_manifest
 
@@ -79,7 +80,8 @@ def test_v1_v2_name_collision_handling() -> None:
     assert RecipeV2Alias is coreason_manifest.v2.spec.definitions.ManifestV2
     assert RecipeV1Alias is coreason_manifest.recipes.RecipeManifest
 
-    assert RecipeV2Alias is not RecipeV1Alias
+    # Suppress overlap error or use cast
+    assert cast(Any, RecipeV2Alias) is not cast(Any, RecipeV1Alias)
 
 
 def test_manifest_load_consistency() -> None:

--- a/tests/test_migration_complex.py
+++ b/tests/test_migration_complex.py
@@ -3,8 +3,9 @@
 import importlib
 from typing import Any, cast
 
-import coreason_manifest
 from pydantic import BaseModel
+
+import coreason_manifest
 
 
 def test_mixed_namespace_usage() -> None:

--- a/tests/test_migration_complex.py
+++ b/tests/test_migration_complex.py
@@ -4,6 +4,7 @@ import importlib
 from typing import Any, cast
 
 import coreason_manifest
+from pydantic import BaseModel
 
 
 def test_mixed_namespace_usage() -> None:
@@ -93,3 +94,27 @@ def test_manifest_load_consistency() -> None:
     from coreason_manifest.v2.io import load_from_yaml
 
     assert coreason_manifest.load is load_from_yaml
+
+
+def test_builder_integration() -> None:
+    """
+    Complex Case: Verify that the Builder SDK still produces valid V1 objects
+    even though the root package has changed.
+    """
+    from coreason_manifest.builder import AgentBuilder, TypedCapability
+    from coreason_manifest.v1 import AgentDefinition
+
+    class Input(BaseModel):
+        q: str
+
+    class Output(BaseModel):
+        a: str
+
+    cap = TypedCapability(name="test", description="test", input_model=Input, output_model=Output)
+
+    builder = AgentBuilder("TestAgent")
+    builder.with_capability(cap)
+    agent = builder.build()
+
+    assert isinstance(agent, AgentDefinition)
+    assert agent.metadata.name == "TestAgent"

--- a/tests/test_migration_complex.py
+++ b/tests/test_migration_complex.py
@@ -1,0 +1,93 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import importlib
+
+import coreason_manifest
+
+
+def test_mixed_namespace_usage() -> None:
+    """
+    Edge Case: Verify that V2 and V1 objects can coexist in the same runtime
+    without type conflicts.
+    """
+    # V2 Import
+    from coreason_manifest import Manifest
+
+    # V1 Import
+    from coreason_manifest.v1 import RecipeManifest
+
+    # Ensure they are distinct types from different modules
+    assert Manifest.__module__.startswith("coreason_manifest.v2")
+    assert RecipeManifest.__module__.startswith("coreason_manifest.recipes")
+
+    # Assert no namespace pollution
+    assert not hasattr(Manifest, "capabilities")  # V1 field
+    assert not hasattr(RecipeManifest, "apiVersion")  # V2 field
+
+
+def test_wildcard_import_safety() -> None:
+    """
+    Edge Case: Verify that 'from coreason_manifest import *' does not leak V1 objects.
+    This is hard to test directly inside a function, so we inspect __all__.
+    """
+    all_exports = coreason_manifest.__all__
+
+    # Allowed V2 exports
+    assert "Manifest" in all_exports
+    assert "load" in all_exports
+
+    # Forbidden V1 exports
+    assert "RecipeManifest" not in all_exports
+    assert "AgentDefinition" not in all_exports
+    assert "Topology" not in all_exports
+
+
+def test_reload_resilience() -> None:
+    """
+    Complex Case: Verify that reloading the module preserves the new V2 defaults.
+    """
+    importlib.reload(coreason_manifest)
+
+    assert coreason_manifest.Manifest.__name__ == "ManifestV2"
+    assert not hasattr(coreason_manifest, "RecipeManifest")
+
+
+def test_submodule_aliasing() -> None:
+    """
+    Edge Case: Ensure that accessing submodules directly still works and doesn't
+    confuse the root namespace.
+    """
+    import coreason_manifest.definitions.agent as agent_def_module
+
+    # The class should be the same as the one exposed in v1
+    from coreason_manifest.v1 import AgentDefinition
+
+    assert agent_def_module.AgentDefinition is AgentDefinition
+
+
+def test_v1_v2_name_collision_handling() -> None:
+    """
+    Complex Case: Both V1 and V2 have a concept of 'Recipe'.
+    Ensure the root 'Recipe' alias points to V2, while V1 'Recipe' is explicit.
+    """
+    # Root alias
+    from coreason_manifest import Recipe as RecipeV2Alias
+
+    # V1 alias
+    from coreason_manifest.v1 import Recipe as RecipeV1Alias
+
+    assert RecipeV2Alias is coreason_manifest.v2.spec.definitions.ManifestV2
+    assert RecipeV1Alias is coreason_manifest.recipes.RecipeManifest
+
+    assert RecipeV2Alias is not RecipeV1Alias
+
+
+def test_manifest_load_consistency() -> None:
+    """
+    Edge Case: Verify that `cm.load` is strictly the V2 loader and rejects
+    V1-style JSON if it doesn't match V2 YAML schema (which it won't).
+    """
+    # This just asserts identity, real loading tests are in test_v2_io.py
+    from coreason_manifest.v2.io import load_from_yaml
+
+    assert coreason_manifest.load is load_from_yaml

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -118,5 +118,5 @@ def test_pattern_extra_forbid() -> None:
             participants=[],
             handoff_mode="x",
             max_turns=1,
-            extra_field="fail",
+            extra_field="fail",  # type: ignore[call-arg]
         )

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from coreason_manifest.definitions.patterns import (
+    HierarchicalTeamPattern,
+    PatternDefinition,
+    PatternType,
+    SwarmPattern,
+)
+
+
+class PatternContainer(BaseModel):
+    pattern: PatternDefinition
+
+
+def test_swarm_pattern_creation() -> None:
+    """Test creating a valid SwarmPattern."""
+    swarm = SwarmPattern(
+        type=PatternType.SWARM,
+        participants=["agent_a", "agent_b"],
+        handoff_mode="shared_scratchpad",
+        max_turns=10,
+        voting_mechanism="consensus",
+    )
+    assert swarm.type == PatternType.SWARM
+    assert swarm.participants == ["agent_a", "agent_b"]
+    assert swarm.handoff_mode == "shared_scratchpad"
+    assert swarm.max_turns == 10
+    assert swarm.voting_mechanism == "consensus"
+
+
+def test_swarm_pattern_defaults() -> None:
+    """Test SwarmPattern defaults (voting_mechanism is optional)."""
+    swarm = SwarmPattern(
+        type=PatternType.SWARM,
+        participants=["agent_a"],
+        handoff_mode="direct",
+        max_turns=5,
+    )
+    assert swarm.voting_mechanism is None
+
+
+def test_hierarchical_team_pattern_creation() -> None:
+    """Test creating a valid HierarchicalTeamPattern."""
+    team = HierarchicalTeamPattern(
+        type=PatternType.HIERARCHICAL_TEAM,
+        manager_id="manager_agent",
+        workers=["worker_1", "worker_2"],
+        escalation_policy="always_escalate",
+        delegation_depth=2,
+    )
+    assert team.type == PatternType.HIERARCHICAL_TEAM
+    assert team.manager_id == "manager_agent"
+    assert len(team.workers) == 2
+    assert team.escalation_policy == "always_escalate"
+    assert team.delegation_depth == 2
+
+
+def test_hierarchical_team_defaults() -> None:
+    """Test HierarchicalTeamPattern optional fields."""
+    team = HierarchicalTeamPattern(
+        type=PatternType.HIERARCHICAL_TEAM,
+        manager_id="manager",
+        workers=[],
+    )
+    assert team.escalation_policy is None
+    assert team.delegation_depth is None
+
+
+def test_polymorphism_swarm() -> None:
+    """Test that PatternDefinition correctly resolves to SwarmPattern."""
+    data = {
+        "pattern": {
+            "type": "swarm",
+            "participants": ["a"],
+            "handoff_mode": "test",
+            "max_turns": 1,
+        }
+    }
+    container = PatternContainer(**data)
+    assert isinstance(container.pattern, SwarmPattern)
+
+
+def test_polymorphism_hierarchical() -> None:
+    """Test that PatternDefinition correctly resolves to HierarchicalTeamPattern."""
+    data = {
+        "pattern": {
+            "type": "hierarchical_team",
+            "manager_id": "mgr",
+            "workers": ["w1"],
+        }
+    }
+    container = PatternContainer(**data)
+    assert isinstance(container.pattern, HierarchicalTeamPattern)
+
+
+def test_invalid_pattern_discriminator() -> None:
+    """Test that an invalid type raises a validation error."""
+    data = {
+        "pattern": {
+            "type": "unknown_pattern",
+            "participants": [],
+        }
+    }
+    with pytest.raises(ValidationError) as exc:
+        PatternContainer(**data)
+    # Pydantic V2 error message for discriminated union
+    assert "Input tag 'unknown_pattern' found using 'type' does not match any of the expected tags" in str(exc.value)
+
+
+def test_pattern_extra_forbid() -> None:
+    """Test that extra fields are forbidden."""
+    with pytest.raises(ValidationError):
+        SwarmPattern(
+            type=PatternType.SWARM,
+            participants=[],
+            handoff_mode="x",
+            max_turns=1,
+            extra_field="fail",
+        )

--- a/tests/test_recipe_v2.py
+++ b/tests/test_recipe_v2.py
@@ -16,8 +16,8 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.definitions.topology import StateDefinition
-from coreason_manifest.v1 import RecipeManifest, Topology
 from coreason_manifest.recipes import RecipeInterface
+from coreason_manifest.v1 import RecipeManifest, Topology
 
 
 def test_full_recipe_v2_creation() -> None:

--- a/tests/test_recipe_v2.py
+++ b/tests/test_recipe_v2.py
@@ -15,8 +15,8 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import RecipeManifest, Topology
 from coreason_manifest.definitions.topology import StateDefinition
+from coreason_manifest.v1 import RecipeManifest, Topology
 from coreason_manifest.recipes import RecipeInterface
 
 

--- a/tests/test_recipe_v2_extras.py
+++ b/tests/test_recipe_v2_extras.py
@@ -13,8 +13,8 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import RecipeManifest, Topology
 from coreason_manifest.definitions.topology import StateDefinition
+from coreason_manifest.v1 import RecipeManifest, Topology
 from coreason_manifest.recipes import RecipeInterface
 
 

--- a/tests/test_recipe_v2_extras.py
+++ b/tests/test_recipe_v2_extras.py
@@ -14,8 +14,8 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.definitions.topology import StateDefinition
-from coreason_manifest.v1 import RecipeManifest, Topology
 from coreason_manifest.recipes import RecipeInterface
+from coreason_manifest.v1 import RecipeManifest, Topology
 
 
 def test_state_schema_aliasing_roundtrip() -> None:

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -11,9 +11,15 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import Edge, RecipeManifest
-from coreason_manifest import Topology as GraphTopology
-from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, StateDefinition
+from coreason_manifest.definitions.topology import (
+    AgentNode,
+    Edge,
+    HumanNode,
+    LogicNode,
+    StateDefinition,
+)
+from coreason_manifest.v1 import RecipeManifest
+from coreason_manifest.v1 import Topology as GraphTopology
 from coreason_manifest.recipes import RecipeInterface
 
 

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -18,9 +18,9 @@ from coreason_manifest.definitions.topology import (
     LogicNode,
     StateDefinition,
 )
+from coreason_manifest.recipes import RecipeInterface
 from coreason_manifest.v1 import RecipeManifest
 from coreason_manifest.v1 import Topology as GraphTopology
-from coreason_manifest.recipes import RecipeInterface
 
 
 def test_recipe_manifest_creation() -> None:

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -11,9 +11,15 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import Edge, RecipeManifest
-from coreason_manifest import Topology as GraphTopology
-from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, StateDefinition
+from coreason_manifest.definitions.topology import (
+    AgentNode,
+    Edge,
+    HumanNode,
+    LogicNode,
+    StateDefinition,
+)
+from coreason_manifest.v1 import RecipeManifest
+from coreason_manifest.v1 import Topology as GraphTopology
 from coreason_manifest.recipes import RecipeInterface
 
 

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -18,9 +18,9 @@ from coreason_manifest.definitions.topology import (
     LogicNode,
     StateDefinition,
 )
+from coreason_manifest.recipes import RecipeInterface
 from coreason_manifest.v1 import RecipeManifest
 from coreason_manifest.v1 import Topology as GraphTopology
-from coreason_manifest.recipes import RecipeInterface
 
 
 def test_invalid_node_discriminator() -> None:

--- a/tests/test_v1_exports.py
+++ b/tests/test_v1_exports.py
@@ -9,13 +9,74 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from coreason_manifest.definitions.agent import AgentDefinition
-from coreason_manifest.definitions.topology import GraphTopology
+from coreason_manifest.definitions.topology import (
+    AgentNode,
+    ConditionalEdge,
+    Edge,
+    GraphTopology,
+    HumanNode,
+    LogicNode,
+    MapNode,
+    RecipeNode,
+    StateDefinition,
+)
 from coreason_manifest.recipes import RecipeManifest
-from coreason_manifest.v1 import Agent, Recipe, Topology
+from coreason_manifest.v1 import (
+    Agent,
+    Recipe,
+    Topology,
+)
+from coreason_manifest.v1 import (
+    AgentDefinition as AgentDef,
+)
+from coreason_manifest.v1 import (
+    AgentNode as AgentNodeV1,
+)
+from coreason_manifest.v1 import (
+    ConditionalEdge as ConditionalEdgeV1,
+)
+from coreason_manifest.v1 import (
+    Edge as EdgeV1,
+)
+from coreason_manifest.v1 import (
+    GraphTopology as GraphTopologyV1,
+)
+from coreason_manifest.v1 import (
+    HumanNode as HumanNodeV1,
+)
+from coreason_manifest.v1 import (
+    LogicNode as LogicNodeV1,
+)
+from coreason_manifest.v1 import (
+    MapNode as MapNodeV1,
+)
+from coreason_manifest.v1 import (
+    RecipeManifest as RecipeManifestV1,
+)
+from coreason_manifest.v1 import (
+    RecipeNode as RecipeNodeV1,
+)
+from coreason_manifest.v1 import (
+    StateDefinition as StateDefinitionV1,
+)
 
 
 def test_v1_imports() -> None:
     """Verify v1 imports point to correct classes."""
+    # Aliases
     assert Agent is AgentDefinition
     assert Recipe is RecipeManifest
     assert Topology is GraphTopology
+
+    # Direct re-exports (Testing coverage for all exports)
+    assert AgentDef is AgentDefinition
+    assert RecipeManifestV1 is RecipeManifest
+    assert GraphTopologyV1 is GraphTopology
+    assert AgentNodeV1 is AgentNode
+    assert HumanNodeV1 is HumanNode
+    assert LogicNodeV1 is LogicNode
+    assert MapNodeV1 is MapNode
+    assert RecipeNodeV1 is RecipeNode
+    assert EdgeV1 is Edge
+    assert ConditionalEdgeV1 is ConditionalEdge
+    assert StateDefinitionV1 is StateDefinition

--- a/tests/test_v2_exports.py
+++ b/tests/test_v2_exports.py
@@ -1,23 +1,27 @@
 # Copyright (c) 2025 CoReason, Inc.
 
 import pytest
-import coreason_manifest as cm
-from coreason_manifest.v2.spec.definitions import ManifestV2
-from coreason_manifest.v2.io import load_from_yaml
 
-def test_v2_defaults():
+import coreason_manifest as cm
+from coreason_manifest.v2.io import load_from_yaml
+from coreason_manifest.v2.spec.definitions import ManifestV2
+
+
+def test_v2_defaults() -> None:
     """Test that the top-level package exports V2 objects by default."""
     assert cm.Manifest is ManifestV2
     assert cm.load is load_from_yaml
 
-def test_v1_removed_from_root():
+
+def test_v1_removed_from_root() -> None:
     """Test that V1 objects are no longer available at the root."""
     with pytest.raises(AttributeError):
-        _ = cm.RecipeManifest
+        _ = cm.RecipeManifest  # type: ignore[attr-defined, unused-ignore]
 
-def test_v1_fallback_access():
+
+def test_v1_fallback_access() -> None:
     """Test that V1 objects can still be imported from the v1 namespace."""
-    from coreason_manifest.v1 import RecipeManifest
     from coreason_manifest.recipes import RecipeManifest as OriginalRecipeManifest
+    from coreason_manifest.v1 import RecipeManifest
 
     assert RecipeManifest is OriginalRecipeManifest

--- a/tests/test_v2_exports.py
+++ b/tests/test_v2_exports.py
@@ -1,0 +1,23 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+import coreason_manifest as cm
+from coreason_manifest.v2.spec.definitions import ManifestV2
+from coreason_manifest.v2.io import load_from_yaml
+
+def test_v2_defaults():
+    """Test that the top-level package exports V2 objects by default."""
+    assert cm.Manifest is ManifestV2
+    assert cm.load is load_from_yaml
+
+def test_v1_removed_from_root():
+    """Test that V1 objects are no longer available at the root."""
+    with pytest.raises(AttributeError):
+        _ = cm.RecipeManifest
+
+def test_v1_fallback_access():
+    """Test that V1 objects can still be imported from the v1 namespace."""
+    from coreason_manifest.v1 import RecipeManifest
+    from coreason_manifest.recipes import RecipeManifest as OriginalRecipeManifest
+
+    assert RecipeManifest is OriginalRecipeManifest


### PR DESCRIPTION
This PR executes the "Breaking Switch" to make Coreason Manifest V2 the default experience.

**Changes:**
1.  **Root Entry Point (`src/coreason_manifest/__init__.py`):**
    *   Removed all V1 exports.
    *   Added exports for V2: `Manifest` (alias for `ManifestV2`), `Recipe` (alias for `ManifestV2`), `load` (`load_from_yaml`), `dump` (`dump_to_yaml`).
    *   Defined `__version__ = "0.12.0"`.

2.  **Legacy Namespace (`src/coreason_manifest/v1/__init__.py`):**
    *   Explicitly exported `RecipeManifest` to support legacy code migration via `from coreason_manifest.v1 import RecipeManifest`.

3.  **Tests:**
    *   Created `tests/test_v2_exports.py` to verify the new default exports and the removal of V1 exports.
    *   Updated `tests/test_exports.py` to match the new API surface.
    *   Refactored existing tests (`tests/test_recipes.py`, `tests/test_recipe_v2.py`, `tests/test_recipe_v2_extras.py`, `tests/test_recipes_edge_cases.py`) to import legacy objects from `coreason_manifest.v1` or their specific definition files.

**Verification:**
*   All 417 tests passed.
*   Confirmed that `import coreason_manifest` provides V2 objects.
*   Confirmed that `coreason_manifest.RecipeManifest` raises `AttributeError`.
*   Confirmed that `from coreason_manifest.v1 import RecipeManifest` works.

---
*PR created automatically by Jules for task [3191785920094646448](https://jules.google.com/task/3191785920094646448) started by @gowthamrao*