### PR TITLE
feat: Add Middleware Extension Interface (Interceptors)

### DIFF
--- a/docs/middleware_extension_interface.md
+++ b/docs/middleware_extension_interface.md
@@ -1,0 +1,76 @@
+# Middleware Extension Interface
+
+The Middleware Extension Interface allows developers to inject custom logic *before* and *after* agent execution. This enables cross-cutting concerns such as PII redaction, toxicity filtering, rate limiting, and observability to be implemented cleanly and reusable across different agents.
+
+## Core Concepts
+
+The middleware system is built on two primary protocols: `IRequestInterceptor` for input processing and `IResponseInterceptor` for output stream modification. Both protocols share a common `InterceptorContext`.
+
+### InterceptorContext
+
+A lightweight, immutable object used to pass shared data and metadata between interceptors in a chain.
+
+```python
+class InterceptorContext(CoReasonBaseModel):
+    """A lightweight immutable object to pass shared data between interceptors."""
+
+    request_id: UUID
+    start_time: datetime
+    metadata: Dict[str, Any]
+```
+
+## Protocols
+
+### IRequestInterceptor
+
+Implement this protocol to intercept, modify, or validate an incoming `AgentRequest` before it reaches the agent.
+
+```python
+@runtime_checkable
+class IRequestInterceptor(Protocol):
+    """Protocol for intercepting and modifying agent requests."""
+
+    async def intercept_request(self, context: SessionContext, request: AgentRequest) -> AgentRequest:
+        """Modify or validate the request before the agent sees it."""
+        ...
+```
+
+**Common Use Cases:**
+- **PII Redaction:** scrubbing sensitive data from the prompt.
+- **Input Validation:** Ensuring the request meets schema requirements.
+- **Security Checks:** Verifying permissions or quotas.
+
+### IResponseInterceptor
+
+Implement this protocol to intercept and modify the outgoing `StreamPacket` stream in real-time.
+
+```python
+@runtime_checkable
+class IResponseInterceptor(Protocol):
+    """Protocol for intercepting and modifying the output stream."""
+
+    async def intercept_stream(self, packet: StreamPacket) -> StreamPacket:
+        """Modify the output stream in real-time."""
+        ...
+```
+
+**Common Use Cases:**
+- **Toxicity Filtering:** checking generated tokens for harmful content.
+- **Format Standardization:** Enforcing specific output structures.
+- **Audit Logging:** creating a shadow copy of the stream for compliance.
+
+## Usage Example
+
+```python
+from coreason_manifest.definitions.middleware import IRequestInterceptor, IResponseInterceptor
+
+class PIIFilter(IRequestInterceptor):
+    async def intercept_request(self, context, request):
+        # ... logic to redact PII ...
+        return redacted_request
+
+class ContentSafetyFilter(IResponseInterceptor):
+    async def intercept_stream(self, packet):
+        # ... logic to check packet content ...
+        return packet
+```

--- a/src/coreason_manifest/definitions/__init__.py
+++ b/src/coreason_manifest/definitions/__init__.py
@@ -36,6 +36,7 @@ from .events import (
 from .identity import Identity
 from .interfaces import AgentInterface, LifecycleInterface
 from .memory import MemoryConfig, MemoryStrategy
+from .middleware import InterceptorContext, IRequestInterceptor, IResponseInterceptor
 from .presentation import (
     CitationBlock,
     CitationItem,
@@ -63,6 +64,9 @@ __all__ = [
     "LifecycleInterface",
     "MemoryConfig",
     "MemoryStrategy",
+    "InterceptorContext",
+    "IRequestInterceptor",
+    "IResponseInterceptor",
     "Persona",
     "DeploymentConfig",
     "ResourceLimits",

--- a/src/coreason_manifest/definitions/middleware.py
+++ b/src/coreason_manifest/definitions/middleware.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from datetime import datetime, timezone
-from typing import Any, Awaitable, Dict, Protocol, runtime_checkable
+from typing import Any, Dict, Protocol, runtime_checkable
 from uuid import UUID
 
 from pydantic import ConfigDict, Field

--- a/src/coreason_manifest/definitions/middleware.py
+++ b/src/coreason_manifest/definitions/middleware.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime, timezone
+from typing import Any, Awaitable, Dict, Protocol, runtime_checkable
+from uuid import UUID
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.common import CoReasonBaseModel
+from coreason_manifest.definitions.presentation import StreamPacket
+from coreason_manifest.definitions.request import AgentRequest
+from coreason_manifest.definitions.session import SessionContext
+
+
+class InterceptorContext(CoReasonBaseModel):
+    """A lightweight immutable object to pass shared data between interceptors."""
+
+    model_config = ConfigDict(frozen=True)
+
+    request_id: UUID = Field(..., description="The unique ID of the request being processed")
+    start_time: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="When the interception chain started",
+    )
+    metadata: Dict[str, Any] = Field(default_factory=dict, description="Shared scratchpad for interceptors")
+
+
+@runtime_checkable
+class IRequestInterceptor(Protocol):
+    """Protocol for intercepting and modifying agent requests."""
+
+    async def intercept_request(self, context: SessionContext, request: AgentRequest) -> AgentRequest:
+        """Modify or validate the request before the agent sees it."""
+        ...
+
+
+@runtime_checkable
+class IResponseInterceptor(Protocol):
+    """Protocol for intercepting and modifying the output stream."""
+
+    async def intercept_stream(self, packet: StreamPacket) -> StreamPacket:
+        """Modify the output stream in real-time."""
+        ...

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -24,8 +24,8 @@ from coreason_manifest.definitions.presentation import StreamOpCode, StreamPacke
 from coreason_manifest.definitions.request import AgentRequest
 from coreason_manifest.definitions.session import SessionContext
 
-
 # --- Mock Implementations ---
+
 
 class PIIFilter:
     async def intercept_request(self, context: SessionContext, request: AgentRequest) -> AgentRequest:
@@ -45,11 +45,7 @@ class FailingInterceptor:
 class ReplacementInterceptor:
     async def intercept_request(self, context: SessionContext, request: AgentRequest) -> AgentRequest:
         # Return a completely new request object
-        return AgentRequest(
-            session_id=request.session_id,
-            payload={"replaced": True},
-            metadata=request.metadata
-        )
+        return AgentRequest(session_id=request.session_id, payload={"replaced": True}, metadata=request.metadata)
 
 
 class StatefulInterceptor:
@@ -62,6 +58,7 @@ class StatefulInterceptor:
 
 
 # --- Basic Protocol Tests ---
+
 
 def test_interceptor_protocols() -> None:
     # Verify PIIFilter implements IRequestInterceptor
@@ -90,6 +87,7 @@ def test_interceptor_context_immutability() -> None:
 
 # --- Edge Case Tests ---
 
+
 @pytest.mark.asyncio
 async def test_interceptor_failure() -> None:
     """Test that an interceptor raising an exception propagates it."""
@@ -99,10 +97,10 @@ async def test_interceptor_failure() -> None:
     context = SessionContext(
         session_id=session_id,
         agent_id=uuid4(),
-        user={"user_id": "u1", "tier": "free", "locale": "en-US"},  # type: ignore
-        trace={"trace_id": uuid4(), "span_id": uuid4()},  # type: ignore
+        user={"user_id": "u1", "tier": "free", "locale": "en-US"},
+        trace={"trace_id": uuid4(), "span_id": uuid4()},
         permissions=[],
-        created_at=asyncio.get_event_loop().time()  # type: ignore
+        created_at=asyncio.get_event_loop().time(),
     )
     request = AgentRequest(session_id=session_id, payload={})
 
@@ -118,10 +116,10 @@ async def test_interceptor_replacement() -> None:
     context = SessionContext(
         session_id=session_id,
         agent_id=uuid4(),
-        user={"user_id": "u1", "tier": "free", "locale": "en-US"},  # type: ignore
-        trace={"trace_id": uuid4(), "span_id": uuid4()},  # type: ignore
+        user={"user_id": "u1", "tier": "free", "locale": "en-US"},
+        trace={"trace_id": uuid4(), "span_id": uuid4()},
         permissions=[],
-        created_at=asyncio.get_event_loop().time()  # type: ignore
+        created_at=asyncio.get_event_loop().time(),
     )
     request = AgentRequest(session_id=session_id, payload={"original": True})
 
@@ -131,6 +129,7 @@ async def test_interceptor_replacement() -> None:
 
 
 # --- Complex Scenario Tests ---
+
 
 @pytest.mark.asyncio
 async def test_chained_interceptors() -> None:
@@ -148,22 +147,22 @@ async def test_chained_interceptors() -> None:
                 session_id=request.session_id,
                 payload=new_payload,
                 metadata=request.metadata,
-                root_request_id=request.root_request_id
+                root_request_id=request.root_request_id,
             )
 
     chain: List[Union[IRequestInterceptor, AppendingInterceptor]] = [
         AppendingInterceptor("step1", "done"),
-        AppendingInterceptor("step2", "done")
+        AppendingInterceptor("step2", "done"),
     ]
 
     session_id = uuid4()
     context = SessionContext(
         session_id=session_id,
         agent_id=uuid4(),
-        user={"user_id": "u1", "tier": "free", "locale": "en-US"},  # type: ignore
-        trace={"trace_id": uuid4(), "span_id": uuid4()},  # type: ignore
+        user={"user_id": "u1", "tier": "free", "locale": "en-US"},
+        trace={"trace_id": uuid4(), "span_id": uuid4()},
         permissions=[],
-        created_at=asyncio.get_event_loop().time()  # type: ignore
+        created_at=asyncio.get_event_loop().time(),
     )
     request = AgentRequest(session_id=session_id, payload={})
 
@@ -181,7 +180,7 @@ async def test_async_concurrency() -> None:
     interceptor = StatefulInterceptor()
 
     packets = [
-        StreamPacket(stream_id=uuid4(), seq=i, op=StreamOpCode.DELTA, t=asyncio.get_event_loop().time(), p="test") # type: ignore
+        StreamPacket(stream_id=uuid4(), seq=i, op=StreamOpCode.DELTA, t=asyncio.get_event_loop().time(), p="test")
         for i in range(100)
     ]
 

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from uuid import uuid4
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.definitions.middleware import (
+    InterceptorContext,
+    IRequestInterceptor,
+    IResponseInterceptor,
+)
+from coreason_manifest.definitions.request import AgentRequest
+from coreason_manifest.definitions.session import SessionContext
+from coreason_manifest.definitions.presentation import StreamPacket
+
+
+class PIIFilter:
+    async def intercept_request(self, context: SessionContext, request: AgentRequest) -> AgentRequest:
+        return request
+
+
+class ToxicityFilter:
+    async def intercept_stream(self, packet: StreamPacket) -> StreamPacket:
+        return packet
+
+
+def test_interceptor_protocols():
+    # Verify PIIFilter implements IRequestInterceptor
+    pii_filter = PIIFilter()
+    assert isinstance(pii_filter, IRequestInterceptor)
+
+    # Verify it doesn't implement IResponseInterceptor
+    assert not isinstance(pii_filter, IResponseInterceptor)
+
+    # Verify ToxicityFilter implements IResponseInterceptor
+    toxicity_filter = ToxicityFilter()
+    assert isinstance(toxicity_filter, IResponseInterceptor)
+
+
+def test_interceptor_context_immutability():
+    ctx = InterceptorContext(request_id=uuid4())
+
+    # Verify default values
+    assert ctx.metadata == {}
+    assert ctx.start_time is not None
+
+    # Verify immutability
+    with pytest.raises(ValidationError):
+        ctx.metadata = {"foo": "bar"}

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -9,7 +9,6 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from uuid import uuid4
-from datetime import datetime, timezone
 
 import pytest
 from pydantic import ValidationError
@@ -19,9 +18,9 @@ from coreason_manifest.definitions.middleware import (
     IRequestInterceptor,
     IResponseInterceptor,
 )
+from coreason_manifest.definitions.presentation import StreamPacket
 from coreason_manifest.definitions.request import AgentRequest
 from coreason_manifest.definitions.session import SessionContext
-from coreason_manifest.definitions.presentation import StreamPacket
 
 
 class PIIFilter:
@@ -34,7 +33,7 @@ class ToxicityFilter:
         return packet
 
 
-def test_interceptor_protocols():
+def test_interceptor_protocols() -> None:
     # Verify PIIFilter implements IRequestInterceptor
     pii_filter = PIIFilter()
     assert isinstance(pii_filter, IRequestInterceptor)
@@ -47,7 +46,7 @@ def test_interceptor_protocols():
     assert isinstance(toxicity_filter, IResponseInterceptor)
 
 
-def test_interceptor_context_immutability():
+def test_interceptor_context_immutability() -> None:
     ctx = InterceptorContext(request_id=uuid4())
 
     # Verify default values
@@ -56,4 +55,4 @@ def test_interceptor_context_immutability():
 
     # Verify immutability
     with pytest.raises(ValidationError):
-        ctx.metadata = {"foo": "bar"}
+        ctx.metadata = {"foo": "bar"}  # type: ignore[misc]


### PR DESCRIPTION
Added `src/coreason_manifest/definitions/middleware.py` defining `InterceptorContext`, `IRequestInterceptor`, and `IResponseInterceptor` to support middleware injection. Updated `definitions/__init__.py` to export them. Added tests in `tests/test_middleware.py`.

---
*PR created automatically by Jules for task [1126509181378686820](https://jules.google.com/task/1126509181378686820) started by @gowthamrao*