### PR TITLE
Switch Coreason Manifest to V2 by default

### DIFF
--- a/docs/coreason_agent_manifest.md
+++ b/docs/coreason_agent_manifest.md
@@ -1,10 +1,10 @@
 # Coreason Agent Manifest (CAM) V2
 
-The **Coreason Agent Manifest (CAM)**, also known as **Manifest V2**, is the "Human-Centric" Canonical YAML format designed for defining Agents and Recipes in the Coreason ecosystem. It serves as the primary interface for developers and the Visual Builder.
+The **Coreason Agent Manifest (CAM)**, also known as **Manifest V2**, is the "Human-Centric" Canonical YAML format designed for defining Agents and Recipes in the Coreason ecosystem. It serves as the **default and primary interface** for developers and the Visual Builder.
 
 > **Note:** The CAM is designed for ease of authoring. At runtime, the Coreason Engine compiles this YAML into strict, machine-optimized Pydantic models. For details on the runtime format, see the [Runtime Agent Definition (V1)](runtime_agent_definition.md) and [Runtime Recipe Definition (V1)](runtime_recipe_definition.md).
 
-## Root Object (`ManifestV2`)
+## Root Object (`Manifest`)
 
 The root of the document follows a "Kubernetes-style" header structure.
 

--- a/docs/migration_guide_v2.md
+++ b/docs/migration_guide_v2.md
@@ -1,0 +1,93 @@
+# Migration Guide: V2 Breaking Switch
+
+This guide outlines the changes introduced in Coreason Manifest **v0.12.0**, which makes the **V2 Agent Manifest (CAM)** the default experience.
+
+## Executive Summary
+
+*   **V2 is Default:** `coreason_manifest` now exports V2 components (`Manifest`, `Recipe`, `load`, `dump`) by default.
+*   **V1 is Deprecated:** Legacy V1 components (`RecipeManifest`, `AgentDefinition`) have been moved to the `coreason_manifest.v1` namespace.
+*   **Action Required:** Existing code that imports directly from the root package will break and must be updated.
+
+## 1. Import Changes
+
+### Breaking Change
+The following imports will now raise an `AttributeError` or import the wrong class (V2 instead of V1):
+
+**❌ Old Code (V1):**
+```python
+from coreason_manifest import RecipeManifest, AgentDefinition
+from coreason_manifest import Topology
+```
+
+### Required Update (Option A: Explicit V1)
+To continue using V1 components without changing logic, update your imports to point to the `v1` namespace.
+
+**✅ New Code (V1 Legacy):**
+```python
+from coreason_manifest.v1 import RecipeManifest, AgentDefinition
+from coreason_manifest.v1 import Topology
+```
+
+### Required Update (Option B: Switch to V2)
+To adopt the new standard, use the root imports for V2.
+
+**✅ New Code (V2 Standard):**
+```python
+from coreason_manifest import Manifest, load
+```
+
+## 2. Loading Files
+
+### V1 Loader (Deprecated)
+The `load_from_json` function has been removed from the root.
+
+**❌ Old Code:**
+```python
+from coreason_manifest import load_from_json
+manifest = load_from_json("recipe.json")
+```
+
+**✅ New Code (V1 Legacy):**
+```python
+# You must construct from Pydantic directly or implement your own JSON loader
+# as load_from_json was a simple helper.
+import json
+from coreason_manifest.v1 import RecipeManifest
+
+with open("recipe.json") as f:
+    data = json.load(f)
+    manifest = RecipeManifest.model_validate(data)
+```
+
+### V2 Loader (Recommended)
+Use the unified `load` function for V2 YAML manifests.
+
+**✅ New Code (V2):**
+```python
+from coreason_manifest import load
+manifest = load("agent.yaml")
+```
+
+## 3. Namespace Reference
+
+| Component | V1 Location (Legacy) | V2 Location (Default) |
+| :--- | :--- | :--- |
+| **Manifest** | `coreason_manifest.v1.RecipeManifest` | `coreason_manifest.Manifest` |
+| **Agent** | `coreason_manifest.v1.AgentDefinition` | `coreason_manifest.Manifest` (kind='Agent') |
+| **Topology** | `coreason_manifest.v1.GraphTopology` | `coreason_manifest.v2.spec.definitions.Workflow` |
+| **Node Types** | `coreason_manifest.v1.AgentNode` | `coreason_manifest.v2.spec.definitions.AgentStep` |
+
+## 4. Bridge Usage
+
+If you need to run a V2 manifest on a V1 engine (like MACO), use the bridge adapter:
+
+```python
+from coreason_manifest import load
+from coreason_manifest.v2.adapter import v2_to_recipe
+
+# 1. Load V2
+v2_obj = load("my_agent.yaml")
+
+# 2. Convert to V1
+v1_recipe = v2_to_recipe(v2_obj)
+```

--- a/docs/runtime_agent_definition.md
+++ b/docs/runtime_agent_definition.md
@@ -2,7 +2,9 @@
 
 The **Runtime Agent Definition** (often referred to as the V1 Manifest) is the strict, machine-optimized Pydantic model used by the Coreason Engine to execute agents. Unlike the [Coreason Agent Manifest (CAM V2)](coreason_agent_manifest.md), which is designed for human authoring, this format is designed for runtime validation, integrity, and performance.
 
-The root of the runtime specification is the `AgentDefinition` class (located in `src/coreason_manifest/definitions/agent.py`). The **V2 Loader Bridge** automatically converts the V2 YAML format into this runtime object.
+> **Note:** V1 components have been moved to the `coreason_manifest.v1` namespace. This document describes the internal runtime format which is typically generated from V2 manifests via the V2 Bridge.
+
+The root of the runtime specification is the `AgentDefinition` class. The **V2 Loader Bridge** automatically converts the V2 YAML format into this runtime object.
 
 ## Core Components
 
@@ -150,8 +152,9 @@ Here is how to programmatically define an Agent using the Runtime SDK:
 ```python
 import uuid
 from datetime import datetime, timezone
+# Import from V1 namespace
+from coreason_manifest.v1 import AgentDefinition
 from coreason_manifest.definitions.agent import (
-    AgentDefinition,
     AgentMetadata,
     AgentCapability,
     CapabilityType,

--- a/docs/runtime_recipe_definition.md
+++ b/docs/runtime_recipe_definition.md
@@ -2,6 +2,8 @@
 
 The **Runtime Recipe Definition** (often referred to as the V1 Recipe Manifest) is the strict, machine-optimized Pydantic model used by the Coreason Engine (MACO) to execute workflows. Unlike the [Coreason Agent Manifest (CAM V2)](coreason_agent_manifest.md), which is designed for human authoring, this format is designed for runtime validation, integrity, and performance.
 
+> **Note:** V1 components have been moved to the `coreason_manifest.v1` namespace. This document describes the internal runtime format which is typically generated from V2 manifests via the V2 Bridge.
+
 The root of the specification is the `RecipeManifest` class. It serves as the shared contract between the **Engine** (runtime) and the **Builder** (visual editor).
 
 ## Root Object (`RecipeManifest`)
@@ -171,7 +173,8 @@ The schema enforces strict validation to prevent runtime errors. Common edge cas
 Here is how to programmatically define a Recipe using the Runtime SDK:
 
 ```python
-from coreason_manifest import (
+# Import V1 components from the v1 namespace
+from coreason_manifest.v1 import (
     RecipeManifest, GraphTopology, AgentNode, HumanNode, Edge,
     ConditionalEdge, StateDefinition
 )

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -6,154 +6,102 @@ It is designed to be a pure data library, meaning it contains **no execution log
 
 ## Core Concepts
 
-### 1. Agent Definition
-The `AgentDefinition` is the source of truth for an AI Agent. It includes:
+### 1. Agent & Recipe Definition
+The `Manifest` (V2) is the source of truth for an AI Agent or Recipe. It includes:
 - **Metadata**: Identity, versioning (Strict SemVer), and authorship.
-- **Capabilities**: Strictly typed modes of interaction (`inputs`, `outputs` as JSON Schema).
-- **Topology**: A graph-based execution flow (`GraphTopology`) supporting cyclic loops (e.g., for reflection).
-- **Dependencies**: MCP Tooling requirements (`ToolRequirement`) and Python libraries.
-- **Policy**: Governance rules for budget and human-in-the-loop triggers (`PolicyConfig`).
-- **Observability**: Telemetry configurations (`ObservabilityConfig`).
+- **Interface**: Strictly typed modes of interaction (`inputs`, `outputs` as JSON Schema).
+- **Topology**: A graph-based execution flow (`Workflow`) supporting cyclic loops (e.g., for reflection).
+- **Definitions**: Reusable components like Tools (`ToolDefinition`) and sub-agents.
+- **Policy**: Governance rules for budget and human-in-the-loop triggers (`PolicyDefinition`).
+- **State**: Shared memory schema (`StateDefinition`).
 
-### 2. Strict Constraints
-To ensure reliability and auditability, the library enforces three strict constraints:
+### 2. Constraints
+To ensure reliability and auditability, the library enforces:
 
-#### A. Immutability
-All dictionary and list fields in the capabilities are converted to immutable types (`MappingProxyType`, `tuple`) upon validation. You cannot modify them in place.
-
-**Incorrect:**
-```python
-agent.capabilities[0].inputs["new_param"] = "value"  # Raises TypeError
-```
-
-**Correct:**
-```python
-# Construct the full dictionary first
-inputs = {
-    "query": {"type": "string"},
-    "max_results": {"type": "integer"}
-}
-# Pass it to the constructor
-```
-
-#### B. Strict SemVer
+#### Strict SemVer
 Versions must strictly follow the `X.Y.Z` format (e.g., `1.0.0`). While `v1.0.0` is normalized to `1.0.0`, loose formats like `1.0` or `beta` are rejected.
-
-#### C. Integrity Hash
-The `integrity_hash` field is mandatory. It must be a valid 64-character SHA256 hex string representing the hash of the agent's source code.
 
 ## Examples
 
-### Creating an Agent Definition
+### Loading a Manifest (V2)
+
+The recommended way to work with manifests is using the YAML loader, which handles recursive imports and validation.
 
 ```python
-import uuid
-from coreason_manifest.definitions.agent import (
-    AgentDefinition,
-    ToolRequirement,
-    ToolRiskLevel,
-    TraceLevel,
-    MemoryConfig,
-    MemoryStrategy
+from coreason_manifest import load
+
+# Load from file (resolves imports automatically)
+manifest = load("my_agent.yaml")
+
+print(f"Loaded {manifest.kind}: {manifest.metadata.name}")
+print(f"Inputs: {manifest.interface.inputs.keys()}")
+```
+
+### Creating a Manifest Programmatically
+
+You can also construct the V2 object directly using Python classes.
+
+```python
+from coreason_manifest import Manifest, Recipe
+from coreason_manifest.v2.spec.definitions import (
+    ManifestMetadata,
+    InterfaceDefinition,
+    StateDefinition,
+    PolicyDefinition,
+    Workflow,
+    AgentStep
 )
 
 # 1. Define Metadata
-metadata = {
-    "id": uuid.uuid4(),
-    "version": "1.0.0",  # Strict SemVer
-    "name": "Research Agent",
-    "author": "Coreason AI",
-    "created_at": "2023-10-27T10:00:00Z"
-}
-
-# 2. Define Topology (Graph)
-# Using logic nodes for demonstration
-nodes = [
-    {"id": "start", "type": "logic", "code": "print('Starting')"},
-    {"id": "process", "type": "logic", "code": "process_data()"},
-    {"id": "end", "type": "logic", "code": "return result"}
-]
-
-edges = [
-    {"source_node_id": "start", "target_node_id": "process"},
-    {"source_node_id": "process", "target_node_id": "end"}
-]
-
-# 3. Instantiate Agent
-agent = AgentDefinition(
-    metadata=metadata,
-    capabilities=[
-        {
-            "name": "default",
-            "type": "atomic",
-            "description": "Default mode",
-            "inputs": {"topic": {"type": "string"}},
-            "outputs": {"summary": {"type": "string"}}
-        }
-    ],
-    config={
-        "nodes": nodes,
-        "edges": edges,
-        "entry_point": "start",
-        "model_config": {"model": "gpt-4", "temperature": 0.0},
-        "memory": MemoryConfig(
-            strategy=MemoryStrategy.SLIDING_WINDOW,
-            limit=20
-        )
-    },
-    dependencies={
-        "tools": [
-            ToolRequirement(
-                uri="mcp://search-service/google",
-                hash="a" * 64,  # Valid SHA256
-                scopes=["search:read"],
-                risk_level=ToolRiskLevel.STANDARD
-            )
-        ],
-        "libraries": ["pandas==2.0.0"]
-    },
-    policy={
-        "budget_caps": {"total_cost": 5.0},
-        "human_in_the_loop": ["process"]
-    },
-    observability={
-        "trace_level": TraceLevel.FULL,
-        "retention_policy": "90_days"
-    },
-    # Mandatory Integrity Hash
-    integrity_hash="e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+metadata = ManifestMetadata(
+    name="Research Agent",
+    version="1.0.0"
 )
 
-print(f"Agent '{agent.metadata.name}' created successfully.")
+# 2. Define Workflow
+workflow = Workflow(
+    start="step1",
+    steps={
+        "step1": AgentStep(
+            id="step1",
+            agent="gpt-4-researcher",
+            next="step2"
+        ),
+        # ... define other steps
+    }
+)
+
+# 3. Instantiate Manifest
+manifest = Recipe(
+    metadata=metadata,
+    interface=InterfaceDefinition(
+        inputs={"topic": {"type": "string"}},
+        outputs={"summary": {"type": "string"}}
+    ),
+    state=StateDefinition(),
+    policy=PolicyDefinition(max_retries=3),
+    workflow=workflow
+)
+
+print(f"Manifest '{manifest.metadata.name}' created successfully.")
 ```
 
-### Visualizing the Topology
-You can export the agent's execution flow as a Mermaid.js graph string for documentation or debugging.
+### Modifying Fields
+
+V2 Manifests are mutable to facilitate authoring and builder tools.
 
 ```python
-mermaid_str = agent.to_mermaid()
-print(mermaid_str)
-# Output:
-# graph TD
-# ...
-# start["start"]:::logic
-# ...
-```
+# Reading
+print(manifest.interface.inputs["topic"])
 
-### Accessing Immutable Fields
-
-```python
-# Reading is allowed
-print(agent.capabilities[0].inputs["topic"])
-
-# Writing raises TypeError
-try:
-    agent.capabilities[0].inputs["topic"] = "int"
-except TypeError as e:
-    print("Caught expected error:", e)
+# Writing
+manifest.interface.inputs["topic"] = {"type": "integer"}
 ```
 
 ## Advanced Documentation
 
-*   [Simulation Architecture](simulation_architecture.md): Details on ATIF compatibility and GAIA scenarios.
-*   [Audit & Compliance](audit_compliance.md): Details on EU AI Act compliance, Chain of Custody, and Integrity Hashing.
+*   [Coreason Agent Manifest (V2)](coreason_agent_manifest.md): The Canonical YAML Authoring Format.
+*   [V2 Loader Bridge](v2_bridge.md): How V2 manifests are compiled to V1 runtime objects.
+*   [Runtime Agent Definition (V1)](runtime_agent_definition.md): The internal runtime model (legacy/compiled).
+*   [Runtime Recipe Definition (V1)](runtime_recipe_definition.md): The internal runtime model (legacy/compiled).
+*   [Migration Guide](migration_guide_v2.md): How to migrate from V1 to V2.

--- a/docs/v2_bridge.md
+++ b/docs/v2_bridge.md
@@ -10,28 +10,28 @@ The bridge consists of three main modules located in `src/coreason_manifest/v2/`
 
 1.  **Compiler** (`compiler.py`): Transforms the implicit "Linked List" topology of V2 into the explicit "Graph" topology of V1.
 2.  **I/O** (`io.py`): Handles loading and dumping of V2 YAML files. It supports **recursive multi-file composition** (via `$ref`) and enforces secure path resolution.
-3.  **Adapter** (`adapter.py`): Converts a loaded V2 `ManifestV2` object into a V1 `RecipeManifest` ready for execution, mapping Interface, State, Policy, and **Component Definitions**.
+3.  **Adapter** (`adapter.py`): Converts a loaded V2 `Manifest` object into a V1 `RecipeManifest` ready for execution, mapping Interface, State, Policy, and **Component Definitions**.
 4.  **Resolver** (`resolver.py`): A helper module used by the loader to securely resolve file paths against a root "Jail" directory.
 
 ## Usage
 
 ### Loading and Executing a V2 Manifest
 
-To run a V2 YAML file, you use the `load_from_yaml` function. This function automatically handles recursive imports and security checks.
+To run a V2 YAML file, you use the `coreason_manifest.load` function. This function automatically handles recursive imports and security checks.
 
 ```python
 from pathlib import Path
-from coreason_manifest.v2.io import load_from_yaml
+from coreason_manifest import load
 from coreason_manifest.v2.adapter import v2_to_recipe
 
 # 1. Load V2 Manifest (Human Friendly)
 # By default, this resolves imports relative to the file's directory.
-v2_manifest = load_from_yaml("my_workflow.v2.yaml")
+v2_manifest = load("my_workflow.v2.yaml")
 
 # 2. Convert to V1 Recipe (Machine Optimized)
 recipe = v2_to_recipe(v2_manifest)
 
-# 3. The 'recipe' object is now a standard RecipeManifest
+# 3. The 'recipe' object is now a standard RecipeManifest (V1)
 # compatible with the coreason-maco engine.
 print(f"Loaded Recipe: {recipe.name} (ID: {recipe.id})")
 print(f"Policy: {recipe.policy.max_retries} retries")
@@ -89,7 +89,7 @@ workflow:
       # ...
 ```
 
-When `load_from_yaml("main.yaml")` is called, the loader recursively resolves `./tools.yaml` and injects its content into `definitions.my_tool`.
+When `load("main.yaml")` is called, the loader recursively resolves `./tools.yaml` and injects its content into `definitions.my_tool`.
 
 ## Security & Safety
 
@@ -105,7 +105,7 @@ You can explicitly set the root directory:
 
 ```python
 # Enforce that all imports must be within /safe/base/dir
-manifest = load_from_yaml(
+manifest = load(
     "project/main.yaml",
     root_dir="/safe/base/dir"
 )
@@ -133,8 +133,8 @@ The compiler performs several transformations:
 You can also programmatically create V2 manifests and dump them to YAML. The dumper ensures that `apiVersion`, `kind`, and `metadata` appear at the top of the file.
 
 ```python
-from coreason_manifest.v2.io import dump_to_yaml
+from coreason_manifest import dump
 
-yaml_str = dump_to_yaml(v2_manifest)
+yaml_str = dump(v2_manifest)
 print(yaml_str)
 ```

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -8,114 +8,14 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from .definitions.agent import AdapterHints, AgentDefinition, AgentStatus, Persona
-from .definitions.audit import AuditLog
-from .definitions.contracts import InterfaceDefinition
-from .definitions.evaluation import EvaluationProfile, SuccessCriterion
-from .definitions.events import (
-    ArtifactGenerated,
-    CloudEvent,
-    CouncilVote,
-    EdgeTraversed,
-    GraphEvent,
-    GraphEventArtifactGenerated,
-    GraphEventCouncilVote,
-    GraphEventEdgeActive,
-    GraphEventError,
-    GraphEventNodeDone,
-    GraphEventNodeInit,
-    GraphEventNodeRestored,
-    GraphEventNodeSkipped,
-    GraphEventNodeStart,
-    GraphEventNodeStream,
-    NodeCompleted,
-    NodeInit,
-    NodeRestored,
-    NodeSkipped,
-    NodeStarted,
-    NodeStream,
-    WorkflowError,
-    migrate_graph_event_to_cloud_event,
-)
-from .definitions.patterns import (
-    HierarchicalTeamPattern,
-    PatternDefinition,
-    PatternType,
-    SwarmPattern,
-)
-from .definitions.simulation import (
-    SimulationMetrics,
-    SimulationScenario,
-    SimulationStep,
-    SimulationTrace,
-    StepType,
-)
-from .definitions.simulation_config import AdversaryProfile, ChaosConfig, SimulationRequest
-from .definitions.topology import (
-    AgentNode,
-    Edge,
-    GraphTopology,
-    Node,
-    StateDefinition,
-    Topology,
-)
-from .dsl import load_from_yaml
-from .governance import ComplianceReport, GovernanceConfig, check_compliance
-from .recipes import RecipeManifest
+from .v2.io import dump_to_yaml, load_from_yaml
+from .v2.spec.definitions import ManifestV2
 
-__all__ = [
-    "AdapterHints",
-    "AgentDefinition",
-    "AgentStatus",
-    "Persona",
-    "InterfaceDefinition",
-    "EvaluationProfile",
-    "SuccessCriterion",
-    "Topology",
-    "GraphTopology",
-    "Node",
-    "AgentNode",
-    "Edge",
-    "StateDefinition",
-    "GraphEvent",
-    "CloudEvent",
-    "GraphEventNodeInit",
-    "GraphEventNodeStart",
-    "GraphEventNodeDone",
-    "GraphEventNodeStream",
-    "GraphEventNodeSkipped",
-    "GraphEventNodeRestored",
-    "GraphEventEdgeActive",
-    "GraphEventCouncilVote",
-    "GraphEventError",
-    "GraphEventArtifactGenerated",
-    "NodeInit",
-    "NodeStarted",
-    "NodeCompleted",
-    "NodeStream",
-    "NodeSkipped",
-    "NodeRestored",
-    "WorkflowError",
-    "CouncilVote",
-    "ArtifactGenerated",
-    "EdgeTraversed",
-    "migrate_graph_event_to_cloud_event",
-    "SimulationScenario",
-    "SimulationTrace",
-    "SimulationStep",
-    "SimulationMetrics",
-    "StepType",
-    "AdversaryProfile",
-    "ChaosConfig",
-    "SimulationRequest",
-    "AuditLog",
-    "RecipeManifest",
-    "GovernanceConfig",
-    "ComplianceReport",
-    "check_compliance",
-    "load_from_yaml",
-    "PatternType",
-    "SwarmPattern",
-    "HierarchicalTeamPattern",
-    "PatternDefinition",
-]
+__version__ = "0.12.0"
+
+Manifest = ManifestV2
+Recipe = ManifestV2
+load = load_from_yaml
+dump = dump_to_yaml
+
+__all__ = ["Manifest", "Recipe", "load", "dump", "__version__"]

--- a/src/coreason_manifest/v1/__init__.py
+++ b/src/coreason_manifest/v1/__init__.py
@@ -8,8 +8,38 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from coreason_manifest.definitions.agent import AgentDefinition
 from coreason_manifest.definitions.agent import AgentDefinition as Agent
-from coreason_manifest.definitions.topology import GraphTopology as Topology
+from coreason_manifest.definitions.topology import (
+    AgentNode,
+    ConditionalEdge,
+    Edge,
+    GraphTopology,
+    HumanNode,
+    LogicNode,
+    MapNode,
+    RecipeNode,
+    StateDefinition,
+)
+from coreason_manifest.definitions.topology import (
+    GraphTopology as Topology,
+)
+from coreason_manifest.recipes import RecipeManifest
 from coreason_manifest.recipes import RecipeManifest as Recipe
 
-__all__ = ["Agent", "Recipe", "Topology"]
+__all__ = [
+    "Agent",
+    "AgentDefinition",
+    "AgentNode",
+    "ConditionalEdge",
+    "Edge",
+    "GraphTopology",
+    "HumanNode",
+    "LogicNode",
+    "MapNode",
+    "Recipe",
+    "RecipeManifest",
+    "RecipeNode",
+    "StateDefinition",
+    "Topology",
+]

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -2,12 +2,14 @@ from pathlib import Path
 
 from coreason_manifest import Manifest, load
 from coreason_manifest.v2.adapter import v2_to_recipe
-from coreason_manifest.v2.spec.definitions import (
-    AgentStep,
+from coreason_manifest.v2.spec.contracts import (
     InterfaceDefinition,
-    ManifestMetadata,
     PolicyDefinition,
     StateDefinition,
+)
+from coreason_manifest.v2.spec.definitions import (
+    AgentStep,
+    ManifestMetadata,
     Workflow,
 )
 

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+
+from coreason_manifest import Manifest, load
+from coreason_manifest.v2.adapter import v2_to_recipe
+from coreason_manifest.v2.spec.definitions import (
+    AgentStep,
+    InterfaceDefinition,
+    ManifestMetadata,
+    PolicyDefinition,
+    StateDefinition,
+    Workflow,
+)
+
+
+def test_usage_guide_programmatic_creation() -> None:
+    """Replicates the 'Creating a Manifest Programmatically' example from usage.md."""
+    # 1. Define Metadata
+    metadata = ManifestMetadata(name="Research Agent", version="1.0.0")
+
+    # 2. Define Workflow
+    workflow = Workflow(
+        start="step1",
+        steps={
+            "step1": AgentStep(id="step1", agent="gpt-4-researcher", next="step2"),
+            # Mock step2 to satisfy integrity
+            "step2": AgentStep(id="step2", agent="summarizer"),
+        },
+    )
+
+    # 3. Instantiate Manifest
+    # Note: 'Recipe' is an alias for ManifestV2 in root
+    manifest = Manifest(
+        kind="Recipe",
+        metadata=metadata,
+        interface=InterfaceDefinition(inputs={"topic": {"type": "string"}}, outputs={"summary": {"type": "string"}}),
+        state=StateDefinition(),
+        policy=PolicyDefinition(max_retries=3),
+        workflow=workflow,
+    )
+
+    assert manifest.metadata.name == "Research Agent"
+    assert manifest.workflow.start == "step1"
+
+
+def test_usage_guide_mutable_fields() -> None:
+    """Replicates 'Accessing Fields' example from usage.md."""
+    manifest = Manifest(
+        kind="Recipe",
+        metadata=ManifestMetadata(name="Test", version="1.0.0"),
+        interface=InterfaceDefinition(inputs={"topic": {"type": "string"}}, outputs={}),
+        state=StateDefinition(),
+        workflow=Workflow(start="s1", steps={"s1": AgentStep(id="s1", agent="a")}),
+    )
+
+    # Reading is allowed
+    assert manifest.interface.inputs["topic"]["type"] == "string"
+
+    # Writing is allowed (V2 Manifests are mutable for ease of authoring)
+    manifest.interface.inputs["topic"] = {"type": "integer"}
+    assert manifest.interface.inputs["topic"]["type"] == "integer"
+
+
+def test_v2_bridge_example(tmp_path: Path) -> None:
+    """Replicates 'Loading and Executing a V2 Manifest' from v2_bridge.md."""
+
+    yaml_content = """
+apiVersion: coreason.ai/v2
+kind: Recipe
+metadata:
+  name: My Workflow
+  version: 1.0.0
+interface:
+  inputs: {}
+  outputs: {}
+state:
+  schema: {}
+definitions:
+  gpt-4:
+    type: agent
+    id: gpt-4
+    name: GPT-4
+    role: Assistant
+    goal: Help user
+    model: gpt-4
+workflow:
+  start: step1
+  steps:
+    step1:
+      type: agent
+      id: step1
+      agent: gpt-4
+"""
+    file_path = tmp_path / "my_workflow.v2.yaml"
+    file_path.write_text(yaml_content, encoding="utf-8")
+
+    # 1. Load V2 Manifest (Human Friendly)
+    v2_manifest = load(file_path)
+
+    # 2. Convert to V1 Recipe (Machine Optimized)
+    recipe = v2_to_recipe(v2_manifest)
+
+    # 3. Verify V1 Recipe
+    assert recipe.name == "My Workflow"
+    assert recipe.topology.nodes[0].id == "step1"
+
+
+def test_migration_guide_v1_legacy_import() -> None:
+    """Verifies that V1 legacy imports work as described in migration guide."""
+    from coreason_manifest.v1 import AgentDefinition, RecipeManifest, Topology
+
+    # Just verify they are the correct classes (implicitly checked by import success)
+    assert RecipeManifest.__name__ == "RecipeManifest"
+    assert AgentDefinition.__name__ == "AgentDefinition"
+    assert Topology.__name__ == "GraphTopology"
+
+
+def test_migration_guide_v2_standard_import() -> None:
+    """Verifies V2 standard imports."""
+    from coreason_manifest import Manifest, load
+
+    assert Manifest.__name__ == "ManifestV2"
+    assert callable(load)

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -8,19 +8,15 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-import coreason_manifest
-from coreason_manifest.definitions.agent import AgentDefinition, AgentStatus
+import coreason_manifest.v1 as v1_manifest
+from coreason_manifest.definitions.agent import AgentDefinition
 
 
-def test_top_level_exports() -> None:
-    """Verify that key components are exported from the top-level package."""
-    # Verify AgentStatus export
-    assert hasattr(coreason_manifest, "AgentStatus")
-    assert coreason_manifest.AgentStatus is AgentStatus
-
+def test_v1_exports() -> None:
+    """Verify that key components are exported from the v1 package."""
     # Verify AgentDefinition export
-    assert hasattr(coreason_manifest, "AgentDefinition")
-    assert coreason_manifest.AgentDefinition is AgentDefinition
+    assert hasattr(v1_manifest, "AgentDefinition")
+    assert v1_manifest.AgentDefinition is AgentDefinition
 
-    # Check __all__ contains AgentStatus
-    assert "AgentStatus" in coreason_manifest.__all__
+    # Check __all__ contains AgentDefinition
+    assert "AgentDefinition" in v1_manifest.__all__

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -1,0 +1,118 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from coreason_manifest.definitions.patterns import (
+    HierarchicalTeamPattern,
+    PatternDefinition,
+    PatternType,
+    SwarmPattern,
+)
+
+
+def test_pattern_type_enum() -> None:
+    """Test PatternType enum values."""
+    assert PatternType.SWARM == "swarm"
+    assert PatternType.HIERARCHICAL_TEAM == "hierarchical_team"
+    assert PatternType.ROUTER_SOLVER == "router_solver"
+
+
+def test_swarm_pattern_creation() -> None:
+    """Test creating a valid SwarmPattern."""
+    pattern = SwarmPattern(
+        type=PatternType.SWARM,
+        participants=["agent1", "agent2"],
+        handoff_mode="shared_scratchpad",
+        max_turns=10,
+        voting_mechanism="consensus",
+    )
+    assert pattern.type == PatternType.SWARM
+    assert pattern.participants == ["agent1", "agent2"]
+    assert pattern.max_turns == 10
+    assert pattern.voting_mechanism == "consensus"
+
+
+def test_hierarchical_team_pattern_creation() -> None:
+    """Test creating a valid HierarchicalTeamPattern."""
+    pattern = HierarchicalTeamPattern(
+        type=PatternType.HIERARCHICAL_TEAM,
+        manager_id="manager1",
+        workers=["worker1", "worker2"],
+        escalation_policy="always",
+        delegation_depth=2,
+    )
+    assert pattern.type == PatternType.HIERARCHICAL_TEAM
+    assert pattern.manager_id == "manager1"
+    assert len(pattern.workers) == 2
+    assert pattern.delegation_depth == 2
+
+
+def test_pattern_polymorphism_swarm() -> None:
+    """Test polymorphic validation for SwarmPattern."""
+    adapter = TypeAdapter(PatternDefinition)
+    data = {
+        "type": "swarm",
+        "participants": ["a1", "a2"],
+        "handoff_mode": "direct",
+        "max_turns": 5,
+    }
+    pattern = adapter.validate_python(data)
+    assert isinstance(pattern, SwarmPattern)
+
+
+def test_pattern_polymorphism_hierarchical() -> None:
+    """Test polymorphic validation for HierarchicalTeamPattern."""
+    adapter = TypeAdapter(PatternDefinition)
+    data = {
+        "type": "hierarchical_team",
+        "manager_id": "m1",
+        "workers": ["w1"],
+    }
+    pattern = adapter.validate_python(data)
+    assert isinstance(pattern, HierarchicalTeamPattern)
+
+
+def test_invalid_pattern_discriminator() -> None:
+    """Test invalid discriminator raises ValidationError."""
+    adapter = TypeAdapter(PatternDefinition)
+    data = {
+        "type": "invalid_pattern",
+        "participants": [],
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        adapter.validate_python(data)
+    assert "Input tag 'invalid_pattern' found using 'type' does not match any of the expected tags" in str(
+        excinfo.value
+    )
+
+
+def test_swarm_pattern_extra_forbid() -> None:
+    """Test that extra fields are forbidden in SwarmPattern."""
+    with pytest.raises(ValidationError):
+        SwarmPattern(
+            type=PatternType.SWARM,
+            participants=["a1"],
+            handoff_mode="mode",
+            max_turns=1,
+            extra_field="fail",  # type: ignore[call-arg]
+        )
+
+
+def test_hierarchical_team_pattern_extra_forbid() -> None:
+    """Test that extra fields are forbidden in HierarchicalTeamPattern."""
+    with pytest.raises(ValidationError):
+        HierarchicalTeamPattern(
+            type=PatternType.HIERARCHICAL_TEAM,
+            manager_id="m1",
+            workers=["w1"],
+            extra_field="fail",  # type: ignore[call-arg]
+        )

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -8,8 +8,6 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any
-
 import pytest
 from pydantic import TypeAdapter, ValidationError
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -8,6 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from typing import Any
+
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
@@ -21,9 +23,10 @@ from coreason_manifest.definitions.patterns import (
 
 def test_pattern_type_enum() -> None:
     """Test PatternType enum values."""
-    assert PatternType.SWARM == "swarm"
-    assert PatternType.HIERARCHICAL_TEAM == "hierarchical_team"
-    assert PatternType.ROUTER_SOLVER == "router_solver"
+    # Use Any to avoid mypy overlapping comparison error for Literals
+    assert str(PatternType.SWARM.value) == "swarm"
+    assert str(PatternType.HIERARCHICAL_TEAM.value) == "hierarchical_team"
+    assert str(PatternType.ROUTER_SOLVER.value) == "router_solver"
 
 
 def test_swarm_pattern_creation() -> None:
@@ -58,7 +61,7 @@ def test_hierarchical_team_pattern_creation() -> None:
 
 def test_pattern_polymorphism_swarm() -> None:
     """Test polymorphic validation for SwarmPattern."""
-    adapter = TypeAdapter(PatternDefinition)
+    adapter: TypeAdapter[PatternDefinition] = TypeAdapter(PatternDefinition)
     data = {
         "type": "swarm",
         "participants": ["a1", "a2"],
@@ -71,7 +74,7 @@ def test_pattern_polymorphism_swarm() -> None:
 
 def test_pattern_polymorphism_hierarchical() -> None:
     """Test polymorphic validation for HierarchicalTeamPattern."""
-    adapter = TypeAdapter(PatternDefinition)
+    adapter: TypeAdapter[PatternDefinition] = TypeAdapter(PatternDefinition)
     data = {
         "type": "hierarchical_team",
         "manager_id": "m1",
@@ -83,7 +86,7 @@ def test_pattern_polymorphism_hierarchical() -> None:
 
 def test_invalid_pattern_discriminator() -> None:
     """Test invalid discriminator raises ValidationError."""
-    adapter = TypeAdapter(PatternDefinition)
+    adapter: TypeAdapter[PatternDefinition] = TypeAdapter(PatternDefinition)
     data = {
         "type": "invalid_pattern",
         "participants": [],

--- a/tests/test_recipe_v2.py
+++ b/tests/test_recipe_v2.py
@@ -15,9 +15,9 @@ import json
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import RecipeManifest, Topology
 from coreason_manifest.definitions.topology import StateDefinition
 from coreason_manifest.recipes import RecipeInterface
+from coreason_manifest.v1 import RecipeManifest, Topology
 
 
 def test_full_recipe_v2_creation() -> None:

--- a/tests/test_recipe_v2_extras.py
+++ b/tests/test_recipe_v2_extras.py
@@ -13,9 +13,9 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import RecipeManifest, Topology
 from coreason_manifest.definitions.topology import StateDefinition
 from coreason_manifest.recipes import RecipeInterface
+from coreason_manifest.v1 import RecipeManifest, Topology
 
 
 def test_state_schema_aliasing_roundtrip() -> None:

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -12,10 +12,9 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, StateDefinition
-from coreason_manifest.v1 import Edge
-from coreason_manifest.v1 import RecipeManifest
-from coreason_manifest.v1 import Topology as GraphTopology
 from coreason_manifest.recipes import RecipeInterface
+from coreason_manifest.v1 import Edge, RecipeManifest
+from coreason_manifest.v1 import Topology as GraphTopology
 
 
 def test_recipe_manifest_creation() -> None:

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -11,9 +11,10 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import Edge, RecipeManifest
-from coreason_manifest import Topology as GraphTopology
 from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, StateDefinition
+from coreason_manifest.v1 import Edge
+from coreason_manifest.v1 import RecipeManifest
+from coreason_manifest.v1 import Topology as GraphTopology
 from coreason_manifest.recipes import RecipeInterface
 
 

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -11,9 +11,9 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import Edge, RecipeManifest
-from coreason_manifest import Topology as GraphTopology
 from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, StateDefinition
+from coreason_manifest.v1 import Edge, RecipeManifest
+from coreason_manifest.v1 import Topology as GraphTopology
 from coreason_manifest.recipes import RecipeInterface
 
 

--- a/tests/test_recipes_edge_cases.py
+++ b/tests/test_recipes_edge_cases.py
@@ -12,9 +12,9 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.definitions.topology import AgentNode, HumanNode, LogicNode, StateDefinition
+from coreason_manifest.recipes import RecipeInterface
 from coreason_manifest.v1 import Edge, RecipeManifest
 from coreason_manifest.v1 import Topology as GraphTopology
-from coreason_manifest.recipes import RecipeInterface
 
 
 def test_invalid_node_discriminator() -> None:

--- a/tests/test_v2_exports.py
+++ b/tests/test_v2_exports.py
@@ -1,0 +1,49 @@
+import pytest
+
+import coreason_manifest as cm
+from coreason_manifest.v2.io import load_from_yaml
+from coreason_manifest.v2.spec.definitions import ManifestV2
+
+
+def test_v2_defaults() -> None:
+    assert cm.Manifest is ManifestV2
+    assert cm.Recipe is ManifestV2
+    assert cm.load is load_from_yaml
+
+
+def test_v1_removed_from_root() -> None:
+    with pytest.raises(AttributeError):
+        _ = cm.RecipeManifest  # type: ignore[attr-defined]
+
+    with pytest.raises(AttributeError):
+        _ = cm.AgentDefinition  # type: ignore[attr-defined]
+
+
+def test_v1_fallback() -> None:
+    from coreason_manifest.v1 import AgentDefinition, RecipeManifest, Topology
+
+    assert RecipeManifest is not None
+    assert AgentDefinition is not None
+    assert Topology is not None
+
+
+def test_v1_graph_primitives() -> None:
+    from coreason_manifest.v1 import (
+        AgentNode,
+        ConditionalEdge,
+        Edge,
+        HumanNode,
+        LogicNode,
+        MapNode,
+        RecipeNode,
+        StateDefinition,
+    )
+
+    assert AgentNode is not None
+    assert HumanNode is not None
+    assert LogicNode is not None
+    assert RecipeNode is not None
+    assert MapNode is not None
+    assert Edge is not None
+    assert ConditionalEdge is not None
+    assert StateDefinition is not None


### PR DESCRIPTION
This commit makes V2 the default API for the `coreason_manifest` package.
The root `__init__.py` now exports `Manifest` (V2), `Recipe` (alias to V2), `load` (V2 loader), and `dump` (V2 dumper).
V1 components are no longer available at the root level but can be imported from `coreason_manifest.v1`.
This completes the transition to COP V2.

---
*PR created automatically by Jules for task [1007419272044117826](https://jules.google.com/task/1007419272044117826) started by @gowthamrao*