### PR TITLE
docs: align documentation with V2 codebase

### DIFF
--- a/docs/governance_policy_enforcement.md
+++ b/docs/governance_policy_enforcement.md
@@ -10,7 +10,7 @@ The module provides configuration models to define organizational standards (e.g
 *   **Domain Restriction**: Whitelist specific domains for external tools (e.g., only allow tools from `*.internal.corp`).
 *   **Risk Level Enforcement**: Set a maximum allowed risk level for tools (e.g., `SAFE` only).
 *   **Authentication Mandates**: Ensure that agents using `CRITICAL` tools enforce user authentication.
-*   **Logic Execution Control**: Restrict the usage of arbitrary Python code in `LogicNode`s and conditional Edges.
+*   **Logic Execution Control**: Restrict the usage of arbitrary Python code in `LogicStep`s and `SwitchStep`s.
 *   **Strict URL Validation**: Enforce strict normalization (lower-case, no trailing dots) on tool URIs to prevent bypasses.
 
 ## Configuration: `GovernanceConfig`
@@ -32,6 +32,7 @@ config = GovernanceConfig(
     require_auth_for_critical_tools=True,
 
     # Prevent agents from running arbitrary Python code (Security)
+    # Controls usage of LogicStep and custom logic in SwitchStep
     # Default: False (Secure by Default)
     allow_custom_logic=False,
 

--- a/tests/test_docs_examples.py
+++ b/tests/test_docs_examples.py
@@ -74,3 +74,28 @@ def test_migration_guide_v2_standard_import() -> None:
 
     assert Manifest.__name__ == "ManifestV2"
     assert callable(load)
+
+
+def test_vignette_example() -> None:
+    """Replicates the 'In Practice' example from VIGNETTE.md."""
+    from coreason_manifest import AgentDefinition
+
+    # 1. Load Raw Data
+    raw_data = {
+        "type": "agent",
+        "id": "research-agent-001",
+        "name": "Deep Researcher",
+        "role": "Senior Researcher",
+        "goal": "Conduct deep internet research on specified topics.",
+        "backstory": "You are a meticulous researcher who verifies all sources.",
+        "model": "gpt-4-turbo",
+        "tools": ["google-search", "web-scraper"],
+        "knowledge": [],
+    }
+
+    # 2. Validate Structure
+    agent = AgentDefinition(**raw_data)
+
+    # 3. Happy Path
+    assert agent.name == "Deep Researcher"
+    assert len(agent.tools) == 2

--- a/tests/test_v2_complex_scenarios.py
+++ b/tests/test_v2_complex_scenarios.py
@@ -105,6 +105,22 @@ def test_all_step_types_usage() -> None:
                 },
             },
         },
+        "definitions": {
+            "agent-1": {
+                "type": "agent",
+                "id": "agent-1",
+                "name": "Agent 1",
+                "role": "agent",
+                "goal": "act",
+            },
+            "agent-2": {
+                "type": "agent",
+                "id": "agent-2",
+                "name": "Agent 2",
+                "role": "agent",
+                "goal": "act",
+            },
+        },
     }
     manifest = ManifestV2.model_validate(data)
     assert len(manifest.workflow.steps) == 4


### PR DESCRIPTION
This pull request updates the documentation to be consistent with the V2 codebase. It fixes outdated code examples, incorrect import paths, and obsolete terminology (e.g., `LogicNode` vs `LogicStep`). It also adds a regression test to ensure the `VIGNETTE.md` example remains valid.

---
*PR created automatically by Jules for task [15768052139807634131](https://jules.google.com/task/15768052139807634131) started by @gowthamrao*