### PR TITLE
Phase 2: Foundation Layer - Serialization & Core Types

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.13.0"
+version = "0.14.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.13.0"
+version = "0.14.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -23,7 +23,7 @@ from .v2.spec.definitions import (
     Workflow,
 )
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 Manifest = ManifestV2
 Recipe = ManifestV2

--- a/src/coreason_manifest/common.py
+++ b/src/coreason_manifest/common.py
@@ -32,8 +32,8 @@ class CoReasonBaseModel(BaseModel):
         Uses mode='json' to ensure types like UUID and datetime are serialized to strings.
         Defaults to by_alias=True and exclude_none=True.
         """
-        # Set defaults but allow overrides
-        kwargs.setdefault("mode", "json")
+        # Strict enforcement of json mode for zero-friction serialization
+        kwargs["mode"] = "json"
         kwargs.setdefault("by_alias", True)
         kwargs.setdefault("exclude_none", True)
         return self.model_dump(**kwargs)

--- a/src/coreason_manifest/v2/spec/definitions.py
+++ b/src/coreason_manifest/v2/spec/definitions.py
@@ -2,11 +2,11 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from coreason_manifest.common import StrictUri, ToolRiskLevel
+from coreason_manifest.common import CoReasonBaseModel, StrictUri, ToolRiskLevel
 from coreason_manifest.v2.spec.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
 
 
-class DesignMetadata(BaseModel):
+class DesignMetadata(CoReasonBaseModel):
     """UI-specific metadata for the visual builder."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+from coreason_manifest.common import CoReasonBaseModel, StrictUri, ToolRiskLevel
+
+
+class TestModel(CoReasonBaseModel):
+    id: UUID
+    timestamp: datetime
+    uri: StrictUri
+    risk: ToolRiskLevel
+
+
+def test_foundation_serialization() -> None:
+    """Test that CoReasonBaseModel.dump() serializes complex types to strings."""
+    model = TestModel(
+        id=uuid4(),
+        timestamp=datetime.now(timezone.utc),
+        uri="https://example.com",
+        risk=ToolRiskLevel.SAFE,
+    )
+
+    data = model.dump()
+
+    # Verify UUID is serialized to str
+    assert isinstance(data["id"], str)
+
+    # Verify datetime is serialized to str (ISO format)
+    assert isinstance(data["timestamp"], str)
+
+    # Verify StrictUri is serialized to str
+    assert isinstance(data["uri"], str)
+    assert data["uri"] == "https://example.com/"  # AnyUrl adds trailing slash or normalizes
+
+    # Verify Enum is serialized to str
+    assert isinstance(data["risk"], str)
+    assert data["risk"] == "safe"
+
+
+def test_foundation_json() -> None:
+    """Test that CoReasonBaseModel.to_json() produces valid JSON string."""
+    model = TestModel(
+        id=uuid4(),
+        timestamp=datetime.now(timezone.utc),
+        uri="https://example.com",
+        risk=ToolRiskLevel.SAFE,
+    )
+
+    json_str = model.to_json()
+
+    assert isinstance(json_str, str)
+    assert str(model.id) in json_str
+    assert "https://example.com" in json_str
+    assert "safe" in json_str


### PR DESCRIPTION
This PR implements Phase 2 (Foundation Layer) of the Coreason Manifest evolution. 

Key changes:
1.  **Serialization Infrastructure**: `CoReasonBaseModel` now strictly enforces `mode='json'` during `dump()`. This guarantees that all Pydantic models inheriting from it (including Foundation models) automatically serialize complex types like `UUID` and `datetime` into their string representations (ISO format for dates). This eliminates the need for manual encoders in downstream systems.
2.  **Foundation Testing**: Added `tests/test_foundation.py` to mathematically prove that `CoReasonBaseModel` produces JSON-ready dictionaries and strings.
3.  **Core Adoption**: Updated `DesignMetadata` in the V2 spec to use the new base model. Verified that `GovernanceConfig` and related governance models are already compliant.
4.  **Version Bump**: Incremented package version to `0.14.0`.

This establishes the "Bedrock" types required for robust schema generation and cross-service communication.

---
*PR created automatically by Jules for task [3759008374187646379](https://jules.google.com/task/3759008374187646379) started by @gowthamrao*