### PR TITLE
Implement Phase 3: Core Schemas and Integrity Checks

### DIFF
--- a/src/coreason_manifest/v2/spec/definitions.py
+++ b/src/coreason_manifest/v2/spec/definitions.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from coreason_manifest.common import CoReasonBaseModel, StrictUri, ToolRiskLevel
 from coreason_manifest.v2.spec.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
@@ -20,7 +20,7 @@ class DesignMetadata(CoReasonBaseModel):
     collapsed: bool = Field(False, description="Whether the node is collapsed in UI.")
 
 
-class ToolDefinition(BaseModel):
+class ToolDefinition(CoReasonBaseModel):
     """Definition of an external tool."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -33,7 +33,7 @@ class ToolDefinition(BaseModel):
     description: Optional[str] = Field(None, description="Description of the tool.")
 
 
-class AgentDefinition(BaseModel):
+class AgentDefinition(CoReasonBaseModel):
     """Definition of an Agent."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -49,13 +49,13 @@ class AgentDefinition(BaseModel):
     knowledge: List[str] = Field(default_factory=list, description="List of file paths or knowledge base IDs.")
 
 
-class GenericDefinition(BaseModel):
+class GenericDefinition(CoReasonBaseModel):
     """Fallback for unknown definitions."""
 
     model_config = ConfigDict(extra="allow")
 
 
-class BaseStep(BaseModel):
+class BaseStep(CoReasonBaseModel):
     """Base attributes for all steps."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -106,7 +106,7 @@ Step = Annotated[
 ]
 
 
-class Workflow(BaseModel):
+class Workflow(CoReasonBaseModel):
     """Defines the execution topology."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -115,7 +115,7 @@ class Workflow(BaseModel):
     steps: Dict[str, Step] = Field(..., description="Dictionary of all steps indexed by ID.")
 
 
-class ManifestMetadata(BaseModel):
+class ManifestMetadata(CoReasonBaseModel):
     """Metadata for the manifest."""
 
     model_config = ConfigDict(extra="allow", populate_by_name=True)
@@ -124,7 +124,7 @@ class ManifestMetadata(BaseModel):
     design_metadata: Optional[DesignMetadata] = Field(None, alias="x-design", description="UI metadata.")
 
 
-class ManifestV2(BaseModel):
+class ManifestV2(CoReasonBaseModel):
     """Root object for Coreason Manifest V2."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -191,6 +191,20 @@ class ManifestV2(BaseModel):
                         raise ValueError(
                             f"CouncilStep '{step.id}' references voter '{voter}' which is not an AgentDefinition "
                             f"(got {type(agent_def).__name__})."
+                        )
+
+        # 5. Validate Agent Tools
+        for def_id, definition in self.definitions.items():
+            if isinstance(definition, AgentDefinition):
+                for tool_id in definition.tools:
+                    if tool_id not in self.definitions:
+                        raise ValueError(f"Agent '{definition.id}' references missing tool '{tool_id}'.")
+
+                    tool_def = self.definitions[tool_id]
+                    if not isinstance(tool_def, ToolDefinition):
+                        raise ValueError(
+                            f"Agent '{definition.id}' references '{tool_id}' which is not a ToolDefinition "
+                            f"(got {type(tool_def).__name__})."
                         )
 
         return self

--- a/src/coreason_manifest/v2/spec/definitions.py
+++ b/src/coreason_manifest/v2/spec/definitions.py
@@ -194,7 +194,7 @@ class ManifestV2(CoReasonBaseModel):
                         )
 
         # 5. Validate Agent Tools
-        for def_id, definition in self.definitions.items():
+        for _, definition in self.definitions.items():
             if isinstance(definition, AgentDefinition):
                 for tool_id in definition.tools:
                     if tool_id not in self.definitions:

--- a/tests/test_v2_complex_scenarios.py
+++ b/tests/test_v2_complex_scenarios.py
@@ -214,7 +214,14 @@ def test_agent_definition_full_spec() -> None:
                 "model": "gpt-4-turbo",
                 "tools": ["tool-1"],
                 "knowledge": ["docs/top_secret.pdf"],
-            }
+            },
+            "tool-1": {
+                "type": "tool",
+                "id": "tool-1",
+                "name": "Tool 1",
+                "uri": "https://example.com/tool1",
+                "risk_level": "safe",
+            },
         },
         "workflow": {"start": "s1", "steps": {"s1": {"type": "logic", "id": "s1", "code": "pass"}}},
     }

--- a/tests/test_v2_spec.py
+++ b/tests/test_v2_spec.py
@@ -129,6 +129,7 @@ def test_agent_definition_tools_type() -> None:
         # If mypy is not complaining locally but CI is complaining about unused ignore, it means environment diff.
         # Let's try casting to Any to bypass Mypy completely, then validation happens at runtime.
         from typing import Any, cast
+
         bad_tools = cast(Any, [123])
         AgentDefinition(
             id="agent1",

--- a/tests/test_v2_spec.py
+++ b/tests/test_v2_spec.py
@@ -1,0 +1,190 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.common import ToolRiskLevel
+from coreason_manifest.v2.spec.definitions import (
+    AgentDefinition,
+    AgentStep,
+    ManifestMetadata,
+    ManifestV2,
+    ToolDefinition,
+    Workflow,
+    SwitchStep,
+)
+
+
+@pytest.fixture
+def base_manifest_kwargs() -> dict:
+    return {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Agent",
+        "metadata": {"name": "Test Manifest"},
+    }
+
+
+def test_integrity_valid(base_manifest_kwargs: dict) -> None:
+    """Test a perfectly valid manifest."""
+    tool = ToolDefinition(
+        id="tool1",
+        name="Tool",
+        uri="https://example.com",
+        risk_level=ToolRiskLevel.SAFE
+    )
+    agent = AgentDefinition(
+        id="agent1",
+        name="Agent",
+        role="Role",
+        goal="Goal",
+        tools=["tool1"]
+    )
+    workflow = Workflow(
+        start="step1",
+        steps={
+            "step1": AgentStep(id="step1", agent="agent1", next="step2"),
+            "step2": AgentStep(id="step2", agent="agent1"),
+        }
+    )
+
+    ManifestV2(
+        workflow=workflow,
+        definitions={"tool1": tool, "agent1": agent},
+        **base_manifest_kwargs
+    )
+
+
+def test_integrity_failure_missing_tool(base_manifest_kwargs: dict) -> None:
+    """Test integrity failure when an Agent references a non-existent Tool ID."""
+    agent = AgentDefinition(
+        id="agent1",
+        name="Agent",
+        role="Role",
+        goal="Goal",
+        tools=["missing-tool"]
+    )
+    workflow = Workflow(
+        start="step1",
+        steps={"step1": AgentStep(id="step1", agent="agent1")}
+    )
+
+    with pytest.raises(ValidationError, match="Agent 'agent1' references missing tool 'missing-tool'"):
+        ManifestV2(
+            workflow=workflow,
+            definitions={"agent1": agent},
+            **base_manifest_kwargs
+        )
+
+
+def test_integrity_failure_wrong_tool_type(base_manifest_kwargs: dict) -> None:
+    """Test integrity failure when an Agent references a definition that is not a Tool."""
+    agent1 = AgentDefinition(
+        id="agent1",
+        name="Agent 1",
+        role="Role",
+        goal="Goal",
+        tools=["agent2"] # referencing another agent as a tool
+    )
+    agent2 = AgentDefinition(
+        id="agent2",
+        name="Agent 2",
+        role="Role",
+        goal="Goal"
+    )
+    workflow = Workflow(
+        start="step1",
+        steps={"step1": AgentStep(id="step1", agent="agent1")}
+    )
+
+    with pytest.raises(ValidationError, match="Agent 'agent1' references 'agent2' which is not a ToolDefinition"):
+        ManifestV2(
+            workflow=workflow,
+            definitions={"agent1": agent1, "agent2": agent2},
+            **base_manifest_kwargs
+        )
+
+
+def test_integrity_failure_missing_next_step(base_manifest_kwargs: dict) -> None:
+    """Test integrity failure when a Step references a non-existent next ID."""
+    agent = AgentDefinition(id="agent1", name="Agent", role="Role", goal="Goal")
+    workflow = Workflow(
+        start="step1",
+        steps={
+            "step1": AgentStep(id="step1", agent="agent1", next="missing-step")
+        }
+    )
+
+    with pytest.raises(ValidationError, match="Step 'step1' references missing next step 'missing-step'"):
+        ManifestV2(
+            workflow=workflow,
+            definitions={"agent1": agent},
+            **base_manifest_kwargs
+        )
+
+
+def test_integrity_failure_missing_switch_target(base_manifest_kwargs: dict) -> None:
+    """Test integrity failure when a SwitchStep references a non-existent step."""
+    workflow = Workflow(
+        start="switch1",
+        steps={
+            "switch1": SwitchStep(
+                id="switch1",
+                cases={"cond": "missing-case"},
+                default="missing-default"
+            )
+        }
+    )
+
+    # It might fail on the first missing one it finds
+    with pytest.raises(ValidationError, match="SwitchStep 'switch1' references missing step"):
+        ManifestV2(
+            workflow=workflow,
+            definitions={},
+            **base_manifest_kwargs
+        )
+
+
+def test_strictness_unknown_field_step() -> None:
+    """Test that steps forbid unknown fields."""
+
+    # We need to bypass the constructor validation or use a dict to trigger pydantic validation
+    # But here we are instantiating the model directly.
+
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AgentStep(
+            id="step1",
+            agent="agent1",
+            magic_parameter=True # type: ignore[call-arg]
+        )
+
+
+def test_strictness_unknown_field_agent_definition() -> None:
+    """Test that AgentDefinition forbids unknown fields."""
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        AgentDefinition(
+            id="agent1",
+            name="Agent",
+            role="Role",
+            goal="Goal",
+            unknown_field="value" # type: ignore[call-arg]
+        )
+
+
+def test_agent_definition_tools_type() -> None:
+    """Test that tools must be a list of strings."""
+    with pytest.raises(ValidationError):
+        AgentDefinition(
+            id="agent1",
+            name="Agent",
+            role="Role",
+            goal="Goal",
+            tools=[123] # type: ignore[list-item]
+        )

--- a/tests/test_v2_spec.py
+++ b/tests/test_v2_spec.py
@@ -8,6 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from typing import Any, Dict
+
 import pytest
 from pydantic import ValidationError
 
@@ -15,16 +17,15 @@ from coreason_manifest.common import ToolRiskLevel
 from coreason_manifest.v2.spec.definitions import (
     AgentDefinition,
     AgentStep,
-    ManifestMetadata,
     ManifestV2,
+    SwitchStep,
     ToolDefinition,
     Workflow,
-    SwitchStep,
 )
 
 
 @pytest.fixture
-def base_manifest_kwargs() -> dict:
+def base_manifest_kwargs() -> Dict[str, Any]:
     return {
         "apiVersion": "coreason.ai/v2",
         "kind": "Agent",
@@ -32,124 +33,65 @@ def base_manifest_kwargs() -> dict:
     }
 
 
-def test_integrity_valid(base_manifest_kwargs: dict) -> None:
+def test_integrity_valid(base_manifest_kwargs: Dict[str, Any]) -> None:
     """Test a perfectly valid manifest."""
-    tool = ToolDefinition(
-        id="tool1",
-        name="Tool",
-        uri="https://example.com",
-        risk_level=ToolRiskLevel.SAFE
-    )
-    agent = AgentDefinition(
-        id="agent1",
-        name="Agent",
-        role="Role",
-        goal="Goal",
-        tools=["tool1"]
-    )
+    tool = ToolDefinition(id="tool1", name="Tool", uri="https://example.com", risk_level=ToolRiskLevel.SAFE)
+    agent = AgentDefinition(id="agent1", name="Agent", role="Role", goal="Goal", tools=["tool1"])
     workflow = Workflow(
         start="step1",
         steps={
             "step1": AgentStep(id="step1", agent="agent1", next="step2"),
             "step2": AgentStep(id="step2", agent="agent1"),
-        }
+        },
     )
 
-    ManifestV2(
-        workflow=workflow,
-        definitions={"tool1": tool, "agent1": agent},
-        **base_manifest_kwargs
-    )
+    ManifestV2(workflow=workflow, definitions={"tool1": tool, "agent1": agent}, **base_manifest_kwargs)
 
 
-def test_integrity_failure_missing_tool(base_manifest_kwargs: dict) -> None:
+def test_integrity_failure_missing_tool(base_manifest_kwargs: Dict[str, Any]) -> None:
     """Test integrity failure when an Agent references a non-existent Tool ID."""
-    agent = AgentDefinition(
-        id="agent1",
-        name="Agent",
-        role="Role",
-        goal="Goal",
-        tools=["missing-tool"]
-    )
-    workflow = Workflow(
-        start="step1",
-        steps={"step1": AgentStep(id="step1", agent="agent1")}
-    )
+    agent = AgentDefinition(id="agent1", name="Agent", role="Role", goal="Goal", tools=["missing-tool"])
+    workflow = Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1")})
 
     with pytest.raises(ValidationError, match="Agent 'agent1' references missing tool 'missing-tool'"):
-        ManifestV2(
-            workflow=workflow,
-            definitions={"agent1": agent},
-            **base_manifest_kwargs
-        )
+        ManifestV2(workflow=workflow, definitions={"agent1": agent}, **base_manifest_kwargs)
 
 
-def test_integrity_failure_wrong_tool_type(base_manifest_kwargs: dict) -> None:
+def test_integrity_failure_wrong_tool_type(base_manifest_kwargs: Dict[str, Any]) -> None:
     """Test integrity failure when an Agent references a definition that is not a Tool."""
     agent1 = AgentDefinition(
         id="agent1",
         name="Agent 1",
         role="Role",
         goal="Goal",
-        tools=["agent2"] # referencing another agent as a tool
+        tools=["agent2"],  # referencing another agent as a tool
     )
-    agent2 = AgentDefinition(
-        id="agent2",
-        name="Agent 2",
-        role="Role",
-        goal="Goal"
-    )
-    workflow = Workflow(
-        start="step1",
-        steps={"step1": AgentStep(id="step1", agent="agent1")}
-    )
+    agent2 = AgentDefinition(id="agent2", name="Agent 2", role="Role", goal="Goal")
+    workflow = Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1")})
 
     with pytest.raises(ValidationError, match="Agent 'agent1' references 'agent2' which is not a ToolDefinition"):
-        ManifestV2(
-            workflow=workflow,
-            definitions={"agent1": agent1, "agent2": agent2},
-            **base_manifest_kwargs
-        )
+        ManifestV2(workflow=workflow, definitions={"agent1": agent1, "agent2": agent2}, **base_manifest_kwargs)
 
 
-def test_integrity_failure_missing_next_step(base_manifest_kwargs: dict) -> None:
+def test_integrity_failure_missing_next_step(base_manifest_kwargs: Dict[str, Any]) -> None:
     """Test integrity failure when a Step references a non-existent next ID."""
     agent = AgentDefinition(id="agent1", name="Agent", role="Role", goal="Goal")
-    workflow = Workflow(
-        start="step1",
-        steps={
-            "step1": AgentStep(id="step1", agent="agent1", next="missing-step")
-        }
-    )
+    workflow = Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1", next="missing-step")})
 
     with pytest.raises(ValidationError, match="Step 'step1' references missing next step 'missing-step'"):
-        ManifestV2(
-            workflow=workflow,
-            definitions={"agent1": agent},
-            **base_manifest_kwargs
-        )
+        ManifestV2(workflow=workflow, definitions={"agent1": agent}, **base_manifest_kwargs)
 
 
-def test_integrity_failure_missing_switch_target(base_manifest_kwargs: dict) -> None:
+def test_integrity_failure_missing_switch_target(base_manifest_kwargs: Dict[str, Any]) -> None:
     """Test integrity failure when a SwitchStep references a non-existent step."""
     workflow = Workflow(
         start="switch1",
-        steps={
-            "switch1": SwitchStep(
-                id="switch1",
-                cases={"cond": "missing-case"},
-                default="missing-default"
-            )
-        }
+        steps={"switch1": SwitchStep(id="switch1", cases={"cond": "missing-case"}, default="missing-default")},
     )
 
     # It might fail on the first missing one it finds
     with pytest.raises(ValidationError, match="SwitchStep 'switch1' references missing step"):
-        ManifestV2(
-            workflow=workflow,
-            definitions={},
-            **base_manifest_kwargs
-        )
+        ManifestV2(workflow=workflow, definitions={}, **base_manifest_kwargs)
 
 
 def test_strictness_unknown_field_step() -> None:
@@ -162,7 +104,7 @@ def test_strictness_unknown_field_step() -> None:
         AgentStep(
             id="step1",
             agent="agent1",
-            magic_parameter=True # type: ignore[call-arg]
+            magic_parameter=True,  # type: ignore[call-arg]
         )
 
 
@@ -174,17 +116,24 @@ def test_strictness_unknown_field_agent_definition() -> None:
             name="Agent",
             role="Role",
             goal="Goal",
-            unknown_field="value" # type: ignore[call-arg]
+            unknown_field="value",  # type: ignore[call-arg]
         )
 
 
 def test_agent_definition_tools_type() -> None:
     """Test that tools must be a list of strings."""
     with pytest.raises(ValidationError):
+        # We need to construct this such that mypy is happy but Pydantic runtime fails
+        # Mypy checks list contents, but casting can bypass it if needed
+        # However, here we are testing runtime behavior.
+        # If mypy is not complaining locally but CI is complaining about unused ignore, it means environment diff.
+        # Let's try casting to Any to bypass Mypy completely, then validation happens at runtime.
+        from typing import Any, cast
+        bad_tools = cast(Any, [123])
         AgentDefinition(
             id="agent1",
             name="Agent",
             role="Role",
             goal="Goal",
-            tools=[123] # type: ignore[list-item]
+            tools=bad_tools,
         )

--- a/tests/test_v2_standalone.py
+++ b/tests/test_v2_standalone.py
@@ -132,7 +132,14 @@ definitions:
     name: Manager
     role: Boss
     goal: Manage
-    tools: ["worker"] # Uses worker as tool
+    tools: ["worker_tool"] # Uses worker as tool via wrapper
+
+  worker_tool:
+    type: tool
+    id: worker_tool
+    name: Worker Tool
+    uri: "agent://worker"
+    risk_level: safe
 
   level_1_director:
     type: agent
@@ -140,7 +147,14 @@ definitions:
     name: Director
     role: Exec
     goal: Direct
-    tools: ["manager"] # Uses manager as tool
+    tools: ["manager_tool"] # Uses manager as tool via wrapper
+
+  manager_tool:
+    type: tool
+    id: manager_tool
+    name: Manager Tool
+    uri: "agent://manager"
+    risk_level: safe
 """
     manifest = ManifestV2(**yaml.safe_load(yaml_content))
 
@@ -152,10 +166,10 @@ definitions:
     assert isinstance(manager_ref, AgentDefinition)
     assert isinstance(worker_ref, AgentDefinition)
 
-    # Director has tool "manager"
-    assert "manager" in director.tools
+    # Director has tool "manager_tool"
+    assert "manager_tool" in director.tools
 
-    # Manager has tool "worker"
-    assert "worker" in manager_ref.tools
+    # Manager has tool "worker_tool"
+    assert "worker_tool" in manager_ref.tools
 
     # We confirm that V2 structure holds this integrity natively.


### PR DESCRIPTION
Implemented strict V2 schemas for Agents and Workflows as part of Phase 3 (The Blueprint). Key changes include upgrading inheritance to `CoReasonBaseModel` for improved serialization, enforcing strict field typing and `extra="forbid"`, and implementing robust referential integrity checks (especially for `AgentDefinition.tools`). Verified with new and existing tests.

---
*PR created automatically by Jules for task [3642121216469011152](https://jules.google.com/task/3642121216469011152) started by @gowthamrao*