### PR TITLE
Refactor V2 models to CoReasonBaseModel

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,9 +90,3 @@ You are strictly forbidden from introducing "Active" or "Runtime" logic into thi
 * You feel a feature requires adding a dependency that is not `pydantic` or `yaml`.
 * You are tempted to add a "helper script" that runs a server.
 * You encounter a requirement that seems to violate the "Shared Kernel" philosophy.
-
-## **7. Roadmap**
-
-| Phase | Description | Status |
-| :--- | :--- | :--- |
-| Phase 4 | Final Polish - Unify Base Models | ✅ COMPLETE |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,3 +90,9 @@ You are strictly forbidden from introducing "Active" or "Runtime" logic into thi
 * You feel a feature requires adding a dependency that is not `pydantic` or `yaml`.
 * You are tempted to add a "helper script" that runs a server.
 * You encounter a requirement that seems to violate the "Shared Kernel" philosophy.
+
+## **7. Roadmap**
+
+| Phase | Description | Status |
+| :--- | :--- | :--- |
+| Phase 4 | Final Polish - Unify Base Models | ✅ COMPLETE |

--- a/src/coreason_manifest/v2/spec/contracts.py
+++ b/src/coreason_manifest/v2/spec/contracts.py
@@ -1,18 +1,20 @@
 from typing import Any, Dict, Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.common import CoReasonBaseModel
 
 
-class InterfaceDefinition(BaseModel):
+class InterfaceDefinition(CoReasonBaseModel):
     """Defines the input/output contract."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     inputs: Dict[str, Any] = Field(default_factory=dict, description="JSON Schema definitions for arguments.")
     outputs: Dict[str, Any] = Field(default_factory=dict, description="JSON Schema definitions for return values.")
 
 
-class StateDefinition(BaseModel):
+class StateDefinition(CoReasonBaseModel):
     """Defines the conversation memory/context structure."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True)
@@ -23,10 +25,10 @@ class StateDefinition(BaseModel):
     backend: Optional[str] = Field(None, description="Backend storage type (e.g., 'redis', 'memory').")
 
 
-class PolicyDefinition(BaseModel):
+class PolicyDefinition(CoReasonBaseModel):
     """Defines execution policy and governance rules."""
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
     max_steps: Optional[int] = Field(None, description="Execution limit on number of steps.")
     max_retries: int = Field(3, description="Maximum number of retries.")


### PR DESCRIPTION
Standardized all V2 data models to use `CoReasonBaseModel` foundation, ensuring consistent JSON serialization and Enum handling. Verified with tests.

---
*PR created automatically by Jules for task [11165185163090457667](https://jules.google.com/task/11165185163090457667) started by @gowthamrao*