### PR TITLE
Implement CAP Wire Protocol Models

### DIFF
--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -1,0 +1,95 @@
+# Coreason Agent Protocol (CAP) - Wire Format
+
+This document defines the **Wire Format** for the Coreason Agent Protocol (CAP). These data contracts ensure consistent communication between components (Lambda, K8s, CLI, Engines) regardless of the underlying transport (HTTP, WebSocket, Queue).
+
+## Request/Response Envelopes
+
+All runtime messages strictly adhere to the following Pydantic models. These models are defined in `coreason_manifest.spec.cap`.
+
+### ServiceRequest
+
+The standard envelope for sending instructions to an Agent.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `request_id` | `UUID` | Unique identifier for the request trace. |
+| `context` | `Dict[str, Any]` | Runtime context (session ID, user ID, auth tokens). |
+| `payload` | `Dict[str, Any]` | The actual arguments for the Agent or Tool. |
+
+**Example JSON:**
+```json
+{
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "context": {
+    "user_id": "user_123",
+    "session_id": "sess_abc"
+  },
+  "payload": {
+    "query": "What is the status of the project?"
+  }
+}
+```
+
+### ServiceResponse
+
+The synchronous result returned by an Agent service.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `request_id` | `UUID` | Corresponds to the request ID. |
+| `created_at` | `datetime` | UTC timestamp of completion (ISO 8601). |
+| `output` | `Dict[str, Any]` | The result data. |
+| `metrics` | `Optional[Dict]` | Execution metrics (latency, tokens used). |
+
+**Example JSON:**
+```json
+{
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "created_at": "2023-10-27T10:00:00Z",
+  "output": {
+    "text": "The project is on track."
+  },
+  "metrics": {
+    "duration_ms": 450,
+    "tokens": 120
+  }
+}
+```
+
+### StreamPacket
+
+Used for streaming partial results or events during execution.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `event` | `str` | Event type (e.g., `token`, `status`, `error`). |
+| `data` | `Union[str, Dict]` | The payload of the event. |
+
+**Example JSON:**
+```json
+{
+  "event": "token",
+  "data": "The"
+}
+```
+
+### HealthCheckResponse
+
+Standard response for system health probes.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `status` | `HealthCheckStatus` | `ok`, `degraded`, or `maintenance`. |
+| `agent_id` | `UUID` | Unique ID of the serving agent instance. |
+| `version` | `str` | Semantic version of the service. |
+| `uptime_seconds` | `float` | Seconds since startup. |
+
+**Example JSON:**
+```json
+{
+  "status": "ok",
+  "agent_id": "123e4567-e89b-12d3-a456-426614174000",
+  "version": "1.0.0",
+  "uptime_seconds": 3600.5
+}
+```

--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -13,8 +13,8 @@ The standard envelope for sending instructions to an Agent.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `request_id` | `UUID` | Unique identifier for the request trace. |
-| `context` | `Dict[str, Any]` | Runtime context (session ID, user ID, auth tokens). |
-| `payload` | `Dict[str, Any]` | The actual arguments for the Agent or Tool. |
+| `context` | `Dict[str, Any]` | Metadata about the request (User Identity, Auth, Session). Separated from logic to enable consistent security policies. |
+| `payload` | `Dict[str, Any]` | The actual arguments for the Agent's business logic. |
 
 **Example JSON:**
 ```json

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -10,6 +10,12 @@
 
 from .common import ToolRiskLevel
 from .governance import ComplianceReport, ComplianceViolation, GovernanceConfig
+from .spec.cap import (
+    HealthCheckResponse,
+    ServiceRequest,
+    ServiceResponse,
+    StreamPacket,
+)
 from .v2.io import dump_to_yaml, load_from_yaml
 from .v2.spec.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
 from .v2.spec.definitions import (
@@ -54,4 +60,8 @@ __all__ = [
     "GovernanceConfig",
     "ComplianceReport",
     "ComplianceViolation",
+    "HealthCheckResponse",
+    "ServiceRequest",
+    "ServiceResponse",
+    "StreamPacket",
 ]

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -12,6 +12,7 @@ from .common import ToolRiskLevel
 from .governance import ComplianceReport, ComplianceViolation, GovernanceConfig
 from .spec.cap import (
     HealthCheckResponse,
+    HealthCheckStatus,
     ServiceRequest,
     ServiceResponse,
     StreamPacket,
@@ -61,6 +62,7 @@ __all__ = [
     "ComplianceReport",
     "ComplianceViolation",
     "HealthCheckResponse",
+    "HealthCheckStatus",
     "ServiceRequest",
     "ServiceResponse",
     "StreamPacket",

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -58,10 +58,19 @@ class ServiceResponse(CoReasonBaseModel):
 
 
 class ServiceRequest(CoReasonBaseModel):
-    """Request to an agent service."""
+    """Request to an agent service.
+
+    Attributes:
+        request_id: Unique trace ID for the transaction.
+        context: Metadata about the request (User Identity, Auth, Session).
+                 Separated from logic to enable consistent security policies.
+        payload: The actual arguments for the Agent's execution.
+    """
 
     model_config = ConfigDict(frozen=True)
 
     request_id: UUID
+    # TODO: In v0.16.0, strictly type 'context' with a SessionContext model
+    # once the Identity primitive is fully integrated.
     context: Dict[str, Any]
     payload: Dict[str, Any]

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import Enum
+from typing import Any, Dict, Optional, Union
+from uuid import UUID
+from datetime import datetime
+
+from pydantic import ConfigDict
+
+from coreason_manifest.common import CoReasonBaseModel
+
+class HealthCheckStatus(str, Enum):
+    """Status of the health check."""
+    OK = "ok"
+    DEGRADED = "degraded"
+    MAINTENANCE = "maintenance"
+
+class HealthCheckResponse(CoReasonBaseModel):
+    """Response for a health check request."""
+    model_config = ConfigDict(frozen=True)
+
+    status: HealthCheckStatus
+    agent_id: UUID
+    version: str
+    uptime_seconds: float
+
+class StreamPacket(CoReasonBaseModel):
+    """A packet of data streaming from an agent."""
+    model_config = ConfigDict(frozen=True)
+
+    event: str
+    data: Union[str, Dict[str, Any]]
+
+class ServiceResponse(CoReasonBaseModel):
+    """Synchronous response from an agent service."""
+    model_config = ConfigDict(frozen=True)
+
+    request_id: UUID
+    created_at: datetime
+    output: Dict[str, Any]
+    metrics: Optional[Dict[str, Any]] = None
+
+class ServiceRequest(CoReasonBaseModel):
+    """Request to an agent service."""
+    model_config = ConfigDict(frozen=True)
+
+    request_id: UUID
+    context: Dict[str, Any]
+    payload: Dict[str, Any]

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -8,23 +8,27 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, Optional, Union
 from uuid import UUID
-from datetime import datetime
 
 from pydantic import ConfigDict
 
 from coreason_manifest.common import CoReasonBaseModel
 
+
 class HealthCheckStatus(str, Enum):
     """Status of the health check."""
+
     OK = "ok"
     DEGRADED = "degraded"
     MAINTENANCE = "maintenance"
 
+
 class HealthCheckResponse(CoReasonBaseModel):
     """Response for a health check request."""
+
     model_config = ConfigDict(frozen=True)
 
     status: HealthCheckStatus
@@ -32,15 +36,19 @@ class HealthCheckResponse(CoReasonBaseModel):
     version: str
     uptime_seconds: float
 
+
 class StreamPacket(CoReasonBaseModel):
     """A packet of data streaming from an agent."""
+
     model_config = ConfigDict(frozen=True)
 
     event: str
     data: Union[str, Dict[str, Any]]
 
+
 class ServiceResponse(CoReasonBaseModel):
     """Synchronous response from an agent service."""
+
     model_config = ConfigDict(frozen=True)
 
     request_id: UUID
@@ -48,8 +56,10 @@ class ServiceResponse(CoReasonBaseModel):
     output: Dict[str, Any]
     metrics: Optional[Dict[str, Any]] = None
 
+
 class ServiceRequest(CoReasonBaseModel):
     """Request to an agent service."""
+
     model_config = ConfigDict(frozen=True)
 
     request_id: UUID

--- a/tests/test_cap.py
+++ b/tests/test_cap.py
@@ -1,0 +1,214 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import json
+from uuid import uuid4, UUID
+from datetime import datetime, timezone
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.cap import (
+    HealthCheckResponse,
+    HealthCheckStatus,
+    StreamPacket,
+    ServiceResponse,
+    ServiceRequest,
+)
+
+# --- Unit Tests ---
+
+def test_health_check_response_serialization() -> None:
+    agent_id = uuid4()
+    response = HealthCheckResponse(
+        status=HealthCheckStatus.OK,
+        agent_id=agent_id,
+        version="1.0.0",
+        uptime_seconds=123.45
+    )
+    dumped = response.dump()
+    assert dumped["status"] == "ok"
+    assert dumped["agent_id"] == str(agent_id)
+    assert dumped["version"] == "1.0.0"
+    assert dumped["uptime_seconds"] == 123.45
+
+def test_stream_packet_creation() -> None:
+    # Test with string data
+    packet1 = StreamPacket(event="token", data="hello")
+    assert packet1.event == "token"
+    assert packet1.data == "hello"
+
+    # Test with dict data
+    packet2 = StreamPacket(event="metadata", data={"tokens": 5, "model": "gpt-4"})
+    assert packet2.data["tokens"] == 5
+
+def test_service_response_serialization() -> None:
+    req_id = uuid4()
+    now = datetime.now(timezone.utc)
+    response = ServiceResponse(
+        request_id=req_id,
+        created_at=now,
+        output={"result": "success"},
+        metrics={"latency": 100}
+    )
+    dumped = response.dump()
+    assert dumped["request_id"] == str(req_id)
+    # Pydantic v2 JSON serialization uses 'Z' for UTC, while python uses +00:00
+    assert dumped["created_at"] == now.isoformat().replace("+00:00", "Z")
+    assert dumped["output"] == {"result": "success"}
+
+def test_service_request_instantiation() -> None:
+    req_id = uuid4()
+    req = ServiceRequest(
+        request_id=req_id,
+        context={"user_id": "u123"},
+        payload={"query": "test"}
+    )
+    assert req.request_id == req_id
+    assert req.context["user_id"] == "u123"
+
+# --- Edge Case Tests ---
+
+def test_invalid_uuid_validation() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ServiceRequest(
+            request_id="not-a-uuid",  # type: ignore[arg-type]
+            context={},
+            payload={}
+        )
+    assert "Input should be a valid UUID" in str(excinfo.value)
+
+def test_invalid_enum_status() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        HealthCheckResponse(
+            status="invalid_status",  # type: ignore[arg-type]
+            agent_id=uuid4(),
+            version="1.0.0",
+            uptime_seconds=10.0
+        )
+    # Pydantic v2 error message for enum
+    assert "Input should be 'ok', 'degraded' or 'maintenance'" in str(excinfo.value)
+
+def test_missing_required_fields() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        ServiceRequest(
+            request_id=uuid4(),
+            # Missing context and payload
+        ) # type: ignore[call-arg]
+    assert "Field required" in str(excinfo.value)
+    assert "context" in str(excinfo.value)
+    assert "payload" in str(excinfo.value)
+
+def test_stream_packet_invalid_data_type() -> None:
+    with pytest.raises(ValidationError):
+        StreamPacket(
+            event="error",
+            data=[1, 2, 3] # type: ignore[arg-type] # List is not allowed, only str or Dict
+        )
+
+# --- Complex Case Tests ---
+
+def test_service_request_deep_nesting() -> None:
+    payload = {
+        "level1": {
+            "level2": {
+                "level3": {
+                    "data": "deep",
+                    "list": [1, 2, {"nested": "item"}]
+                }
+            }
+        }
+    }
+    req = ServiceRequest(
+        request_id=uuid4(),
+        context={},
+        payload=payload
+    )
+    dumped = req.dump()
+    assert dumped["payload"]["level1"]["level2"]["level3"]["data"] == "deep"
+    assert dumped["payload"]["level1"]["level2"]["level3"]["list"][2]["nested"] == "item"
+
+def test_round_trip_json_serialization() -> None:
+    original_req = ServiceRequest(
+        request_id=uuid4(),
+        context={"session": "s1"},
+        payload={"action": "run", "params": {"x": 10}}
+    )
+
+    # Dump to JSON string
+    json_str = original_req.to_json()
+
+    # Load back from JSON string
+    loaded_req = ServiceRequest.model_validate_json(json_str)
+
+    assert loaded_req.request_id == original_req.request_id
+    assert loaded_req.context == original_req.context
+    assert loaded_req.payload == original_req.payload
+
+    # Ensure deep equality
+    assert loaded_req == original_req
+
+def test_immutability_frozen() -> None:
+    req = ServiceRequest(
+        request_id=uuid4(),
+        context={},
+        payload={}
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        req.context = {"new": "context"} # type: ignore[misc]
+
+    # Error message for frozen instance assignment
+    assert "Instance is frozen" in str(excinfo.value)
+
+def test_type_preservation_in_dict() -> None:
+    """Ensure that native types in Dict[str, Any] are preserved and not aggressively coerced to strings if not needed."""
+    payload = {
+        "int_val": 123,
+        "float_val": 45.67,
+        "bool_val": True,
+        "none_val": None,
+        "list_val": [1, "two"]
+    }
+    req = ServiceRequest(
+        request_id=uuid4(),
+        context={},
+        payload=payload
+    )
+
+    # Dump using the CoReasonBaseModel.dump() which sets mode='json'
+    dumped = req.dump()
+
+    # In mode='json', Pydantic might serialize types to their JSON equivalents.
+    # int -> int, float -> float, bool -> bool, None -> null
+    assert dumped["payload"]["int_val"] == 123
+    assert dumped["payload"]["float_val"] == 45.67
+    assert dumped["payload"]["bool_val"] is True
+    assert dumped["payload"]["none_val"] is None
+    assert dumped["payload"]["list_val"] == [1, "two"]
+
+def test_extra_fields_behavior() -> None:
+    """Verify behavior when extra fields are passed (should be ignored or allowed, but not crash)."""
+    # By default, Pydantic ignores extra fields unless configured otherwise.
+    # We want to confirm it doesn't raise ValidationError.
+
+    data = {
+        "request_id": str(uuid4()),
+        "context": {},
+        "payload": {},
+        "extra_field": "should_be_ignored"
+    }
+
+    # Should not raise
+    req = ServiceRequest.model_validate(data)
+
+    # Check if extra field is present or not.
+    # Since config is not explicit about extra, default is usually 'ignore'.
+    # If it's 'ignore', hasattr is False.
+    assert not hasattr(req, "extra_field")


### PR DESCRIPTION
Implemented the Coreason Agent Protocol (CAP) Wire Format models (`ServiceRequest`, `ServiceResponse`, `StreamPacket`, `HealthCheckResponse`) as strict Pydantic V2 models. These models inherit from `CoReasonBaseModel` to ensure consistent serialization of UUIDs and Datetimes. Added extensive tests covering unit scenarios, edge cases (invalid types, missing fields), and complex nested structures. Also added `docs/cap/wire_protocol.md` to document these runtime envelopes separate from the static manifest.

---
*PR created automatically by Jules for task [4683738284226305707](https://jules.google.com/task/4683738284226305707) started by @gowthamrao*