### PR TITLE
Protocol Hardening: Strict CAP Error Handling

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -12,10 +12,13 @@ from .common import ToolRiskLevel
 from .definitions.identity import Identity
 from .governance import ComplianceReport, ComplianceViolation, GovernanceConfig
 from .spec.cap import (
+    ErrorSeverity,
     HealthCheckResponse,
     HealthCheckStatus,
     ServiceRequest,
     ServiceResponse,
+    StreamError,
+    StreamOpCode,
     StreamPacket,
 )
 from .v2.io import dump_to_yaml, load_from_yaml
@@ -68,4 +71,7 @@ __all__ = [
     "ServiceRequest",
     "ServiceResponse",
     "StreamPacket",
+    "StreamError",
+    "StreamOpCode",
+    "ErrorSeverity",
 ]

--- a/src/coreason_manifest/definitions/identity.py
+++ b/src/coreason_manifest/definitions/identity.py
@@ -22,9 +22,7 @@ class Identity(CoReasonBaseModel):
 
     id: str = Field(..., description="Unique identifier for the actor (e.g., UUID, slug).")
     name: str = Field(..., description="Human-readable display name.")
-    role: Optional[str] = Field(
-        None, description="Contextual role (e.g., 'user', 'assistant', 'system')."
-    )
+    role: Optional[str] = Field(None, description="Contextual role (e.g., 'user', 'assistant', 'system').")
 
     def __str__(self) -> str:
         return f"{self.name} ({self.id})"

--- a/tests/test_cap.py
+++ b/tests/test_cap.py
@@ -39,14 +39,14 @@ def test_health_check_response_serialization() -> None:
 
 def test_stream_packet_creation() -> None:
     # Test with string data
-    packet1 = StreamPacket(event="token", data="hello")
-    assert packet1.event == "token"
-    assert packet1.data == "hello"
+    packet1 = StreamPacket(op="delta", p="hello")
+    assert packet1.op == "delta"
+    assert packet1.p == "hello"
 
     # Test with dict data
-    packet2 = StreamPacket(event="metadata", data={"tokens": 5, "model": "gpt-4"})
-    assert isinstance(packet2.data, dict)
-    assert packet2.data["tokens"] == 5
+    packet2 = StreamPacket(op="event", p={"tokens": 5, "model": "gpt-4"})
+    assert isinstance(packet2.p, dict)
+    assert packet2.p["tokens"] == 5
 
 
 def test_service_response_serialization() -> None:
@@ -113,8 +113,8 @@ def test_stream_packet_invalid_data_type() -> None:
     with pytest.raises(ValidationError):
         StreamPacket.model_validate(
             {
-                "event": "error",
-                "data": [1, 2, 3],
+                "op": "error",
+                "p": [1, 2, 3],
             }
         )
 

--- a/tests/test_cap_complex.py
+++ b/tests/test_cap_complex.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.cap import (
+    ErrorSeverity,
+    StreamError,
+    StreamOpCode,
+    StreamPacket,
+)
+
+
+def test_close_op_payload() -> None:
+    """Test CLOSE op behavior. It allows None payload."""
+    packet = StreamPacket(op=StreamOpCode.CLOSE, p=None)
+    assert packet.op == StreamOpCode.CLOSE
+    assert packet.p is None
+
+    # Verify it dumps correctly
+    dumped = packet.dump()
+    assert dumped["op"] == "close"
+    # CoReasonBaseModel.dump() excludes None fields by default
+    assert "p" not in dumped
+
+
+def test_event_op_complex_payload() -> None:
+    """Test EVENT op with nested dictionary payload."""
+    complex_payload = {
+        "type": "tool_call",
+        "tool": "calculator",
+        "inputs": {"expression": "2 + 2"},
+        "metadata": {"timestamp": 1234567890, "source": "agent_v1"}
+    }
+    packet = StreamPacket(op=StreamOpCode.EVENT, p=complex_payload)
+    assert packet.op == StreamOpCode.EVENT
+    assert packet.p["type"] == "tool_call"
+    assert packet.p["inputs"]["expression"] == "2 + 2"
+
+
+def test_error_coercion_failure_missing_fields() -> None:
+    """Test that dictionary coercion to StreamError fails if required fields are missing."""
+    # "code" and "message" and "severity" are required.
+    invalid_payload = {
+        "code": "oops",
+        # missing message and severity
+    }
+
+    # op=ERROR expects StreamError. Pydantic will try to coerce `p` to StreamError.
+    # Since it fails validation (missing fields), and `p` allows Dict, does it fall back to Dict?
+    # NO. The validator I wrote `validate_structure` strictly checks:
+    # "if self.op == StreamOpCode.ERROR: if not isinstance(self.p, StreamError): raise ValueError..."
+    #
+    # However, Pydantic's Union parsing happens BEFORE my validator.
+    # `p` is Union[StreamError, str, Dict, None].
+    # `left_to_right` mode means:
+    # 1. Try StreamError. `invalid_payload` fails StreamError validation.
+    # 2. Try str. Fails.
+    # 3. Try Dict. SUCCEEDS.
+    # So `self.p` becomes a Dict.
+    #
+    # THEN `validate_structure` runs.
+    # It checks `isinstance(self.p, StreamError)`. It is a Dict.
+    # So it raises ValueError.
+
+    with pytest.raises(ValueError) as excinfo:
+        StreamPacket(op=StreamOpCode.ERROR, p=invalid_payload)
+
+    assert "Payload 'p' must be a valid StreamError when op is ERROR" in str(excinfo.value)
+
+
+def test_round_trip_serialization() -> None:
+    """Test full JSON round-trip for various packet types."""
+
+    # 1. Delta
+    p1 = StreamPacket(op=StreamOpCode.DELTA, p="chunk")
+    p1_json = p1.model_dump_json()
+    p1_restored = StreamPacket.model_validate_json(p1_json)
+    assert p1_restored == p1
+
+    # 2. Error
+    error = StreamError(code="e1", message="m1", severity=ErrorSeverity.FATAL)
+    p2 = StreamPacket(op=StreamOpCode.ERROR, p=error)
+    p2_json = p2.model_dump_json()
+    p2_restored = StreamPacket.model_validate_json(p2_json)
+    assert p2_restored == p2
+    assert isinstance(p2_restored.p, StreamError)
+
+    # 3. Event
+    p3 = StreamPacket(op=StreamOpCode.EVENT, p={"k": "v"})
+    p3_json = p3.model_dump_json()
+    p3_restored = StreamPacket.model_validate_json(p3_json)
+    assert p3_restored == p3
+
+
+def test_ambiguous_payload_coercion() -> None:
+    """Test what happens when a Dict payload LOOKS like a StreamError but op is EVENT."""
+    # It matches StreamError structure exactly.
+    payload = {
+        "code": "fake_error",
+        "message": "not actually an error op",
+        "severity": "transient"
+    }
+
+    # op=EVENT.
+    # Union is `StreamError | str | Dict | None`.
+    # Pydantic (left_to_right) will match StreamError FIRST because it fits the schema.
+    # So `p` will be parsed as a `StreamError` object.
+    packet = StreamPacket(op=StreamOpCode.EVENT, p=payload)
+
+    # Is this desired?
+    # The requirement said "IF op is ERROR: payload MUST be StreamError".
+    # It didn't strictly say "IF op is EVENT: payload MUST NOT be StreamError".
+    # However, having an EVENT with a StreamError payload is... odd but technically valid types.
+    # The validator only checks ERROR and DELTA.
+    #
+    # Let's verify what it actually is.
+    assert isinstance(packet.p, StreamError)
+
+    # If we want to FORCE it to be a dict, we'd need to ensure it doesn't match StreamError schema,
+    # or rely on the user passing a generic dict that doesn't match.
+    # But strictly speaking, if it quacks like a StreamError, it becomes one in the model.
+    #
+    # Test that we can use it as a dict if we cast it back? No, it's a model.
+    # This test documents the behavior: "Greedy matching of StreamError in Union".
+
+
+def test_stream_error_details_nested() -> None:
+    """Test StreamError with complex nested details."""
+    details = {
+        "trace": ["a", "b", "c"],
+        "meta": {"foo": {"bar": 123}},
+        "timestamp": "2023-01-01"
+    }
+    error = StreamError(code="c", message="m", severity=ErrorSeverity.TRANSIENT, details=details)
+    packet = StreamPacket(op=StreamOpCode.ERROR, p=error)
+
+    assert packet.p.details["meta"]["foo"]["bar"] == 123
+
+
+def test_large_payload() -> None:
+    """Test a large string payload for DELTA."""
+    large_str = "a" * 10_000
+    packet = StreamPacket(op=StreamOpCode.DELTA, p=large_str)
+    assert len(packet.p) == 10_000

--- a/tests/test_cap_errors.py
+++ b/tests/test_cap_errors.py
@@ -43,7 +43,7 @@ def test_happy_path_coercion() -> None:
         "severity": "fatal",
     }
     # This relies on Pydantic coercing dict -> StreamError because StreamError is in the Union
-    packet = StreamPacket(op=StreamOpCode.ERROR, p=payload)  # type: ignore[arg-type]
+    packet = StreamPacket(op=StreamOpCode.ERROR, p=payload)
 
     assert isinstance(packet.p, StreamError)
     assert packet.p.code == "auth_failed"
@@ -81,6 +81,6 @@ def test_immutability() -> None:
     )
 
     with pytest.raises(ValidationError) as excinfo:
-        error.code = "new_code"  # type: ignore[misc]
+        error.code = "new_code"
 
     assert "Instance is frozen" in str(excinfo.value)

--- a/tests/test_cap_errors.py
+++ b/tests/test_cap_errors.py
@@ -81,6 +81,7 @@ def test_immutability() -> None:
     )
 
     with pytest.raises(ValidationError) as excinfo:
-        error.code = "new_code"
+        # Use setattr to bypass static analysis but trigger runtime immutability check
+        setattr(error, "code", "new_code")
 
     assert "Instance is frozen" in str(excinfo.value)

--- a/tests/test_cap_errors.py
+++ b/tests/test_cap_errors.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.cap import (
+    ErrorSeverity,
+    StreamError,
+    StreamOpCode,
+    StreamPacket,
+)
+
+
+def test_happy_path_error() -> None:
+    """Create a StreamPacket with op=ERROR and a valid StreamError object."""
+    error = StreamError(
+        code="rate_limit_exceeded",
+        message="Too many requests",
+        severity=ErrorSeverity.TRANSIENT,
+        details={"retry_after": 60},
+    )
+    packet = StreamPacket(op=StreamOpCode.ERROR, p=error)
+
+    dumped = packet.dump()
+    assert dumped["op"] == "error"
+    assert dumped["p"]["code"] == "rate_limit_exceeded"
+    assert dumped["p"]["severity"] == "transient"
+
+
+def test_happy_path_coercion() -> None:
+    """Create a StreamPacket with op=ERROR and a dict payload."""
+    payload = {
+        "code": "auth_failed",
+        "message": "Invalid token",
+        "severity": "fatal",
+    }
+    # This relies on Pydantic coercing dict -> StreamError because StreamError is in the Union
+    packet = StreamPacket(op=StreamOpCode.ERROR, p=payload)  # type: ignore[arg-type]
+
+    assert isinstance(packet.p, StreamError)
+    assert packet.p.code == "auth_failed"
+    assert packet.p.severity == ErrorSeverity.FATAL
+
+
+def test_violation_string_error() -> None:
+    """Attempt to create a packet with op=ERROR and p='Simple string error'."""
+    with pytest.raises(ValueError) as excinfo:
+        StreamPacket(op=StreamOpCode.ERROR, p="Simple string error")
+
+    # The validator raises ValueError
+    assert "Payload 'p' must be a valid StreamError when op is ERROR" in str(excinfo.value)
+
+
+def test_violation_delta_type() -> None:
+    """Attempt to create a packet with op=DELTA and p=StreamError(...)."""
+    error = StreamError(
+        code="oops",
+        message="oops",
+        severity=ErrorSeverity.TRANSIENT,
+    )
+    with pytest.raises(ValueError) as excinfo:
+        StreamPacket(op=StreamOpCode.DELTA, p=error)
+
+    assert "Payload 'p' must be a string when op is DELTA" in str(excinfo.value)
+
+
+def test_immutability() -> None:
+    """Ensure StreamError cannot be modified after creation."""
+    error = StreamError(
+        code="oops",
+        message="oops",
+        severity=ErrorSeverity.TRANSIENT,
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        error.code = "new_code"  # type: ignore[misc]
+
+    assert "Instance is frozen" in str(excinfo.value)

--- a/tests/test_cap_errors.py
+++ b/tests/test_cap_errors.py
@@ -82,6 +82,6 @@ def test_immutability() -> None:
 
     with pytest.raises(ValidationError) as excinfo:
         # Use setattr to bypass static analysis but trigger runtime immutability check
-        setattr(error, "code", "new_code")
+        setattr(error, "code", "new_code")  # noqa: B010
 
     assert "Instance is frozen" in str(excinfo.value)

--- a/tests/test_cap_security.py
+++ b/tests/test_cap_security.py
@@ -1,4 +1,3 @@
-
 # Copyright (c) 2025 CoReason, Inc.
 #
 # This software is proprietary and dual-licensed.

--- a/tests/test_cap_security.py
+++ b/tests/test_cap_security.py
@@ -1,0 +1,30 @@
+
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any, Dict
+
+from coreason_manifest.spec.cap import StreamOpCode, StreamPacket
+
+
+def test_deeply_nested_payload_dos_check() -> None:
+    """Ensure deeply nested payloads don't crash validation (though they might hit recursion limits)."""
+    # Create a nested dict 500 levels deep
+    deep_payload: Dict[str, Any] = {}
+    current = deep_payload
+    for _ in range(500):
+        current["next"] = {}
+        current = current["next"]
+
+    # This should pass validation as a Dict, or fail gracefully with RecursionError if too deep for Python.
+    # 500 is usually safe for default recursion limit (1000).
+    packet = StreamPacket(op=StreamOpCode.EVENT, p=deep_payload)
+    assert packet.op == StreamOpCode.EVENT
+    assert isinstance(packet.p, dict)


### PR DESCRIPTION
This PR implements Work Package A: Protocol Hardening. It upgrades the Coreason Agent Protocol (CAP) wire format to support strict, typed error handling.

Changes include:
- Added `ErrorSeverity` and `StreamOpCode` enums.
- Added `StreamError` model.
- Refactored `StreamPacket` to strictly enforce payload types based on the operation code.
- Added extensive tests for error handling and validation.

This is a breaking change for `StreamPacket` serialization (renamed fields `event` -> `op`, `data` -> `p`).

---
*PR created automatically by Jules for task [1533999978631576128](https://jules.google.com/task/1533999978631576128) started by @gowthamrao*