### PR TITLE
Add AnyPresentationEvent union type alias

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -12,6 +12,7 @@ from .common import ToolRiskLevel
 from .definitions.identity import Identity
 from .definitions.message import ChatMessage, Role
 from .definitions.presentation import (
+    AnyPresentationEvent,
     ArtifactEvent,
     CitationEvent,
     PresentationEvent,
@@ -79,6 +80,7 @@ __all__ = [
     "ChatMessage",
     "PresentationEventType",
     "PresentationEvent",
+    "AnyPresentationEvent",
     "CitationEvent",
     "ArtifactEvent",
     "HealthCheckResponse",

--- a/src/coreason_manifest/definitions/presentation.py
+++ b/src/coreason_manifest/definitions/presentation.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from enum import Enum
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from pydantic import ConfigDict, Field
 
@@ -47,3 +47,6 @@ class ArtifactEvent(PresentationEvent):
     artifact_id: str = Field(..., description="Unique ID of the artifact.")
     mime_type: str = Field(..., description="MIME type of the artifact.")
     url: Optional[str] = Field(None, description="Download URL if applicable.")
+
+
+AnyPresentationEvent = Union[CitationEvent, ArtifactEvent]

--- a/tests/test_presentation_parsing.py
+++ b/tests/test_presentation_parsing.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import List
+
+from pydantic import TypeAdapter
+
+from coreason_manifest import (
+    AnyPresentationEvent,
+    ArtifactEvent,
+    CitationEvent,
+    PresentationEventType,
+)
+
+
+def test_parse_any_presentation_event() -> None:
+    """Test parsing a list of mixed presentation events using AnyPresentationEvent."""
+    data = [
+        {
+            "type": "citation",
+            "uri": "https://example.com/ref",
+            "text": "This is a citation.",
+            "indices": [0, 10],
+        },
+        {
+            "type": "artifact",
+            "artifact_id": "art-123",
+            "mime_type": "text/markdown",
+            "url": "https://example.com/download",
+        },
+    ]
+
+    adapter = TypeAdapter(List[AnyPresentationEvent])
+    parsed_events = adapter.validate_python(data)
+
+    assert len(parsed_events) == 2
+
+    # Check first event
+    assert isinstance(parsed_events[0], CitationEvent)
+    assert parsed_events[0].type == PresentationEventType.CITATION
+    assert parsed_events[0].uri == "https://example.com/ref"
+
+    # Check second event
+    assert isinstance(parsed_events[1], ArtifactEvent)
+    assert parsed_events[1].type == PresentationEventType.ARTIFACT
+    assert parsed_events[1].artifact_id == "art-123"


### PR DESCRIPTION
Added `AnyPresentationEvent` Union type alias to `presentation.py` to simplify parsing of polymorphic events. Exported it in `__init__.py` and added a test case.

---
*PR created automatically by Jules for task [4335328322288110157](https://jules.google.com/task/4335328322288110157) started by @gowthamrao*