### PR TITLE
Create comprehensive documentation index

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ For full details, see the [Usage Documentation](docs/usage.md).
 
 ## Documentation
 
+**[Full Documentation Index](docs/index.md)**
+
 *   [Usage Guide](docs/usage.md): How to load and create manifests.
 *   [Governance & Policy Enforcement](docs/governance_policy_enforcement.md): Validating agents against organizational rules.
 *   [Coreason Agent Manifest (CAM)](docs/cap/specification.md): The Canonical YAML Authoring Format.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,9 +1,30 @@
 # Welcome to Coreason Manifest
 
-This is the documentation for the `coreason-manifest` project, which defines the standard schemas and protocols for the Coreason AI ecosystem.
+This is the central documentation index for the `coreason-manifest` project, which defines the standard schemas, protocols, and governance models for the Coreason AI ecosystem.
 
-## Documentation
+## Core Documentation
 
-*   **[Coreason Agent Manifest (CAM)](cap/specification.md)**: The authoritative "Human-Centric" YAML format for defining Agents and Recipes.
-*   **[Usage Guide](usage.md)**: How to define and validate configurations.
-*   **[Governance & Policy](governance_policy_enforcement.md)**: Enforcing organizational rules.
+*   **[Usage Guide](usage.md)**
+    *   A comprehensive guide on how to use `coreason-manifest` to define agents, recipes, and work with the library's core concepts programmatically.
+
+*   **[Secure Composition](composition.md)**
+    *   Explains the Secure Recursive Loader, the `$ref` syntax for modular composition, the "Jail" security model, and cycle detection mechanisms.
+
+*   **[Governance & Policy Enforcement](governance_policy_enforcement.md)**
+    *   Details the Governance module for defining and enforcing organizational rules, risk levels, and compliance policies on agents and tools.
+
+## Specifications & Protocols
+
+*   **[Coreason Agent Manifest (CAM) Specification](cap/specification.md)**
+    *   The authoritative "Human-Centric" YAML format specification for defining Agents, Recipes, Workflows, and their components.
+
+*   **[Coreason Agent Protocol (CAP) Wire Format](cap/wire_protocol.md)**
+    *   Defines the runtime wire protocol, including standard request/response envelopes (`ServiceRequest`, `ServiceResponse`) and streaming contracts (`StreamPacket`).
+
+## Architecture & Rationale
+
+*   **[Product Requirements & Philosophy](product_requirements.md)**
+    *   Outlines the "Shared Kernel" philosophy, architectural standards, and the role of `coreason-manifest` as the definitive source of truth ("The Blueprint").
+
+*   **[CoReasonBaseModel Rationale](coreason_base_model_rationale.md)**
+    *   Explains the architectural decision to use `CoReasonBaseModel` for solving JSON serialization challenges with UUIDs and Datetimes.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,13 @@ theme:
   name: material
 nav:
   - Home: index.md
-  - Usage: usage.md
-  - Specification: cap/specification.md
-  - Governance: governance_policy_enforcement.md
+  - Core Documentation:
+    - Usage Guide: usage.md
+    - Secure Composition: composition.md
+    - Governance & Policy: governance_policy_enforcement.md
+  - Specifications & Protocols:
+    - CAM Specification: cap/specification.md
+    - CAP Wire Protocol: cap/wire_protocol.md
+  - Architecture & Rationale:
+    - Product Requirements: product_requirements.md
+    - Base Model Rationale: coreason_base_model_rationale.md


### PR DESCRIPTION
This PR enhances the documentation accessibility by creating a comprehensive index in `docs/index.md` that lists all available documentation files with summaries. It groups them logically and updates the `README.md` to point to this index. Additionally, it ensures `mkdocs.yml` navigation structure mirrors this organization, making the generated documentation site more complete and navigable.

---
*PR created automatically by Jules for task [392469115236150651](https://jules.google.com/task/392469115236150651) started by @gowthamrao*