### PR TITLE
Work Package E2: Service Contracts

### DIFF
--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -14,7 +14,7 @@ The standard envelope for sending instructions to an Agent.
 | :--- | :--- | :--- |
 | `request_id` | `UUID` | Unique identifier for the request trace. |
 | `context` | `Dict[str, Any]` | Metadata about the request (User Identity, Auth, Session). Separated from logic to enable consistent security policies. |
-| `payload` | `Dict[str, Any]` | The actual arguments for the Agent's business logic. |
+| `payload` | `Dict[str, Any]` | The actual arguments for the Agent's business logic. Standardized as `AgentRequest`. |
 
 **Example JSON:**
 ```json
@@ -25,10 +25,23 @@ The standard envelope for sending instructions to an Agent.
     "session_id": "sess_abc"
   },
   "payload": {
-    "query": "What is the status of the project?"
+    "query": "What is the status of the project?",
+    "files": [],
+    "conversation_id": "conv_123"
   }
 }
 ```
+
+### AgentRequest
+
+The strict payload schema used within `ServiceRequest`.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `query` | `str` | The user's primary input/instruction. |
+| `files` | `List[str]` | List of file URIs or references (default: `[]`). |
+| `conversation_id` | `Optional[str]` | ID for continuing a session (default: `None`). |
+| `meta` | `Dict[str, Any]` | Extra context like timezone (default: `{}`). |
 
 ### ServiceResponse
 

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -18,6 +18,7 @@ from .definitions.presentation import (
     PresentationEvent,
     PresentationEventType,
 )
+from .definitions.service import AgentRequest, ServiceContract
 from .governance import ComplianceReport, ComplianceViolation, GovernanceConfig
 from .spec.cap import (
     ErrorSeverity,
@@ -94,4 +95,6 @@ __all__ = [
     "validate_integrity",
     "validate_loose",
     "check_compliance_v2",
+    "AgentRequest",
+    "ServiceContract",
 ]

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -1,5 +1,7 @@
 from typing import Any, Dict, List, Optional
+
 from pydantic import ConfigDict
+
 from ..common import CoReasonBaseModel
 from ..spec.cap import ServiceRequest, ServiceResponse
 
@@ -26,9 +28,7 @@ class ServiceContract:
                 "summary": "Invoke Agent",
                 "requestBody": {
                     "content": {
-                        "application/json": {
-                            "schema": ServiceRequest.model_json_schema()
-                        }
+                        "application/json": {"schema": ServiceRequest.model_json_schema()}
                     }
                 },
                 "responses": {
@@ -38,8 +38,8 @@ class ServiceContract:
                             "application/json": {
                                 "schema": ServiceResponse.model_json_schema()
                             }
-                        }
+                        },
                     }
-                }
+                },
             }
         }

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -1,0 +1,45 @@
+from typing import Any, Dict, List, Optional
+from pydantic import ConfigDict
+from ..common import CoReasonBaseModel
+from ..spec.cap import ServiceRequest, ServiceResponse
+
+
+class AgentRequest(CoReasonBaseModel):
+    """Strictly typed payload inside a ServiceRequest."""
+
+    model_config = ConfigDict(frozen=True)
+
+    query: str
+    files: List[str] = []
+    conversation_id: Optional[str] = None
+    meta: Dict[str, Any] = {}
+
+
+class ServiceContract:
+    """Utility class to generate the OpenAPI specification."""
+
+    @staticmethod
+    def generate_openapi() -> Dict[str, Any]:
+        """Generate the OpenAPI 3.1 Path Item Object for the agent service."""
+        return {
+            "post": {
+                "summary": "Invoke Agent",
+                "requestBody": {
+                    "content": {
+                        "application/json": {
+                            "schema": ServiceRequest.model_json_schema()
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Successful Response",
+                        "content": {
+                            "application/json": {
+                                "schema": ServiceResponse.model_json_schema()
+                            }
+                        }
+                    }
+                }
+            }
+        }

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -28,7 +28,9 @@ class ServiceContract:
                 "summary": "Invoke Agent",
                 "requestBody": {
                     "content": {
-                        "application/json": {"schema": ServiceRequest.model_json_schema()}
+                        "application/json": {
+                            "schema": ServiceRequest.model_json_schema()
+                        }
                     }
                 },
                 "responses": {

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -26,21 +26,11 @@ class ServiceContract:
         return {
             "post": {
                 "summary": "Invoke Agent",
-                "requestBody": {
-                    "content": {
-                        "application/json": {
-                            "schema": ServiceRequest.model_json_schema()
-                        }
-                    }
-                },
+                "requestBody": {"content": {"application/json": {"schema": ServiceRequest.model_json_schema()}}},
                 "responses": {
                     "200": {
                         "description": "Successful Response",
-                        "content": {
-                            "application/json": {
-                                "schema": ServiceResponse.model_json_schema()
-                            }
-                        },
+                        "content": {"application/json": {"schema": ServiceResponse.model_json_schema()}},
                     }
                 },
             }

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -1,6 +1,8 @@
-from pydantic import ValidationError
 import pytest
+from pydantic import ValidationError
+
 from coreason_manifest import AgentRequest, ServiceContract
+
 
 def test_agent_request_serialization() -> None:
     req = AgentRequest(query="Hello", conversation_id="123")
@@ -9,6 +11,7 @@ def test_agent_request_serialization() -> None:
     assert dump["conversation_id"] == "123"
     assert dump["files"] == []
     assert dump["meta"] == {}
+
 
 def test_service_contract_generation() -> None:
     schema = ServiceContract.generate_openapi()
@@ -32,6 +35,7 @@ def test_service_contract_generation() -> None:
     assert "request_id" in resp_200["properties"]
     assert "output" in resp_200["properties"]
 
+
 def test_agent_request_defaults() -> None:
     """Test that default values are correctly populated."""
     req = AgentRequest(query="Just checking")
@@ -45,6 +49,7 @@ def test_agent_request_defaults() -> None:
     assert "conversation_id" not in dump
     assert dump["meta"] == {}
 
+
 def test_agent_request_immutability() -> None:
     """Test that AgentRequest is frozen/immutable."""
     req = AgentRequest(query="Immutable?")
@@ -53,19 +58,21 @@ def test_agent_request_immutability() -> None:
         # or just suppress the static error if running mypy, but here we run pytest.
         # But python sees it as attribute error if using slots, or validation error if pydantic.
         # Pydantic v2 raises ValidationError.
-        req.query = "Changed" # type: ignore
+        req.query = "Changed"  # type: ignore
+
 
 def test_agent_request_complex_meta() -> None:
     """Test AgentRequest with complex nested metadata."""
     meta = {
         "user_info": {"timezone": "UTC", "role": "admin"},
         "history": [1, 2, 3],
-        "flags": {"experimental": True}
+        "flags": {"experimental": True},
     }
     req = AgentRequest(query="Complex", meta=meta)
     dump = req.dump()
     assert dump["meta"]["user_info"]["timezone"] == "UTC"
     assert dump["meta"]["history"] == [1, 2, 3]
+
 
 def test_agent_request_with_files() -> None:
     """Test AgentRequest with files list."""
@@ -74,6 +81,7 @@ def test_agent_request_with_files() -> None:
     dump = req.dump()
     assert len(dump["files"]) == 2
     assert dump["files"][0] == "s3://bucket/file1.txt"
+
 
 def test_service_contract_schema_details() -> None:
     """Deep check of the generated OpenAPI schema."""

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -1,0 +1,32 @@
+import pytest
+from coreason_manifest import AgentRequest, ServiceContract
+
+def test_agent_request_serialization() -> None:
+    req = AgentRequest(query="Hello", conversation_id="123")
+    dump = req.dump()
+    assert dump["query"] == "Hello"
+    assert dump["conversation_id"] == "123"
+    assert dump["files"] == []
+    assert dump["meta"] == {}
+
+def test_service_contract_generation() -> None:
+    schema = ServiceContract.generate_openapi()
+    assert isinstance(schema, dict)
+
+    # Check structure
+    post = schema["post"]
+    assert post["summary"] == "Invoke Agent"
+
+    # Check Request Body
+    req_body = post["requestBody"]["content"]["application/json"]["schema"]
+    # ServiceRequest has request_id, context, payload
+    assert "properties" in req_body
+    assert "request_id" in req_body["properties"]
+    assert "payload" in req_body["properties"]
+
+    # Check Response
+    resp_200 = post["responses"]["200"]["content"]["application/json"]["schema"]
+    # ServiceResponse has request_id, created_at, output
+    assert "properties" in resp_200
+    assert "request_id" in resp_200["properties"]
+    assert "output" in resp_200["properties"]

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -1,3 +1,4 @@
+from pydantic import ValidationError
 import pytest
 from coreason_manifest import AgentRequest, ServiceContract
 
@@ -30,3 +31,65 @@ def test_service_contract_generation() -> None:
     assert "properties" in resp_200
     assert "request_id" in resp_200["properties"]
     assert "output" in resp_200["properties"]
+
+def test_agent_request_defaults() -> None:
+    """Test that default values are correctly populated."""
+    req = AgentRequest(query="Just checking")
+    assert req.files == []
+    assert req.conversation_id is None
+    assert req.meta == {}
+
+    dump = req.dump()
+    assert dump["files"] == []
+    # None fields are excluded by CoReasonBaseModel.dump(exclude_none=True)
+    assert "conversation_id" not in dump
+    assert dump["meta"] == {}
+
+def test_agent_request_immutability() -> None:
+    """Test that AgentRequest is frozen/immutable."""
+    req = AgentRequest(query="Immutable?")
+    with pytest.raises(ValidationError):
+        # Mypy will complain about assignment to frozen field, so we use setattr
+        # or just suppress the static error if running mypy, but here we run pytest.
+        # But python sees it as attribute error if using slots, or validation error if pydantic.
+        # Pydantic v2 raises ValidationError.
+        req.query = "Changed" # type: ignore
+
+def test_agent_request_complex_meta() -> None:
+    """Test AgentRequest with complex nested metadata."""
+    meta = {
+        "user_info": {"timezone": "UTC", "role": "admin"},
+        "history": [1, 2, 3],
+        "flags": {"experimental": True}
+    }
+    req = AgentRequest(query="Complex", meta=meta)
+    dump = req.dump()
+    assert dump["meta"]["user_info"]["timezone"] == "UTC"
+    assert dump["meta"]["history"] == [1, 2, 3]
+
+def test_agent_request_with_files() -> None:
+    """Test AgentRequest with files list."""
+    files = ["s3://bucket/file1.txt", "http://example.com/image.png"]
+    req = AgentRequest(query="Analyze this", files=files)
+    dump = req.dump()
+    assert len(dump["files"]) == 2
+    assert dump["files"][0] == "s3://bucket/file1.txt"
+
+def test_service_contract_schema_details() -> None:
+    """Deep check of the generated OpenAPI schema."""
+    schema = ServiceContract.generate_openapi()
+
+    # Check Content-Type keys
+    assert "application/json" in schema["post"]["requestBody"]["content"]
+    assert "application/json" in schema["post"]["responses"]["200"]["content"]
+
+    # Check that the request body schema is indeed ServiceRequest
+    # We can check for a known field of ServiceRequest like 'context'
+    req_schema = schema["post"]["requestBody"]["content"]["application/json"]["schema"]
+    properties = req_schema.get("properties", {})
+    assert "context" in properties
+    assert "request_id" in properties
+
+    # Check strictness or other attributes if present
+    # Pydantic v2 schemas usually have 'title': 'ServiceRequest'
+    assert req_schema.get("title") == "ServiceRequest"


### PR DESCRIPTION
Work Package E2: Service Contracts.
Implemented the strict input schema (`AgentRequest`) and a utility class (`ServiceContract`) to auto-generate the OpenAPI specification for the Engine.
This ensures the runtime contract is defined by code.


---
*PR created automatically by Jules for task [957123472120143665](https://jules.google.com/task/957123472120143665) started by @gowthamrao*