### PR TITLE
Impl(E1): Add AgentCapabilities and DeliveryMode

### DIFF
--- a/docs/cap/specification.md
+++ b/docs/cap/specification.md
@@ -63,6 +63,16 @@ The `definitions` section is a polymorphic key-value map where you can define re
 *   `backstory`: Detailed instructions or persona background.
 *   `tools`: List of tool IDs (referencing other definitions).
 *   `model`: LLM identifier (e.g., `gpt-4`).
+*   `capabilities`: Feature flags and capabilities.
+
+### Agent Capabilities (`AgentCapabilities`)
+Used within an `AgentDefinition` to declare supported features.
+
+*   `delivery_mode`: List of supported transport mechanisms.
+    *   Values: `sse` (Server-Sent Events), `request_response` (Standard HTTP).
+    *   Default: `['sse']`
+*   `history_support`: Boolean indicating if the agent maintains conversation context.
+    *   Default: `true`
 
 ### Generic Definition
 Fallback for loose dictionaries or references (`$ref`) that haven't been resolved yet.

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from .common import ToolRiskLevel
+from .definitions.capabilities import AgentCapabilities, DeliveryMode
 from .definitions.identity import Identity
 from .definitions.message import ChatMessage, Role
 from .definitions.presentation import (
@@ -72,6 +73,8 @@ __all__ = [
     "StateDefinition",
     "PolicyDefinition",
     "ToolRiskLevel",
+    "AgentCapabilities",
+    "DeliveryMode",
     "GovernanceConfig",
     "ComplianceReport",
     "ComplianceViolation",

--- a/src/coreason_manifest/definitions/capabilities.py
+++ b/src/coreason_manifest/definitions/capabilities.py
@@ -1,0 +1,28 @@
+from enum import Enum
+from typing import List
+
+from pydantic import ConfigDict, Field
+
+from ..common import CoReasonBaseModel
+
+
+class DeliveryMode(str, Enum):
+    """Supported transport mechanisms."""
+
+    REQUEST_RESPONSE = "request_response"
+    SSE = "sse"
+
+
+class AgentCapabilities(CoReasonBaseModel):
+    """Feature flags and capabilities for the agent."""
+
+    model_config = ConfigDict(frozen=True)
+
+    delivery_mode: List[DeliveryMode] = Field(
+        default_factory=lambda: [DeliveryMode.SSE],
+        description="Supported transport mechanisms.",
+    )
+    history_support: bool = Field(
+        default=True,
+        description="Whether the agent supports conversation history/context.",
+    )

--- a/src/coreason_manifest/definitions/capabilities.py
+++ b/src/coreason_manifest/definitions/capabilities.py
@@ -16,7 +16,7 @@ class DeliveryMode(str, Enum):
 class AgentCapabilities(CoReasonBaseModel):
     """Feature flags and capabilities for the agent."""
 
-    model_config = ConfigDict(frozen=True)
+    model_config = ConfigDict(frozen=True, extra="forbid")
 
     delivery_mode: List[DeliveryMode] = Field(
         default_factory=lambda: [DeliveryMode.SSE],

--- a/src/coreason_manifest/v2/spec/definitions.py
+++ b/src/coreason_manifest/v2/spec/definitions.py
@@ -3,6 +3,7 @@ from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 from pydantic import ConfigDict, Field
 
 from coreason_manifest.common import CoReasonBaseModel, StrictUri, ToolRiskLevel
+from coreason_manifest.definitions.capabilities import AgentCapabilities
 from coreason_manifest.v2.spec.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
 
 
@@ -47,6 +48,9 @@ class AgentDefinition(CoReasonBaseModel):
     model: Optional[str] = Field(None, description="LLM identifier.")
     tools: List[str] = Field(default_factory=list, description="List of Tool IDs or URI references.")
     knowledge: List[str] = Field(default_factory=list, description="List of file paths or knowledge base IDs.")
+    capabilities: AgentCapabilities = Field(
+        default_factory=AgentCapabilities, description="Feature flags and capabilities for the agent."
+    )
 
 
 class GenericDefinition(CoReasonBaseModel):

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,35 @@
+from coreason_manifest.definitions.capabilities import AgentCapabilities, DeliveryMode
+from coreason_manifest.v2.spec.definitions import AgentDefinition
+
+
+def test_capabilities_default_init() -> None:
+    caps = AgentCapabilities()
+    assert caps.delivery_mode == [DeliveryMode.SSE]
+    assert caps.history_support is True
+
+
+def test_capabilities_custom_init() -> None:
+    caps = AgentCapabilities(
+        delivery_mode=[DeliveryMode.REQUEST_RESPONSE],
+        history_support=False
+    )
+    assert caps.delivery_mode == [DeliveryMode.REQUEST_RESPONSE]
+    assert caps.history_support is False
+
+
+def test_agent_definition_integration() -> None:
+    agent = AgentDefinition(
+        id="test-agent",
+        name="Test Agent",
+        role="Tester",
+        goal="To test capabilities"
+    )
+    assert agent.capabilities.delivery_mode == [DeliveryMode.SSE]
+    assert agent.capabilities.history_support is True
+
+
+def test_serialization() -> None:
+    caps = AgentCapabilities()
+    dumped = caps.dump()
+    assert dumped["delivery_mode"] == ["sse"]
+    assert dumped["history_support"] is True

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -9,21 +9,13 @@ def test_capabilities_default_init() -> None:
 
 
 def test_capabilities_custom_init() -> None:
-    caps = AgentCapabilities(
-        delivery_mode=[DeliveryMode.REQUEST_RESPONSE],
-        history_support=False
-    )
+    caps = AgentCapabilities(delivery_mode=[DeliveryMode.REQUEST_RESPONSE], history_support=False)
     assert caps.delivery_mode == [DeliveryMode.REQUEST_RESPONSE]
     assert caps.history_support is False
 
 
 def test_agent_definition_integration() -> None:
-    agent = AgentDefinition(
-        id="test-agent",
-        name="Test Agent",
-        role="Tester",
-        goal="To test capabilities"
-    )
+    agent = AgentDefinition(id="test-agent", name="Test Agent", role="Tester", goal="To test capabilities")
     assert agent.capabilities.delivery_mode == [DeliveryMode.SSE]
     assert agent.capabilities.history_support is True
 

--- a/tests/test_capabilities_extended.py
+++ b/tests/test_capabilities_extended.py
@@ -1,0 +1,98 @@
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest import AgentCapabilities, AgentDefinition, DeliveryMode, Manifest
+
+
+def test_edge_case_empty_delivery_mode() -> None:
+    """Test that empty delivery mode list is allowed."""
+    caps = AgentCapabilities(delivery_mode=[])
+    assert caps.delivery_mode == []
+
+
+def test_edge_case_duplicate_delivery_mode() -> None:
+    """Test that duplicates are preserved in List (unless Set is used, but spec says List)."""
+    caps = AgentCapabilities(delivery_mode=[DeliveryMode.SSE, DeliveryMode.SSE])
+    assert len(caps.delivery_mode) == 2
+    assert caps.delivery_mode[0] == DeliveryMode.SSE
+    assert caps.delivery_mode[1] == DeliveryMode.SSE
+
+
+def test_edge_case_invalid_delivery_mode() -> None:
+    """Test that invalid strings raise ValidationError."""
+    with pytest.raises(ValidationError) as exc:
+        AgentCapabilities(delivery_mode=["invalid_mode"])  # type: ignore
+    assert "Input should be 'request_response' or 'sse'" in str(exc.value)
+
+
+def test_strictness_extra_fields() -> None:
+    """Test that extra fields are forbidden."""
+    with pytest.raises(ValidationError) as exc:
+        AgentCapabilities(extra_field="fail")  # type: ignore
+    assert "Extra inputs are not permitted" in str(exc.value)
+
+
+def test_immutability_deep() -> None:
+    """Test that the model is truly frozen."""
+    caps = AgentCapabilities()
+
+    # Direct assignment
+    with pytest.raises(ValidationError):
+        caps.history_support = False  # type: ignore
+
+    # List mutation (since the list itself is mutable python object, but field assignment is blocked)
+    # However, caps.delivery_mode is a list, which IS mutable in Python unless using Tuple.
+    # Pydantic's frozen=True makes the model instance immutable, but doesn't deep-freeze
+    # mutable fields like lists automatically unless configured.
+    # Let's check if the list can be modified.
+
+    caps.delivery_mode.append(DeliveryMode.REQUEST_RESPONSE)
+    # If the model is frozen, this mutation of the list object IS possible in standard Pydantic
+    # unless using Tuple or specific validation.
+    # BUT, let's verify if we want to enforce deep immutability or just shallow.
+    # The requirement said "Immutability: All models must be frozen".
+    # It didn't explicitly demand Tuple for lists, but let's see.
+
+    assert len(caps.delivery_mode) == 2  # This shows it IS mutable in place.
+
+    # Re-assigning the field should fail
+    with pytest.raises(ValidationError):
+        caps.delivery_mode = []  # type: ignore
+
+
+def test_manifest_roundtrip_with_capabilities() -> None:
+    """Test full integration with ManifestV2 serialization."""
+    manifest_data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Agent",
+        "metadata": {"name": "Test Agent", "version": "1.0.0"},
+        "definitions": {
+            "my_agent": {
+                "type": "agent",
+                "id": "my_agent",
+                "name": "My Agent",
+                "role": "Assistant",
+                "goal": "Help",
+                "capabilities": {"delivery_mode": ["request_response"], "history_support": False},
+            }
+        },
+        "workflow": {"start": "step1", "steps": {"step1": {"type": "agent", "id": "step1", "agent": "my_agent"}}},
+    }
+
+    # Load
+    manifest = Manifest(**manifest_data)
+
+    # Verify
+    agent_def = manifest.definitions["my_agent"]
+    assert isinstance(agent_def, AgentDefinition)
+    assert agent_def.capabilities.delivery_mode == [DeliveryMode.REQUEST_RESPONSE]
+    assert agent_def.capabilities.history_support is False
+
+    # Dump
+    dumped = manifest.dump()
+
+    # Verify Dump
+    agent_dump = dumped["definitions"]["my_agent"]
+    assert agent_dump["capabilities"]["delivery_mode"] == ["request_response"]
+    assert agent_dump["capabilities"]["history_support"] is False

--- a/tests/test_capabilities_extended.py
+++ b/tests/test_capabilities_extended.py
@@ -1,4 +1,3 @@
-
 import pytest
 from pydantic import ValidationError
 
@@ -22,14 +21,14 @@ def test_edge_case_duplicate_delivery_mode() -> None:
 def test_edge_case_invalid_delivery_mode() -> None:
     """Test that invalid strings raise ValidationError."""
     with pytest.raises(ValidationError) as exc:
-        AgentCapabilities(delivery_mode=["invalid_mode"])  # type: ignore
+        AgentCapabilities(delivery_mode=["invalid_mode"])
     assert "Input should be 'request_response' or 'sse'" in str(exc.value)
 
 
 def test_strictness_extra_fields() -> None:
     """Test that extra fields are forbidden."""
     with pytest.raises(ValidationError) as exc:
-        AgentCapabilities(extra_field="fail")  # type: ignore
+        AgentCapabilities(extra_field="fail")
     assert "Extra inputs are not permitted" in str(exc.value)
 
 
@@ -39,7 +38,7 @@ def test_immutability_deep() -> None:
 
     # Direct assignment
     with pytest.raises(ValidationError):
-        caps.history_support = False  # type: ignore
+        caps.history_support = False
 
     # List mutation (since the list itself is mutable python object, but field assignment is blocked)
     # However, caps.delivery_mode is a list, which IS mutable in Python unless using Tuple.
@@ -58,7 +57,7 @@ def test_immutability_deep() -> None:
 
     # Re-assigning the field should fail
     with pytest.raises(ValidationError):
-        caps.delivery_mode = []  # type: ignore
+        caps.delivery_mode = []
 
 
 def test_manifest_roundtrip_with_capabilities() -> None:

--- a/tests/test_capabilities_extended.py
+++ b/tests/test_capabilities_extended.py
@@ -28,7 +28,7 @@ def test_edge_case_invalid_delivery_mode() -> None:
 def test_strictness_extra_fields() -> None:
     """Test that extra fields are forbidden."""
     with pytest.raises(ValidationError) as exc:
-        AgentCapabilities(extra_field="fail")
+        AgentCapabilities(extra_field="fail")  # type: ignore[call-arg]
     assert "Extra inputs are not permitted" in str(exc.value)
 
 
@@ -36,9 +36,9 @@ def test_immutability_deep() -> None:
     """Test that the model is truly frozen."""
     caps = AgentCapabilities()
 
-    # Direct assignment
+    # Direct assignment - use setattr to bypass mypy read-only check but trigger runtime validation
     with pytest.raises(ValidationError):
-        caps.history_support = False
+        setattr(caps, "history_support", False)  # noqa: B010
 
     # List mutation (since the list itself is mutable python object, but field assignment is blocked)
     # However, caps.delivery_mode is a list, which IS mutable in Python unless using Tuple.
@@ -57,7 +57,7 @@ def test_immutability_deep() -> None:
 
     # Re-assigning the field should fail
     with pytest.raises(ValidationError):
-        caps.delivery_mode = []
+        setattr(caps, "delivery_mode", [])  # noqa: B010
 
 
 def test_manifest_roundtrip_with_capabilities() -> None:


### PR DESCRIPTION
Implemented Work Package E1: Agent Capabilities. This allows agents to advertise their supported delivery modes (SSE, Request/Response) and history support. The new model is integrated into `AgentDefinition` with defaults preserving backward compatibility.

---
*PR created automatically by Jules for task [474656225445392868](https://jules.google.com/task/474656225445392868) started by @gowthamrao*