### PR TITLE
Bump minor version to 0.16.0 (#251)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.15.0"
+version = "0.16.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.15.0"
+version = "0.16.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Updated `pyproject.toml` to increment the version from 0.15.0 to 0.16.0 in both `[tool.poetry]` and `[project]` sections. Synchronized `poetry.lock` (no changes were necessary as dependencies were untouched). Verified changes with `poetry check` and ran full test suite with 100% coverage.