### PR TITLE
Bump minor version to 0.17.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.16.0"
+version = "0.17.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -32,7 +32,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.16.0"
+version = "0.17.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -48,7 +48,7 @@ from .v2.spec.definitions import (
 )
 from .v2.validator import validate_integrity, validate_loose
 
-__version__ = "0.15.0"
+__version__ = "0.17.0"
 
 Manifest = ManifestV2
 Recipe = ManifestV2


### PR DESCRIPTION
Bumped the minor version from 0.16.0 to 0.17.0 in `pyproject.toml` and `src/coreason_manifest/__init__.py`. Synced the version numbers which were previously inconsistent (`0.16.0` vs `0.15.0`). Verified changes and ran tests to ensure no regressions.

---
*PR created automatically by Jules for task [12095831518749641005](https://jules.google.com/task/12095831518749641005) started by @gowthamrao*