### PR TITLE
Strict Envelope Refactor: ServiceRequest uses SessionContext and AgentRequest

### DIFF
--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -13,16 +13,20 @@ The standard envelope for sending instructions to an Agent.
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `request_id` | `UUID` | Unique identifier for the request trace. |
-| `context` | `Dict[str, Any]` | Metadata about the request (User Identity, Auth, Session). Separated from logic to enable consistent security policies. |
-| `payload` | `Dict[str, Any]` | The actual arguments for the Agent's business logic. Standardized as `AgentRequest`. |
+| `context` | `SessionContext` | Metadata about the request (User Identity, Auth, Session). Separated from logic to enable consistent security policies. |
+| `payload` | `AgentRequest` | The actual arguments for the Agent's business logic. |
 
 **Example JSON:**
 ```json
 {
   "request_id": "550e8400-e29b-41d4-a716-446655440000",
   "context": {
-    "user_id": "user_123",
-    "session_id": "sess_abc"
+    "session_id": "sess_abc",
+    "user": {
+      "id": "user_123",
+      "name": "Alice",
+      "role": "user"
+    }
   },
   "payload": {
     "query": "What is the status of the project?",
@@ -31,6 +35,16 @@ The standard envelope for sending instructions to an Agent.
   }
 }
 ```
+
+### SessionContext
+
+Strict context containing authentication and session details.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `session_id` | `str` | Unique identifier for the session. |
+| `user` | `Identity` | The authenticated user making the request. |
+| `agent` | `Optional[Identity]` | The target agent (if applicable). |
 
 ### AgentRequest
 

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -19,14 +19,16 @@ from .definitions.presentation import (
     PresentationEvent,
     PresentationEventType,
 )
-from .definitions.service import AgentRequest, ServiceContract
+from .definitions.service import ServiceContract
 from .governance import ComplianceReport, ComplianceViolation, GovernanceConfig
 from .spec.cap import (
+    AgentRequest,
     ErrorSeverity,
     HealthCheckResponse,
     HealthCheckStatus,
     ServiceRequest,
     ServiceResponse,
+    SessionContext,
     StreamError,
     StreamOpCode,
     StreamPacket,
@@ -99,5 +101,6 @@ __all__ = [
     "validate_loose",
     "check_compliance_v2",
     "AgentRequest",
+    "SessionContext",
     "ServiceContract",
 ]

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict
 
-from ..spec.cap import AgentRequest, ServiceRequest, ServiceResponse
+from ..spec.cap import ServiceRequest, ServiceResponse
 
 
 class ServiceContract:

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -1,20 +1,6 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
-from pydantic import ConfigDict
-
-from ..common import CoReasonBaseModel
-from ..spec.cap import ServiceRequest, ServiceResponse
-
-
-class AgentRequest(CoReasonBaseModel):
-    """Strictly typed payload inside a ServiceRequest."""
-
-    model_config = ConfigDict(frozen=True)
-
-    query: str
-    files: List[str] = []
-    conversation_id: Optional[str] = None
-    meta: Dict[str, Any] = {}
+from ..spec.cap import AgentRequest, ServiceRequest, ServiceResponse
 
 
 class ServiceContract:

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -10,12 +10,13 @@
 
 from datetime import datetime
 from enum import Enum
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from uuid import UUID
 
 from pydantic import ConfigDict, Field, model_validator
 
 from coreason_manifest.common import CoReasonBaseModel
+from coreason_manifest.definitions.identity import Identity
 
 
 class HealthCheckStatus(str, Enum):
@@ -96,6 +97,27 @@ class ServiceResponse(CoReasonBaseModel):
     metrics: Optional[Dict[str, Any]] = None
 
 
+class AgentRequest(CoReasonBaseModel):
+    """Strictly typed payload inside a ServiceRequest."""
+
+    model_config = ConfigDict(frozen=True)
+
+    query: str
+    files: List[str] = []
+    conversation_id: Optional[str] = None
+    meta: Dict[str, Any] = {}
+
+
+class SessionContext(CoReasonBaseModel):
+    """Strict context containing authentication and session details."""
+
+    model_config = ConfigDict(frozen=True)
+
+    session_id: str
+    user: Identity
+    agent: Optional[Identity] = None
+
+
 class ServiceRequest(CoReasonBaseModel):
     """Request to an agent service.
 
@@ -109,7 +131,5 @@ class ServiceRequest(CoReasonBaseModel):
     model_config = ConfigDict(frozen=True)
 
     request_id: UUID
-    # TODO: In v0.16.0, strictly type 'context' with a SessionContext model
-    # once the Identity primitive is fully integrated.
-    context: Dict[str, Any]
-    payload: Dict[str, Any]
+    context: SessionContext
+    payload: AgentRequest

--- a/tests/test_cap.py
+++ b/tests/test_cap.py
@@ -144,9 +144,7 @@ def test_service_request_deep_nesting() -> None:
 def test_round_trip_json_serialization() -> None:
     context = SessionContext(session_id="s1", user=Identity.anonymous())
     payload = AgentRequest(query="run", meta={"params": {"x": 10}})
-    original_req = ServiceRequest(
-        request_id=uuid4(), context=context, payload=payload
-    )
+    original_req = ServiceRequest(request_id=uuid4(), context=context, payload=payload)
 
     # Dump to JSON string
     json_str = original_req.to_json()
@@ -203,7 +201,7 @@ def test_extra_fields_behavior() -> None:
         "request_id": str(uuid4()),
         "context": {"session_id": "s1", "user": {"id": "u1", "name": "User"}},
         "payload": {"query": "q"},
-        "extra_field": "should_be_ignored"
+        "extra_field": "should_be_ignored",
     }
 
     # Should not raise

--- a/tests/test_cap.py
+++ b/tests/test_cap.py
@@ -14,11 +14,14 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
+from coreason_manifest.definitions.identity import Identity
 from coreason_manifest.spec.cap import (
+    AgentRequest,
     HealthCheckResponse,
     HealthCheckStatus,
     ServiceRequest,
     ServiceResponse,
+    SessionContext,
     StreamPacket,
 )
 
@@ -64,9 +67,13 @@ def test_service_response_serialization() -> None:
 
 def test_service_request_instantiation() -> None:
     req_id = uuid4()
-    req = ServiceRequest(request_id=req_id, context={"user_id": "u123"}, payload={"query": "test"})
+    user = Identity.anonymous()
+    context = SessionContext(session_id="s123", user=user)
+    payload = AgentRequest(query="test")
+    req = ServiceRequest(request_id=req_id, context=context, payload=payload)
     assert req.request_id == req_id
-    assert req.context["user_id"] == "u123"
+    assert req.context.session_id == "s123"
+    assert req.payload.query == "test"
 
 
 # --- Edge Case Tests ---
@@ -77,8 +84,8 @@ def test_invalid_uuid_validation() -> None:
         ServiceRequest.model_validate(
             {
                 "request_id": "not-a-uuid",
-                "context": {},
-                "payload": {},
+                "context": {"session_id": "s1", "user": {"id": "u1", "name": "User"}},
+                "payload": {"query": "q"},
             }
         )
     assert "Input should be a valid UUID" in str(excinfo.value)
@@ -123,16 +130,22 @@ def test_stream_packet_invalid_data_type() -> None:
 
 
 def test_service_request_deep_nesting() -> None:
-    payload = {"level1": {"level2": {"level3": {"data": "deep", "list": [1, 2, {"nested": "item"}]}}}}
-    req = ServiceRequest(request_id=uuid4(), context={}, payload=payload)
+    # Use meta for nested data
+    meta = {"level1": {"level2": {"level3": {"data": "deep", "list": [1, 2, {"nested": "item"}]}}}}
+    payload = AgentRequest(query="test", meta=meta)
+    context = SessionContext(session_id="s1", user=Identity.anonymous())
+    req = ServiceRequest(request_id=uuid4(), context=context, payload=payload)
+
     dumped = req.dump()
-    assert dumped["payload"]["level1"]["level2"]["level3"]["data"] == "deep"
-    assert dumped["payload"]["level1"]["level2"]["level3"]["list"][2]["nested"] == "item"
+    assert dumped["payload"]["meta"]["level1"]["level2"]["level3"]["data"] == "deep"
+    assert dumped["payload"]["meta"]["level1"]["level2"]["level3"]["list"][2]["nested"] == "item"
 
 
 def test_round_trip_json_serialization() -> None:
+    context = SessionContext(session_id="s1", user=Identity.anonymous())
+    payload = AgentRequest(query="run", meta={"params": {"x": 10}})
     original_req = ServiceRequest(
-        request_id=uuid4(), context={"session": "s1"}, payload={"action": "run", "params": {"x": 10}}
+        request_id=uuid4(), context=context, payload=payload
     )
 
     # Dump to JSON string
@@ -150,10 +163,12 @@ def test_round_trip_json_serialization() -> None:
 
 
 def test_immutability_frozen() -> None:
-    req = ServiceRequest(request_id=uuid4(), context={}, payload={})
+    context = SessionContext(session_id="s1", user=Identity.anonymous())
+    payload = AgentRequest(query="test")
+    req = ServiceRequest(request_id=uuid4(), context=context, payload=payload)
 
     with pytest.raises(ValidationError) as excinfo:
-        req.context = {"new": "context"}  # type: ignore[misc]
+        req.context = context  # type: ignore[misc]
 
     # Error message for frozen instance assignment
     assert "Instance is frozen" in str(excinfo.value)
@@ -162,19 +177,21 @@ def test_immutability_frozen() -> None:
 def test_type_preservation_in_dict() -> None:
     """Ensure that native types in Dict[str, Any] are preserved."""
     # Ensure they are not aggressively coerced to strings if not needed.
-    payload = {"int_val": 123, "float_val": 45.67, "bool_val": True, "none_val": None, "list_val": [1, "two"]}
-    req = ServiceRequest(request_id=uuid4(), context={}, payload=payload)
+    meta = {"int_val": 123, "float_val": 45.67, "bool_val": True, "none_val": None, "list_val": [1, "two"]}
+    context = SessionContext(session_id="s1", user=Identity.anonymous())
+    payload = AgentRequest(query="test", meta=meta)
+    req = ServiceRequest(request_id=uuid4(), context=context, payload=payload)
 
     # Dump using the CoReasonBaseModel.dump() which sets mode='json'
     dumped = req.dump()
 
     # In mode='json', Pydantic might serialize types to their JSON equivalents.
     # int -> int, float -> float, bool -> bool, None -> null
-    assert dumped["payload"]["int_val"] == 123
-    assert dumped["payload"]["float_val"] == 45.67
-    assert dumped["payload"]["bool_val"] is True
-    assert dumped["payload"]["none_val"] is None
-    assert dumped["payload"]["list_val"] == [1, "two"]
+    assert dumped["payload"]["meta"]["int_val"] == 123
+    assert dumped["payload"]["meta"]["float_val"] == 45.67
+    assert dumped["payload"]["meta"]["bool_val"] is True
+    assert dumped["payload"]["meta"]["none_val"] is None
+    assert dumped["payload"]["meta"]["list_val"] == [1, "two"]
 
 
 def test_extra_fields_behavior() -> None:
@@ -182,7 +199,12 @@ def test_extra_fields_behavior() -> None:
     # By default, Pydantic ignores extra fields unless configured otherwise.
     # We want to confirm it doesn't raise ValidationError.
 
-    data = {"request_id": str(uuid4()), "context": {}, "payload": {}, "extra_field": "should_be_ignored"}
+    data = {
+        "request_id": str(uuid4()),
+        "context": {"session_id": "s1", "user": {"id": "u1", "name": "User"}},
+        "payload": {"query": "q"},
+        "extra_field": "should_be_ignored"
+    }
 
     # Should not raise
     req = ServiceRequest.model_validate(data)


### PR DESCRIPTION
This PR refactors the `ServiceRequest` model in the Coreason Agent Protocol (CAP) to enforce strict typing, addressing Work Package F. It replaces the loose `Dict[str, Any]` typing for `context` and `payload` with `SessionContext` and `AgentRequest` models respectively. This change improves type safety, security, and developer experience by ensuring that context information (like user identity) and payload structure are strictly validated. It also resolves a potential circular import by moving `AgentRequest` to `spec/cap.py`. Tests have been updated to reflect these changes.

---
*PR created automatically by Jules for task [6881518189495462159](https://jules.google.com/task/6881518189495462159) started by @gowthamrao*