### PR TITLE
feat: Implement Observability & Tracing models

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Coreason Agent Protocol (CAP) Wire Format](cap/wire_protocol.md)**
     *   Defines the runtime wire protocol, including standard request/response envelopes (`ServiceRequest`, `ServiceResponse`) and streaming contracts (`StreamPacket`).
 
+*   **[Observability & Tracing](observability.md)**
+    *   Standard telemetry envelopes (`CloudEvent`, `ReasoningTrace`) for system notifications, audit logs, and distributed tracing.
+
 ## Architecture & Rationale
 
 *   **[Product Requirements & Philosophy](product_requirements.md)**

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,93 @@
+# Observability & Tracing
+
+`coreason-manifest` defines standard envelopes for emitting telemetry and audit logs from the Coreason Engine. These models ensure that all system events are machine-parsable, strictly typed, and compliant with industry standards.
+
+## CloudEvent Envelope
+
+We use the [CloudEvents 1.0 JSON Format](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/json-format.md) for all system notifications and asynchronous events.
+
+### Model: `CloudEvent`
+
+A strict Pydantic model representing a CloudEvent.
+
+**Import:**
+```python
+from coreason_manifest import CloudEvent
+```
+
+**Fields:**
+
+| Field | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `specversion` | `Literal["1.0"]` | The CloudEvents specification version. | Yes | `"1.0"` |
+| `id` | `str` | Unique event identifier. | Yes | - |
+| `source` | `str` | URI reference to the event producer (e.g., `urn:node:step-1`). | Yes | - |
+| `type` | `str` | Reverse-DNS event type (e.g., `ai.coreason.node.started`). | Yes | - |
+| `time` | `datetime` | Timestamp of occurrence (UTC). | Yes | - |
+| `datacontenttype` | `str` | MIME type of the data. | Yes | `"application/json"` |
+| `data` | `Optional[Dict[str, Any]]` | The event payload. | No | `None` |
+| `traceparent` | `Optional[str]` | W3C Trace Context parent ID. | No | `None` |
+| `tracestate` | `Optional[str]` | W3C Trace Context state. | No | `None` |
+
+**Example:**
+
+```python
+from datetime import datetime, timezone
+from coreason_manifest import CloudEvent
+
+event = CloudEvent(
+    id="evt-123",
+    source="urn:process:workflow-a",
+    type="ai.coreason.workflow.completed",
+    time=datetime.now(timezone.utc),
+    data={"result": "success", "tokens": 150}
+)
+
+print(event.to_json())
+```
+
+---
+
+## Reasoning Trace
+
+Structured audit logs for tracking the execution lineage of Agents, Workflows, and Steps.
+
+### Model: `ReasoningTrace`
+
+**Import:**
+```python
+from coreason_manifest import ReasoningTrace
+```
+
+**Fields:**
+
+| Field | Type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| `request_id` | `UUID` | Unique ID for this specific trace entry. | Yes |
+| `root_request_id` | `UUID` | The original user request ID (preserves lineage). | Yes |
+| `parent_request_id` | `Optional[UUID]` | The ID of the parent span/step. | No |
+| `node_id` | `str` | The name or ID of the step/component. | Yes |
+| `status` | `str` | Execution status (`"success"`, `"failed"`). | Yes |
+| `inputs` | `Optional[Dict]` | Input arguments to the node. | No |
+| `outputs` | `Optional[Dict]` | Output results from the node. | No |
+| `latency_ms` | `float` | Execution duration in milliseconds. | Yes |
+| `timestamp` | `datetime` | Time of log entry. | Yes |
+
+**Example:**
+
+```python
+from uuid import uuid4
+from datetime import datetime, timezone
+from coreason_manifest import ReasoningTrace
+
+trace = ReasoningTrace(
+    request_id=uuid4(),
+    root_request_id=uuid4(),
+    node_id="summarize-text",
+    status="success",
+    inputs={"text_length": 5000},
+    outputs={"summary_length": 200},
+    latency_ms=1250.5,
+    timestamp=datetime.now(timezone.utc)
+)
+```

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -12,6 +12,7 @@ from .common import ToolRiskLevel
 from .definitions.capabilities import AgentCapabilities, DeliveryMode
 from .definitions.identity import Identity
 from .definitions.message import ChatMessage, Role
+from .definitions.observability import CloudEvent, ReasoningTrace
 from .definitions.presentation import (
     AnyPresentationEvent,
     ArtifactEvent,
@@ -100,4 +101,6 @@ __all__ = [
     "check_compliance_v2",
     "AgentRequest",
     "ServiceContract",
+    "CloudEvent",
+    "ReasoningTrace",
 ]

--- a/src/coreason_manifest/definitions/observability.py
+++ b/src/coreason_manifest/definitions/observability.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime
+from typing import Any, Dict, Literal, Optional
+from uuid import UUID
+
+from pydantic import Field
+
+from ..common import CoReasonBaseModel
+
+
+class CloudEvent(CoReasonBaseModel):
+    """
+    A strictly typed Pydantic model compliant with the CloudEvents 1.0 JSON Format.
+    https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/json-format.md
+    """
+
+    model_config = {"frozen": True}
+
+    specversion: Literal["1.0"] = "1.0"
+    id: str = Field(description="Unique event ID")
+    source: str = Field(description="URI reference to the producer, e.g., urn:node:step-1")
+    type: str = Field(description="Reverse-DNS type, e.g., ai.coreason.node.started")
+    time: datetime = Field(description="Timestamp of when the occurrence happened (UTC)")
+    datacontenttype: str = Field(default="application/json")
+    data: Optional[Dict[str, Any]] = None
+
+    # Extensions for Distributed Tracing (W3C Trace Context)
+    traceparent: Optional[str] = None
+    tracestate: Optional[str] = None
+
+
+class ReasoningTrace(CoReasonBaseModel):
+    """
+    A structured log entry for audit trails.
+    """
+
+    model_config = {"frozen": True}
+
+    request_id: UUID
+    root_request_id: UUID = Field(description="The original user request ID (for lineage)")
+    parent_request_id: Optional[UUID] = None
+    node_id: str = Field(description="The step name")
+    status: str = Field(description='"success" or "failed"')
+    inputs: Optional[Dict[str, Any]] = None
+    outputs: Optional[Dict[str, Any]] = None
+    latency_ms: float
+    timestamp: datetime

--- a/src/coreason_manifest/definitions/observability.py
+++ b/src/coreason_manifest/definitions/observability.py
@@ -41,6 +41,10 @@ class CloudEvent(CoReasonBaseModel):
 class ReasoningTrace(CoReasonBaseModel):
     """
     A structured log entry for audit trails.
+
+    Warning:
+        This model does not automatically redact PII or secrets.
+        Ensure `inputs` and `outputs` are sanitized before logging.
     """
 
     model_config = {"frozen": True}

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.definitions.observability import CloudEvent, ReasoningTrace
+
+
+def test_cloud_event_serialization() -> None:
+    now = datetime.now(timezone.utc)
+    event = CloudEvent(
+        id="evt-1",
+        source="urn:node:step-1",
+        type="ai.coreason.node.started",
+        time=now,
+        data={"message": "hello"},
+    )
+
+    dumped = event.dump()
+    assert dumped["specversion"] == "1.0"
+    assert dumped["id"] == "evt-1"
+    assert dumped["source"] == "urn:node:step-1"
+    assert dumped["type"] == "ai.coreason.node.started"
+    # CoReasonBaseModel serializes datetime with Z suffix
+    assert dumped["time"] == now.isoformat().replace("+00:00", "Z")
+    assert dumped["datacontenttype"] == "application/json"
+    assert dumped["data"] == {"message": "hello"}
+
+
+def test_cloud_event_tracing_extensions() -> None:
+    now = datetime.now(timezone.utc)
+    event = CloudEvent(
+        id="evt-2",
+        source="urn:node:step-2",
+        type="ai.coreason.node.completed",
+        time=now,
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+        tracestate="rojo=00f067aa0ba902b7-01",
+    )
+    dumped = event.dump()
+    assert dumped["traceparent"] == "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    assert dumped["tracestate"] == "rojo=00f067aa0ba902b7-01"
+
+
+def test_reasoning_trace_serialization() -> None:
+    req_id = uuid4()
+    root_id = uuid4()
+    now = datetime.now(timezone.utc)
+
+    trace = ReasoningTrace(
+        request_id=req_id,
+        root_request_id=root_id,
+        node_id="step-analysis",
+        status="success",
+        inputs={"query": "why?"},
+        outputs={"answer": "because"},
+        latency_ms=123.4,
+        timestamp=now,
+    )
+
+    dumped = trace.dump()
+    assert dumped["request_id"] == str(req_id)
+    assert dumped["root_request_id"] == str(root_id)
+    assert dumped["node_id"] == "step-analysis"
+    assert dumped["status"] == "success"
+    assert dumped["inputs"] == {"query": "why?"}
+    assert dumped["outputs"] == {"answer": "because"}
+    assert dumped["latency_ms"] == 123.4
+    assert dumped["timestamp"] == now.isoformat().replace("+00:00", "Z")
+
+
+def test_immutability() -> None:
+    now = datetime.now(timezone.utc)
+    event = CloudEvent(
+        id="evt-3",
+        source="urn:node:step-3",
+        type="test",
+        time=now,
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        setattr(event, "id", "new-id")  # noqa: B010
+
+    assert "Instance is frozen" in str(excinfo.value)
+
+    trace = ReasoningTrace(
+        request_id=uuid4(),
+        root_request_id=uuid4(),
+        node_id="test",
+        status="success",
+        latency_ms=1.0,
+        timestamp=now,
+    )
+
+    with pytest.raises(ValidationError) as excinfo:
+        setattr(trace, "status", "failed")  # noqa: B010
+
+    assert "Instance is frozen" in str(excinfo.value)

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -16,8 +16,8 @@ from pydantic import ValidationError
 
 from coreason_manifest.definitions.observability import CloudEvent, ReasoningTrace
 
-
 # --- Unit Tests ---
+
 
 def test_cloud_event_serialization() -> None:
     now = datetime.now(timezone.utc)
@@ -113,15 +113,11 @@ def test_immutability() -> None:
 
 # --- Edge Case Tests ---
 
+
 def test_cloud_event_minimal() -> None:
     """Test CloudEvent with only required fields."""
     now = datetime.now(timezone.utc)
-    event = CloudEvent(
-        id="evt-min",
-        source="urn:min",
-        type="test.min",
-        time=now
-    )
+    event = CloudEvent(id="evt-min", source="urn:min", type="test.min", time=now)
     dumped = event.dump()
     assert dumped["id"] == "evt-min"
     # data is optional and None by default, so exclude_none=True removes it
@@ -132,12 +128,7 @@ def test_cloud_event_minimal() -> None:
 
 def test_cloud_event_data_variations() -> None:
     """Test CloudEvent with different data shapes (None, Empty Dict)."""
-    base_args = {
-        "id": "evt-data",
-        "source": "urn:data",
-        "type": "test.data",
-        "time": datetime.now(timezone.utc)
-    }
+    base_args = {"id": "evt-data", "source": "urn:data", "type": "test.data", "time": datetime.now(timezone.utc)}
 
     # None
     evt_none = CloudEvent(**base_args, data=None)
@@ -162,7 +153,7 @@ def test_reasoning_trace_missing_optional() -> None:
         status="success",
         # inputs/outputs omitted (None)
         latency_ms=10.0,
-        timestamp=now
+        timestamp=now,
     )
 
     dumped = trace.dump()
@@ -176,11 +167,7 @@ def test_validation_failure_missing_fields() -> None:
     """Test that missing required fields raises ValidationError."""
     with pytest.raises(ValidationError):
         # Missing 'id'
-        CloudEvent(
-            source="urn:test",
-            type="test",
-            time=datetime.now(timezone.utc)
-        ) # type: ignore
+        CloudEvent(source="urn:test", type="test", time=datetime.now(timezone.utc))  # type: ignore
 
     with pytest.raises(ValidationError):
         # Missing 'latency_ms'
@@ -189,11 +176,12 @@ def test_validation_failure_missing_fields() -> None:
             root_request_id=uuid4(),
             node_id="test",
             status="ok",
-            timestamp=datetime.now(timezone.utc)
-        ) # type: ignore
+            timestamp=datetime.now(timezone.utc),
+        )  # type: ignore
 
 
 # --- Complex Case Tests ---
+
 
 def test_complex_nested_payloads() -> None:
     """Test serialization of deeply nested complex data structures."""
@@ -202,22 +190,15 @@ def test_complex_nested_payloads() -> None:
             "profile": {
                 "name": "Test User",
                 "roles": ["admin", "editor"],
-                "settings": {"theme": "dark", "notifications": True}
+                "settings": {"theme": "dark", "notifications": True},
             },
-            "history": [
-                {"event": "login", "ts": 123456},
-                {"event": "click", "coords": {"x": 10, "y": 20}}
-            ]
+            "history": [{"event": "login", "ts": 123456}, {"event": "click", "coords": {"x": 10, "y": 20}}],
         },
-        "meta": "top-level"
+        "meta": "top-level",
     }
 
     event = CloudEvent(
-        id="evt-complex",
-        source="urn:complex",
-        type="test.complex",
-        time=datetime.now(timezone.utc),
-        data=complex_data
+        id="evt-complex", source="urn:complex", type="test.complex", time=datetime.now(timezone.utc), data=complex_data
     )
 
     dumped = event.dump()
@@ -241,7 +222,7 @@ def test_trace_chain_simulation() -> None:
         node_id="orchestrator",
         status="running",
         latency_ms=5.0,
-        timestamp=start_time
+        timestamp=start_time,
     )
 
     # 2. Child Trace (Analysis)
@@ -254,7 +235,7 @@ def test_trace_chain_simulation() -> None:
         status="success",
         inputs={"doc": "text"},
         latency_ms=50.0,
-        timestamp=datetime.now(timezone.utc)
+        timestamp=datetime.now(timezone.utc),
     )
 
     # 3. Child Trace (Generation) - child of Analysis (hypothetically, or usually child of root)
@@ -271,7 +252,7 @@ def test_trace_chain_simulation() -> None:
         status="success",
         outputs={"score": 0.9},
         latency_ms=10.0,
-        timestamp=datetime.now(timezone.utc)
+        timestamp=datetime.now(timezone.utc),
     )
 
     # Verification

--- a/tests/test_observability_security.py
+++ b/tests/test_observability_security.py
@@ -1,9 +1,10 @@
-import pytest
-from uuid import uuid4
-from typing import Any, Dict
-
 from datetime import datetime, timezone
+from typing import Any, Dict
+from uuid import uuid4
+
+import pytest
 from pydantic import ValidationError
+
 from coreason_manifest.definitions.observability import CloudEvent, ReasoningTrace
 
 

--- a/tests/test_observability_security.py
+++ b/tests/test_observability_security.py
@@ -1,0 +1,118 @@
+import pytest
+from uuid import uuid4
+from datetime import datetime, timezone
+from pydantic import ValidationError
+from coreason_manifest.definitions.observability import CloudEvent, ReasoningTrace
+
+def test_security_massive_payload_dos() -> None:
+    """
+    Red Team: Attempt to cause DoS/Memory exhaustion with a massive payload.
+    Pydantic should handle this, but we check for crashes or extreme latency.
+    """
+    massive_string = "a" * 1_000_000  # 1MB string
+    massive_dict = {f"key_{i}": massive_string for i in range(10)} # 10MB payload
+
+    start = datetime.now()
+    event = CloudEvent(
+        id="dos-test",
+        source="urn:redteam",
+        type="attack.dos",
+        time=datetime.now(timezone.utc),
+        data=massive_dict
+    )
+    dumped = event.dump()
+    duration = (datetime.now() - start).total_seconds()
+
+    assert dumped["data"]["key_0"] == massive_string
+    # Ensure serialization is reasonably fast (< 1s for 10MB is expected on modern CPUs)
+    # This is a soft check; main goal is no crash.
+    assert duration < 5.0
+
+def test_security_deep_nesting_recursion() -> None:
+    """
+    Red Team: Attempt stack overflow via deep recursion in `data`.
+    Standard JSON parsers have recursion limits; Pydantic might too.
+    """
+    deep_dict = {}
+    current = deep_dict
+    for _ in range(1000):
+        current["next"] = {}
+        current = current["next"]
+
+    event = CloudEvent(
+        id="recursion-test",
+        source="urn:redteam",
+        type="attack.recursion",
+        time=datetime.now(timezone.utc),
+        data=deep_dict
+    )
+
+    # Dump should fail with RecursionError or ValueError due to depth
+    # Pydantic serializer raises ValueError: Circular reference detected (depth exceeded)
+    # Python raises RecursionError if stack limit hit.
+    with pytest.raises((ValueError, RecursionError)):
+        event.dump()
+
+def test_security_injection_strings() -> None:
+    """
+    Red Team: Verify that injection strings (SQLi, XSS) are preserved literally
+    and not executed or interpreted during serialization.
+    """
+    malicious_payload = {
+        "sqli": "'; DROP TABLE users; --",
+        "xss": "<script>alert('xss')</script>",
+        "cmd": "$(rm -rf /)"
+    }
+
+    event = CloudEvent(
+        id="injection-test",
+        source="urn:redteam",
+        type="attack.injection",
+        time=datetime.now(timezone.utc),
+        data=malicious_payload
+    )
+
+    dumped = event.dump()
+    # Pydantic/JSON serialization must escape these, preventing execution if blindly rendered.
+    # We verify the content remains preserved as data.
+    assert dumped["data"]["sqli"] == "'; DROP TABLE users; --"
+    assert dumped["data"]["xss"] == "<script>alert('xss')</script>"
+
+def test_security_pii_leakage_warning() -> None:
+    """
+    Red Team: ReasoningTrace `inputs` and `outputs` might contain PII/Secrets.
+    There is no automatic redaction, so we just verify they accept any dict.
+    (This is a finding for the documentation, not a code failure per se).
+    """
+    secret_payload = {"api_key": "sk-1234567890", "password": "super_secret"}
+
+    trace = ReasoningTrace(
+        request_id=uuid4(),
+        root_request_id=uuid4(),
+        node_id="auth-service",
+        status="success",
+        inputs=secret_payload,
+        latency_ms=1.0,
+        timestamp=datetime.now(timezone.utc)
+    )
+
+    dumped = trace.dump()
+    # Confirm secrets are present (i.e., NOT redacted).
+    # This confirms the risk: The consumer is responsible for scrubbing.
+    assert dumped["inputs"]["api_key"] == "sk-1234567890"
+
+def test_security_type_spoofing() -> None:
+    """
+    Red Team: Declare datacontenttype='application/json' but provide non-dict data?
+    CloudEvent model enforces `data: Optional[Dict[str, Any]]`.
+    So we cannot pass a string or bytes if we want to be valid Pydantic.
+    """
+    with pytest.raises(ValidationError):
+        CloudEvent(
+            id="spoof-test",
+            source="urn:redteam",
+            type="attack.spoof",
+            time=datetime.now(timezone.utc),
+            datacontenttype="application/json",
+            data="<xml>not json</xml>" # type: ignore
+        )


### PR DESCRIPTION
Implemented standard envelopes for telemetry as specified in Work Package G.
This includes:
1. `CloudEvent` model: A strictly typed Pydantic model compliant with CloudEvents 1.0, including W3C Trace Context extensions (`traceparent`, `tracestate`).
2. `ReasoningTrace` model: A structured log entry for audit trails with execution metrics.

Both models inherit from `CoReasonBaseModel` and are immutable.
Verified with new test suite `tests/test_observability.py`.

---
*PR created automatically by Jules for task [10625898636626358368](https://jules.google.com/task/10625898636626358368) started by @gowthamrao*