### PR TITLE
feat: Semantic Error Handling (Work Package H)

### DIFF
--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -191,3 +191,12 @@ Polymorphic events for UI rendering (referenced in `StreamPacket` `op=event`).
 | `artifact_id` | `str` | Unique ID of the generated artifact. |
 | `mime_type` | `str` | Content type (e.g., `image/png`, `text/csv`). |
 | `url` | `Optional[str]` | Download URL. |
+
+#### UserErrorEvent (`type: user_error`)
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `message` | `str` | Human-readable message. |
+| `code` | `Optional[int]` | Semantic integer code (e.g., 400, 503). |
+| `domain` | `ErrorDomain` | Source (`client`, `system`, `llm`, `tool`, `security`). |
+| `retryable` | `bool` | Whether the error is retryable. |

--- a/docs/error_handling_standards.md
+++ b/docs/error_handling_standards.md
@@ -1,0 +1,54 @@
+# Semantic Error Handling Standards
+
+This document defines the standard for Semantic Error Handling in the CoReason ecosystem. The goal is to move from generic exceptions to structured, machine-readable error codes and user-friendly error events.
+
+## Concepts
+
+### Error Domains
+
+Errors are categorized into "Domains" to help consumers (UIs, Agents) understand the source of the failure.
+
+| Domain | Value | Description |
+| :--- | :--- | :--- |
+| **CLIENT** | `client` | The request was invalid (e.g., 4xx HTTP range). |
+| **SYSTEM** | `system` | Internal platform failure (e.g., database down, 5xx HTTP range). |
+| **LLM** | `llm` | Failure from the Model Provider (e.g., overloaded, refusal). |
+| **TOOL** | `tool` | Failure execution of an external tool (MCP, API). |
+| **SECURITY** | `security` | Authentication, Authorization, or Governance rejection. |
+
+These are defined in the `ErrorDomain` enum in `coreason_manifest`.
+
+### User Error Event
+
+The `UserErrorEvent` is a specialized `PresentationEvent` designed to be rendered directly to the end-user. It allows the backend to control the error messaging, iconography (via domain), and retry logic.
+
+It is part of the `AnyPresentationEvent` union and can be streamed via `StreamPacket` (op=`event`) or included in message history.
+
+**Schema:**
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `type` | `Literal["user_error"]` | - | Discriminator. |
+| `message` | `str` | - | Human-readable message. |
+| `code` | `Optional[int]` | `None` | Semantic integer code (e.g., 400, 429, 503). |
+| `domain` | `ErrorDomain` | `system` | Source of the error. |
+| `retryable` | `bool` | `False` | Whether the client should suggest a retry. |
+
+**Example JSON:**
+
+```json
+{
+  "type": "user_error",
+  "message": "The search tool is currently unavailable. Please try again later.",
+  "code": 503,
+  "domain": "tool",
+  "retryable": true
+}
+```
+
+## Usage
+
+### When to use `UserErrorEvent` vs `StreamError`?
+
+*   **`StreamError` (CAP)**: Use this for protocol-level failures where the stream itself is broken or the agent has crashed fatally. This is a "System Exception".
+*   **`UserErrorEvent` (Presentation)**: Use this when the agent is still healthy, but a specific sub-task failed (e.g., a tool failed), and you want to inform the user gracefully without crashing the conversation. This is a "User Notification".

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Observability & Tracing](observability.md)**
     *   Standard telemetry envelopes (`CloudEvent`, `ReasoningTrace`) for system notifications, audit logs, and distributed tracing.
 
+*   **[Semantic Error Handling](error_handling_standards.md)**
+    *   Defines standard Error Domains and the `UserErrorEvent` for structured, user-friendly error reporting.
+
 ## Architecture & Rationale
 
 *   **[Product Requirements & Philosophy](product_requirements.md)**

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -10,6 +10,7 @@
 
 from .common import ToolRiskLevel
 from .definitions.capabilities import AgentCapabilities, DeliveryMode
+from .definitions.error import ErrorDomain
 from .definitions.identity import Identity
 from .definitions.message import ChatMessage, Role
 from .definitions.observability import CloudEvent, ReasoningTrace
@@ -19,6 +20,7 @@ from .definitions.presentation import (
     CitationEvent,
     PresentationEvent,
     PresentationEventType,
+    UserErrorEvent,
 )
 from .definitions.service import ServiceContract
 from .governance import ComplianceReport, ComplianceViolation, GovernanceConfig
@@ -85,11 +87,13 @@ __all__ = [
     "Identity",
     "Role",
     "ChatMessage",
+    "ErrorDomain",
     "PresentationEventType",
     "PresentationEvent",
     "AnyPresentationEvent",
     "CitationEvent",
     "ArtifactEvent",
+    "UserErrorEvent",
     "HealthCheckResponse",
     "HealthCheckStatus",
     "ServiceRequest",

--- a/src/coreason_manifest/definitions/error.py
+++ b/src/coreason_manifest/definitions/error.py
@@ -1,0 +1,21 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import Enum
+
+
+class ErrorDomain(str, Enum):
+    """Domains where errors can originate."""
+
+    CLIENT = "client"
+    SYSTEM = "system"
+    LLM = "llm"
+    TOOL = "tool"
+    SECURITY = "security"

--- a/src/coreason_manifest/definitions/presentation.py
+++ b/src/coreason_manifest/definitions/presentation.py
@@ -14,6 +14,7 @@ from typing import List, Literal, Optional, Union
 from pydantic import ConfigDict, Field
 
 from ..common import CoReasonBaseModel
+from .error import ErrorDomain
 
 
 class PresentationEventType(str, Enum):
@@ -21,6 +22,7 @@ class PresentationEventType(str, Enum):
 
     CITATION = "citation"
     ARTIFACT = "artifact"
+    USER_ERROR = "user_error"
 
 
 class PresentationEvent(CoReasonBaseModel):
@@ -49,4 +51,14 @@ class ArtifactEvent(PresentationEvent):
     url: Optional[str] = Field(None, description="Download URL if applicable.")
 
 
-AnyPresentationEvent = Union[CitationEvent, ArtifactEvent]
+class UserErrorEvent(PresentationEvent):
+    """An event representing a user-facing error."""
+
+    type: Literal[PresentationEventType.USER_ERROR] = PresentationEventType.USER_ERROR
+    message: str = Field(..., description="The human-readable message.")
+    code: Optional[int] = Field(None, description="Semantic integer code, e.g. 400, 503.")
+    domain: ErrorDomain = Field(ErrorDomain.SYSTEM, description="The domain of the error.")
+    retryable: bool = Field(False, description="Whether the error is retryable.")
+
+
+AnyPresentationEvent = Union[CitationEvent, ArtifactEvent, UserErrorEvent]

--- a/tests/test_semantic_errors.py
+++ b/tests/test_semantic_errors.py
@@ -9,10 +9,11 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import pytest
-from pydantic import TypeAdapter
+from pydantic import TypeAdapter, ValidationError
 
 from coreason_manifest import (
     AnyPresentationEvent,
+    CitationEvent,
     ErrorDomain,
     PresentationEventType,
     UserErrorEvent,
@@ -21,18 +22,18 @@ from coreason_manifest import (
 
 def test_error_domain_serialization() -> None:
     """Verify ErrorDomain serializes correctly."""
-    assert ErrorDomain.CLIENT == "client"
-    assert ErrorDomain.SYSTEM == "system"
-    assert ErrorDomain.LLM == "llm"
-    assert ErrorDomain.TOOL == "tool"
-    assert ErrorDomain.SECURITY == "security"
+    assert ErrorDomain.CLIENT.value == "client"
+    assert ErrorDomain.SYSTEM.value == "system"
+    assert ErrorDomain.LLM.value == "llm"
+    assert ErrorDomain.TOOL.value == "tool"
+    assert ErrorDomain.SECURITY.value == "security"
 
     # Test serialization via Pydantic model implicitly (UserErrorEvent uses it)
     event = UserErrorEvent(
         message="Model failed",
         domain=ErrorDomain.LLM,
     )
-    dumped = event.model_dump(mode='json')
+    dumped = event.model_dump(mode="json")
     assert dumped["domain"] == "llm"
 
 
@@ -73,9 +74,66 @@ def test_any_presentation_event_union() -> None:
         "domain": "security",
     }
 
-    adapter = TypeAdapter(AnyPresentationEvent)
+    adapter: TypeAdapter[AnyPresentationEvent] = TypeAdapter(AnyPresentationEvent)
     event = adapter.validate_python(payload)
 
     assert isinstance(event, UserErrorEvent)
     assert event.domain == ErrorDomain.SECURITY
     assert event.code == 403
+
+
+def test_edge_case_empty_strings() -> None:
+    """Verify empty message strings are handled."""
+    event = UserErrorEvent(message="", domain=ErrorDomain.SYSTEM)
+    assert event.message == ""
+    dumped = event.model_dump(mode="json")
+    assert dumped["message"] == ""
+
+
+def test_edge_case_numeric_limits() -> None:
+    """Verify large/negative codes."""
+    # Negative code
+    event = UserErrorEvent(message="Negative", code=-1)
+    assert event.code == -1
+
+    # Large code
+    event = UserErrorEvent(message="Large", code=999999)
+    assert event.code == 999999
+
+
+def test_complex_polymorphism_structure() -> None:
+    """Verify nested unions and serialization."""
+    events: list[AnyPresentationEvent] = [
+        UserErrorEvent(message="Error 1"),
+        CitationEvent(uri="http://example.com", text="Quote"),
+        UserErrorEvent(message="Error 2", code=500),
+    ]
+
+    adapter: TypeAdapter[list[AnyPresentationEvent]] = TypeAdapter(list[AnyPresentationEvent])
+    dumped = adapter.dump_python(events, mode="json")
+
+    assert len(dumped) == 3
+    assert dumped[0]["type"] == "user_error"
+    assert dumped[1]["type"] == "citation"
+    assert dumped[2]["type"] == "user_error"
+
+    # Round trip
+    loaded = adapter.validate_python(dumped)
+    assert isinstance(loaded[0], UserErrorEvent)
+    assert isinstance(loaded[1], CitationEvent)
+    assert isinstance(loaded[2], UserErrorEvent)
+
+
+def test_redundant_validation_scenarios() -> None:
+    """Verify validation failures."""
+    # Missing required field 'message'
+    with pytest.raises(ValidationError):
+        UserErrorEvent.model_validate({"type": "user_error"})
+
+    # Invalid domain string
+    with pytest.raises(ValidationError):
+        UserErrorEvent.model_validate({
+            "type": "user_error",
+            "message": "Fail",
+            "domain": "invalid_domain"
+        })

--- a/tests/test_semantic_errors.py
+++ b/tests/test_semantic_errors.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import TypeAdapter
+
+from coreason_manifest import (
+    AnyPresentationEvent,
+    ErrorDomain,
+    PresentationEventType,
+    UserErrorEvent,
+)
+
+
+def test_error_domain_serialization() -> None:
+    """Verify ErrorDomain serializes correctly."""
+    assert ErrorDomain.CLIENT == "client"
+    assert ErrorDomain.SYSTEM == "system"
+    assert ErrorDomain.LLM == "llm"
+    assert ErrorDomain.TOOL == "tool"
+    assert ErrorDomain.SECURITY == "security"
+
+    # Test serialization via Pydantic model implicitly (UserErrorEvent uses it)
+    event = UserErrorEvent(
+        message="Model failed",
+        domain=ErrorDomain.LLM,
+    )
+    dumped = event.model_dump(mode='json')
+    assert dumped["domain"] == "llm"
+
+
+def test_user_error_event_parsing() -> None:
+    """Verify parsing a dict into UserErrorEvent."""
+    payload = {
+        "type": "user_error",
+        "message": "Rate limit exceeded",
+        "code": 429,
+        "retryable": True,
+        "domain": "client",
+    }
+
+    event = UserErrorEvent.model_validate(payload)
+
+    assert event.type == PresentationEventType.USER_ERROR
+    assert event.message == "Rate limit exceeded"
+    assert event.code == 429
+    assert event.retryable is True
+    assert event.domain == ErrorDomain.CLIENT
+
+
+def test_user_error_event_defaults() -> None:
+    """Verify default values for UserErrorEvent."""
+    event = UserErrorEvent(message="Something went wrong")
+
+    assert event.domain == ErrorDomain.SYSTEM
+    assert event.retryable is False
+    assert event.code is None
+
+
+def test_any_presentation_event_union() -> None:
+    """Verify AnyPresentationEvent can parse a UserErrorEvent."""
+    payload = {
+        "type": "user_error",
+        "message": "Forbidden",
+        "code": 403,
+        "domain": "security",
+    }
+
+    adapter = TypeAdapter(AnyPresentationEvent)
+    event = adapter.validate_python(payload)
+
+    assert isinstance(event, UserErrorEvent)
+    assert event.domain == ErrorDomain.SECURITY
+    assert event.code == 403

--- a/tests/test_semantic_errors.py
+++ b/tests/test_semantic_errors.py
@@ -132,8 +132,10 @@ def test_redundant_validation_scenarios() -> None:
 
     # Invalid domain string
     with pytest.raises(ValidationError):
-        UserErrorEvent.model_validate({
-            "type": "user_error",
-            "message": "Fail",
-            "domain": "invalid_domain"
-        })
+        UserErrorEvent.model_validate(
+            {
+                "type": "user_error",
+                "message": "Fail",
+                "domain": "invalid_domain",
+            }
+        )


### PR DESCRIPTION
Standardizes error handling by introducing Semantic Error Codes and Error Domains.

- **Error Primitives**: Created `ErrorDomain` enum with values `CLIENT`, `SYSTEM`, `LLM`, `TOOL`, `SECURITY`.
- **User Error Event**: Implemented `UserErrorEvent` inheriting from `PresentationEvent` to support "friendly" errors with `message`, `code`, `domain`, and `retryable` fields.
- **Integration**: Updated `PresentationEventType` and `AnyPresentationEvent` to include the new event type.
- **Verification**: Added comprehensive tests for serialization, parsing, and default values.

---
*PR created automatically by Jules for task [17047705450811793492](https://jules.google.com/task/17047705450811793492) started by @gowthamrao*