### PR TITLE
feat: Enforce AGENTS.md compliance for licenses and docs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,9 @@ nav:
   - Specifications & Protocols:
     - CAM Specification: cap/specification.md
     - CAP Wire Protocol: cap/wire_protocol.md
+    - Observability & Tracing: observability.md
+    - Semantic Error Handling: error_handling_standards.md
+    - Event Content Types: event_content_types.md
   - Architecture & Rationale:
     - Product Requirements: product_requirements.md
     - Base Model Rationale: coreason_base_model_rationale.md

--- a/src/coreason_manifest/definitions/capabilities.py
+++ b/src/coreason_manifest/definitions/capabilities.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from enum import Enum
 from typing import List
 

--- a/src/coreason_manifest/definitions/service.py
+++ b/src/coreason_manifest/definitions/service.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any, Dict
 
 from ..spec.cap import ServiceRequest, ServiceResponse

--- a/src/coreason_manifest/v2/__init__.py
+++ b/src/coreason_manifest/v2/__init__.py
@@ -1,1 +1,11 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 # Coreason Manifest V2

--- a/src/coreason_manifest/v2/spec/__init__.py
+++ b/src/coreason_manifest/v2/spec/__init__.py
@@ -1,1 +1,11 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 # Coreason Manifest V2 Spec Definitions

--- a/src/coreason_manifest/v2/spec/contracts.py
+++ b/src/coreason_manifest/v2/spec/contracts.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any, Dict, Optional
 
 from pydantic import ConfigDict, Field

--- a/src/coreason_manifest/v2/spec/definitions.py
+++ b/src/coreason_manifest/v2/spec/definitions.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import ConfigDict, Field


### PR DESCRIPTION
This PR addresses compliance issues flagged during a critical review of the codebase against `AGENTS.md`.

**Changes:**
1.  **License Headers:** Added the mandatory license header to 6 Python files in `src/` that were missing it. This ensures all source code carries the correct copyright and license information.
2.  **Documentation:** Updated `mkdocs.yml` to include `observability.md`, `error_handling_standards.md`, and `event_content_types.md` in the "Specifications & Protocols" section. These files existed in `docs/` but were orphaned from the generated site.

**Verification:**
-   Ran `poetry run pytest` -> Passed with 100% coverage.
-   Manually verified `src/coreason_manifest/spec/cap.py` already had the license header (addressing a potential review concern).
-   Verified existence of the added markdown files in `docs/`.
-   Verified `mkdocs.yml` syntax.

---
*PR created automatically by Jules for task [11120656266966906166](https://jules.google.com/task/11120656266966906166) started by @gowthamrao*