### PR TITLE
feat: Add Multi-Modal Primitives and Interaction Model

### DIFF
--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -57,6 +57,32 @@ The strict payload schema used within `ServiceRequest`.
 | `conversation_id` | `Optional[str]` | ID for continuing a session (default: `None`). |
 | `meta` | `Dict[str, Any]` | Extra context like timezone (default: `{}`). |
 
+### MultiModalInput
+
+Container for rich user turns (text interleaved with files).
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `parts` | `List[ContentPart]` | Ordered list of content parts. |
+
+### ContentPart
+
+A discrete unit of input.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `text` | `Optional[str]` | The textual instruction. |
+| `attachments` | `List[AttachedFile]` | List of attached files. |
+
+### AttachedFile
+
+Reference to an uploaded file.
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `id` | `str` | Unique file ID. |
+| `mime_type` | `Optional[str]` | MIME type (e.g. `application/pdf`). |
+
 ### ServiceResponse
 
 The synchronous result returned by an Agent service.

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Coreason Agent Protocol (CAP) Wire Format](cap/wire_protocol.md)**
     *   Defines the runtime wire protocol, including standard request/response envelopes (`ServiceRequest`, `ServiceResponse`) and streaming contracts (`StreamPacket`).
 
+*   **[Multi-Modal Interactions](multimodal_inputs.md)**
+    *   Defines strict data models (`MultiModalInput`, `AttachedFile`) for handling rich inputs interleaving text and files.
+
 *   **[Observability & Tracing](observability.md)**
     *   Standard telemetry envelopes (`CloudEvent`, `ReasoningTrace`) for system notifications, audit logs, and distributed tracing.
 

--- a/docs/multimodal_inputs.md
+++ b/docs/multimodal_inputs.md
@@ -1,0 +1,115 @@
+# Multi-Modal Interactions
+
+This document defines the data structures and patterns for supporting **Multi-Modal Interactions** in the Coreason ecosystem. This upgrades the system from relying on simple strings or loose dictionaries to using strictly typed Pydantic models for rich user inputs (interleaving text with files/images).
+
+## Rationale
+
+Modern agents often require inputs that go beyond simple text strings. Users may want to:
+1.  Analyze a specific file.
+2.  Ask a question about an image.
+3.  Provide context via multiple attachments interleaved with instructions.
+
+To support this safely and consistently across the "Shared Kernel," we introduce a set of strict, frozen data models.
+
+## Data Models
+
+All models are defined in `src/coreason_manifest/definitions/message.py` and inherit from `CoReasonBaseModel`.
+
+### 1. `AttachedFile`
+
+Represents a reference to a file that has already been uploaded to a blob storage or similar system. It does *not* contain the file content itself, but rather a stable identifier.
+
+```python
+class AttachedFile(CoReasonBaseModel):
+    id: str  # Unique ID/UUID
+    mime_type: Optional[str]  # e.g., "application/pdf"
+```
+
+### 2. `ContentPart`
+
+A discrete unit of input. A user's turn may consist of multiple parts. A part can contain text, attachments, or both.
+
+```python
+class ContentPart(CoReasonBaseModel):
+    text: Optional[str]
+    attachments: List[AttachedFile] = []
+```
+
+### 3. `MultiModalInput`
+
+The container for a rich user turn. This is the top-level object used when an input is complex.
+
+```python
+class MultiModalInput(CoReasonBaseModel):
+    parts: List[ContentPart]
+```
+
+## Session Interaction
+
+The `Interaction` model (in `src/coreason_manifest/definitions/session.py`) captures a single cycle of "User Request -> Assistant Response". To ensure backward compatibility, the `input` field is polymorphic.
+
+```python
+class Interaction(CoReasonBaseModel):
+    # Supports strictly typed rich input, legacy simple strings, and legacy dictionaries
+    input: Union[MultiModalInput, str, Dict[str, Any]]
+    output: Optional[ChatMessage]
+    timestamp: datetime
+```
+
+## Examples
+
+### Scenario A: Simple Text (Legacy)
+
+```python
+interaction = Interaction(input="What is the time?")
+```
+
+### Scenario B: Analyze a PDF (Rich)
+
+```python
+file_ref = AttachedFile(id="doc-123", mime_type="application/pdf")
+part = ContentPart(text="Please summarize this document.", attachments=[file_ref])
+rich_input = MultiModalInput(parts=[part])
+
+interaction = Interaction(input=rich_input)
+```
+
+### Scenario C: Mixed Content (Rich)
+
+```python
+# User: "Look at this image [IMG] and this log [LOG], then explain the error."
+img = AttachedFile(id="img-001", mime_type="image/png")
+log = AttachedFile(id="log-999", mime_type="text/plain")
+
+part1 = ContentPart(text="Look at this image", attachments=[img])
+part2 = ContentPart(text="and this log", attachments=[log])
+part3 = ContentPart(text="then explain the error.")
+
+rich_input = MultiModalInput(parts=[part1, part2, part3])
+interaction = Interaction(input=rich_input)
+```
+
+## JSON Serialization
+
+Because all models inherit from `CoReasonBaseModel`, they serialize cleanly to JSON using `.dump()`.
+
+**Output for Scenario B:**
+```json
+{
+  "input": {
+    "parts": [
+      {
+        "text": "Please summarize this document.",
+        "attachments": [
+          {
+            "id": "doc-123",
+            "mime_type": "application/pdf"
+          }
+        ]
+      }
+    ]
+  },
+  "output": null,
+  "timestamp": "2023-10-27T10:00:00Z"
+}
+```

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -12,7 +12,13 @@ from .common import ToolRiskLevel
 from .definitions.capabilities import AgentCapabilities, DeliveryMode
 from .definitions.error import ErrorDomain
 from .definitions.identity import Identity
-from .definitions.message import ChatMessage, Role
+from .definitions.message import (
+    AttachedFile,
+    ChatMessage,
+    ContentPart,
+    MultiModalInput,
+    Role,
+)
 from .definitions.observability import CloudEvent, EventContentType, ReasoningTrace
 from .definitions.presentation import (
     AnyPresentationEvent,
@@ -23,6 +29,7 @@ from .definitions.presentation import (
     UserErrorEvent,
 )
 from .definitions.service import ServiceContract
+from .definitions.session import Interaction
 from .governance import ComplianceReport, ComplianceViolation, GovernanceConfig
 from .spec.cap import (
     AgentRequest,
@@ -87,6 +94,10 @@ __all__ = [
     "Identity",
     "Role",
     "ChatMessage",
+    "AttachedFile",
+    "ContentPart",
+    "MultiModalInput",
+    "Interaction",
     "ErrorDomain",
     "PresentationEventType",
     "PresentationEvent",

--- a/src/coreason_manifest/definitions/message.py
+++ b/src/coreason_manifest/definitions/message.py
@@ -47,9 +47,7 @@ class AttachedFile(CoReasonBaseModel):
     model_config = ConfigDict(frozen=True)
 
     id: str = Field(..., description="The unique file ID/UUID.")
-    mime_type: Optional[str] = Field(
-        None, description="The MIME type of the file (e.g., 'application/pdf')."
-    )
+    mime_type: Optional[str] = Field(None, description="The MIME type of the file (e.g., 'application/pdf').")
 
 
 class ContentPart(CoReasonBaseModel):
@@ -58,9 +56,7 @@ class ContentPart(CoReasonBaseModel):
     model_config = ConfigDict(frozen=True)
 
     text: Optional[str] = Field(None, description="The textual instruction.")
-    attachments: List[AttachedFile] = Field(
-        default_factory=list, description="List of attached files."
-    )
+    attachments: List[AttachedFile] = Field(default_factory=list, description="List of attached files.")
 
 
 class MultiModalInput(CoReasonBaseModel):

--- a/src/coreason_manifest/definitions/message.py
+++ b/src/coreason_manifest/definitions/message.py
@@ -10,7 +10,7 @@
 
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import ConfigDict, Field
 
@@ -39,3 +39,33 @@ class ChatMessage(CoReasonBaseModel):
         default_factory=lambda: datetime.now(timezone.utc),
         description="The timestamp of the message.",
     )
+
+
+class AttachedFile(CoReasonBaseModel):
+    """Represents a reference to a file uploaded to the blob storage."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(..., description="The unique file ID/UUID.")
+    mime_type: Optional[str] = Field(
+        None, description="The MIME type of the file (e.g., 'application/pdf')."
+    )
+
+
+class ContentPart(CoReasonBaseModel):
+    """A discrete unit of input that can contain text, attachments, or both."""
+
+    model_config = ConfigDict(frozen=True)
+
+    text: Optional[str] = Field(None, description="The textual instruction.")
+    attachments: List[AttachedFile] = Field(
+        default_factory=list, description="List of attached files."
+    )
+
+
+class MultiModalInput(CoReasonBaseModel):
+    """The container for a rich user turn."""
+
+    model_config = ConfigDict(frozen=True)
+
+    parts: List[ContentPart] = Field(..., description="List of content parts.")

--- a/src/coreason_manifest/definitions/session.py
+++ b/src/coreason_manifest/definitions/session.py
@@ -1,0 +1,32 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Union
+
+from pydantic import ConfigDict, Field
+
+from ..common import CoReasonBaseModel
+from .message import ChatMessage, MultiModalInput
+
+
+class Interaction(CoReasonBaseModel):
+    """Represents a single 'User Request -> Assistant Response' cycle."""
+
+    model_config = ConfigDict(frozen=True)
+
+    input: Union[MultiModalInput, str, Dict[str, Any]] = Field(
+        ..., description="The user input (strict, string, or legacy dict)."
+    )
+    output: Optional[ChatMessage] = Field(None, description="The assistant's response.")
+    timestamp: datetime = Field(
+        default_factory=lambda: datetime.now(timezone.utc),
+        description="The timestamp of the interaction.",
+    )

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -1,0 +1,65 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest import (
+    AttachedFile,
+    ContentPart,
+    MultiModalInput,
+    Interaction,
+)
+
+def test_strict_serialization() -> None:
+    """Test serialization of MultiModalInput."""
+    file = AttachedFile(id="file-123", mime_type="application/pdf")
+    part = ContentPart(text="Analyze this", attachments=[file])
+    mm_input = MultiModalInput(parts=[part])
+
+    dumped = mm_input.dump()
+
+    assert dumped == {
+        "parts": [
+            {
+                "text": "Analyze this",
+                "attachments": [
+                    {"id": "file-123", "mime_type": "application/pdf"}
+                ]
+            }
+        ]
+    }
+
+def test_interaction_polymorphism_rich() -> None:
+    """Test Interaction with MultiModalInput."""
+    file = AttachedFile(id="f1")
+    part = ContentPart(attachments=[file])
+    mm_input = MultiModalInput(parts=[part])
+
+    interaction = Interaction(input=mm_input)
+    assert interaction.input == mm_input
+
+def test_interaction_polymorphism_string() -> None:
+    """Test Interaction with string input."""
+    interaction = Interaction(input="Simple string")
+    assert interaction.input == "Simple string"
+
+def test_interaction_polymorphism_dict() -> None:
+    """Test Interaction with dict input."""
+    data = {"raw": "data", "foo": 123}
+    interaction = Interaction(input=data)
+    assert interaction.input == data
+
+def test_immutability() -> None:
+    """Test that models are frozen."""
+    part = ContentPart(text="foo")
+    mm_input = MultiModalInput(parts=[part])
+
+    with pytest.raises(ValidationError):
+        mm_input.parts = []  # type: ignore[misc]
+
+    file = AttachedFile(id="123")
+    with pytest.raises(ValidationError):
+        file.id = "456"  # type: ignore[misc]
+
+    # Test Interaction immutability
+    interaction = Interaction(input="test")
+    with pytest.raises(ValidationError):
+        interaction.input = "new"  # type: ignore[misc]

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -4,8 +4,8 @@ from pydantic import ValidationError
 from coreason_manifest import (
     AttachedFile,
     ContentPart,
-    MultiModalInput,
     Interaction,
+    MultiModalInput,
 )
 
 

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -4,8 +4,8 @@ from pydantic import ValidationError
 from coreason_manifest import (
     AttachedFile,
     ContentPart,
-    Interaction,
     MultiModalInput,
+    Interaction,
 )
 
 
@@ -61,3 +61,57 @@ def test_immutability() -> None:
     interaction = Interaction(input="test")
     with pytest.raises(ValidationError):
         interaction.input = "new"  # type: ignore[misc]
+
+
+def test_edge_case_empty_parts() -> None:
+    """Test MultiModalInput with empty parts list."""
+    mm_input = MultiModalInput(parts=[])
+    assert mm_input.parts == []
+    assert mm_input.dump() == {"parts": []}
+
+
+def test_edge_case_empty_content_part() -> None:
+    """Test ContentPart with no text and no attachments."""
+    part = ContentPart()
+    assert part.text is None
+    assert part.attachments == []
+    # CoReasonBaseModel excludes none, so it should be empty dict if no attachments
+    # But attachments has a default factory of list, so it will be present as []?
+    # Let's check serialization behavior. CoReasonBaseModel uses exclude_none=True.
+    # Empty list is not None.
+    assert part.dump() == {"attachments": []}
+
+
+def test_edge_case_huge_text() -> None:
+    """Test ContentPart with a very large string."""
+    huge_text = "a" * 10_000
+    part = ContentPart(text=huge_text)
+    assert part.text == huge_text
+
+
+def test_edge_case_many_attachments() -> None:
+    """Test ContentPart with many attachments."""
+    attachments = [AttachedFile(id=f"id-{i}") for i in range(100)]
+    part = ContentPart(attachments=attachments)
+    assert len(part.attachments) == 100
+    assert part.attachments[99].id == "id-99"
+
+
+def test_complex_mixed_content() -> None:
+    """Test MultiModalInput with mixed content parts."""
+    img = AttachedFile(id="img-1")
+    doc = AttachedFile(id="doc-1")
+
+    p1 = ContentPart(text="Look at this:")
+    p2 = ContentPart(attachments=[img])
+    p3 = ContentPart(text="and this document", attachments=[doc])
+
+    mm_input = MultiModalInput(parts=[p1, p2, p3])
+
+    assert len(mm_input.parts) == 3
+    assert mm_input.parts[0].text == "Look at this:"
+    assert len(mm_input.parts[0].attachments) == 0
+    assert mm_input.parts[1].text is None
+    assert mm_input.parts[1].attachments[0].id == "img-1"
+    assert mm_input.parts[2].text == "and this document"
+    assert mm_input.parts[2].attachments[0].id == "doc-1"

--- a/tests/test_multimodal.py
+++ b/tests/test_multimodal.py
@@ -4,9 +4,10 @@ from pydantic import ValidationError
 from coreason_manifest import (
     AttachedFile,
     ContentPart,
-    MultiModalInput,
     Interaction,
+    MultiModalInput,
 )
+
 
 def test_strict_serialization() -> None:
     """Test serialization of MultiModalInput."""
@@ -17,15 +18,9 @@ def test_strict_serialization() -> None:
     dumped = mm_input.dump()
 
     assert dumped == {
-        "parts": [
-            {
-                "text": "Analyze this",
-                "attachments": [
-                    {"id": "file-123", "mime_type": "application/pdf"}
-                ]
-            }
-        ]
+        "parts": [{"text": "Analyze this", "attachments": [{"id": "file-123", "mime_type": "application/pdf"}]}]
     }
+
 
 def test_interaction_polymorphism_rich() -> None:
     """Test Interaction with MultiModalInput."""
@@ -36,16 +31,19 @@ def test_interaction_polymorphism_rich() -> None:
     interaction = Interaction(input=mm_input)
     assert interaction.input == mm_input
 
+
 def test_interaction_polymorphism_string() -> None:
     """Test Interaction with string input."""
     interaction = Interaction(input="Simple string")
     assert interaction.input == "Simple string"
+
 
 def test_interaction_polymorphism_dict() -> None:
     """Test Interaction with dict input."""
     data = {"raw": "data", "foo": 123}
     interaction = Interaction(input=data)
     assert interaction.input == data
+
 
 def test_immutability() -> None:
     """Test that models are frozen."""

--- a/tests/test_multimodal_security.py
+++ b/tests/test_multimodal_security.py
@@ -1,0 +1,95 @@
+import pytest
+
+from coreason_manifest import (
+    AttachedFile,
+    ContentPart,
+    Interaction,
+    MultiModalInput,
+)
+
+
+def test_security_massive_payload_dos() -> None:
+    """Test handling of massive payloads to prevent DoS."""
+    # Create a massive text string
+    massive_text = "A" * 1_000_000  # 1MB string
+
+    # Create many parts
+    parts = [ContentPart(text=massive_text) for _ in range(10)]
+
+    # This should instantiate without crashing, but we might want to see if it's too slow
+    # Pydantic validates this fine, but downstream consumers need to handle it.
+    # Here we just verify the model accepts it (as it's just a data container).
+    mm_input = MultiModalInput(parts=parts)
+    assert len(mm_input.parts) == 10
+    assert len(mm_input.parts[0].text) == 1_000_000  # type: ignore
+
+
+def test_security_injection_payloads() -> None:
+    """Test that models accept injection strings (they are just data containers).
+
+    The security responsibility lies with the consumer (sanitization),
+    but the model itself should not execute anything.
+    """
+    xss_payload = "<script>alert('xss')</script>"
+    sql_payload = "'; DROP TABLE users; --"
+
+    part = ContentPart(text=xss_payload)
+    assert part.text == xss_payload
+
+    file_ref = AttachedFile(id=sql_payload)  # ID field might be vulnerable if used raw in DB
+    assert file_ref.id == sql_payload
+
+
+def test_security_recursion_depth() -> None:
+    """Test recursion handling.
+
+    The `Interaction` model allows `Dict[str, Any]`. Pydantic V2 is generally smart enough
+    to handle recursive dictionaries in `Any` fields without crashing immediately during validation,
+    unless serialization is attempted.
+    """
+    recursive_dict = {}
+    recursive_dict["self"] = recursive_dict
+
+    # This should NOT raise RecursionError during instantiation.
+    # Note: Pydantic creates a copy, so 'is' identity check fails.
+    interaction = Interaction(input=recursive_dict)
+    assert isinstance(interaction.input, dict)
+
+    # However, attempting to DUMP it should probably fail or crash with RecursionError
+    with pytest.raises((ValueError, RecursionError)):
+        interaction.dump()
+
+
+def test_security_type_confusion() -> None:
+    """Test type confusion (Smart Union Behavior).
+
+    In Pydantic V2, `Union[MultiModalInput, str, Dict]` uses 'smart' mode.
+    If a dict matches the schema of `MultiModalInput`, it WILL be coerced.
+    This is generally desired for API robustness but can be surprising.
+    """
+    # A dict that looks exactly like MultiModalInput
+    fake_input = {"parts": [{"text": "fake", "attachments": []}]}
+
+    interaction = Interaction(input=fake_input)
+
+    # Pydantic V2 coerces this to MultiModalInput because it fits the schema perfectly
+    assert isinstance(interaction.input, MultiModalInput)
+    assert interaction.input.parts[0].text == "fake"
+
+    # A dict that implies MultiModalInput but fails validation (e.g. invalid type inside)
+    # should fall back to Dict if possible?
+    # Actually, if it matches the shape enough to try validation but fails, Pydantic might raise error
+    # OR fall back to the next type in Union (Dict).
+
+    # Let's try a dict that definitely IS NOT a MultiModalInput
+    plain_dict = {"foo": "bar"}
+    interaction_plain = Interaction(input=plain_dict)
+    assert isinstance(interaction_plain.input, dict)
+    assert interaction_plain.input == plain_dict
+
+
+def test_security_unicode_normalization() -> None:
+    """Test weird unicode characters."""
+    weird_text = "\u202ereversed text\u202c"  # Right-to-Left Override
+    part = ContentPart(text=weird_text)
+    assert part.text == weird_text

--- a/tests/test_multimodal_security.py
+++ b/tests/test_multimodal_security.py
@@ -47,7 +47,7 @@ def test_security_recursion_depth() -> None:
     to handle recursive dictionaries in `Any` fields without crashing immediately during validation,
     unless serialization is attempted.
     """
-    recursive_dict = {}
+    recursive_dict: dict[str, object] = {}
     recursive_dict["self"] = recursive_dict
 
     # This should NOT raise RecursionError during instantiation.


### PR DESCRIPTION
This PR introduces strict Pydantic models to support multi-modal interactions (text + files) while maintaining backward compatibility for legacy inputs.

Changes:
- Added `AttachedFile`, `ContentPart`, and `MultiModalInput` to `src/coreason_manifest/definitions/message.py`.
- Created `src/coreason_manifest/definitions/session.py` with `Interaction` model supporting polymorphic input.
- Updated `src/coreason_manifest/__init__.py` to export new models.
- Added comprehensive tests in `tests/test_multimodal.py`.

All models are frozen and inherit from `CoReasonBaseModel`.

---
*PR created automatically by Jules for task [15344555496489678694](https://jules.google.com/task/15344555496489678694) started by @gowthamrao*