### PR TITLE
Fix: Enforce AGENTS.md compliance in CI and Tests

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -55,12 +55,6 @@ jobs:
         shell: bash
 
       - name: Run tests
-        env:
-          PGHOST: ${{ secrets.DB_POSTGRES_TEST_HOST}}
-          PGPORT: ${{ secrets.DB_POSTGRES_TEST_PORT }}
-          PGUSER: ${{ secrets.DB_POSTGRES_TEST_USERNAME}}
-          PGPASSWORD: ${{ secrets.DB_POSTGRES_TEST_PASSWORD}}
-          PGDATABASE: ${{ secrets.DB_POSTGRES_TEST_PATIENT_SYNTHETIC_DATA}}
         run: poetry run pytest --cov=src --cov-report=xml
         shell: bash
 

--- a/tests/test_foundation.py
+++ b/tests/test_foundation.py
@@ -14,7 +14,7 @@ from uuid import UUID, uuid4
 from coreason_manifest.common import CoReasonBaseModel, StrictUri, ToolRiskLevel
 
 
-class TestModel(CoReasonBaseModel):
+class FoundationTestModel(CoReasonBaseModel):
     id: UUID
     timestamp: datetime
     uri: StrictUri
@@ -23,7 +23,7 @@ class TestModel(CoReasonBaseModel):
 
 def test_foundation_serialization() -> None:
     """Test that CoReasonBaseModel.dump() serializes complex types to strings."""
-    model = TestModel(
+    model = FoundationTestModel(
         id=uuid4(),
         timestamp=datetime.now(timezone.utc),
         uri="https://example.com",
@@ -49,7 +49,7 @@ def test_foundation_serialization() -> None:
 
 def test_foundation_json() -> None:
     """Test that CoReasonBaseModel.to_json() produces valid JSON string."""
-    model = TestModel(
+    model = FoundationTestModel(
         id=uuid4(),
         timestamp=datetime.now(timezone.utc),
         uri="https://example.com",


### PR DESCRIPTION
This PR addresses critical compliance issues with `AGENTS.md`. 
1.  **CI/CD Cleanup**: Removed PostgreSQL environment variables from the CI/CD workflow. This repository is a "Pure Data Library" and should not have access to or dependencies on external databases, even in tests (mocking is required). The presence of these variables implied potential integration testing against real infrastructure, which violates the "Passive" and "No Runtime" laws.
2.  **Test Hygiene**: Renamed `TestModel` in `tests/test_foundation.py` to `FoundationTestModel` to prevent Pytest from incorrectly collecting it as a test suite, resolving a warning.
3.  **Verification**: Verified 100% test coverage and passing tests locally. Checked for other violations (side effects on import, forbidden dependencies) and found none aside from the CI config.

---
*PR created automatically by Jules for task [3658824970616209999](https://jules.google.com/task/3658824970616209999) started by @gowthamrao*