### PR TITLE
docs: Improve documentation cohesiveness and cross-linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,4 @@ For full details, see the [Usage Documentation](docs/usage.md).
 *   [Usage Guide](docs/usage.md): How to load and create manifests.
 *   [Governance & Policy Enforcement](docs/governance_policy_enforcement.md): Validating agents against organizational rules.
 *   [Coreason Agent Manifest (CAM)](docs/cap/specification.md): The Canonical YAML Authoring Format.
+*   [Architecture Vignette](VIGNETTE.md): A deep dive into the philosophy and architecture.

--- a/VIGNETTE.md
+++ b/VIGNETTE.md
@@ -57,3 +57,7 @@ except Exception as e:
 ```
 
 In this snippet, the library ensures that the data structure is sound and strictly typed. If a field is missing or an ID is invalid, it fails fast before the data enters the system.
+
+## Further Reading
+
+For comprehensive details, please refer to the [Documentation Index](docs/index.md).

--- a/docs/cap/specification.md
+++ b/docs/cap/specification.md
@@ -229,3 +229,7 @@ workflow:
       agent: "gpt-4-turbo" # Can reference model directly if simple
       system_prompt: "Summarize the findings."
 ```
+
+## See Also
+
+*   [CAP Wire Protocol](wire_protocol.md): The runtime wire format specification.

--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -200,3 +200,7 @@ Polymorphic events for UI rendering (referenced in `StreamPacket` `op=event`).
 | `code` | `Optional[int]` | Semantic integer code (e.g., 400, 503). |
 | `domain` | `ErrorDomain` | Source (`client`, `system`, `llm`, `tool`, `security`). |
 | `retryable` | `bool` | Whether the error is retryable. |
+
+## See Also
+
+*   [CAM Specification](specification.md): The authoring format specification.


### PR DESCRIPTION
This PR improves the documentation organization by ensuring key files are cross-linked. It addresses the issue where `VIGNETTE.md` was orphaned and the CAM/CAP specifications were not referencing each other.

Changes:
- Added a link to `VIGNETTE.md` in `README.md`.
- Added a "Further Reading" section to `VIGNETTE.md` pointing to the docs index.
- Added "See Also" sections to `docs/cap/specification.md` and `docs/cap/wire_protocol.md`.

---
*PR created automatically by Jules for task [17822272821283419348](https://jules.google.com/task/17822272821283419348) started by @gowthamrao*