### PR TITLE
feat: Add AuditLog and enforce request lineage with auto-rooting

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -19,7 +19,12 @@ from .definitions.message import (
     MultiModalInput,
     Role,
 )
-from .definitions.observability import CloudEvent, EventContentType, ReasoningTrace
+from .definitions.observability import (
+    AuditLog,
+    CloudEvent,
+    EventContentType,
+    ReasoningTrace,
+)
 from .definitions.presentation import (
     AnyPresentationEvent,
     ArtifactEvent,
@@ -122,4 +127,5 @@ __all__ = [
     "CloudEvent",
     "EventContentType",
     "ReasoningTrace",
+    "AuditLog",
 ]

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -11,7 +11,7 @@
 from datetime import datetime
 from enum import Enum
 from typing import Any, Dict, List, Optional, Union
-from uuid import UUID
+from uuid import UUID, uuid4
 
 from pydantic import ConfigDict, Field, model_validator
 
@@ -102,10 +102,27 @@ class AgentRequest(CoReasonBaseModel):
 
     model_config = ConfigDict(frozen=True)
 
+    request_id: UUID = Field(default_factory=uuid4)
+    root_request_id: Optional[UUID] = Field(default=None)
+    parent_request_id: Optional[UUID] = None
+
     query: str
     files: List[str] = []
     conversation_id: Optional[str] = None
     meta: Dict[str, Any] = {}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _auto_root(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            # Ensure request_id exists
+            if data.get("request_id") is None:
+                data["request_id"] = uuid4()
+
+            # Ensure root_request_id exists (copy request_id if missing)
+            if data.get("root_request_id") is None:
+                data["root_request_id"] = data["request_id"]
+        return data
 
 
 class SessionContext(CoReasonBaseModel):

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -42,24 +42,13 @@ def test_reasoning_trace_auto_rooting() -> None:
     now = datetime.now(timezone.utc)
 
     # 1. Provide request_id (via auto-gen or explicit) but no root
-    trace = ReasoningTrace(
-        node_id="test",
-        status="ok",
-        latency_ms=1.0,
-        timestamp=now
-    )
+    trace = ReasoningTrace(node_id="test", status="ok", latency_ms=1.0, timestamp=now)
     assert trace.request_id is not None
     assert trace.root_request_id == trace.request_id
 
     # 2. Provide request_id explicit
     rid = uuid4()
-    trace2 = ReasoningTrace(
-        request_id=rid,
-        node_id="test",
-        status="ok",
-        latency_ms=1.0,
-        timestamp=now
-    )
+    trace2 = ReasoningTrace(request_id=rid, node_id="test", status="ok", latency_ms=1.0, timestamp=now)
     assert trace2.request_id == rid
     assert trace2.root_request_id == rid
 
@@ -67,12 +56,7 @@ def test_reasoning_trace_auto_rooting() -> None:
     rid = uuid4()
     root = uuid4()
     trace3 = ReasoningTrace(
-        request_id=rid,
-        root_request_id=root,
-        node_id="test",
-        status="ok",
-        latency_ms=1.0,
-        timestamp=now
+        request_id=rid, root_request_id=root, node_id="test", status="ok", latency_ms=1.0, timestamp=now
     )
     assert trace3.request_id == rid
     assert trace3.root_request_id == root

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from coreason_manifest.definitions.observability import ReasoningTrace
+from coreason_manifest.spec.cap import AgentRequest
+
+
+def test_agent_request_auto_rooting() -> None:
+    """Test that AgentRequest automatically sets root_request_id if missing."""
+    # 1. Provide nothing
+    req = AgentRequest(query="test")
+    assert req.request_id is not None
+    assert req.root_request_id == req.request_id
+    assert req.parent_request_id is None
+
+    # 2. Provide request_id but no root
+    rid = uuid4()
+    req2 = AgentRequest(query="test", request_id=rid)
+    assert req2.request_id == rid
+    assert req2.root_request_id == rid
+
+    # 3. Provide root explicit
+    rid = uuid4()
+    root = uuid4()
+    req3 = AgentRequest(query="test", request_id=rid, root_request_id=root)
+    assert req3.request_id == rid
+    assert req3.root_request_id == root
+
+
+def test_reasoning_trace_auto_rooting() -> None:
+    """Test that ReasoningTrace automatically sets root_request_id if missing."""
+    now = datetime.now(timezone.utc)
+
+    # 1. Provide request_id (via auto-gen or explicit) but no root
+    trace = ReasoningTrace(
+        node_id="test",
+        status="ok",
+        latency_ms=1.0,
+        timestamp=now
+    )
+    assert trace.request_id is not None
+    assert trace.root_request_id == trace.request_id
+
+    # 2. Provide request_id explicit
+    rid = uuid4()
+    trace2 = ReasoningTrace(
+        request_id=rid,
+        node_id="test",
+        status="ok",
+        latency_ms=1.0,
+        timestamp=now
+    )
+    assert trace2.request_id == rid
+    assert trace2.root_request_id == rid
+
+    # 3. Provide root explicit
+    rid = uuid4()
+    root = uuid4()
+    trace3 = ReasoningTrace(
+        request_id=rid,
+        root_request_id=root,
+        node_id="test",
+        status="ok",
+        latency_ms=1.0,
+        timestamp=now
+    )
+    assert trace3.request_id == rid
+    assert trace3.root_request_id == root


### PR DESCRIPTION
This PR introduces the `AuditLog` model and enforces strict request lineage across `ReasoningTrace` and `AgentRequest`.

Key changes:
1.  **Observability:** Added `AuditLog` for immutable security/compliance logging.
2.  **Lineage:** Implemented `auto-rooting` in `ReasoningTrace` and `AgentRequest`. If `root_request_id` is missing, it defaults to `request_id` (generating it if necessary).
3.  **CAP:** Enhanced `AgentRequest` with standard lineage fields to ensure traceability.
4.  **Testing:** Added comprehensive tests for lineage logic and AuditLog serialization.

All changes follow the "Passive by Design" and "Pure Data Library" principles defined in `AGENTS.md`.

---
*PR created automatically by Jules for task [18301010424238637316](https://jules.google.com/task/18301010424238637316) started by @gowthamrao*