### PR TITLE
Implement Interoperability Layer (WP-M)

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -21,6 +21,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Coreason Agent Protocol (CAP) Wire Format](cap/wire_protocol.md)**
     *   Defines the runtime wire protocol, including standard request/response envelopes (`ServiceRequest`, `ServiceResponse`) and streaming contracts (`StreamPacket`).
 
+*   **[Interoperability](interoperability.md)**
+    *   Describes the "Rosetta Stone" layer (`AdapterHints`, `AgentRuntimeConfig`) for transpiling manifests to external frameworks like LangGraph and AutoGen.
+
 *   **[Observability & Tracing](observability.md)**
     *   Standard telemetry envelopes (`CloudEvent`, `ReasoningTrace`) for system notifications, audit logs, and distributed tracing.
 

--- a/docs/interoperability.md
+++ b/docs/interoperability.md
@@ -1,0 +1,118 @@
+# Interoperability & Adapter Hints
+
+The **Interoperability Layer** (also known as the "Rosetta Stone" layer) allows the Coreason Manifest to carry metadata for external transpilers and runtimes without introducing runtime dependencies into the shared kernel.
+
+This enables a single Manifest definition to be transpiled into code for various agent frameworks, such as LangGraph, AutoGen, or CrewAI, by providing framework-specific "hints" and configurations.
+
+## Core Concepts
+
+### Adapter Hints
+
+`AdapterHints` provide instructions to a transpiler on how to map a generic Coreason Agent or Step to a specific construct in a target framework.
+
+*   **Framework:** The target runtime (e.g., `'langgraph'`, `'autogen'`).
+*   **Adapter Type:** The specific class or construct to generate (e.g., `'ReActNode'`, `'AssistantAgent'`).
+*   **Settings:** An arbitrary dictionary of configuration parameters specific to that framework.
+
+### Agent Runtime Config
+
+The `AgentRuntimeConfig` container holds a list of `AdapterHints` for a given agent. This allows a single agent definition to support multiple targets simultaneously.
+
+## Schema
+
+### AdapterHints
+
+```python
+class AdapterHints(CoReasonBaseModel):
+    framework: str        # e.g., 'langgraph'
+    adapter_type: str     # e.g., 'ReActNode'
+    settings: Dict[str, Any] # Framework-specific config
+```
+
+### AgentRuntimeConfig
+
+```python
+class AgentRuntimeConfig(CoReasonBaseModel):
+    adapters: List[AdapterHints]
+```
+
+### Integration in AgentDefinition
+
+The `AgentDefinition` now includes an optional `runtime` field:
+
+```python
+class AgentDefinition(CoReasonBaseModel):
+    # ... standard fields ...
+    runtime: Optional[AgentRuntimeConfig] = None
+```
+
+## Usage Examples
+
+### Defining Hints in Python
+
+```python
+from coreason_manifest import (
+    AgentDefinition,
+    AgentRuntimeConfig,
+    AdapterHints
+)
+
+# Define hints for LangGraph
+langgraph_hint = AdapterHints(
+    framework="langgraph",
+    adapter_type="ReActNode",
+    settings={
+        "recursion_limit": 50,
+        "checkpoint_memory": True
+    }
+)
+
+# Define hints for AutoGen
+autogen_hint = AdapterHints(
+    framework="autogen",
+    adapter_type="AssistantAgent",
+    settings={
+        "llm_config": {
+            "seed": 42,
+            "temperature": 0.1
+        },
+        "human_input_mode": "NEVER"
+    }
+)
+
+# Create the Agent Definition
+agent = AgentDefinition(
+    id="researcher-1",
+    name="Deep Researcher",
+    role="Researcher",
+    goal="Analyze complex topics",
+    runtime=AgentRuntimeConfig(
+        adapters=[langgraph_hint, autogen_hint]
+    )
+)
+```
+
+### Transpiler Implementation Pattern
+
+A transpiler reading this manifest would look for hints matching its target framework:
+
+```python
+def transpile_agent(agent_def: AgentDefinition, target_framework: str):
+    if not agent_def.runtime:
+        return default_transpilation(agent_def)
+
+    # Find relevant hint
+    hint = next(
+        (a for a in agent_def.runtime.adapters if a.framework == target_framework),
+        None
+    )
+
+    if hint:
+        return generate_code(
+            type=hint.adapter_type,
+            config=hint.settings,
+            core_def=agent_def
+        )
+    else:
+        return default_transpilation(agent_def)
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -10,6 +10,7 @@ nav:
   - Specifications & Protocols:
     - CAM Specification: cap/specification.md
     - CAP Wire Protocol: cap/wire_protocol.md
+    - Interoperability: interoperability.md
   - Architecture & Rationale:
     - Product Requirements: product_requirements.md
     - Base Model Rationale: coreason_base_model_rationale.md

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -12,6 +12,7 @@ from .common import ToolRiskLevel
 from .definitions.capabilities import AgentCapabilities, DeliveryMode
 from .definitions.error import ErrorDomain
 from .definitions.identity import Identity
+from .definitions.interoperability import AdapterHints, AgentRuntimeConfig
 from .definitions.message import ChatMessage, Role
 from .definitions.observability import (
     AuditLog,
@@ -117,4 +118,6 @@ __all__ = [
     "EventContentType",
     "ReasoningTrace",
     "AuditLog",
+    "AdapterHints",
+    "AgentRuntimeConfig",
 ]

--- a/src/coreason_manifest/definitions/interoperability.py
+++ b/src/coreason_manifest/definitions/interoperability.py
@@ -1,0 +1,35 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any, Dict, List
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.common import CoReasonBaseModel
+
+
+class AdapterHints(CoReasonBaseModel):
+    """Configuration for external framework transpilers."""
+
+    model_config = ConfigDict(frozen=True)
+
+    framework: str = Field(..., description="Target framework, e.g. 'langgraph', 'autogen'")
+    adapter_type: str = Field(..., description="The class/construct to generate, e.g. 'ReActNode'")
+    settings: Dict[str, Any] = Field(default_factory=dict, description="Framework-specific configuration")
+
+
+class AgentRuntimeConfig(CoReasonBaseModel):
+    """Runtime configuration and adapter hints for an agent."""
+
+    model_config = ConfigDict(frozen=True)
+
+    adapters: List[AdapterHints] = Field(
+        default_factory=list, description="List of adapter configurations for different runtimes"
+    )

--- a/src/coreason_manifest/v2/spec/definitions.py
+++ b/src/coreason_manifest/v2/spec/definitions.py
@@ -4,6 +4,7 @@ from pydantic import ConfigDict, Field
 
 from coreason_manifest.common import CoReasonBaseModel, StrictUri, ToolRiskLevel
 from coreason_manifest.definitions.capabilities import AgentCapabilities
+from coreason_manifest.definitions.interoperability import AgentRuntimeConfig
 from coreason_manifest.v2.spec.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
 
 
@@ -50,6 +51,9 @@ class AgentDefinition(CoReasonBaseModel):
     knowledge: List[str] = Field(default_factory=list, description="List of file paths or knowledge base IDs.")
     capabilities: AgentCapabilities = Field(
         default_factory=AgentCapabilities, description="Feature flags and capabilities for the agent."
+    )
+    runtime: Optional[AgentRuntimeConfig] = Field(
+        default=None, description="Runtime-specific configuration and adapter hints."
     )
 
 

--- a/tests/test_interoperability.py
+++ b/tests/test_interoperability.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest import AdapterHints, AgentDefinition, AgentRuntimeConfig
+
+
+def test_adapter_hint_serialization():
+    """Test that AdapterHints correctly serializes settings."""
+    settings = {"recursion_limit": 50, "experimental": True}
+    hint = AdapterHints(framework="langgraph", adapter_type="ReActNode", settings=settings)
+
+    dumped = hint.dump()
+    assert dumped["framework"] == "langgraph"
+    assert dumped["adapter_type"] == "ReActNode"
+    assert dumped["settings"] == settings
+
+
+def test_runtime_config_integration():
+    """Test integration of AgentRuntimeConfig with AgentDefinition."""
+    langgraph_hint = AdapterHints(
+        framework="langgraph", adapter_type="ReActNode", settings={"recursion_limit": 50}
+    )
+    autogen_hint = AdapterHints(
+        framework="autogen", adapter_type="AssistantAgent", settings={"llm_config": {"seed": 42}}
+    )
+
+    runtime_config = AgentRuntimeConfig(adapters=[langgraph_hint, autogen_hint])
+
+    agent = AgentDefinition(
+        id="agent-1",
+        name="Test Agent",
+        role="Tester",
+        goal="Test integration",
+        runtime=runtime_config,
+    )
+
+    assert agent.runtime is not None
+    assert len(agent.runtime.adapters) == 2
+    assert agent.runtime.adapters[0].framework == "langgraph"
+    assert agent.runtime.adapters[1].framework == "autogen"
+
+
+def test_immutability():
+    """Test that models are immutable."""
+    hint = AdapterHints(framework="langgraph", adapter_type="ReActNode")
+
+    with pytest.raises(ValidationError):
+        hint.settings = {"new": "value"}  # type: ignore
+
+    runtime_config = AgentRuntimeConfig(adapters=[hint])
+
+    with pytest.raises(ValidationError):
+        runtime_config.adapters = []  # type: ignore
+
+    agent = AgentDefinition(
+        id="agent-1",
+        name="Test Agent",
+        role="Tester",
+        goal="Test immutability",
+        runtime=runtime_config,
+    )
+
+    with pytest.raises(ValidationError):
+        agent.runtime.adapters = []  # type: ignore

--- a/tests/test_interoperability.py
+++ b/tests/test_interoperability.py
@@ -14,7 +14,7 @@ from pydantic import ValidationError
 from coreason_manifest import AdapterHints, AgentDefinition, AgentRuntimeConfig
 
 
-def test_adapter_hint_serialization():
+def test_adapter_hint_serialization() -> None:
     """Test that AdapterHints correctly serializes settings."""
     settings = {"recursion_limit": 50, "experimental": True}
     hint = AdapterHints(framework="langgraph", adapter_type="ReActNode", settings=settings)
@@ -25,11 +25,9 @@ def test_adapter_hint_serialization():
     assert dumped["settings"] == settings
 
 
-def test_runtime_config_integration():
+def test_runtime_config_integration() -> None:
     """Test integration of AgentRuntimeConfig with AgentDefinition."""
-    langgraph_hint = AdapterHints(
-        framework="langgraph", adapter_type="ReActNode", settings={"recursion_limit": 50}
-    )
+    langgraph_hint = AdapterHints(framework="langgraph", adapter_type="ReActNode", settings={"recursion_limit": 50})
     autogen_hint = AdapterHints(
         framework="autogen", adapter_type="AssistantAgent", settings={"llm_config": {"seed": 42}}
     )
@@ -50,7 +48,7 @@ def test_runtime_config_integration():
     assert agent.runtime.adapters[1].framework == "autogen"
 
 
-def test_immutability():
+def test_immutability() -> None:
     """Test that models are immutable."""
     hint = AdapterHints(framework="langgraph", adapter_type="ReActNode")
 

--- a/tests/test_interoperability.py
+++ b/tests/test_interoperability.py
@@ -8,6 +8,9 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+import json
+from typing import Any, Dict
+
 import pytest
 from pydantic import ValidationError
 
@@ -68,5 +71,105 @@ def test_immutability() -> None:
         runtime=runtime_config,
     )
 
+    # Note: AgentDefinition fields might be mutable depending on its config,
+    # but AgentRuntimeConfig fields are frozen.
+    # Trying to replace the entire runtime object on the agent is allowed if AgentDefinition is not frozen,
+    # but modifying the internals of the runtime object should fail.
+    # AgentRuntimeConfig is frozen, so:
     with pytest.raises(ValidationError):
         agent.runtime.adapters = []  # type: ignore
+
+
+# --- Edge Cases ---
+
+
+def test_edge_case_empty_values() -> None:
+    """Test AdapterHints with empty strings and dictionaries."""
+    hint = AdapterHints(framework="", adapter_type="", settings={})
+    assert hint.framework == ""
+    assert hint.adapter_type == ""
+    assert hint.settings == {}
+
+    dumped = hint.dump()
+    assert dumped["framework"] == ""
+    assert dumped["adapter_type"] == ""
+    assert dumped["settings"] == {}
+
+
+def test_edge_case_nested_settings() -> None:
+    """Test AdapterHints with deeply nested mixed-type settings."""
+    complex_settings: Dict[str, Any] = {
+        "level1": {
+            "level2": [
+                {"level3": "value"},
+                123,
+                None,
+                True,
+            ]
+        },
+        "unicode": "🤖",
+        "empty_list": [],
+    }
+    hint = AdapterHints(framework="test", adapter_type="Deep", settings=complex_settings)
+
+    # Verify structure is preserved in dump
+    dumped = hint.dump()
+    assert dumped["settings"]["level1"]["level2"][0]["level3"] == "value"
+    assert dumped["settings"]["unicode"] == "🤖"
+
+    # Verify JSON serialization works
+    json_str = hint.to_json()
+    loaded = json.loads(json_str)
+    assert loaded["settings"]["unicode"] == "🤖"
+
+
+def test_edge_case_large_payload() -> None:
+    """Test serialization with a large settings payload."""
+    large_list = list(range(1000))
+    large_settings = {"data": large_list, "meta": "x" * 1000}
+    hint = AdapterHints(framework="loadtest", adapter_type="Heavy", settings=large_settings)
+
+    dumped = hint.dump()
+    assert len(dumped["settings"]["data"]) == 1000
+    assert len(dumped["settings"]["meta"]) == 1000
+
+
+# --- Complex Cases ---
+
+
+def test_complex_langgraph_config() -> None:
+    """Test a realistic complex LangGraph configuration."""
+    langgraph_settings = {
+        "checkpointer": "MemorySaver",
+        "interrupt_before": ["human_review"],
+        "nodes": {
+            "agent": {"type": "runnable", "model": "gpt-4"},
+            "tools": {"type": "tool_node", "tools": ["search", "calc"]},
+        },
+        "edges": [
+            {"from": "agent", "to": "tools", "condition": "has_tools"},
+            {"from": "tools", "to": "agent"},
+        ],
+        "recursion_limit": 100,
+    }
+
+    hint = AdapterHints(framework="langgraph", adapter_type="CompiledGraph", settings=langgraph_settings)
+
+    config = AgentRuntimeConfig(adapters=[hint])
+    agent = AgentDefinition(id="lg-agent", name="LG Agent", role="Graph", goal="Run graph", runtime=config)
+
+    assert agent.runtime is not None
+    assert agent.runtime.adapters[0].settings["nodes"]["agent"]["model"] == "gpt-4"
+    assert "human_review" in agent.runtime.adapters[0].settings["interrupt_before"]
+
+
+def test_complex_redundant_adapters() -> None:
+    """Test multiple adapters for the same framework (valid case)."""
+    # A user might want to generate both a Node and a full Graph for the same agent
+    hint_node = AdapterHints(framework="langgraph", adapter_type="Node", settings={"style": "functional"})
+    hint_graph = AdapterHints(framework="langgraph", adapter_type="Graph", settings={"style": "compiled"})
+
+    config = AgentRuntimeConfig(adapters=[hint_node, hint_graph])
+    assert len(config.adapters) == 2
+    assert config.adapters[0].adapter_type == "Node"
+    assert config.adapters[1].adapter_type == "Graph"


### PR DESCRIPTION
Implement the "Rosetta Stone" interoperability layer defined in Work Package M.
This introduces `AdapterHints` and `AgentRuntimeConfig` to support external transpilers (e.g., LangGraph, AutoGen) by carrying framework-specific metadata in the manifest.
These models are pure data, frozen, and inherit from `CoReasonBaseModel`.
The `AgentDefinition` schema is updated to include an optional `runtime` configuration field.
Tests verify serialization, integration, and immutability.

---
*PR created automatically by Jules for task [16516569752949157800](https://jules.google.com/task/16516569752949157800) started by @gowthamrao*