### PR TITLE
feat(governance): Enforce Auth Mandate for Critical Tools

### DIFF
--- a/debug_pydantic.py
+++ b/debug_pydantic.py
@@ -1,0 +1,5 @@
+from coreason_manifest.v2.spec.definitions import ManifestMetadata
+
+m = ManifestMetadata(name="test", requires_auth=True)
+print(f"getattr: {getattr(m, 'requires_auth', 'NOT_FOUND')}")
+print(f"model_extra: {m.model_extra}")

--- a/docs/governance_policy_enforcement.md
+++ b/docs/governance_policy_enforcement.md
@@ -9,7 +9,7 @@ The module provides configuration models to define organizational standards (e.g
 ### Key Features
 *   **Domain Restriction**: Whitelist specific domains for external tools (e.g., only allow tools from `*.internal.corp`).
 *   **Risk Level Enforcement**: Set a maximum allowed risk level for tools (e.g., `SAFE` only).
-*   **Authentication Mandates**: Ensure that agents using `CRITICAL` tools enforce user authentication.
+*   **Authentication Mandates**: Ensure that agents using `CRITICAL` tools enforce user authentication. If `require_auth_for_critical_tools` is enabled (default), any manifest defining a `CRITICAL` tool must explicitly set `requires_auth: true` in its metadata.
 *   **Logic Execution Control**: Restrict the usage of arbitrary Python code in `LogicStep`s and `SwitchStep`s.
 *   **Strict URL Validation**: Enforce strict normalization (lower-case, no trailing dots) on tool URIs to prevent bypasses.
 

--- a/src/coreason_manifest/v2/governance.py
+++ b/src/coreason_manifest/v2/governance.py
@@ -139,7 +139,9 @@ def check_compliance_v2(manifest: ManifestV2, config: GovernanceConfig) -> Compl
             violations.append(
                 ComplianceViolation(
                     rule="auth_mandate_missing",
-                    message="Agent uses CRITICAL tools but does not enforce authentication (metadata.requires_auth=True).",
+                    message=(
+                        "Agent uses CRITICAL tools but does not enforce authentication (metadata.requires_auth=True)."
+                    ),
                     component_id="metadata",
                 )
             )

--- a/src/coreason_manifest/v2/governance.py
+++ b/src/coreason_manifest/v2/governance.py
@@ -126,14 +126,9 @@ def check_compliance_v2(manifest: ManifestV2, config: GovernanceConfig) -> Compl
                     )
 
     if config.require_auth_for_critical_tools and has_critical_tools:
-        # Check if auth is required in metadata
-        requires_auth = False
-        # Try direct attribute access first (if it were defined in schema)
-        if getattr(manifest.metadata, "requires_auth", False):
-            requires_auth = True
-        # Try model_extra for dynamic fields
-        elif manifest.metadata.model_extra and manifest.metadata.model_extra.get("requires_auth"):
-            requires_auth = True
+        # Check if auth is required in metadata.
+        # Pydantic V2 allows accessing extra fields via getattr if extra='allow'.
+        requires_auth = getattr(manifest.metadata, "requires_auth", False)
 
         if not requires_auth:
             violations.append(

--- a/src/coreason_manifest/v2/governance.py
+++ b/src/coreason_manifest/v2/governance.py
@@ -56,8 +56,13 @@ def check_compliance_v2(manifest: ManifestV2, config: GovernanceConfig) -> Compl
     violations: List[ComplianceViolation] = []
 
     # 1. Check Tools in Definitions
+    has_critical_tools = False
+
     for _, definition in manifest.definitions.items():
         if isinstance(definition, ToolDefinition):
+            if definition.risk_level == ToolRiskLevel.CRITICAL:
+                has_critical_tools = True
+
             # Check Risk Level
             if config.max_risk_level:
                 tool_score = _risk_score(definition.risk_level)
@@ -119,6 +124,25 @@ def check_compliance_v2(manifest: ManifestV2, config: GovernanceConfig) -> Compl
                             component_id=definition.id,
                         )
                     )
+
+    if config.require_auth_for_critical_tools and has_critical_tools:
+        # Check if auth is required in metadata
+        requires_auth = False
+        # Try direct attribute access first (if it were defined in schema)
+        if getattr(manifest.metadata, "requires_auth", False):
+            requires_auth = True
+        # Try model_extra for dynamic fields
+        elif manifest.metadata.model_extra and manifest.metadata.model_extra.get("requires_auth"):
+            requires_auth = True
+
+        if not requires_auth:
+            violations.append(
+                ComplianceViolation(
+                    rule="auth_mandate_missing",
+                    message="Agent uses CRITICAL tools but does not enforce authentication (metadata.requires_auth=True).",
+                    component_id="metadata",
+                )
+            )
 
     # 2. Check Workflow Steps for Custom Logic
     if not config.allow_custom_logic:

--- a/tests/test_v2_phase3.py
+++ b/tests/test_v2_phase3.py
@@ -84,7 +84,7 @@ def test_governance_tool_risk() -> None:
     )
 
     # Config allowing only STANDARD
-    config = GovernanceConfig(max_risk_level=ToolRiskLevel.STANDARD)
+    config = GovernanceConfig(max_risk_level=ToolRiskLevel.STANDARD, require_auth_for_critical_tools=False)
 
     report = check_compliance_v2(manifest, config)
     assert not report.passed

--- a/tests/test_validation_governance.py
+++ b/tests/test_validation_governance.py
@@ -15,6 +15,7 @@ from coreason_manifest import (
     GovernanceConfig,
     LogicStep,
     Manifest,
+    ManifestMetadata,
     ToolDefinition,
     ToolRiskLevel,
     Workflow,
@@ -65,7 +66,7 @@ def test_governance_risk() -> None:
         workflow=Workflow(start="A", steps={"A": AgentStep(id="A", agent="bond")}),
     )
 
-    config = GovernanceConfig(max_risk_level=ToolRiskLevel.STANDARD)
+    config = GovernanceConfig(max_risk_level=ToolRiskLevel.STANDARD, require_auth_for_critical_tools=False)
     report = check_compliance_v2(manifest, config)
 
     assert report.passed is False
@@ -86,3 +87,35 @@ def test_governance_logic_block() -> None:
 
     assert report.passed is False
     assert any("LogicStep containing custom code is not allowed" in v.message for v in report.violations)
+
+
+def test_governance_auth_mandate() -> None:
+    """Test governance policy enforcement on authentication for critical tools."""
+    tool = ToolDefinition(id="nuke", name="Nuke", uri="https://nuke.com", risk_level=ToolRiskLevel.CRITICAL)
+    config = GovernanceConfig(require_auth_for_critical_tools=True)
+
+    # Case 1: Violation
+    manifest_insecure = Manifest(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Insecure"),
+        definitions={"nuke": tool},
+        workflow=Workflow(start="A", steps={"A": AgentStep(id="A", agent="bond")}),
+    )
+
+    report = check_compliance_v2(manifest_insecure, config)
+    assert report.passed is False
+    assert len(report.violations) == 1
+    assert report.violations[0].rule == "auth_mandate_missing"
+    assert "uses CRITICAL tools but does not enforce authentication" in report.violations[0].message
+
+    # Case 2: Compliant
+    manifest_secure = Manifest(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Secure", requires_auth=True),
+        definitions={"nuke": tool},
+        workflow=Workflow(start="A", steps={"A": AgentStep(id="A", agent="bond")}),
+    )
+
+    report_secure = check_compliance_v2(manifest_secure, config)
+    assert report_secure.passed is True
+    assert len(report_secure.violations) == 0

--- a/tests/test_validation_governance_complex.py
+++ b/tests/test_validation_governance_complex.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+
+from coreason_manifest import (
+    AgentStep,
+    GovernanceConfig,
+    Manifest,
+    ManifestMetadata,
+    ToolDefinition,
+    ToolRiskLevel,
+    Workflow,
+    check_compliance_v2,
+)
+
+
+def test_complex_large_manifest_many_tools() -> None:
+    """Case 7: Large manifest with many tools (stress test logic)."""
+    tools = {}
+    # Generate 50 safe tools
+    for i in range(50):
+        tools[f"safe_{i}"] = ToolDefinition(
+            id=f"safe_{i}", name=f"Safe {i}", uri=f"https://safe{i}.com", risk_level=ToolRiskLevel.SAFE
+        )
+
+    # Generate 1 critical tool hidden in the middle
+    tools["hidden_critical"] = ToolDefinition(
+        id="hidden_critical", name="Critical", uri="https://crit.com", risk_level=ToolRiskLevel.CRITICAL
+    )
+
+    # Generate 49 more standard tools
+    for i in range(49):
+        tools[f"std_{i}"] = ToolDefinition(
+            id=f"std_{i}", name=f"Std {i}", uri=f"https://std{i}.com", risk_level=ToolRiskLevel.STANDARD
+        )
+
+    config = GovernanceConfig(require_auth_for_critical_tools=True)
+    manifest = Manifest(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Large Manifest"),
+        definitions=tools,
+        workflow=Workflow(start="A", steps={"A": AgentStep(id="A", agent="bond")}),
+    )
+
+    report = check_compliance_v2(manifest, config)
+    assert report.passed is False
+    assert len(report.violations) == 1
+    assert report.violations[0].rule == "auth_mandate_missing"
+
+
+def test_complex_compliant_large_manifest() -> None:
+    """Case 8: Large compliant manifest."""
+    tools = {}
+    tools["hidden_critical"] = ToolDefinition(
+        id="hidden_critical", name="Critical", uri="https://crit.com", risk_level=ToolRiskLevel.CRITICAL
+    )
+
+    config = GovernanceConfig(require_auth_for_critical_tools=True)
+    manifest = Manifest(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Large Compliant", requires_auth=True),
+        definitions=tools,
+        workflow=Workflow(start="A", steps={"A": AgentStep(id="A", agent="bond")}),
+    )
+
+    report = check_compliance_v2(manifest, config)
+    assert report.passed is True

--- a/tests/test_validation_governance_complex.py
+++ b/tests/test_validation_governance_complex.py
@@ -8,8 +8,6 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-import pytest
-
 from coreason_manifest import (
     AgentStep,
     GovernanceConfig,

--- a/tests/test_validation_governance_edge_cases.py
+++ b/tests/test_validation_governance_edge_cases.py
@@ -1,0 +1,129 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+
+from coreason_manifest import (
+    AgentStep,
+    GovernanceConfig,
+    Manifest,
+    ManifestMetadata,
+    ToolDefinition,
+    ToolRiskLevel,
+    Workflow,
+    check_compliance_v2,
+)
+
+
+@pytest.fixture
+def base_workflow() -> Workflow:
+    return Workflow(start="A", steps={"A": AgentStep(id="A", agent="bond")})
+
+
+def test_auth_mandate_explicit_false(base_workflow: Workflow) -> None:
+    """Case 1: Manifest with CRITICAL tool but requires_auth=False explicitly."""
+    tool = ToolDefinition(id="nuke", name="Nuke", uri="https://nuke.com", risk_level=ToolRiskLevel.CRITICAL)
+    config = GovernanceConfig(require_auth_for_critical_tools=True)
+
+    manifest = Manifest(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Explicit Insecure", requires_auth=False),
+        definitions={"nuke": tool},
+        workflow=base_workflow,
+    )
+
+    report = check_compliance_v2(manifest, config)
+    assert report.passed is False
+    assert len(report.violations) == 1
+    assert report.violations[0].rule == "auth_mandate_missing"
+
+
+def test_auth_mandate_none_default(base_workflow: Workflow) -> None:
+    """Case 2: Manifest with CRITICAL tool and requires_auth=None (default)."""
+    tool = ToolDefinition(id="nuke", name="Nuke", uri="https://nuke.com", risk_level=ToolRiskLevel.CRITICAL)
+    config = GovernanceConfig(require_auth_for_critical_tools=True)
+
+    manifest = Manifest(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Default Insecure"),
+        definitions={"nuke": tool},
+        workflow=base_workflow,
+    )
+
+    report = check_compliance_v2(manifest, config)
+    assert report.passed is False
+    assert len(report.violations) == 1
+    assert report.violations[0].rule == "auth_mandate_missing"
+
+
+def test_auth_mandate_mixed_tools(base_workflow: Workflow) -> None:
+    """Case 3: Manifest with multiple tools, mixed risk levels.
+    Ensures presence of ONE critical tool triggers the mandate.
+    """
+    tools = {
+        "safe_tool": ToolDefinition(id="safe", name="Safe", uri="https://safe.com", risk_level=ToolRiskLevel.SAFE),
+        "std_tool": ToolDefinition(id="std", name="Std", uri="https://std.com", risk_level=ToolRiskLevel.STANDARD),
+        "crit_tool": ToolDefinition(id="crit", name="Crit", uri="https://crit.com", risk_level=ToolRiskLevel.CRITICAL),
+    }
+    config = GovernanceConfig(require_auth_for_critical_tools=True)
+
+    manifest = Manifest(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Mixed Risk Agent"),
+        definitions=tools,
+        workflow=base_workflow,
+    )
+
+    report = check_compliance_v2(manifest, config)
+    assert report.passed is False
+    assert len(report.violations) == 1
+    assert report.violations[0].rule == "auth_mandate_missing"
+
+
+def test_auth_mandate_config_disabled(base_workflow: Workflow) -> None:
+    """Case 4: GovernanceConfig with require_auth_for_critical_tools=False.
+    Manifest has critical tools but no auth. Should PASS.
+    """
+    tool = ToolDefinition(id="nuke", name="Nuke", uri="https://nuke.com", risk_level=ToolRiskLevel.CRITICAL)
+    config = GovernanceConfig(require_auth_for_critical_tools=False)
+
+    manifest = Manifest(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Config Disabled Agent"),
+        definitions={"nuke": tool},
+        workflow=base_workflow,
+    )
+
+    report = check_compliance_v2(manifest, config)
+    assert report.passed is True
+    assert len(report.violations) == 0
+
+
+def test_auth_mandate_dynamic_extra_field(base_workflow: Workflow) -> None:
+    """Case 5: Manifest with requires_auth set via model_extra.
+    (Simulating loading from YAML where field isn't in schema but allowed).
+    """
+    tool = ToolDefinition(id="nuke", name="Nuke", uri="https://nuke.com", risk_level=ToolRiskLevel.CRITICAL)
+    config = GovernanceConfig(require_auth_for_critical_tools=True)
+
+    # Creating metadata with extra field directly via constructor if allowed,
+    # or by forcing it into model_extra.
+    # ManifestMetadata has extra='allow'.
+    metadata = ManifestMetadata(name="Dynamic Secure", requires_auth=True)
+
+    manifest = Manifest(
+        kind="Agent",
+        metadata=metadata,
+        definitions={"nuke": tool},
+        workflow=base_workflow,
+    )
+
+    report = check_compliance_v2(manifest, config)
+    assert report.passed is True


### PR DESCRIPTION
This PR implements the Auth Mandate Governance check as part of Work Package K.

It modifies the `Governance Engine` (specifically `check_compliance_v2`) to strictly enforce that any agent definition using tools with `ToolRiskLevel.CRITICAL` must also have `requires_auth: true` in its metadata, provided the `GovernanceConfig.require_auth_for_critical_tools` flag is enabled (which it is by default).

Changes:
1.  **Logic Update in `src/coreason_manifest/v2/governance.py`**:
    *   Added logic to detect presence of `CRITICAL` tools during definition iteration.
    *   Added a post-loop check: if critical tools are present and the policy requires auth, verify `manifest.metadata.requires_auth` is truthy.
    *   Added a new `ComplianceViolation` with rule `auth_mandate_missing` if the check fails.

2.  **Test Updates in `tests/test_validation_governance.py`**:
    *   Added `test_governance_auth_mandate` to verify the new rule.
        *   Case 1: Manifest with critical tool + default metadata -> Violation.
        *   Case 2: Manifest with critical tool + `requires_auth=True` -> Pass.
    *   Updated existing `test_governance_risk` to set `require_auth_for_critical_tools=False` in the config. This ensures the test continues to focus solely on risk level validation without failing due to the new auth mandate (since the test fixture lacks auth metadata).

This closes the security gap where critical tools could potentially be exposed without requiring user authentication.

---
*PR created automatically by Jules for task [13729303278917797661](https://jules.google.com/task/13729303278917797661) started by @gowthamrao*