### PR TITLE
Fix: Restore interoperability module and strict license headers

### DIFF
--- a/src/coreason_manifest/spec/common/capabilities.py
+++ b/src/coreason_manifest/spec/common/capabilities.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from enum import Enum
 from typing import List
 

--- a/src/coreason_manifest/spec/common/interoperability.py
+++ b/src/coreason_manifest/spec/common/interoperability.py
@@ -1,0 +1,34 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Dict, Optional
+
+from pydantic import ConfigDict, Field
+
+from ..common_base import CoReasonBaseModel
+
+
+class AdapterHints(CoReasonBaseModel):
+    """Metadata for external transpilers/adapters."""
+
+    model_config = ConfigDict(frozen=True)
+
+    target: str = Field(..., description="Target runtime/framework (e.g. 'langchain', 'autogen').")
+    version: Optional[str] = Field(None, description="Target version compatibility.")
+    config: Dict[str, str] = Field(default_factory=dict, description="Adapter-specific configuration.")
+
+
+class AgentRuntimeConfig(CoReasonBaseModel):
+    """Configuration for the agent runtime environment."""
+
+    model_config = ConfigDict(frozen=True)
+
+    env_vars: Dict[str, str] = Field(default_factory=dict, description="Environment variables to set.")
+    adapter_hints: Optional[AdapterHints] = Field(None, description="Hints for external adapters.")

--- a/src/coreason_manifest/spec/common/service.py
+++ b/src/coreason_manifest/spec/common/service.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any, Dict
 
 from ..cap import ServiceRequest, ServiceResponse

--- a/src/coreason_manifest/spec/v2/__init__.py
+++ b/src/coreason_manifest/spec/v2/__init__.py
@@ -1,1 +1,11 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 # Coreason Manifest V2 Spec Definitions

--- a/src/coreason_manifest/spec/v2/contracts.py
+++ b/src/coreason_manifest/spec/v2/contracts.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any, Dict, Optional
 
 from pydantic import ConfigDict, Field

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -1,8 +1,19 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Annotated, Any, Dict, List, Literal, Optional, Union
 
 from pydantic import ConfigDict, Field
 
 from coreason_manifest.spec.common.capabilities import AgentCapabilities
+from coreason_manifest.spec.common.interoperability import AgentRuntimeConfig
 from coreason_manifest.spec.common_base import CoReasonBaseModel, StrictUri, ToolRiskLevel
 from coreason_manifest.spec.v2.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
 
@@ -50,6 +61,9 @@ class AgentDefinition(CoReasonBaseModel):
     knowledge: List[str] = Field(default_factory=list, description="List of file paths or knowledge base IDs.")
     capabilities: AgentCapabilities = Field(
         default_factory=AgentCapabilities, description="Feature flags and capabilities for the agent."
+    )
+    runtime: Optional[AgentRuntimeConfig] = Field(
+        None, description="Configuration for the agent runtime environment (e.g. environment variables)."
     )
 
 

--- a/tests/test_interoperability.py
+++ b/tests/test_interoperability.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.common.interoperability import AdapterHints, AgentRuntimeConfig
+from coreason_manifest.spec.v2.definitions import AgentDefinition
+
+
+def test_adapter_hints_serialization() -> None:
+    """Test serialization of AdapterHints."""
+    hints = AdapterHints(
+        target="langchain",
+        version="0.1.0",
+        config={"experimental": "true"},
+    )
+    payload = hints.dump()
+    assert payload["target"] == "langchain"
+    assert payload["version"] == "0.1.0"
+    assert payload["config"] == {"experimental": "true"}
+
+
+def test_agent_runtime_config_serialization() -> None:
+    """Test serialization of AgentRuntimeConfig."""
+    config = AgentRuntimeConfig(
+        env_vars={"API_KEY": "secret"},
+        adapter_hints=AdapterHints(target="autogen"),
+    )
+    payload = config.dump()
+    assert payload["env_vars"] == {"API_KEY": "secret"}
+    assert payload["adapter_hints"]["target"] == "autogen"
+
+
+def test_immutability() -> None:
+    """Test that models are frozen."""
+    hints = AdapterHints(target="test")
+    with pytest.raises(ValidationError):
+        hints.target = "modified"  # type: ignore
+
+    config = AgentRuntimeConfig()
+    with pytest.raises(ValidationError):
+        config.env_vars = {"NEW": "val"}  # type: ignore
+
+
+def test_integration_with_agent_definition() -> None:
+    """Test embedding RuntimeConfig in AgentDefinition."""
+    agent = AgentDefinition(
+        id="agent-1",
+        name="Test Agent",
+        role="Tester",
+        goal="Test things",
+        runtime=AgentRuntimeConfig(
+            env_vars={"DEBUG": "1"},
+        ),
+    )
+    payload = agent.dump()
+    assert "runtime" in payload
+    assert payload["runtime"]["env_vars"] == {"DEBUG": "1"}
+
+    # Test default is None (excluded by exclude_none=True in dump())
+    agent_minimal = AgentDefinition(
+        id="agent-2",
+        name="Minimal Agent",
+        role="Tester",
+        goal="Test things",
+    )
+    assert "runtime" not in agent_minimal.dump()


### PR DESCRIPTION
This PR addresses critical violations of `AGENTS.md` by ensuring all source files carry the Prosperity Public License 3.0 header. It also restores the `interoperability` module (`AdapterHints`, `AgentRuntimeConfig`) and updates `AgentDefinition` to support runtime configuration, which was missing despite being referenced in memory/documentation. All changes are verified with new tests and static analysis.

---
*PR created automatically by Jules for task [16563195063009495702](https://jules.google.com/task/16563195063009495702) started by @gowthamrao*