### PR TITLE
fix: enforce strict immutability and separate logic from specs

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -48,7 +48,6 @@ from .spec.common.presentation import (
     PresentationEventType,
     UserErrorEvent,
 )
-from .spec.common.service import ServiceContract
 from .spec.common_base import ToolRiskLevel
 from .spec.governance import ComplianceReport, ComplianceViolation, GovernanceConfig
 from .spec.v2.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
@@ -65,6 +64,7 @@ from .spec.v2.definitions import (
     Workflow,
 )
 from .utils.migration import migrate_graph_event_to_cloud_event
+from .utils.service import ServiceContract
 from .utils.v2.governance import check_compliance_v2
 from .utils.v2.io import dump_to_yaml, load_from_yaml
 from .utils.v2.validator import validate_integrity, validate_loose

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 from uuid import UUID, uuid4
 
@@ -19,7 +19,7 @@ from coreason_manifest.spec.common.identity import Identity
 from coreason_manifest.spec.common_base import CoReasonBaseModel
 
 
-class HealthCheckStatus(str, Enum):
+class HealthCheckStatus(StrEnum):
     """Status of the health check."""
 
     OK = "ok"
@@ -38,14 +38,14 @@ class HealthCheckResponse(CoReasonBaseModel):
     uptime_seconds: float
 
 
-class ErrorSeverity(str, Enum):
+class ErrorSeverity(StrEnum):
     """Severity of a stream error."""
 
     TRANSIENT = "transient"
     FATAL = "fatal"
 
 
-class StreamOpCode(str, Enum):
+class StreamOpCode(StrEnum):
     """Operation code for a stream packet."""
 
     DELTA = "delta"

--- a/src/coreason_manifest/spec/common/capabilities.py
+++ b/src/coreason_manifest/spec/common/capabilities.py
@@ -8,14 +8,14 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import ConfigDict, Field
 
 from ..common_base import CoReasonBaseModel
 
 
-class DeliveryMode(str, Enum):
+class DeliveryMode(StrEnum):
     """Supported transport mechanisms."""
 
     REQUEST_RESPONSE = "request_response"

--- a/src/coreason_manifest/spec/common/error.py
+++ b/src/coreason_manifest/spec/common/error.py
@@ -8,10 +8,10 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from enum import Enum
+from enum import StrEnum
 
 
-class ErrorDomain(str, Enum):
+class ErrorDomain(StrEnum):
     """Domains where errors can originate."""
 
     CLIENT = "client"

--- a/src/coreason_manifest/spec/common/interoperability.py
+++ b/src/coreason_manifest/spec/common/interoperability.py
@@ -8,8 +8,6 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Dict, Optional
-
 from pydantic import ConfigDict, Field
 
 from ..common_base import CoReasonBaseModel
@@ -21,8 +19,8 @@ class AdapterHints(CoReasonBaseModel):
     model_config = ConfigDict(frozen=True)
 
     target: str = Field(..., description="Target runtime/framework (e.g. 'langchain', 'autogen').")
-    version: Optional[str] = Field(None, description="Target version compatibility.")
-    config: Dict[str, str] = Field(default_factory=dict, description="Adapter-specific configuration.")
+    version: str | None = Field(None, description="Target version compatibility.")
+    config: dict[str, str] = Field(default_factory=dict, description="Adapter-specific configuration.")
 
 
 class AgentRuntimeConfig(CoReasonBaseModel):
@@ -30,5 +28,5 @@ class AgentRuntimeConfig(CoReasonBaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    env_vars: Dict[str, str] = Field(default_factory=dict, description="Environment variables to set.")
-    adapter_hints: Optional[AdapterHints] = Field(None, description="Hints for external adapters.")
+    env_vars: dict[str, str] = Field(default_factory=dict, description="Environment variables to set.")
+    adapter_hints: AdapterHints | None = Field(None, description="Hints for external adapters.")

--- a/src/coreason_manifest/spec/common/message.py
+++ b/src/coreason_manifest/spec/common/message.py
@@ -9,14 +9,14 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import ConfigDict, Field
 
 from ..common_base import CoReasonBaseModel
 
 
-class Role(str, Enum):
+class Role(StrEnum):
     """The role of the message sender."""
 
     SYSTEM = "system"

--- a/src/coreason_manifest/spec/common/observability.py
+++ b/src/coreason_manifest/spec/common/observability.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any, Literal
 from uuid import UUID
 
@@ -18,7 +18,7 @@ from pydantic import ConfigDict, Field, model_validator
 from ..common_base import CoReasonBaseModel
 
 
-class EventContentType(str, Enum):
+class EventContentType(StrEnum):
     JSON = "application/json"
     STREAM = "application/vnd.coreason.stream+json"
     ERROR = "application/vnd.coreason.error+json"

--- a/src/coreason_manifest/spec/common/presentation.py
+++ b/src/coreason_manifest/spec/common/presentation.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import ConfigDict, Field
@@ -17,7 +17,7 @@ from ..common_base import CoReasonBaseModel
 from .error import ErrorDomain
 
 
-class PresentationEventType(str, Enum):
+class PresentationEventType(StrEnum):
     """Types of presentation events."""
 
     CITATION = "citation"

--- a/src/coreason_manifest/spec/common_base.py
+++ b/src/coreason_manifest/spec/common_base.py
@@ -23,7 +23,7 @@ class CoReasonBaseModel(BaseModel):
     For a detailed rationale, see `docs/coreason_base_model_rationale.md`.
     """
 
-    model_config = ConfigDict(populate_by_name=True)
+    model_config = ConfigDict(populate_by_name=True, frozen=True)
 
     def dump(self, **kwargs: Any) -> dict[str, Any]:
         """Serialize the model to a JSON-compatible dictionary.

--- a/src/coreason_manifest/spec/common_base.py
+++ b/src/coreason_manifest/spec/common_base.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from enum import Enum
+from enum import StrEnum
 from typing import Annotated, Any
 
 from pydantic import AnyUrl, BaseModel, ConfigDict, PlainSerializer
@@ -55,7 +55,7 @@ StrictUri = Annotated[
 ]
 
 
-class ToolRiskLevel(str, Enum):
+class ToolRiskLevel(StrEnum):
     """Risk level for the tool."""
 
     SAFE = "safe"

--- a/src/coreason_manifest/spec/v2/contracts.py
+++ b/src/coreason_manifest/spec/v2/contracts.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from pydantic import ConfigDict, Field
 

--- a/src/coreason_manifest/spec/v2/contracts.py
+++ b/src/coreason_manifest/spec/v2/contracts.py
@@ -18,7 +18,7 @@ from coreason_manifest.spec.common_base import CoReasonBaseModel
 class InterfaceDefinition(CoReasonBaseModel):
     """Defines the input/output contract."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     inputs: dict[str, Any] = Field(default_factory=dict, description="JSON Schema definitions for arguments.")
     outputs: dict[str, Any] = Field(default_factory=dict, description="JSON Schema definitions for return values.")
@@ -27,7 +27,7 @@ class InterfaceDefinition(CoReasonBaseModel):
 class StateDefinition(CoReasonBaseModel):
     """Defines the conversation memory/context structure."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     schema_: dict[str, Any] = Field(
         default_factory=dict, alias="schema", description="The structure of the conversation memory/context."
@@ -38,7 +38,7 @@ class StateDefinition(CoReasonBaseModel):
 class PolicyDefinition(CoReasonBaseModel):
     """Defines execution policy and governance rules."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     max_steps: int | None = Field(None, description="Execution limit on number of steps.")
     max_retries: int = Field(3, description="Maximum number of retries.")

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -21,7 +21,7 @@ from coreason_manifest.spec.v2.contracts import InterfaceDefinition, PolicyDefin
 class DesignMetadata(CoReasonBaseModel):
     """UI-specific metadata for the visual builder."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     x: float = Field(..., description="X coordinate on the canvas.")
     y: float = Field(..., description="Y coordinate on the canvas.")
@@ -35,7 +35,7 @@ class DesignMetadata(CoReasonBaseModel):
 class ToolDefinition(CoReasonBaseModel):
     """Definition of an external tool."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     type: Literal["tool"] = "tool"
     id: str = Field(..., description="Unique ID for the tool within the manifest.")
@@ -48,7 +48,7 @@ class ToolDefinition(CoReasonBaseModel):
 class AgentDefinition(CoReasonBaseModel):
     """Definition of an Agent."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     type: Literal["agent"] = "agent"
     id: str = Field(..., description="Unique ID for the agent.")
@@ -70,13 +70,13 @@ class AgentDefinition(CoReasonBaseModel):
 class GenericDefinition(CoReasonBaseModel):
     """Fallback for unknown definitions."""
 
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(extra="allow", frozen=True)
 
 
 class BaseStep(CoReasonBaseModel):
     """Base attributes for all steps."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     id: str = Field(..., description="Unique identifier for the step.")
     inputs: dict[str, Any] = Field(default_factory=dict, description="Input arguments for the step.")
@@ -127,7 +127,7 @@ Step = Annotated[
 class Workflow(CoReasonBaseModel):
     """Defines the execution topology."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     start: str = Field(..., description="ID of the starting step.")
     steps: dict[str, Step] = Field(..., description="Dictionary of all steps indexed by ID.")
@@ -136,7 +136,7 @@ class Workflow(CoReasonBaseModel):
 class ManifestMetadata(CoReasonBaseModel):
     """Metadata for the manifest."""
 
-    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    model_config = ConfigDict(extra="allow", populate_by_name=True, frozen=True)
 
     name: str = Field(..., description="Human-readable name of the workflow/agent.")
     design_metadata: DesignMetadata | None = Field(None, alias="x-design", description="UI metadata.")
@@ -145,7 +145,7 @@ class ManifestMetadata(CoReasonBaseModel):
 class ManifestV2(CoReasonBaseModel):
     """Root object for Coreason Manifest V2."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     apiVersion: Literal["coreason.ai/v2"] = Field("coreason.ai/v2", description="API Version.")
     kind: Literal["Recipe", "Agent"] = Field(..., description="Kind of the object.")

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Annotated, Any, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, Literal
 
 from pydantic import ConfigDict, Field
 
@@ -62,7 +62,7 @@ class AgentDefinition(CoReasonBaseModel):
     capabilities: AgentCapabilities = Field(
         default_factory=AgentCapabilities, description="Feature flags and capabilities for the agent."
     )
-    runtime: Optional[AgentRuntimeConfig] = Field(
+    runtime: AgentRuntimeConfig | None = Field(
         None, description="Configuration for the agent runtime environment (e.g. environment variables)."
     )
 

--- a/src/coreason_manifest/utils/service.py
+++ b/src/coreason_manifest/utils/service.py
@@ -8,9 +8,9 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, Dict
+from typing import Any
 
-from ..cap import ServiceRequest, ServiceResponse
+from ..spec.cap import ServiceRequest, ServiceResponse
 
 
 class ServiceContract:

--- a/tests/test_cap_complex.py
+++ b/tests/test_cap_complex.py
@@ -71,9 +71,7 @@ def test_error_coercion_failure_missing_fields() -> None:
     # It checks `isinstance(self.p, StreamError)`. It is a Dict.
     # So it raises ValueError.
 
-    with pytest.raises(
-        ValueError, match="Payload 'p' must be a valid StreamError when op is ERROR"
-    ):
+    with pytest.raises(ValueError, match="Payload 'p' must be a valid StreamError when op is ERROR"):
         StreamPacket(op=StreamOpCode.ERROR, p=invalid_payload)
 
 

--- a/tests/test_cap_errors.py
+++ b/tests/test_cap_errors.py
@@ -52,9 +52,7 @@ def test_happy_path_coercion() -> None:
 
 def test_violation_string_error() -> None:
     """Attempt to create a packet with op=ERROR and p='Simple string error'."""
-    with pytest.raises(
-        ValueError, match="Payload 'p' must be a valid StreamError when op is ERROR"
-    ):
+    with pytest.raises(ValueError, match="Payload 'p' must be a valid StreamError when op is ERROR"):
         StreamPacket(op=StreamOpCode.ERROR, p="Simple string error")
 
 

--- a/tests/test_v2_standalone.py
+++ b/tests/test_v2_standalone.py
@@ -24,10 +24,10 @@ def test_bridge_is_gone() -> None:
     This ensures no one accidentally relies on 'dead code'.
     """
     with pytest.raises(ModuleNotFoundError):
-        import coreason_manifest.v2.adapter  # type: ignore
+        import coreason_manifest.v2.adapter
 
     with pytest.raises(ModuleNotFoundError):
-        import coreason_manifest.v2.compiler  # type: ignore # noqa: F401
+        import coreason_manifest.v2.compiler  # noqa: F401
 
 
 def test_vestigial_bridge_fields() -> None:


### PR DESCRIPTION
This PR enforces strict immutability across the `coreason_manifest` package by enabling `frozen=True` on `CoReasonBaseModel` and all V2 specification models. It also refactors the package structure by moving the `ServiceContract` utility class from the `spec` directory to the `utils` directory, ensuring strict separation between data models and runtime logic as mandated by the `AGENTS.md` supreme law. All existing tests pass with 100% coverage.

---
*PR created automatically by Jules for task [9285756519481279403](https://jules.google.com/task/9285756519481279403) started by @gowthamrao*