### PR TITLE
Enforce Broken Chain Prevention in Lineage Validation

### DIFF
--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -120,11 +120,10 @@ class AgentRequest(CoReasonBaseModel):
                 data["request_id"] = uuid4()
 
             # Check for Broken Chain FIRST
-            if data.get("parent_request_id") is not None:
-                if data.get("root_request_id") is None:
-                    raise ValueError(
-                        "Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present."
-                    )
+            if data.get("parent_request_id") is not None and data.get("root_request_id") is None:
+                raise ValueError(
+                    "Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present."
+                )
 
             # Auto-rooting (Only if no parent)
             if data.get("root_request_id") is None:

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -121,9 +121,7 @@ class AgentRequest(CoReasonBaseModel):
 
             # Check for Broken Chain FIRST
             if data.get("parent_request_id") is not None and data.get("root_request_id") is None:
-                raise ValueError(
-                    "Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present."
-                )
+                raise ValueError("Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present.")
 
             # Auto-rooting (Only if no parent)
             if data.get("root_request_id") is None:

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -119,8 +119,15 @@ class AgentRequest(CoReasonBaseModel):
             if "request_id" not in data:
                 data["request_id"] = uuid4()
 
-            # Auto-rooting: If root is missing, it is the root
-            if "root_request_id" not in data or data["root_request_id"] is None:
+            # Check for Broken Chain FIRST
+            if data.get("parent_request_id") is not None:
+                if data.get("root_request_id") is None:
+                    raise ValueError(
+                        "Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present."
+                    )
+
+            # Auto-rooting (Only if no parent)
+            if data.get("root_request_id") is None:
                 data["root_request_id"] = data["request_id"]
         return data
 

--- a/src/coreason_manifest/spec/common/observability.py
+++ b/src/coreason_manifest/spec/common/observability.py
@@ -75,9 +75,7 @@ class ReasoningTrace(CoReasonBaseModel):
         if isinstance(data, dict):
             # Check for Broken Chain FIRST
             if data.get("parent_request_id") is not None and data.get("root_request_id") is None:
-                raise ValueError(
-                    "Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present."
-                )
+                raise ValueError("Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present.")
 
             if (data.get("root_request_id") is None) and ("request_id" in data):
                 # Auto-rooting: If root is missing, it is the root (derived from request_id)

--- a/src/coreason_manifest/spec/common/observability.py
+++ b/src/coreason_manifest/spec/common/observability.py
@@ -74,11 +74,10 @@ class ReasoningTrace(CoReasonBaseModel):
     def enforce_lineage(cls, data: Any) -> Any:
         if isinstance(data, dict):
             # Check for Broken Chain FIRST
-            if data.get("parent_request_id") is not None:
-                if data.get("root_request_id") is None:
-                    raise ValueError(
-                        "Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present."
-                    )
+            if data.get("parent_request_id") is not None and data.get("root_request_id") is None:
+                raise ValueError(
+                    "Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present."
+                )
 
             if (data.get("root_request_id") is None) and ("request_id" in data):
                 # Auto-rooting: If root is missing, it is the root (derived from request_id)


### PR DESCRIPTION
Updated AgentRequest and ReasoningTrace validators to enforce that if a parent_request_id is provided, root_request_id must also be explicitly provided. Auto-rooting is now restricted to cases where no parent is present.

---
*PR created automatically by Jules for task [4261870269285242328](https://jules.google.com/task/4261870269285242328) started by @gowthamrao*