### PR TITLE
fix: resolve mypy errors in test_v2_standalone.py

### DIFF
--- a/tests/test_v2_standalone.py
+++ b/tests/test_v2_standalone.py
@@ -8,6 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+import importlib
+
 import pytest
 import yaml
 
@@ -24,10 +26,10 @@ def test_bridge_is_gone() -> None:
     This ensures no one accidentally relies on 'dead code'.
     """
     with pytest.raises(ModuleNotFoundError):
-        import coreason_manifest.v2.adapter  # type: ignore
+        importlib.import_module("coreason_manifest.v2.adapter")
 
     with pytest.raises(ModuleNotFoundError):
-        import coreason_manifest.v2.compiler  # type: ignore  # noqa: F401
+        importlib.import_module("coreason_manifest.v2.compiler")
 
 
 def test_vestigial_bridge_fields() -> None:

--- a/tests/test_v2_standalone.py
+++ b/tests/test_v2_standalone.py
@@ -24,10 +24,10 @@ def test_bridge_is_gone() -> None:
     This ensures no one accidentally relies on 'dead code'.
     """
     with pytest.raises(ModuleNotFoundError):
-        import coreason_manifest.v2.adapter
+        import coreason_manifest.v2.adapter  # type: ignore
 
     with pytest.raises(ModuleNotFoundError):
-        import coreason_manifest.v2.compiler  # noqa: F401
+        import coreason_manifest.v2.compiler  # type: ignore  # noqa: F401
 
 
 def test_vestigial_bridge_fields() -> None:


### PR DESCRIPTION
Fixes Mypy errors in `tests/test_v2_standalone.py` by adding `# type: ignore` to intentional missing module imports. Performs a full code audit against `AGENTS.md` and confirms compliance.

---
*PR created automatically by Jules for task [5900478652867390080](https://jules.google.com/task/5900478652867390080) started by @gowthamrao*