### PR TITLE
feat: implement SessionState and MemoryStrategy

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -27,6 +27,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Memory Governance](memory_governance.md)**
     *   Declarative configuration for agent memory eviction policies (Sliding Window, Summary, etc.) and `MemoryConfig` models.
 
+*   **[Session Management](session_management.md)**
+    *   Architecture for strict, immutable, and stateless management of conversational memory (`SessionState`, `MemoryStrategy`).
+
 *   **[Request Lineage Implementation](request_lineage_implementation.md)**
     *   Details the tracking of cryptographic causality, distributed tracing IDs (`request_id`, `root_request_id`), and auto-rooting logic.
 

--- a/docs/session_management.md
+++ b/docs/session_management.md
@@ -1,0 +1,65 @@
+# Session Management
+
+The Coreason Manifest Runtime Engine employs a strict, stateless, and immutable approach to session management. This ensures predictable state transitions, simplifies debugging, and enables functional memory management strategies.
+
+## Core Concepts
+
+### 1. Immutable Session State
+The `SessionState` model is the container for all conversational context. It is strictly immutable (`frozen=True`), meaning any change to the session (e.g., adding a message, pruning history) results in a **new** instance of the `SessionState` object.
+
+```python
+class SessionState(CoReasonBaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    id: str                 # Unique Session ID
+    agent_id: str          # Owner Agent
+    user_id: str           # Owner User
+    history: list[Interaction]  # Conversation History
+    variables: dict[str, Any]   # Arbitrary State Variables
+```
+
+### 2. Functional Memory Pruning
+Memory management is handled via the `.prune()` method, which implements the **Functional Pattern**. Instead of modifying the existing list of interactions in place, it returns a new `SessionState` with the applied eviction strategy.
+
+#### Strategies (`MemoryStrategy`)
+
+| Strategy | Description |
+| :--- | :--- |
+| `ALL` | Retains the entire history. No pruning. |
+| `SLIDING_WINDOW` | Retains the last `N` interactions defined by the `limit`. |
+| `TOKEN_BUFFER` | Retains the last `N` tokens (Requires external tokenizer implementation). |
+| `SUMMARY` | (Legacy/External) Replaces older history with a summary. |
+| `VECTOR_STORE` | (Legacy/External) Offloads history to a vector database. |
+
+#### Usage Example
+
+```python
+# Initial State with 10 items
+state = load_session(session_id)
+
+# Prune to last 5 items
+new_state = state.prune(strategy=MemoryStrategy.SLIDING_WINDOW, limit=5)
+
+# Original 'state' remains untouched (length 10)
+# 'new_state' has length 5 and a newer 'updated_at' timestamp
+save_session(new_state)
+```
+
+## Integration
+
+### Agent Request
+The `AgentRequest` envelope includes an optional `session_id` field to correlate stateless requests with their persistent session context.
+
+```python
+class AgentRequest(CoReasonBaseModel):
+    query: str
+    session_id: str | None = None
+    # ...
+```
+
+### Runtime Behavior
+1.  **Load:** The runtime fetches the latest `SessionState` by ID.
+2.  **Execute:** The agent processes the request, potentially generating new `Interaction` items.
+3.  **Update:** A new `SessionState` is created with the appended history.
+4.  **Prune:** If a memory policy is active, `.prune()` is called on the new state.
+5.  **Save:** The final `SessionState` is persisted.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ nav:
     - CAP Wire Protocol: cap/wire_protocol.md
     - Stream Identity & Lifecycle: cap/stream_lifecycle.md
     - Memory Governance: memory_governance.md
+    - Session Management: session_management.md
     - Request Lineage Implementation: request_lineage_implementation.md
     - Observability & Tracing: observability.md
     - Frontend Integration & Graph Events: frontend_integration.md

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -36,7 +36,7 @@ from .spec.common.graph_events import (
 )
 from .spec.common.identity import Identity
 from .spec.common.interoperability import AgentRuntimeConfig
-from .spec.common.memory import MemoryConfig, MemoryStrategy
+from .spec.common.memory import MemoryConfig
 from .spec.common.message import ChatMessage, Role
 from .spec.common.observability import (
     AuditLog,
@@ -52,6 +52,7 @@ from .spec.common.presentation import (
     PresentationEventType,
     UserErrorEvent,
 )
+from .spec.common.session import MemoryStrategy, SessionState
 from .spec.common.stream import StreamReference, StreamState
 from .spec.common_base import ToolRiskLevel
 from .spec.governance import ComplianceReport, ComplianceViolation, GovernanceConfig
@@ -132,6 +133,7 @@ __all__ = [
     "ServiceRequest",
     "ServiceResponse",
     "SessionContext",
+    "SessionState",
     "StateDefinition",
     "Step",
     "StreamError",

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -109,6 +109,7 @@ class AgentRequest(CoReasonBaseModel):
     query: str
     files: list[str] = Field(default_factory=list)
     conversation_id: str | None = None
+    session_id: str | None = None
     meta: dict[str, Any] = Field(default_factory=dict)
 
     @model_validator(mode="before")

--- a/src/coreason_manifest/spec/common/memory.py
+++ b/src/coreason_manifest/spec/common/memory.py
@@ -8,21 +8,12 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from enum import Enum
 from typing import Self
 
 from pydantic import ConfigDict, Field, model_validator
 
 from ..common_base import CoReasonBaseModel
-
-
-class MemoryStrategy(str, Enum):
-    """Strategy for memory eviction."""
-
-    SLIDING_WINDOW = "sliding_window"
-    TOKEN_BUFFER = "token_buffer"
-    SUMMARY = "summary"
-    VECTOR_STORE = "vector_store"
+from .session import MemoryStrategy
 
 
 class MemoryConfig(CoReasonBaseModel):

--- a/src/coreason_manifest/spec/common/memory.py
+++ b/src/coreason_manifest/spec/common/memory.py
@@ -15,6 +15,8 @@ from pydantic import ConfigDict, Field, model_validator
 from ..common_base import CoReasonBaseModel
 from .session import MemoryStrategy
 
+__all__ = ["MemoryConfig", "MemoryStrategy"]
+
 
 class MemoryConfig(CoReasonBaseModel):
     """Configuration for agent memory and eviction policies."""

--- a/src/coreason_manifest/spec/common/session.py
+++ b/src/coreason_manifest/spec/common/session.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
 from typing import Any
 from uuid import uuid4
@@ -67,14 +67,8 @@ class SessionState(CoReasonBaseModel):
             return self
 
         if strategy == MemoryStrategy.SLIDING_WINDOW:
-            if limit > 0:
-                new_history = self.history[-limit:]
-            else:
-                new_history = []
+            new_history = self.history[-limit:] if limit > 0 else []
 
-            return self.model_copy(update={
-                "history": new_history,
-                "updated_at": datetime.now(timezone.utc)
-            })
+            return self.model_copy(update={"history": new_history, "updated_at": datetime.now(UTC)})
 
         return self

--- a/src/coreason_manifest/spec/common/session.py
+++ b/src/coreason_manifest/spec/common/session.py
@@ -8,12 +8,25 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from datetime import datetime, timezone
+from enum import Enum
 from typing import Any
 from uuid import uuid4
 
 from pydantic import ConfigDict, Field
 
 from coreason_manifest.spec.common_base import CoReasonBaseModel
+
+
+class MemoryStrategy(str, Enum):
+    """Strategy for memory eviction."""
+
+    ALL = "all"
+    SLIDING_WINDOW = "sliding_window"
+    TOKEN_BUFFER = "token_buffer"
+    # Legacy/Config supported strategies
+    SUMMARY = "summary"
+    VECTOR_STORE = "vector_store"
 
 
 class LineageMetadata(CoReasonBaseModel):
@@ -33,3 +46,35 @@ class Interaction(CoReasonBaseModel):
     id: str = Field(default_factory=lambda: str(uuid4()))
     input: Any = None
     lineage: LineageMetadata | None = None
+
+
+class SessionState(CoReasonBaseModel):
+    """Immutable container for conversational memory state."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str = Field(default_factory=lambda: str(uuid4()))
+    agent_id: str
+    user_id: str
+    created_at: datetime
+    updated_at: datetime
+    history: list[Interaction] = Field(default_factory=list)
+    variables: dict[str, Any] = Field(default_factory=dict)
+
+    def prune(self, strategy: MemoryStrategy, limit: int) -> "SessionState":
+        """Return a new SessionState with pruned history based on strategy."""
+        if strategy == MemoryStrategy.ALL:
+            return self
+
+        if strategy == MemoryStrategy.SLIDING_WINDOW:
+            if limit > 0:
+                new_history = self.history[-limit:]
+            else:
+                new_history = []
+
+            return self.model_copy(update={
+                "history": new_history,
+                "updated_at": datetime.now(timezone.utc)
+            })
+
+        return self

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from coreason_manifest import MemoryStrategy, SessionState
 from coreason_manifest.spec.common.session import Interaction
@@ -20,11 +20,14 @@ def test_session_state_immutability_and_pruning() -> None:
     # Create 5 interactions
     history = [Interaction(input=f"message {i}") for i in range(5)]
 
+    # Use a past timestamp to ensure 'now' is strictly greater even on fast execution
+    past_time = datetime.now(UTC) - timedelta(seconds=1)
+
     state = SessionState(
         agent_id="test_agent",
         user_id="test_user",
-        created_at=datetime.now(UTC),
-        updated_at=datetime.now(UTC),
+        created_at=past_time,
+        updated_at=past_time,
         history=history,
         variables={"foo": "bar"},
     )
@@ -127,3 +130,92 @@ def test_sliding_window_zero_limit() -> None:
 
     new_state_neg = state.prune(MemoryStrategy.SLIDING_WINDOW, limit=-1)
     assert len(new_state_neg.history) == 0
+
+
+def test_sliding_window_limit_exceeds_history() -> None:
+    """Test pruning with limit larger than history size returns full history."""
+    history = [Interaction(input="msg") for _ in range(3)]
+    state = SessionState(
+        agent_id="a", user_id="u", created_at=datetime.now(UTC), updated_at=datetime.now(UTC), history=history
+    )
+
+    new_state = state.prune(MemoryStrategy.SLIDING_WINDOW, limit=10)
+    assert len(new_state.history) == 3
+    assert new_state.history == state.history
+
+
+def test_prune_empty_history() -> None:
+    """Test pruning an already empty history."""
+    state = SessionState(
+        agent_id="a", user_id="u", created_at=datetime.now(UTC), updated_at=datetime.now(UTC), history=[]
+    )
+
+    new_state = state.prune(MemoryStrategy.SLIDING_WINDOW, limit=5)
+    assert len(new_state.history) == 0
+    assert new_state.history == []
+
+
+def test_memory_strategy_all() -> None:
+    """Test MemoryStrategy.ALL returns the exact same object (or logically equivalent)."""
+    state = SessionState(
+        agent_id="a",
+        user_id="u",
+        created_at=datetime.now(UTC),
+        updated_at=datetime.now(UTC),
+        history=[Interaction(input="msg")],
+    )
+
+    new_state = state.prune(MemoryStrategy.ALL, limit=10)
+    assert new_state is state
+
+
+def test_complex_sequential_pruning() -> None:
+    """Test a sequence of updates and pruning operations simulating a conversation."""
+    base_time = datetime.now(UTC)
+    state = SessionState(agent_id="agent", user_id="user", created_at=base_time, updated_at=base_time, history=[])
+
+    # Turn 1: Add 2 messages
+    history_v1 = [Interaction(input="1"), Interaction(input="2")]
+    state_v1 = state.model_copy(update={"history": state.history + history_v1, "updated_at": datetime.now(UTC)})
+
+    # Prune v1 (Limit 1)
+    state_v2 = state_v1.prune(MemoryStrategy.SLIDING_WINDOW, limit=1)
+    assert len(state_v2.history) == 1
+    assert state_v2.history[0].input == "2"
+
+    # Turn 2: Add 3 messages to v2
+    history_v3 = [Interaction(input="3"), Interaction(input="4"), Interaction(input="5")]
+    state_v3 = state_v2.model_copy(update={"history": state_v2.history + history_v3, "updated_at": datetime.now(UTC)})
+
+    # State v3 should have "2", "3", "4", "5"
+    assert len(state_v3.history) == 4
+    assert state_v3.history[0].input == "2"
+    assert state_v3.history[-1].input == "5"
+
+    # Prune v3 (Limit 2)
+    state_v4 = state_v3.prune(MemoryStrategy.SLIDING_WINDOW, limit=2)
+    assert len(state_v4.history) == 2
+    assert state_v4.history[0].input == "4"
+    assert state_v4.history[1].input == "5"
+
+    # Verify ID persistence across versions
+    assert state.id == state_v1.id == state_v2.id == state_v3.id == state_v4.id
+
+
+def test_deep_variable_preservation() -> None:
+    """Test that deep variables are preserved and not referenced incorrectly during copy."""
+    vars_data = {"context": {"user_pref": {"theme": "dark"}, "flags": [1, 2, 3]}}
+    state = SessionState(
+        agent_id="a", user_id="u", created_at=datetime.now(UTC), updated_at=datetime.now(UTC), variables=vars_data
+    )
+
+    # Prune
+    new_state = state.prune(MemoryStrategy.SLIDING_WINDOW, limit=5)
+
+    # Verify content
+    assert new_state.variables == vars_data
+
+    # Ensure it's a shallow copy of the container (Pydantic model_copy default)
+    # but since frozen=True, we can't mutate safely anyway.
+    # Just checking logic correctness.
+    assert new_state.variables is state.variables

--- a/tests/test_session_management.py
+++ b/tests/test_session_management.py
@@ -1,0 +1,137 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime, timezone
+import json
+from uuid import uuid4
+
+from coreason_manifest import SessionState, MemoryStrategy
+from coreason_manifest.spec.common.session import Interaction
+
+
+def test_session_state_immutability_and_pruning():
+    """Test that SessionState is immutable and prune returns a new instance."""
+    # Create 5 interactions
+    history = [Interaction(input=f"message {i}") for i in range(5)]
+
+    state = SessionState(
+        agent_id="test_agent",
+        user_id="test_user",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        history=history,
+        variables={"foo": "bar"}
+    )
+
+    assert len(state.history) == 5
+
+    # Prune
+    new_state = state.prune(MemoryStrategy.SLIDING_WINDOW, limit=2)
+
+    # Assert
+    assert len(new_state.history) == 2
+    assert new_state.history[0].input == "message 3"
+    assert new_state.history[1].input == "message 4"
+
+    # Verify immutability of original
+    assert len(state.history) == 5
+    assert state.history[0].input == "message 0"
+
+    # Verify ID match
+    assert new_state.id == state.id
+
+    # Verify updated_at changed
+    assert new_state.updated_at > state.updated_at
+
+    # Verify ALL strategy
+    same_state = state.prune(MemoryStrategy.ALL, limit=2)
+    assert same_state is state  # Should return self if optimized, or equal
+
+
+def test_session_serialization():
+    """Test serialization of SessionState."""
+    history = [Interaction(input="test")]
+    variables = {"key": "value", "number": 42, "nested": {"a": 1}}
+
+    state = SessionState(
+        agent_id="agent-1",
+        user_id="user-1",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        history=history,
+        variables=variables
+    )
+
+    json_str = state.model_dump_json()
+    data = json.loads(json_str)
+
+    assert data["agent_id"] == "agent-1"
+    assert data["user_id"] == "user-1"
+    assert len(data["history"]) == 1
+    assert data["history"][0]["input"] == "test"
+    assert data["variables"]["key"] == "value"
+    assert data["variables"]["number"] == 42
+    assert data["variables"]["nested"]["a"] == 1
+
+
+def test_variable_storage():
+    """Verify variables can store arbitrary JSON-serializable data."""
+    complex_vars = {
+        "string": "s",
+        "int": 10,
+        "float": 3.14,
+        "bool": True,
+        "list": [1, 2, 3],
+        "dict": {"x": "y"}
+    }
+
+    state = SessionState(
+        agent_id="agent",
+        user_id="user",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        variables=complex_vars
+    )
+
+    assert state.variables["list"] == [1, 2, 3]
+    assert state.variables["dict"]["x"] == "y"
+
+    # Verify we can dump and load back
+    dumped = state.model_dump()
+    assert dumped["variables"] == complex_vars
+
+def test_prune_unsupported_strategy():
+    """Test pruning with unsupported strategy returns self."""
+    state = SessionState(
+        agent_id="agent",
+        user_id="user",
+        created_at=datetime.now(timezone.utc),
+        updated_at=datetime.now(timezone.utc),
+        history=[Interaction(input="msg")]
+    )
+
+    # Token buffer not implemented here
+    new_state = state.prune(MemoryStrategy.TOKEN_BUFFER, limit=10)
+    assert new_state is state
+
+def test_sliding_window_zero_limit():
+    """Test sliding window with limit <= 0 clears history."""
+    history = [Interaction(input="msg") for _ in range(3)]
+    state = SessionState(
+        agent_id="a", user_id="u",
+        created_at=datetime.now(timezone.utc), updated_at=datetime.now(timezone.utc),
+        history=history
+    )
+
+    new_state = state.prune(MemoryStrategy.SLIDING_WINDOW, limit=0)
+    assert len(new_state.history) == 0
+
+    new_state_neg = state.prune(MemoryStrategy.SLIDING_WINDOW, limit=-1)
+    assert len(new_state_neg.history) == 0


### PR DESCRIPTION
Implemented strict Session State management as per Work Package N.
- Created `SessionState` in `src/coreason_manifest/spec/common/session.py` with `frozen=True` and functional `prune` method.
- Moved `MemoryStrategy` from `src/coreason_manifest/spec/common/memory.py` to `session.py` to allow shared usage and avoid circular imports.
- Updated `AgentRequest` in `src/coreason_manifest/spec/cap.py` to include `session_id`.
- Updated `src/coreason_manifest/__init__.py` to export new symbols.
- Added `tests/test_session_management.py` verifying immutability, pruning (SLIDING_WINDOW), serialization, and variable storage.

---
*PR created automatically by Jules for task [857114232555951850](https://jules.google.com/task/857114232555951850) started by @gowthamrao*