### PR TITLE
Implement Explicit Streaming Contracts (WP-R)

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -20,7 +20,7 @@ from .spec.cap import (
     StreamOpCode,
     StreamPacket,
 )
-from .spec.common.capabilities import AgentCapabilities, DeliveryMode
+from .spec.common.capabilities import AgentCapabilities, CapabilityType, DeliveryMode
 from .spec.common.error import ErrorDomain
 from .spec.common.graph_events import (
     GraphEvent,
@@ -92,6 +92,7 @@ __all__ = [
     "AgentRuntimeConfig",
     "AgentStep",
     "AuditLog",
+    "CapabilityType",
     "ChatMessage",
     "CitationBlock",
     "CitationItem",

--- a/src/coreason_manifest/spec/common/capabilities.py
+++ b/src/coreason_manifest/spec/common/capabilities.py
@@ -34,9 +34,7 @@ class AgentCapabilities(CoReasonBaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    type: CapabilityType = Field(
-        default=CapabilityType.GRAPH, description="The architectural complexity of the agent."
-    )
+    type: CapabilityType = Field(default=CapabilityType.GRAPH, description="The architectural complexity of the agent.")
     delivery_mode: DeliveryMode = Field(
         default=DeliveryMode.REQUEST_RESPONSE, description="The primary transport mechanism."
     )

--- a/src/coreason_manifest/spec/common/capabilities.py
+++ b/src/coreason_manifest/spec/common/capabilities.py
@@ -15,11 +15,18 @@ from pydantic import ConfigDict, Field
 from ..common_base import CoReasonBaseModel
 
 
+class CapabilityType(StrEnum):
+    """Architectural complexity of the agent."""
+
+    ATOMIC = "atomic"
+    GRAPH = "graph"
+
+
 class DeliveryMode(StrEnum):
     """Supported transport mechanisms."""
 
     REQUEST_RESPONSE = "request_response"
-    SSE = "sse"
+    SERVER_SENT_EVENTS = "server_sent_events"
 
 
 class AgentCapabilities(CoReasonBaseModel):
@@ -27,11 +34,13 @@ class AgentCapabilities(CoReasonBaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    delivery_mode: list[DeliveryMode] = Field(
-        default_factory=lambda: [DeliveryMode.SSE],
-        description="Supported transport mechanisms.",
+    type: CapabilityType = Field(
+        default=CapabilityType.GRAPH, description="The architectural complexity of the agent."
+    )
+    delivery_mode: DeliveryMode = Field(
+        default=DeliveryMode.REQUEST_RESPONSE, description="The primary transport mechanism."
     )
     history_support: bool = Field(
         default=True,
-        description="Whether the agent supports conversation history/context.",
+        description="Whether the agent manages conversation history.",
     )

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -4,24 +4,24 @@ from coreason_manifest.spec.v2.definitions import AgentDefinition
 
 def test_capabilities_default_init() -> None:
     caps = AgentCapabilities()
-    assert caps.delivery_mode == [DeliveryMode.SSE]
+    assert caps.delivery_mode == DeliveryMode.REQUEST_RESPONSE
     assert caps.history_support is True
 
 
 def test_capabilities_custom_init() -> None:
-    caps = AgentCapabilities(delivery_mode=[DeliveryMode.REQUEST_RESPONSE], history_support=False)
-    assert caps.delivery_mode == [DeliveryMode.REQUEST_RESPONSE]
+    caps = AgentCapabilities(delivery_mode=DeliveryMode.SERVER_SENT_EVENTS, history_support=False)
+    assert caps.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
     assert caps.history_support is False
 
 
 def test_agent_definition_integration() -> None:
     agent = AgentDefinition(id="test-agent", name="Test Agent", role="Tester", goal="To test capabilities")
-    assert agent.capabilities.delivery_mode == [DeliveryMode.SSE]
+    assert agent.capabilities.delivery_mode == DeliveryMode.REQUEST_RESPONSE
     assert agent.capabilities.history_support is True
 
 
 def test_serialization() -> None:
     caps = AgentCapabilities()
     dumped = caps.dump()
-    assert dumped["delivery_mode"] == ["sse"]
+    assert dumped["delivery_mode"] == "request_response"
     assert dumped["history_support"] is True

--- a/tests/test_capabilities_extended.py
+++ b/tests/test_capabilities_extended.py
@@ -4,25 +4,11 @@ from pydantic import ValidationError
 from coreason_manifest import AgentCapabilities, AgentDefinition, DeliveryMode, Manifest
 
 
-def test_edge_case_empty_delivery_mode() -> None:
-    """Test that empty delivery mode list is allowed."""
-    caps = AgentCapabilities(delivery_mode=[])
-    assert caps.delivery_mode == []
-
-
-def test_edge_case_duplicate_delivery_mode() -> None:
-    """Test that duplicates are preserved in List (unless Set is used, but spec says List)."""
-    caps = AgentCapabilities(delivery_mode=[DeliveryMode.SSE, DeliveryMode.SSE])
-    assert len(caps.delivery_mode) == 2
-    assert caps.delivery_mode[0] == DeliveryMode.SSE
-    assert caps.delivery_mode[1] == DeliveryMode.SSE
-
-
 def test_edge_case_invalid_delivery_mode() -> None:
     """Test that invalid strings raise ValidationError."""
     with pytest.raises(ValidationError) as exc:
-        AgentCapabilities(delivery_mode=["invalid_mode"])
-    assert "Input should be 'request_response' or 'sse'" in str(exc.value)
+        AgentCapabilities(delivery_mode="invalid_mode")
+    assert "Input should be 'request_response' or 'server_sent_events'" in str(exc.value)
 
 
 def test_strictness_extra_fields() -> None:
@@ -40,24 +26,10 @@ def test_immutability_deep() -> None:
     with pytest.raises(ValidationError):
         setattr(caps, "history_support", False)  # noqa: B010
 
-    # List mutation (since the list itself is mutable python object, but field assignment is blocked)
-    # However, caps.delivery_mode is a list, which IS mutable in Python unless using Tuple.
-    # Pydantic's frozen=True makes the model instance immutable, but doesn't deep-freeze
-    # mutable fields like lists automatically unless configured.
-    # Let's check if the list can be modified.
-
-    caps.delivery_mode.append(DeliveryMode.REQUEST_RESPONSE)
-    # If the model is frozen, this mutation of the list object IS possible in standard Pydantic
-    # unless using Tuple or specific validation.
-    # BUT, let's verify if we want to enforce deep immutability or just shallow.
-    # The requirement said "Immutability: All models must be frozen".
-    # It didn't explicitly demand Tuple for lists, but let's see.
-
-    assert len(caps.delivery_mode) == 2  # This shows it IS mutable in place.
-
-    # Re-assigning the field should fail
+    # Since delivery_mode is scalar Enum, it's immutable.
+    # Attempting to assign new value should fail.
     with pytest.raises(ValidationError):
-        setattr(caps, "delivery_mode", [])  # noqa: B010
+        setattr(caps, "delivery_mode", DeliveryMode.SERVER_SENT_EVENTS)  # noqa: B010
 
 
 def test_manifest_roundtrip_with_capabilities() -> None:
@@ -73,7 +45,7 @@ def test_manifest_roundtrip_with_capabilities() -> None:
                 "name": "My Agent",
                 "role": "Assistant",
                 "goal": "Help",
-                "capabilities": {"delivery_mode": ["request_response"], "history_support": False},
+                "capabilities": {"delivery_mode": "request_response", "history_support": False},
             }
         },
         "workflow": {"start": "step1", "steps": {"step1": {"type": "agent", "id": "step1", "agent": "my_agent"}}},
@@ -85,7 +57,7 @@ def test_manifest_roundtrip_with_capabilities() -> None:
     # Verify
     agent_def = manifest.definitions["my_agent"]
     assert isinstance(agent_def, AgentDefinition)
-    assert agent_def.capabilities.delivery_mode == [DeliveryMode.REQUEST_RESPONSE]
+    assert agent_def.capabilities.delivery_mode == DeliveryMode.REQUEST_RESPONSE
     assert agent_def.capabilities.history_support is False
 
     # Dump
@@ -93,5 +65,5 @@ def test_manifest_roundtrip_with_capabilities() -> None:
 
     # Verify Dump
     agent_dump = dumped["definitions"]["my_agent"]
-    assert agent_dump["capabilities"]["delivery_mode"] == ["request_response"]
+    assert agent_dump["capabilities"]["delivery_mode"] == "request_response"
     assert agent_dump["capabilities"]["history_support"] is False

--- a/tests/test_streaming_contracts.py
+++ b/tests/test_streaming_contracts.py
@@ -1,0 +1,39 @@
+import pytest
+from pydantic import ValidationError
+from coreason_manifest.spec.common.capabilities import AgentCapabilities, CapabilityType, DeliveryMode
+
+def test_streaming_contracts_defaults() -> None:
+    """Verify default values for streaming contracts."""
+    caps = AgentCapabilities()
+    assert caps.type == CapabilityType.GRAPH
+    assert caps.delivery_mode == DeliveryMode.REQUEST_RESPONSE
+    assert caps.history_support is True
+
+def test_streaming_contracts_explicit_configuration() -> None:
+    """Verify explicit configuration of streaming contracts."""
+    caps = AgentCapabilities(
+        type=CapabilityType.ATOMIC,
+        delivery_mode=DeliveryMode.SERVER_SENT_EVENTS
+    )
+    assert caps.type == CapabilityType.ATOMIC
+    assert caps.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
+
+def test_streaming_contracts_immutability() -> None:
+    """Verify that AgentCapabilities is immutable."""
+    caps = AgentCapabilities()
+
+    with pytest.raises(ValidationError):
+        caps.delivery_mode = DeliveryMode.SERVER_SENT_EVENTS
+
+    with pytest.raises(ValidationError):
+        caps.type = CapabilityType.ATOMIC
+
+def test_streaming_contracts_serialization() -> None:
+    """Verify JSON serialization of streaming contracts."""
+    caps = AgentCapabilities(
+        type=CapabilityType.ATOMIC,
+        delivery_mode=DeliveryMode.SERVER_SENT_EVENTS
+    )
+    json_output = caps.model_dump_json()
+    assert '"atomic"' in json_output
+    assert '"server_sent_events"' in json_output

--- a/tests/test_streaming_contracts.py
+++ b/tests/test_streaming_contracts.py
@@ -1,6 +1,8 @@
 import pytest
 from pydantic import ValidationError
+
 from coreason_manifest.spec.common.capabilities import AgentCapabilities, CapabilityType, DeliveryMode
+
 
 def test_streaming_contracts_defaults() -> None:
     """Verify default values for streaming contracts."""
@@ -9,31 +11,28 @@ def test_streaming_contracts_defaults() -> None:
     assert caps.delivery_mode == DeliveryMode.REQUEST_RESPONSE
     assert caps.history_support is True
 
+
 def test_streaming_contracts_explicit_configuration() -> None:
     """Verify explicit configuration of streaming contracts."""
-    caps = AgentCapabilities(
-        type=CapabilityType.ATOMIC,
-        delivery_mode=DeliveryMode.SERVER_SENT_EVENTS
-    )
+    caps = AgentCapabilities(type=CapabilityType.ATOMIC, delivery_mode=DeliveryMode.SERVER_SENT_EVENTS)
     assert caps.type == CapabilityType.ATOMIC
     assert caps.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
+
 
 def test_streaming_contracts_immutability() -> None:
     """Verify that AgentCapabilities is immutable."""
     caps = AgentCapabilities()
 
     with pytest.raises(ValidationError):
-        caps.delivery_mode = DeliveryMode.SERVER_SENT_EVENTS
+        setattr(caps, "delivery_mode", DeliveryMode.SERVER_SENT_EVENTS)  # noqa: B010
 
     with pytest.raises(ValidationError):
-        caps.type = CapabilityType.ATOMIC
+        setattr(caps, "type", CapabilityType.ATOMIC)  # noqa: B010
+
 
 def test_streaming_contracts_serialization() -> None:
     """Verify JSON serialization of streaming contracts."""
-    caps = AgentCapabilities(
-        type=CapabilityType.ATOMIC,
-        delivery_mode=DeliveryMode.SERVER_SENT_EVENTS
-    )
+    caps = AgentCapabilities(type=CapabilityType.ATOMIC, delivery_mode=DeliveryMode.SERVER_SENT_EVENTS)
     json_output = caps.model_dump_json()
     assert '"atomic"' in json_output
     assert '"server_sent_events"' in json_output


### PR DESCRIPTION
Refactors AgentCapabilities to use strict scalar contracts for delivery_mode and type. Updates DeliveryMode enum to use SERVER_SENT_EVENTS. Adds CapabilityType enum. Updates tests to reflect these changes.

---
*PR created automatically by Jules for task [17739564459648724704](https://jules.google.com/task/17739564459648724704) started by @gowthamrao*