### PR TITLE
WP-R: Implement Explicit Streaming Contracts

### DIFF
--- a/docs/cap/specification.md
+++ b/docs/cap/specification.md
@@ -68,9 +68,12 @@ The `definitions` section is a polymorphic key-value map where you can define re
 ### Agent Capabilities (`AgentCapabilities`)
 Used within an `AgentDefinition` to declare supported features.
 
-*   `delivery_mode`: List of supported transport mechanisms.
-    *   Values: `sse` (Server-Sent Events), `request_response` (Standard HTTP).
-    *   Default: `['sse']`
+*   `type`: The architectural complexity of the agent.
+    *   Values: `atomic` (Simple, linear), `graph` (Complex workflow).
+    *   Default: `graph`
+*   `delivery_mode`: Primary transport mechanism.
+    *   Values: `server_sent_events` (Streaming CloudEvents), `request_response` (Standard HTTP).
+    *   Default: `request_response`
 *   `history_support`: Boolean indicating if the agent maintains conversation context.
     *   Default: `true`
 

--- a/docs/cap/streaming_contracts.md
+++ b/docs/cap/streaming_contracts.md
@@ -1,0 +1,63 @@
+# Explicit Streaming Contracts
+
+The Coreason Agent Manifest (CAM) V2 enforces explicit contracts between Agents and Clients regarding execution behavior and transport protocols. This removes ambiguity and allows clients to deterministicly handle agent interactions.
+
+## Core Concepts
+
+The contract is defined in `AgentCapabilities` and consists of two primary dimensions:
+
+1.  **Architectural Complexity (`type`)**
+2.  **Delivery Mode (`delivery_mode`)**
+
+### 1. Architectural Complexity (`type`)
+
+Defines the internal structure and execution model of the agent.
+
+*   **`atomic`**:
+    *   **Description:** A simple, linear agent that executes a single logical step (e.g., an LLM call, a tool execution).
+    *   **Behavior:** Typically fast, synchronous or single-stream.
+    *   **Use Case:** Chatbots, simple lookups, "functions as agents".
+
+*   **`graph`**:
+    *   **Description:** A complex agent composed of multiple steps, loops, or a directed acyclic graph (DAG).
+    *   **Behavior:** Long-running, multi-step execution. Often requires intermediate state updates.
+    *   **Use Case:** Research assistants, coding agents, multi-agent workflows.
+    *   **Default:** This is the default type if not specified.
+
+### 2. Delivery Mode (`delivery_mode`)
+
+Defines the transport protocol used to deliver results.
+
+*   **`request_response`**:
+    *   **Description:** Standard Synchronous HTTP (REST).
+    *   **Behavior:** The client sends a request and waits for a single, final JSON response.
+    *   **Constraint:** Best for `atomic` agents or very short `graph` executions.
+    *   **Default:** This is the default mode if not specified.
+
+*   **`server_sent_events`**:
+    *   **Description:** Streaming CloudEvents via Server-Sent Events (SSE).
+    *   **Behavior:** The client connects and receives a stream of events (`CloudEvent`) representing progress, partial thoughts, reasoning traces, and the final result.
+    *   **Constraint:** Recommended for `graph` agents or `atomic` agents generating long text (LLM streaming).
+    *   **Note:** Replaces the legacy `sse` abbreviation.
+
+## Valid Configurations
+
+| Type | Delivery Mode | Scenario |
+| :--- | :--- | :--- |
+| `atomic` | `request_response` | **Simple API**: A calculator tool or quick lookup. |
+| `atomic` | `server_sent_events` | **Streaming Chat**: A simple LLM wrapper streaming tokens. |
+| `graph` | `request_response` | **Batch Job**: A background process where intermediate progress isn't watched (uncommon for interactive apps). |
+| `graph` | `server_sent_events` | **Interactive Workflow**: A complex agent (e.g., Researcher) streaming its thought process and steps to the user. |
+
+## Schema Example
+
+```yaml
+definitions:
+  my_researcher:
+    type: agent
+    id: researcher
+    capabilities:
+      type: graph
+      delivery_mode: server_sent_events
+      history_support: true
+```

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -20,7 +20,7 @@ from .spec.cap import (
     StreamOpCode,
     StreamPacket,
 )
-from .spec.common.capabilities import AgentCapabilities, DeliveryMode
+from .spec.common.capabilities import AgentCapabilities, CapabilityType, DeliveryMode
 from .spec.common.error import ErrorDomain
 from .spec.common.graph_events import (
     GraphEvent,
@@ -92,6 +92,7 @@ __all__ = [
     "AgentRuntimeConfig",
     "AgentStep",
     "AuditLog",
+    "CapabilityType",
     "ChatMessage",
     "CitationBlock",
     "CitationItem",

--- a/src/coreason_manifest/spec/common/capabilities.py
+++ b/src/coreason_manifest/spec/common/capabilities.py
@@ -15,11 +15,18 @@ from pydantic import ConfigDict, Field
 from ..common_base import CoReasonBaseModel
 
 
+class CapabilityType(StrEnum):
+    """Architectural complexity of the agent."""
+
+    ATOMIC = "atomic"
+    GRAPH = "graph"
+
+
 class DeliveryMode(StrEnum):
     """Supported transport mechanisms."""
 
     REQUEST_RESPONSE = "request_response"
-    SSE = "sse"
+    SERVER_SENT_EVENTS = "server_sent_events"
 
 
 class AgentCapabilities(CoReasonBaseModel):
@@ -27,11 +34,15 @@ class AgentCapabilities(CoReasonBaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    delivery_mode: list[DeliveryMode] = Field(
-        default_factory=lambda: [DeliveryMode.SSE],
-        description="Supported transport mechanisms.",
+    type: CapabilityType = Field(
+        default=CapabilityType.GRAPH,
+        description="The architectural complexity of the agent.",
+    )
+    delivery_mode: DeliveryMode = Field(
+        default=DeliveryMode.REQUEST_RESPONSE,
+        description="The primary transport mechanism.",
     )
     history_support: bool = Field(
         default=True,
-        description="Whether the agent supports conversation history/context.",
+        description="Whether the agent manages conversation history.",
     )

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -4,24 +4,24 @@ from coreason_manifest.spec.v2.definitions import AgentDefinition
 
 def test_capabilities_default_init() -> None:
     caps = AgentCapabilities()
-    assert caps.delivery_mode == [DeliveryMode.SSE]
+    assert caps.delivery_mode == DeliveryMode.REQUEST_RESPONSE
     assert caps.history_support is True
 
 
 def test_capabilities_custom_init() -> None:
-    caps = AgentCapabilities(delivery_mode=[DeliveryMode.REQUEST_RESPONSE], history_support=False)
-    assert caps.delivery_mode == [DeliveryMode.REQUEST_RESPONSE]
+    caps = AgentCapabilities(delivery_mode=DeliveryMode.SERVER_SENT_EVENTS, history_support=False)
+    assert caps.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
     assert caps.history_support is False
 
 
 def test_agent_definition_integration() -> None:
     agent = AgentDefinition(id="test-agent", name="Test Agent", role="Tester", goal="To test capabilities")
-    assert agent.capabilities.delivery_mode == [DeliveryMode.SSE]
+    assert agent.capabilities.delivery_mode == DeliveryMode.REQUEST_RESPONSE
     assert agent.capabilities.history_support is True
 
 
 def test_serialization() -> None:
     caps = AgentCapabilities()
     dumped = caps.dump()
-    assert dumped["delivery_mode"] == ["sse"]
+    assert dumped["delivery_mode"] == "request_response"
     assert dumped["history_support"] is True

--- a/tests/test_capabilities_extended.py
+++ b/tests/test_capabilities_extended.py
@@ -4,25 +4,11 @@ from pydantic import ValidationError
 from coreason_manifest import AgentCapabilities, AgentDefinition, DeliveryMode, Manifest
 
 
-def test_edge_case_empty_delivery_mode() -> None:
-    """Test that empty delivery mode list is allowed."""
-    caps = AgentCapabilities(delivery_mode=[])
-    assert caps.delivery_mode == []
-
-
-def test_edge_case_duplicate_delivery_mode() -> None:
-    """Test that duplicates are preserved in List (unless Set is used, but spec says List)."""
-    caps = AgentCapabilities(delivery_mode=[DeliveryMode.SSE, DeliveryMode.SSE])
-    assert len(caps.delivery_mode) == 2
-    assert caps.delivery_mode[0] == DeliveryMode.SSE
-    assert caps.delivery_mode[1] == DeliveryMode.SSE
-
-
 def test_edge_case_invalid_delivery_mode() -> None:
     """Test that invalid strings raise ValidationError."""
     with pytest.raises(ValidationError) as exc:
-        AgentCapabilities(delivery_mode=["invalid_mode"])
-    assert "Input should be 'request_response' or 'sse'" in str(exc.value)
+        AgentCapabilities(delivery_mode="invalid_mode")
+    assert "Input should be 'request_response' or 'server_sent_events'" in str(exc.value)
 
 
 def test_strictness_extra_fields() -> None:
@@ -40,24 +26,9 @@ def test_immutability_deep() -> None:
     with pytest.raises(ValidationError):
         setattr(caps, "history_support", False)  # noqa: B010
 
-    # List mutation (since the list itself is mutable python object, but field assignment is blocked)
-    # However, caps.delivery_mode is a list, which IS mutable in Python unless using Tuple.
-    # Pydantic's frozen=True makes the model instance immutable, but doesn't deep-freeze
-    # mutable fields like lists automatically unless configured.
-    # Let's check if the list can be modified.
-
-    caps.delivery_mode.append(DeliveryMode.REQUEST_RESPONSE)
-    # If the model is frozen, this mutation of the list object IS possible in standard Pydantic
-    # unless using Tuple or specific validation.
-    # BUT, let's verify if we want to enforce deep immutability or just shallow.
-    # The requirement said "Immutability: All models must be frozen".
-    # It didn't explicitly demand Tuple for lists, but let's see.
-
-    assert len(caps.delivery_mode) == 2  # This shows it IS mutable in place.
-
     # Re-assigning the field should fail
     with pytest.raises(ValidationError):
-        setattr(caps, "delivery_mode", [])  # noqa: B010
+        setattr(caps, "delivery_mode", DeliveryMode.SERVER_SENT_EVENTS)  # noqa: B010
 
 
 def test_manifest_roundtrip_with_capabilities() -> None:
@@ -73,7 +44,7 @@ def test_manifest_roundtrip_with_capabilities() -> None:
                 "name": "My Agent",
                 "role": "Assistant",
                 "goal": "Help",
-                "capabilities": {"delivery_mode": ["request_response"], "history_support": False},
+                "capabilities": {"delivery_mode": "request_response", "history_support": False},
             }
         },
         "workflow": {"start": "step1", "steps": {"step1": {"type": "agent", "id": "step1", "agent": "my_agent"}}},
@@ -85,7 +56,7 @@ def test_manifest_roundtrip_with_capabilities() -> None:
     # Verify
     agent_def = manifest.definitions["my_agent"]
     assert isinstance(agent_def, AgentDefinition)
-    assert agent_def.capabilities.delivery_mode == [DeliveryMode.REQUEST_RESPONSE]
+    assert agent_def.capabilities.delivery_mode == DeliveryMode.REQUEST_RESPONSE
     assert agent_def.capabilities.history_support is False
 
     # Dump
@@ -93,5 +64,5 @@ def test_manifest_roundtrip_with_capabilities() -> None:
 
     # Verify Dump
     agent_dump = dumped["definitions"]["my_agent"]
-    assert agent_dump["capabilities"]["delivery_mode"] == ["request_response"]
+    assert agent_dump["capabilities"]["delivery_mode"] == "request_response"
     assert agent_dump["capabilities"]["history_support"] is False

--- a/tests/test_streaming_contracts.py
+++ b/tests/test_streaming_contracts.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.common.capabilities import (
+    AgentCapabilities,
+    CapabilityType,
+    DeliveryMode,
+)
+
+
+def test_contract_defaults() -> None:
+    """Verify default values for streaming contract."""
+    caps = AgentCapabilities()
+    assert caps.type == CapabilityType.GRAPH
+    assert caps.delivery_mode == DeliveryMode.REQUEST_RESPONSE
+    assert caps.history_support is True
+
+
+def test_explicit_configuration() -> None:
+    """Verify explicit configuration of streaming contract."""
+    caps = AgentCapabilities(
+        type=CapabilityType.ATOMIC,
+        delivery_mode=DeliveryMode.SERVER_SENT_EVENTS,
+    )
+    assert caps.type == CapabilityType.ATOMIC
+    assert caps.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
+
+
+def test_immutability() -> None:
+    """Verify that the model is frozen."""
+    caps = AgentCapabilities()
+
+    with pytest.raises(ValidationError):
+        caps.delivery_mode = DeliveryMode.SERVER_SENT_EVENTS  # type: ignore
+
+
+def test_serialization() -> None:
+    """Verify JSON serialization uses correct string values."""
+    caps = AgentCapabilities(
+        type=CapabilityType.ATOMIC,
+        delivery_mode=DeliveryMode.SERVER_SENT_EVENTS,
+    )
+    data = caps.model_dump(mode="json")
+    assert data["type"] == "atomic"
+    assert data["delivery_mode"] == "server_sent_events"

--- a/tests/test_streaming_contracts_edge_cases.py
+++ b/tests/test_streaming_contracts_edge_cases.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.common.capabilities import (
+    AgentCapabilities,
+    CapabilityType,
+    DeliveryMode,
+)
+from coreason_manifest.spec.v2.definitions import AgentDefinition, ManifestV2 as Manifest
+
+
+def test_invalid_enum_values() -> None:
+    """Test validation errors for invalid enum values."""
+    with pytest.raises(ValidationError) as exc:
+        AgentCapabilities(type="super_complex")  # type: ignore
+    assert "Input should be 'atomic' or 'graph'" in str(exc.value)
+
+    with pytest.raises(ValidationError) as exc:
+        AgentCapabilities(delivery_mode="websocket")  # type: ignore
+    assert "Input should be 'request_response' or 'server_sent_events'" in str(exc.value)
+
+
+def test_legacy_list_format_failure() -> None:
+    """Test that the old list format for delivery_mode raises a clear validation error."""
+    with pytest.raises(ValidationError) as exc:
+        AgentCapabilities(delivery_mode=["sse"])  # type: ignore
+    # Pydantic's default error for wrong type
+    assert "Input should be 'request_response' or 'server_sent_events'" in str(exc.value)
+
+
+def test_none_values() -> None:
+    """Test that None is not accepted for fields without default None."""
+    with pytest.raises(ValidationError):
+        AgentCapabilities(type=None)  # type: ignore
+
+    with pytest.raises(ValidationError):
+        AgentCapabilities(delivery_mode=None)  # type: ignore
+
+
+def test_manifest_complex_configurations() -> None:
+    """Test Manifest parsing with various capability configurations."""
+    manifest_yaml = """
+    apiVersion: coreason.ai/v2
+    kind: Agent
+    metadata:
+        name: Complex Test
+        version: 1.0.0
+    definitions:
+        atomic_sse:
+            type: agent
+            id: atomic_sse
+            name: Streamer
+            role: Bot
+            goal: Chat
+            capabilities:
+                type: atomic
+                delivery_mode: server_sent_events
+
+        graph_req_res:
+            type: agent
+            id: graph_req_res
+            name: Batch Processor
+            role: Worker
+            goal: Process
+            capabilities:
+                type: graph
+                delivery_mode: request_response
+
+        default_agent:
+            type: agent
+            id: default_agent
+            name: Default
+            role: Default
+            goal: Default
+            # capabilities should use defaults
+
+    workflow:
+        start: atomic_sse
+        steps:
+            atomic_sse:
+                type: agent
+                id: atomic_sse
+                agent: atomic_sse
+    """
+
+    # We'll use the load_from_yaml utility indirectly via Model parsing for simplicity
+    # or just parse the dict structure if we don't want to write a file.
+    # But Manifest expects a dict if passed directly.
+    import yaml
+    data = yaml.safe_load(manifest_yaml)
+
+    manifest = Manifest(**data)
+
+    # Check Atomic SSE
+    atomic_agent = manifest.definitions["atomic_sse"]
+    assert isinstance(atomic_agent, AgentDefinition)
+    assert atomic_agent.capabilities.type == CapabilityType.ATOMIC
+    assert atomic_agent.capabilities.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
+
+    # Check Graph Req/Res
+    graph_agent = manifest.definitions["graph_req_res"]
+    assert isinstance(graph_agent, AgentDefinition)
+    assert graph_agent.capabilities.type == CapabilityType.GRAPH
+    assert graph_agent.capabilities.delivery_mode == DeliveryMode.REQUEST_RESPONSE
+
+    # Check Defaults
+    default_agent = manifest.definitions["default_agent"]
+    assert isinstance(default_agent, AgentDefinition)
+    # Defaults: Graph, Req/Res
+    assert default_agent.capabilities.type == CapabilityType.GRAPH
+    assert default_agent.capabilities.delivery_mode == DeliveryMode.REQUEST_RESPONSE
+
+
+def test_mixed_type_coercion() -> None:
+    """Test that valid strings are coerced to Enums correctly."""
+    caps = AgentCapabilities(
+        type="atomic",
+        delivery_mode="server_sent_events"
+    )
+    assert caps.type == CapabilityType.ATOMIC
+    assert caps.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
+    assert isinstance(caps.type, CapabilityType)
+    assert isinstance(caps.delivery_mode, DeliveryMode)


### PR DESCRIPTION
Refactored AgentCapabilities to enforce explicit streaming contracts.
* Introduced CapabilityType enum (ATOMIC, GRAPH).
* Refactored DeliveryMode to use scalar values (REQUEST_RESPONSE, SERVER_SENT_EVENTS) instead of a list.
* Updated AgentCapabilities to use scalar type and delivery_mode fields.
* Updated tests to reflect these breaking changes.
* Exported CapabilityType in __init__.py.

---
*PR created automatically by Jules for task [11034285270861279787](https://jules.google.com/task/11034285270861279787) started by @gowthamrao*