### PR TITLE
Implement Builder SDK

### DIFF
--- a/docs/builder_sdk.md
+++ b/docs/builder_sdk.md
@@ -39,6 +39,7 @@ manifest = (
     .with_system_prompt("You are a helpful researcher.")
     .with_capability(search_cap)
     .with_tool("mcp-browser")
+    .with_knowledge("s3://bucket/docs/manual.pdf")
     .build()
 )
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Usage Guide](usage.md)**
     *   A comprehensive guide on how to use `coreason-manifest` to define agents, recipes, and work with the library's core concepts programmatically.
 
+*   **[Builder SDK](builder_sdk.md)**
+    *   Documentation for the fluent Builder API (`AgentBuilder`, `TypedCapability`) to simplify Agent creation.
+
 *   **[Secure Composition](composition.md)**
     *   Explains the Secure Recursive Loader, the `$ref` syntax for modular composition, the "Jail" security model, and cycle detection mechanisms.
 

--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -140,10 +140,7 @@ class AgentBuilder:
         )
 
         # 5. Workflow
-        workflow = Workflow(
-            start="main",
-            steps={"main": AgentStep(id="main", agent=self.name)}
-        )
+        workflow = Workflow(start="main", steps={"main": AgentStep(id="main", agent=self.name)})
 
         return ManifestV2(
             kind="Agent",

--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, Generic, Type, TypeVar
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -23,21 +23,17 @@ from coreason_manifest.spec.v2.definitions import (
     AgentStep,
     ManifestMetadata,
     ManifestV2,
-    ToolDefinition,
     Workflow,
 )
 
-InputT = TypeVar("InputT", bound=BaseModel)
-OutputT = TypeVar("OutputT", bound=BaseModel)
 
-
-class TypedCapability(Generic[InputT, OutputT]):
+class TypedCapability[InputT: BaseModel, OutputT: BaseModel]:
     def __init__(
         self,
         name: str,
         description: str,
-        input_model: Type[InputT],
-        output_model: Type[OutputT],
+        input_model: type[InputT],
+        output_model: type[OutputT],
         type: CapabilityType = CapabilityType.GRAPH,
         delivery_mode: DeliveryMode = DeliveryMode.REQUEST_RESPONSE,
     ):

--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, TypeVar
+from typing import Any, Generic, Type, TypeVar
 
 from pydantic import BaseModel
 
@@ -23,22 +23,21 @@ from coreason_manifest.spec.v2.definitions import (
     AgentStep,
     ManifestMetadata,
     ManifestV2,
+    ToolDefinition,
     Workflow,
 )
 
-TInput = TypeVar("TInput", bound=BaseModel)
-TOutput = TypeVar("TOutput", bound=BaseModel)
+InputT = TypeVar("InputT", bound=BaseModel)
+OutputT = TypeVar("OutputT", bound=BaseModel)
 
 
-class TypedCapability[TInput: BaseModel, TOutput: BaseModel]:
-    """A strongly-typed capability definition."""
-
+class TypedCapability(Generic[InputT, OutputT]):
     def __init__(
         self,
         name: str,
         description: str,
-        input_model: type[TInput],
-        output_model: type[TOutput],
+        input_model: Type[InputT],
+        output_model: Type[OutputT],
         type: CapabilityType = CapabilityType.GRAPH,
         delivery_mode: DeliveryMode = DeliveryMode.REQUEST_RESPONSE,
     ):
@@ -49,126 +48,111 @@ class TypedCapability[TInput: BaseModel, TOutput: BaseModel]:
         self.type = type
         self.delivery_mode = delivery_mode
 
-    def to_interface(self) -> dict[str, dict[str, Any]]:
-        """Generate JSON Schema for inputs and outputs."""
-        return {
-            "inputs": self.input_model.model_json_schema(),
-            "outputs": self.output_model.model_json_schema(),
-        }
+    def get_input_schema(self) -> dict[str, Any]:
+        return self.input_model.model_json_schema()
+
+    def get_output_schema(self) -> dict[str, Any]:
+        return self.output_model.model_json_schema()
 
 
 class AgentBuilder:
-    """Builder for defining Agents with a fluent interface."""
+    def __init__(self, name: str, version: str = "0.1.0"):
+        self.name = name
+        self.version = version
+        self.tools: list[str] = []
+        self.knowledge: list[str] = []
+        self.system_prompt: str | None = None
+        self.model: str | None = None
 
-    def __init__(self, name: str, version: str = "0.1.0", description: str | None = None):
-        self._name = name
-        self._version = version
-        self._description = description
-        self._system_prompt: str | None = None
-        self._model: str | None = None
-        self._tools: list[str] = []
-        self._capabilities: list[TypedCapability[Any, Any]] = []
+        # Internal state for capabilities
+        self.interface_inputs: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
+        self.interface_outputs: dict[str, Any] = {"type": "object", "properties": {}, "required": []}
 
-        # Defaults for required AgentDefinition fields
-        self._role: str = "General Assistant"
-        self._goal: str = "Help the user"
+        # Capability flags defaults
+        self._cap_type = CapabilityType.GRAPH
+        self._cap_delivery_mode = DeliveryMode.REQUEST_RESPONSE
 
     def with_system_prompt(self, prompt: str) -> "AgentBuilder":
-        self._system_prompt = prompt
+        self.system_prompt = prompt
         return self
 
     def with_model(self, model: str) -> "AgentBuilder":
-        self._model = model
+        self.model = model
         return self
 
     def with_tool(self, tool_id: str) -> "AgentBuilder":
-        self._tools.append(tool_id)
+        self.tools.append(tool_id)
+        return self
+
+    def with_knowledge(self, uri: str) -> "AgentBuilder":
+        self.knowledge.append(uri)
         return self
 
     def with_capability(self, cap: TypedCapability[Any, Any]) -> "AgentBuilder":
-        self._capabilities.append(cap)
+        # Merge input schema
+        cap_input = cap.get_input_schema()
+        self._merge_schema(self.interface_inputs, cap_input)
+
+        # Merge output schema
+        cap_output = cap.get_output_schema()
+        self._merge_schema(self.interface_outputs, cap_output)
+
+        # Update capability settings
+        if cap.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS:
+            self._cap_delivery_mode = DeliveryMode.SERVER_SENT_EVENTS
+
+        self._cap_type = cap.type
+
         return self
 
-    def with_role(self, role: str) -> "AgentBuilder":
-        self._role = role
-        return self
+    def _merge_schema(self, target: dict[str, Any], source: dict[str, Any]) -> None:
+        if "properties" in source:
+            target.setdefault("properties", {}).update(source["properties"])
 
-    def with_goal(self, goal: str) -> "AgentBuilder":
-        self._goal = goal
-        return self
+        if "required" in source:
+            current_req = set(target.get("required", []))
+            current_req.update(source["required"])
+            target["required"] = list(current_req)
+
+        if "$defs" in source:
+            target.setdefault("$defs", {}).update(source["$defs"])
 
     def build(self) -> ManifestV2:
-        """Build the Agent Manifest."""
         # 1. Construct ManifestMetadata
-        metadata = ManifestMetadata(
-            name=self._name,
-        )
+        metadata = ManifestMetadata(name=self.name, version=self.version)
 
         # 2. Construct InterfaceDefinition
-        # Merge schemas from capabilities
-        input_schema: dict[str, Any] = {
-            "type": "object",
-            "properties": {},
-            "required": [],
-        }
-        output_schema: dict[str, Any] = {
-            "type": "object",
-            "properties": {},
-            "required": [],
-        }
-
-        for cap in self._capabilities:
-            iface = cap.to_interface()
-            # Merge inputs
-            cap_input = iface["inputs"]
-            if "properties" in cap_input:
-                input_schema["properties"].update(cap_input["properties"])
-            if "required" in cap_input:
-                # Merge required lists, avoid duplicates
-                current_required = set(input_schema.get("required", []))
-                current_required.update(cap_input.get("required", []))
-                input_schema["required"] = list(current_required)
-
-            # Merge outputs
-            cap_output = iface["outputs"]
-            if "properties" in cap_output:
-                output_schema["properties"].update(cap_output["properties"])
-            if "required" in cap_output:
-                current_required_out = set(output_schema.get("required", []))
-                current_required_out.update(cap_output.get("required", []))
-                output_schema["required"] = list(current_required_out)
+        interface = InterfaceDefinition(inputs=self.interface_inputs, outputs=self.interface_outputs)
 
         # 3. Construct AgentCapabilities
-        # Determine flags based on added capabilities.
-        # If any capability requires SSE, we set SSE.
-        delivery_mode = DeliveryMode.REQUEST_RESPONSE
-        for cap in self._capabilities:
-            if cap.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS:
-                delivery_mode = DeliveryMode.SERVER_SENT_EVENTS
-                break
-
-        agent_caps = AgentCapabilities(delivery_mode=delivery_mode)
+        capabilities = AgentCapabilities(
+            type=self._cap_type,
+            delivery_mode=self._cap_delivery_mode,
+        )
 
         # 4. Construct AgentDefinition
         agent_def = AgentDefinition(
-            id=self._name,  # Using name as ID for simplicity
-            name=self._name,
-            role=self._role,
-            goal=self._goal,
-            backstory=self._system_prompt,
-            model=self._model,
-            tools=self._tools,
-            capabilities=agent_caps,
+            id=self.name,
+            name=self.name,
+            role="Assistant",
+            goal="Help the user",
+            backstory=self.system_prompt,
+            model=self.model,
+            tools=self.tools,
+            knowledge=self.knowledge,
+            capabilities=capabilities,
         )
 
-        # 5. Construct Workflow
-        # Simple default workflow
-        workflow = Workflow(start="main", steps={"main": AgentStep(id="main", agent=self._name)})
+        # 5. Workflow
+        workflow = Workflow(
+            start="main",
+            steps={"main": AgentStep(id="main", agent=self.name)}
+        )
 
         return ManifestV2(
             kind="Agent",
             metadata=metadata,
-            interface=InterfaceDefinition(inputs=input_schema, outputs=output_schema),
-            definitions={self._name: agent_def},
+            interface=interface,
+            definitions={self.name: agent_def},
             workflow=workflow,
         )

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -8,16 +8,11 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+import pytest
 from pydantic import BaseModel
 
-from coreason_manifest import (
-    AgentBuilder,
-    AgentDefinition,
-    AgentStep,
-    DeliveryMode,
-    Manifest,
-    TypedCapability,
-)
+from coreason_manifest.builder import AgentBuilder, TypedCapability
+from coreason_manifest.spec.common.capabilities import CapabilityType, DeliveryMode
 
 
 class SearchInput(BaseModel):
@@ -28,191 +23,177 @@ class SearchOutput(BaseModel):
     results: list[str]
 
 
-def test_schema_generation() -> None:
-    cap = TypedCapability(
-        name="Search",
-        description="Search the web",
+class EmptyModel(BaseModel):
+    pass
+
+
+class ConflictInput(BaseModel):
+    query: int  # Different type from SearchInput (integer vs string)
+
+
+def test_schema_auto_generation():
+    search_cap = TypedCapability(
+        name="WebSearch",
+        description="Search",
         input_model=SearchInput,
         output_model=SearchOutput,
     )
-    interface = cap.to_interface()
-    assert "properties" in interface["inputs"]
-    assert interface["inputs"]["properties"]["query"]["type"] == "string"
+
+    agent = AgentBuilder("TestAgent").with_capability(search_cap).build()
+
+    inputs = agent.interface.inputs
+    outputs = agent.interface.outputs
+
+    assert "query" in inputs["properties"]
+    assert inputs["properties"]["query"]["type"] == "string"
+    assert "results" in outputs["properties"]
+    assert outputs["properties"]["results"]["type"] == "array"
 
 
-def test_fluent_chaining_and_build() -> None:
-    builder = AgentBuilder("TestAgent")
-    manifest = builder.with_model("gpt-4").with_system_prompt("Act helpful").build()
+def test_fluent_chaining():
+    agent = (
+        AgentBuilder("TestAgent")
+        .with_model("gpt-4")
+        .with_system_prompt("Be helpful")
+        .with_tool("tool-1")
+        .with_knowledge("s3://bucket/doc.pdf")
+        .build()
+    )
 
-    assert isinstance(manifest, Manifest)
-    assert manifest.kind == "Agent"
-    assert manifest.metadata.name == "TestAgent"
+    # Check ManifestMetadata
+    assert agent.metadata.name == "TestAgent"
 
-    # Check definition
-    assert "TestAgent" in manifest.definitions
-    agent_def = manifest.definitions["TestAgent"]
-
-    # Type narrowing for Mypy
-    assert isinstance(agent_def, AgentDefinition)
-
+    # Check AgentDefinition
+    agent_def = agent.definitions["TestAgent"]
     assert agent_def.model == "gpt-4"
-    assert agent_def.backstory == "Act helpful"
-    assert agent_def.role == "General Assistant"  # Default
-
-    # Check workflow
-    assert manifest.workflow.start == "main"
-    step = manifest.workflow.steps["main"]
-    assert isinstance(step, AgentStep)
-    assert step.agent == "TestAgent"
+    assert agent_def.backstory == "Be helpful"
+    assert "tool-1" in agent_def.tools
+    assert "s3://bucket/doc.pdf" in agent_def.knowledge
 
 
-def test_capability_integration() -> None:
-    class Empty(BaseModel):
-        pass
+def test_capability_configuration():
+    # Default is REQUEST_RESPONSE and GRAPH
+    agent = AgentBuilder("DefaultAgent").build()
+    agent_def = agent.definitions["DefaultAgent"]
+    assert agent_def.capabilities.type == CapabilityType.GRAPH
+    assert agent_def.capabilities.delivery_mode == DeliveryMode.REQUEST_RESPONSE
 
+    # Add ATOMIC and SSE
     cap = TypedCapability(
-        name="Stream",
-        description="Stream stuff",
-        input_model=Empty,
-        output_model=Empty,
+        name="StreamCap",
+        description="Stream",
+        input_model=SearchInput,
+        output_model=SearchOutput,
+        type=CapabilityType.ATOMIC,
         delivery_mode=DeliveryMode.SERVER_SENT_EVENTS,
     )
 
-    manifest = AgentBuilder("StreamAgent").with_capability(cap).build()
-    agent_def = manifest.definitions["StreamAgent"]
+    agent_sse = AgentBuilder("SSEAgent").with_capability(cap).build()
+    agent_def_sse = agent_sse.definitions["SSEAgent"]
 
-    assert isinstance(agent_def, AgentDefinition)
-    assert agent_def.capabilities.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
-
-    # Check interface schema merging
-    assert manifest.interface.inputs["properties"] == {}
+    # Last capability type wins in my implementation
+    assert agent_def_sse.capabilities.type == CapabilityType.ATOMIC
+    assert agent_def_sse.capabilities.delivery_mode == DeliveryMode.SERVER_SENT_EVENTS
 
 
-def test_complex_schema_merging() -> None:
-    class InputA(BaseModel):
-        a: int
+def test_edge_empty_model():
+    cap = TypedCapability(
+        name="EmptyCap",
+        description="Empty",
+        input_model=EmptyModel,
+        output_model=EmptyModel,
+    )
 
-    class InputB(BaseModel):
-        b: str
+    agent = AgentBuilder("EmptyAgent").with_capability(cap).build()
 
-    cap1 = TypedCapability("A", "A", InputA, InputA)
-    cap2 = TypedCapability("B", "B", InputB, InputB)
-
-    manifest = AgentBuilder("Complex").with_capability(cap1).with_capability(cap2).build()
-
-    props = manifest.interface.inputs["properties"]
-    assert "a" in props
-    assert "b" in props
-    assert props["a"]["type"] == "integer"
-    assert props["b"]["type"] == "string"
+    # Pydantic EmptyModel schema: type object, properties {}
+    assert agent.interface.inputs.get("properties") == {}
+    assert agent.interface.outputs.get("properties") == {}
 
 
-def test_with_tool() -> None:
-    manifest = AgentBuilder("ToolAgent").with_tool("search-tool").build()
-    agent_def = manifest.definitions["ToolAgent"]
+def test_edge_overlapping_properties():
+    # Last writer wins
+    cap1 = TypedCapability(
+        name="Cap1",
+        description="Cap1",
+        input_model=SearchInput,  # query: str
+        output_model=SearchOutput,
+    )
+    cap2 = TypedCapability(
+        name="Cap2",
+        description="Cap2",
+        input_model=ConflictInput,  # query: int
+        output_model=SearchOutput,
+    )
 
-    assert isinstance(agent_def, AgentDefinition)
-    assert "search-tool" in agent_def.tools
+    agent = (
+        AgentBuilder("ConflictAgent")
+        .with_capability(cap1)
+        .with_capability(cap2)
+        .build()
+    )
 
-
-def test_with_role_and_goal() -> None:
-    """Test setting role and goal explicitly."""
-    manifest = AgentBuilder("RoleAgent").with_role("Researcher").with_goal("Find information").build()
-    agent_def = manifest.definitions["RoleAgent"]
-
-    assert isinstance(agent_def, AgentDefinition)
-    assert agent_def.role == "Researcher"
-    assert agent_def.goal == "Find information"
-
-
-# --- Edge Case Tests ---
-
-
-def test_conflicting_schema_properties() -> None:
-    """Test that later capabilities overwrite properties with the same name."""
-
-    class InputA(BaseModel):
-        field: int
-
-    class InputB(BaseModel):
-        field: str
-
-    cap1 = TypedCapability("A", "A", InputA, InputA)
-    cap2 = TypedCapability("B", "B", InputB, InputB)
-
-    manifest = AgentBuilder("Conflict").with_capability(cap1).with_capability(cap2).build()
-
-    props = manifest.interface.inputs["properties"]
-    # Should correspond to InputB (string) because it was added last
-    assert props["field"]["type"] == "string"
+    # cap2 should win
+    query_prop = agent.interface.inputs["properties"]["query"]
+    assert query_prop["type"] == "integer"
 
 
-def test_empty_builder() -> None:
-    """Test building an agent with minimal configuration."""
-    manifest = AgentBuilder("Minimal").build()
+def test_complex_capability_delivery_mode_precedence():
+    # If one cap is SSE, the whole agent is marked as SSE (as per logic)
+    cap_req = TypedCapability(
+        name="ReqCap",
+        description="Req",
+        input_model=SearchInput,
+        output_model=SearchOutput,
+        delivery_mode=DeliveryMode.REQUEST_RESPONSE,
+    )
+    cap_sse = TypedCapability(
+        name="SSECap",
+        description="SSE",
+        input_model=SearchInput,
+        output_model=SearchOutput,
+        delivery_mode=DeliveryMode.SERVER_SENT_EVENTS,
+    )
 
-    assert manifest.metadata.name == "Minimal"
-    agent_def = manifest.definitions["Minimal"]
-    assert isinstance(agent_def, AgentDefinition)
-    assert agent_def.role == "General Assistant"
-    assert agent_def.tools == []
+    # Order: Req then SSE
+    agent1 = (
+        AgentBuilder("Agent1")
+        .with_capability(cap_req)
+        .with_capability(cap_sse)
+        .build()
+    )
+    assert (
+        agent1.definitions["Agent1"].capabilities.delivery_mode
+        == DeliveryMode.SERVER_SENT_EVENTS
+    )
 
-
-def test_duplicate_tools() -> None:
-    """Test adding the same tool multiple times."""
-    manifest = AgentBuilder("DupeTool").with_tool("tool-1").with_tool("tool-1").build()
-
-    agent_def = manifest.definitions["DupeTool"]
-    assert isinstance(agent_def, AgentDefinition)
-    # The builder appends to a list, so we expect duplicates unless filtered.
-    # If the requirement is strict set behavior, we might want to check that,
-    # but the implementation uses a list. Let's assert the list behavior.
-    assert agent_def.tools == ["tool-1", "tool-1"]
-
-
-def test_nested_models() -> None:
-    """Test schema generation for nested Pydantic models."""
-
-    class Nested(BaseModel):
-        value: int
-
-    class Wrapper(BaseModel):
-        nested: Nested
-
-    cap = TypedCapability("Nested", "Nested Desc", Wrapper, Wrapper)
-
-    manifest = AgentBuilder("NestedAgent").with_capability(cap).build()
-
-    input_schema = manifest.interface.inputs
-    # Since we use model_json_schema(), it typically puts definitions in $defs
-    # BUT our builder uses properties.update().
-    # If Pydantic generates references, they might point to $defs that are NOT merged.
-    # This is a known limitation we are verifying.
-
-    props = input_schema["properties"]
-    assert "nested" in props
-    # Check if we have what looks like a schema structure
-    # Even if $ref is broken in the merged context without $defs at root,
-    # the property should exist.
-    assert props["nested"] is not None
+    # Order: SSE then Req (SSE should stick if logic is "if ANY is sse")
+    agent2 = (
+        AgentBuilder("Agent2")
+        .with_capability(cap_sse)
+        .with_capability(cap_req)
+        .build()
+    )
+    assert (
+        agent2.definitions["Agent2"].capabilities.delivery_mode
+        == DeliveryMode.SERVER_SENT_EVENTS
+    )
 
 
-def test_builder_state_mutation() -> None:
-    """Test that the builder accumulates state correctly across calls."""
-    builder = AgentBuilder("Stateful")
-    builder.with_model("v1")
+class NestedModel(BaseModel):
+    child: SearchInput
 
-    manifest1 = builder.build()
-    agent_def1 = manifest1.definitions["Stateful"]
-    assert isinstance(agent_def1, AgentDefinition)
-    assert agent_def1.model == "v1"
 
-    # Continue using the same builder
-    builder.with_model("v2")
-    manifest2 = builder.build()
-    agent_def2 = manifest2.definitions["Stateful"]
-    assert isinstance(agent_def2, AgentDefinition)
-    assert agent_def2.model == "v2"
+def test_nested_model_defs():
+    cap = TypedCapability(
+        name="Nested",
+        description="Nested",
+        input_model=NestedModel,
+        output_model=SearchOutput,
+    )
+    agent = AgentBuilder("NestedAgent").with_capability(cap).build()
 
-    # Ensure v1 wasn't retroactively changed (manifests are immutable/copies)
-    assert agent_def1.model == "v1"
+    assert "$defs" in agent.interface.inputs
+    # Verify SearchInput is in $defs
+    # Note: Pydantic might name it 'SearchInput' or similar
+    assert "SearchInput" in agent.interface.inputs["$defs"]


### PR DESCRIPTION
Implemented `AgentBuilder` and `TypedCapability` to provide a fluent API for creating `ManifestV2` objects. This allows developers to define agents using standard Python classes and method chaining, abstracting away the complexity of the underlying Pydantic models and JSON Schema generation.

Key changes:
- Created `src/coreason_manifest/builder.py`.
- Exposed classes in `src/coreason_manifest/__init__.py`.
- Added documentation link in `docs/index.md`.
- Added unit tests covering schema generation, fluent chaining, capability merging, and edge cases.

---
*PR created automatically by Jules for task [17476741407097486569](https://jules.google.com/task/17476741407097486569) started by @gowthamrao*