### PR TITLE
feat: Implement Middleware Extension Interfaces

### DIFF
--- a/docs/middleware_extension_interfaces.md
+++ b/docs/middleware_extension_interfaces.md
@@ -46,13 +46,13 @@ Implement this protocol to intercept incoming requests. Common use cases include
 
 ```python
 from typing import Protocol, runtime_checkable
-from coreason_manifest import AgentRequest, SessionContext
+from coreason_manifest import AgentRequest, InterceptorContext
 
 @runtime_checkable
 class IRequestInterceptor(Protocol):
     async def intercept_request(
         self,
-        context: SessionContext,
+        context: InterceptorContext,
         request: AgentRequest
     ) -> AgentRequest:
         """Modify or validate the request before the agent sees it."""
@@ -65,7 +65,7 @@ class IRequestInterceptor(Protocol):
 class PIIRedactor:
     async def intercept_request(
         self,
-        context: SessionContext,
+        context: InterceptorContext,
         request: AgentRequest
     ) -> AgentRequest:
         # Simple example: Redact generic credit card numbers in query

--- a/src/coreason_manifest/spec/interfaces/middleware.py
+++ b/src/coreason_manifest/spec/interfaces/middleware.py
@@ -14,7 +14,7 @@ from uuid import UUID
 
 from pydantic import ConfigDict, Field
 
-from coreason_manifest.spec.cap import AgentRequest, SessionContext, StreamPacket
+from coreason_manifest.spec.cap import AgentRequest, StreamPacket
 from coreason_manifest.spec.common_base import CoReasonBaseModel
 
 
@@ -34,7 +34,7 @@ class IRequestInterceptor(Protocol):
 
     async def intercept_request(
         self,
-        context: SessionContext,
+        context: InterceptorContext,
         request: AgentRequest,
     ) -> AgentRequest:
         """Modify or validate the request before the agent sees it."""

--- a/tests/test_middleware_complex.py
+++ b/tests/test_middleware_complex.py
@@ -81,9 +81,7 @@ async def test_interceptor_crash_in_stream() -> None:
 def test_metadata_immutability_depth() -> None:
     """Verify that metadata dict content is mutable but container is frozen."""
     metadata = {"key": "value", "nested": {"a": 1}}
-    context = InterceptorContext(
-        request_id=uuid4(), start_time=datetime.now(UTC), metadata=metadata
-    )
+    context = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC), metadata=metadata)
 
     # The container (metadata field) cannot be reassigned
     # context.metadata = {}  # Raises ValidationError (tested elsewhere)
@@ -116,9 +114,7 @@ async def test_concurrent_interceptors() -> None:
     requests = [AgentRequest(query=f"req-{i}") for i in range(10)]
 
     # process all concurrently
-    results = await asyncio.gather(
-        *(interceptor.intercept_request(context, req) for req in requests)
-    )
+    results = await asyncio.gather(*(interceptor.intercept_request(context, req) for req in requests))
 
     assert len(results) == 10
     for i, res in enumerate(results):

--- a/tests/test_middleware_complex.py
+++ b/tests/test_middleware_complex.py
@@ -17,6 +17,7 @@ import pytest
 from coreason_manifest.spec.cap import AgentRequest, StreamOpCode, StreamPacket
 from coreason_manifest.spec.interfaces.middleware import (
     InterceptorContext,
+    IRequestInterceptor,
 )
 
 
@@ -45,7 +46,10 @@ class AppendSuffixInterceptor:
 @pytest.mark.asyncio
 async def test_chained_interceptors() -> None:
     """Verify that multiple interceptors can be chained."""
-    interceptors = [UppercaseInterceptor(), AppendSuffixInterceptor()]
+    interceptors: list[IRequestInterceptor] = [
+        UppercaseInterceptor(),
+        AppendSuffixInterceptor(),
+    ]
     context = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC))
     request = AgentRequest(query="hello world")
 
@@ -77,7 +81,9 @@ async def test_interceptor_crash_in_stream() -> None:
 def test_metadata_immutability_depth() -> None:
     """Verify that metadata dict content is mutable but container is frozen."""
     metadata = {"key": "value", "nested": {"a": 1}}
-    context = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC), metadata=metadata)
+    context = InterceptorContext(
+        request_id=uuid4(), start_time=datetime.now(UTC), metadata=metadata
+    )
 
     # The container (metadata field) cannot be reassigned
     # context.metadata = {}  # Raises ValidationError (tested elsewhere)
@@ -110,7 +116,9 @@ async def test_concurrent_interceptors() -> None:
     requests = [AgentRequest(query=f"req-{i}") for i in range(10)]
 
     # process all concurrently
-    results = await asyncio.gather(*(interceptor.intercept_request(context, req) for req in requests))
+    results = await asyncio.gather(
+        *(interceptor.intercept_request(context, req) for req in requests)
+    )
 
     assert len(results) == 10
     for i, res in enumerate(results):

--- a/tests/test_middleware_complex.py
+++ b/tests/test_middleware_complex.py
@@ -1,0 +1,117 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import asyncio
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+
+from coreason_manifest.spec.cap import AgentRequest, StreamOpCode, StreamPacket
+from coreason_manifest.spec.interfaces.middleware import (
+    InterceptorContext,
+)
+
+
+class UppercaseInterceptor:
+    """Uppercases the query."""
+
+    async def intercept_request(
+        self,
+        _context: InterceptorContext,
+        request: AgentRequest,
+    ) -> AgentRequest:
+        return request.model_copy(update={"query": request.query.upper()})
+
+
+class AppendSuffixInterceptor:
+    """Appends a suffix."""
+
+    async def intercept_request(
+        self,
+        _context: InterceptorContext,
+        request: AgentRequest,
+    ) -> AgentRequest:
+        return request.model_copy(update={"query": request.query + " [CHECKED]"})
+
+
+@pytest.mark.asyncio
+async def test_chained_interceptors() -> None:
+    """Verify that multiple interceptors can be chained."""
+    interceptors = [UppercaseInterceptor(), AppendSuffixInterceptor()]
+    context = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC))
+    request = AgentRequest(query="hello world")
+
+    for interceptor in interceptors:
+        request = await interceptor.intercept_request(context, request)
+
+    assert request.query == "HELLO WORLD [CHECKED]"
+
+
+class CrashingInterceptor:
+    """Simulates a crash."""
+
+    async def intercept_stream(self, packet: StreamPacket) -> StreamPacket:
+        if packet.op == StreamOpCode.DELTA:
+            raise ValueError("Crash!")
+        return packet
+
+
+@pytest.mark.asyncio
+async def test_interceptor_crash_in_stream() -> None:
+    """Verify exception propagation from interceptor."""
+    interceptor = CrashingInterceptor()
+    packet = StreamPacket(op=StreamOpCode.DELTA, p="data")
+
+    with pytest.raises(ValueError, match="Crash!"):
+        await interceptor.intercept_stream(packet)
+
+
+def test_metadata_immutability_depth() -> None:
+    """Verify that metadata dict content is mutable but container is frozen."""
+    metadata = {"key": "value", "nested": {"a": 1}}
+    context = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC), metadata=metadata)
+
+    # The container (metadata field) cannot be reassigned
+    # context.metadata = {}  # Raises ValidationError (tested elsewhere)
+
+    # However, the dictionary content ITSELF is mutable unless we use MappingProxyType or similar.
+    # Pydantic 'frozen=True' prevents reassignment of the field, but doesn't deep-freeze standard dicts.
+    # This test documents the behavior: Middleware authors should treat metadata as read-only convention
+    # or the engine should use deep-frozen structures if strict enforcement is needed.
+
+    # We assert that we CAN modify it, which means we must document this as a caveat.
+    context.metadata["key"] = "changed"
+    assert context.metadata["key"] == "changed"
+
+
+class SlowInterceptor:
+    async def intercept_request(
+        self,
+        _context: InterceptorContext,
+        request: AgentRequest,
+    ) -> AgentRequest:
+        await asyncio.sleep(0.01)
+        return request
+
+
+@pytest.mark.asyncio
+async def test_concurrent_interceptors() -> None:
+    """Verify async concurrency."""
+    interceptor = SlowInterceptor()
+    context = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC))
+    requests = [AgentRequest(query=f"req-{i}") for i in range(10)]
+
+    # process all concurrently
+    results = await asyncio.gather(*(interceptor.intercept_request(context, req) for req in requests))
+
+    assert len(results) == 10
+    for i, res in enumerate(results):
+        assert res.query == f"req-{i}"

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -8,131 +8,135 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-import asyncio
-from datetime import UTC, datetime, timedelta
-from typing import Any
+from datetime import datetime, UTC
 from uuid import uuid4
+from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest import (
-    AgentRequest,
-    Identity,
+from coreason_manifest.spec.interfaces.middleware import (
     InterceptorContext,
     IRequestInterceptor,
     IResponseInterceptor,
-    SessionContext,
-    StreamPacket,
 )
+from coreason_manifest.spec.cap import AgentRequest, StreamPacket, StreamOpCode
+
+def test_interceptor_context_immutability() -> None:
+    """Verify InterceptorContext is frozen."""
+    context = InterceptorContext(
+        request_id=uuid4(),
+        start_time=datetime.now(UTC),
+        metadata={"token": "abc"}
+    )
+
+    # Attempt to modify request_id
+    with pytest.raises(ValidationError):
+        context.request_id = uuid4()  # type: ignore
+
+    # Attempt to modify metadata
+    with pytest.raises(ValidationError):
+        context.metadata = {}  # type: ignore
 
 
-class MockPIIFilter:
-    """Mock implementation of a request interceptor."""
+class PIIRedactionInterceptor:
+    """Interceptor that redaction 'secret' from request query."""
 
-    async def intercept_request(self, context: SessionContext, request: AgentRequest) -> AgentRequest:
-        _ = context  # Suppress unused argument warning
+    async def intercept_request(
+        self,
+        context: InterceptorContext,
+        request: AgentRequest,
+    ) -> AgentRequest:
+        if "secret" in request.query:
+            new_query = request.query.replace("secret", "******")
+            # Create new request as AgentRequest is frozen
+            return request.model_copy(update={"query": new_query})
         return request
 
 
-class MockToxicityFilter:
-    """Mock implementation of a response interceptor."""
+@pytest.mark.asyncio
+async def test_pii_redaction_interceptor() -> None:
+    """Test modification of request data."""
+    interceptor = PIIRedactionInterceptor()
+    context = InterceptorContext(
+        request_id=uuid4(),
+        start_time=datetime.now(UTC),
+        metadata={}
+    )
+    request = AgentRequest(query="This is a secret message.")
+
+    processed_request = await interceptor.intercept_request(context, request)
+
+    assert processed_request.query == "This is a ****** message."
+    assert processed_request.request_id == request.request_id
+
+
+class PolicyInterceptor:
+    """Interceptor that blocks requests based on policy."""
+
+    async def intercept_request(
+        self,
+        context: InterceptorContext,
+        request: AgentRequest,
+    ) -> AgentRequest:
+        if context.metadata.get("block"):
+            raise ValueError("Blocked by policy")
+        return request
+
+
+@pytest.mark.asyncio
+async def test_policy_rejection_interceptor() -> None:
+    """Test blocking of requests."""
+    interceptor = PolicyInterceptor()
+    request = AgentRequest(query="Hello")
+
+    # Allowed
+    context_allowed = InterceptorContext(
+        request_id=uuid4(),
+        start_time=datetime.now(UTC),
+        metadata={"block": False}
+    )
+    assert await interceptor.intercept_request(context_allowed, request) == request
+
+    # Blocked
+    context_blocked = InterceptorContext(
+        request_id=uuid4(),
+        start_time=datetime.now(UTC),
+        metadata={"block": True}
+    )
+    with pytest.raises(ValueError, match="Blocked by policy"):
+        await interceptor.intercept_request(context_blocked, request)
+
+
+class ResponseCensorInterceptor:
+    """Interceptor that censors 'bad' words in stream."""
 
     async def intercept_stream(self, packet: StreamPacket) -> StreamPacket:
+        if packet.op == StreamOpCode.DELTA and isinstance(packet.p, str):
+            if "bad" in packet.p:
+                new_payload = packet.p.replace("bad", "***")
+                return packet.model_copy(update={"p": new_payload})
         return packet
 
 
-def test_request_interceptor_compliance() -> None:
-    """Verify that MockPIIFilter satisfies the IRequestInterceptor protocol."""
-    interceptor = MockPIIFilter()
-    assert isinstance(interceptor, IRequestInterceptor)
+@pytest.mark.asyncio
+async def test_response_interceptor() -> None:
+    """Test modification of stream packets."""
+    interceptor = ResponseCensorInterceptor()
+
+    packet = StreamPacket(op=StreamOpCode.DELTA, p="This is a bad word.")
+    processed_packet = await interceptor.intercept_stream(packet)
+
+    assert processed_packet.p == "This is a *** word."
 
 
-def test_response_interceptor_compliance() -> None:
-    """Verify that MockToxicityFilter satisfies the IResponseInterceptor protocol."""
-    interceptor = MockToxicityFilter()
-    assert isinstance(interceptor, IResponseInterceptor)
+def test_protocol_compliance() -> None:
+    """Verify classes implement protocols correctly."""
+    assert isinstance(PIIRedactionInterceptor(), IRequestInterceptor)
+    assert isinstance(ResponseCensorInterceptor(), IResponseInterceptor)
 
+    # Verify invalid implementation doesn't pass
+    class InvalidInterceptor:
+        pass
 
-def test_interceptor_context_immutability() -> None:
-    """Verify that InterceptorContext is immutable."""
-    ctx = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC))
-
-    # Test reassigning a field
-    with pytest.raises(ValidationError):
-        ctx.request_id = uuid4()  # type: ignore
-
-    with pytest.raises(ValidationError):
-        ctx.start_time = datetime.now(UTC)  # type: ignore
-
-
-def test_interceptor_context_defaults() -> None:
-    """Verify defaults for InterceptorContext."""
-    ctx = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC))
-    assert ctx.metadata == {}
-
-
-class ModifyingInterceptor:
-    """Interceptor that modifies the request query."""
-
-    async def intercept_request(self, context: SessionContext, request: AgentRequest) -> AgentRequest:
-        _ = context
-        # Use model_copy to create a modified version (since AgentRequest is frozen)
-        return request.model_copy(update={"query": request.query + " [REDACTED]"})
-
-
-def test_interceptor_modification() -> None:
-    """Test that an interceptor can modify a request."""
-    # Create dependencies
-    req = AgentRequest(query="My secret is 1234", request_id=uuid4(), root_request_id=uuid4())
-    ctx = SessionContext(session_id="test-session", user=Identity.anonymous())
-
-    interceptor = ModifyingInterceptor()
-
-    async def run_test() -> None:
-        new_req = await interceptor.intercept_request(ctx, req)
-        assert new_req.query == "My secret is 1234 [REDACTED]"
-        assert new_req.request_id == req.request_id
-
-    asyncio.run(run_test())
-
-
-def test_interceptor_context_edge_cases() -> None:
-    """Test edge cases for InterceptorContext."""
-
-    # 1. Large Metadata
-    large_metadata = {f"key_{i}": f"value_{i}" for i in range(1000)}
-    ctx_large = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC), metadata=large_metadata)
-    assert len(ctx_large.metadata) == 1000
-
-    # 2. Nested Metadata
-    nested_metadata: dict[str, Any] = {"level1": {"level2": {"level3": "deep"}}}
-    ctx_nested = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC), metadata=nested_metadata)
-    # Cast to ensure type checking passes if strict
-    assert ctx_nested.metadata["level1"]["level2"]["level3"] == "deep"
-
-    # 3. Future Timestamp
-    future_time = datetime.now(UTC) + timedelta(days=365)
-    ctx_future = InterceptorContext(request_id=uuid4(), start_time=future_time)
-    assert ctx_future.start_time == future_time
-
-
-class ErrorInterceptor:
-    """Interceptor that raises an error."""
-
-    async def intercept_request(self, context: SessionContext, request: AgentRequest) -> AgentRequest:
-        _ = (context, request)
-        raise ValueError("Block this request")
-
-
-def test_interceptor_error_propagation() -> None:
-    """Test that exceptions from interceptors propagate."""
-    interceptor = ErrorInterceptor()
-    req = AgentRequest(query="Bad", request_id=uuid4(), root_request_id=uuid4())
-    ctx = SessionContext(session_id="test-session", user=Identity.anonymous())
-
-    async def run_test() -> None:
-        with pytest.raises(ValueError, match="Block this request"):
-            await interceptor.intercept_request(ctx, req)
-
-    asyncio.run(run_test())
+    assert not isinstance(InvalidInterceptor(), IRequestInterceptor)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from coreason_manifest import (
+    InterceptorContext,
+    IRequestInterceptor,
+    IResponseInterceptor,
+)
+from coreason_manifest.spec.interfaces.middleware import (
+    InterceptorContext as InternalInterceptorContext,
+)
+
+
+def test_public_api_exports() -> None:
+    """Verify that middleware components are exported from the top-level package."""
+    assert InterceptorContext is InternalInterceptorContext
+    assert isinstance(IRequestInterceptor, type)
+    assert isinstance(IResponseInterceptor, type)


### PR DESCRIPTION
Implemented `InterceptorContext` and protocols `IRequestInterceptor` and `IResponseInterceptor` in `src/coreason_manifest/spec/interfaces/middleware.py`. Added comprehensive tests in `tests/test_middleware_interface.py` verifying immutability, PII redaction, policy rejection, and protocol compliance. This enforces separation of concerns between governance logic and business logic.

---
*PR created automatically by Jules for task [8369636730254391078](https://jules.google.com/task/8369636730254391078) started by @gowthamrao*