### PR TITLE
chore: fix Ruff UP042 compliance by using StrEnum

### DIFF
--- a/src/coreason_manifest/spec/common/session.py
+++ b/src/coreason_manifest/spec/common/session.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from datetime import UTC, datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 from uuid import uuid4
 
@@ -18,7 +18,7 @@ from pydantic import ConfigDict, Field
 from coreason_manifest.spec.common_base import CoReasonBaseModel
 
 
-class MemoryStrategy(str, Enum):
+class MemoryStrategy(StrEnum):
     """Strategy for memory eviction."""
 
     ALL = "all"


### PR DESCRIPTION
Refactor `MemoryStrategy` to use `StrEnum` to comply with Ruff rule `UP042` and project standards. Verified with `ruff check` and 100% test coverage.

---
*PR created automatically by Jules for task [12199746738410057641](https://jules.google.com/task/12199746738410057641) started by @gowthamrao*