### PR TITLE
Security Fix: Add safety_metadata to AuditLog model

### DIFF
--- a/src/coreason_manifest/spec/common/observability.py
+++ b/src/coreason_manifest/spec/common/observability.py
@@ -95,6 +95,8 @@ class AuditLog(CoReasonBaseModel):
     actor: str
     action: str
     outcome: str
-    safety_metadata: dict[str, Any] | None = Field(default=None, description="Security context and policy decision metadata.")
+    safety_metadata: dict[str, Any] | None = Field(
+        default=None, description="Security context and policy decision metadata."
+    )
     previous_hash: str | None = Field(None, description="Hash of the preceding log entry for tamper-evidence.")
     integrity_hash: str = Field(description="SHA-256 hash of this record.")

--- a/src/coreason_manifest/spec/common/observability.py
+++ b/src/coreason_manifest/spec/common/observability.py
@@ -95,5 +95,6 @@ class AuditLog(CoReasonBaseModel):
     actor: str
     action: str
     outcome: str
+    safety_metadata: dict[str, Any] | None = Field(default=None, description="Security context and policy decision metadata.")
     previous_hash: str | None = Field(None, description="Hash of the preceding log entry for tamper-evidence.")
     integrity_hash: str = Field(description="SHA-256 hash of this record.")

--- a/tests/test_audit_security.py
+++ b/tests/test_audit_security.py
@@ -1,0 +1,83 @@
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from coreason_manifest.spec.common.observability import AuditLog
+from coreason_manifest.utils.audit import compute_audit_hash, verify_chain
+
+def test_audit_log_safety_metadata_roundtrip() -> None:
+    """
+    Security Test: Verify that AuditLog correctly preserves safety_metadata
+    and that the integrity hash matches between dict source and model instance.
+    """
+    log_id = uuid.uuid4()
+    req_id = uuid.uuid4()
+
+    # Source data with security context
+    data: dict[str, Any] = {
+        "id": log_id,
+        "request_id": req_id,
+        "root_request_id": req_id,
+        "timestamp": datetime.now(timezone.utc),
+        "actor": "admin",
+        "action": "override_policy",
+        "outcome": "success",
+        "safety_metadata": {"reason": "emergency", "approved_by": "CISO"},
+        "previous_hash": None
+    }
+
+    # 1. Compute hash from raw data (simulating storage/transport)
+    expected_hash = compute_audit_hash(data)
+
+    # 2. Load into AuditLog model (simulating verification)
+    log = AuditLog(
+        **data,
+        integrity_hash=expected_hash
+    )
+
+    # 3. Verify that the model retained the metadata
+    assert log.safety_metadata == data["safety_metadata"]
+
+    # 4. Verify that re-computing hash from model matches expected hash
+    computed_hash = compute_audit_hash(log)
+    assert computed_hash == expected_hash, "Hash mismatch: AuditLog lost security context!"
+
+    # 5. Verify chain validation passes
+    assert verify_chain([log]) is True
+
+def test_audit_log_safety_metadata_tamper() -> None:
+    """Verify that modifying safety_metadata invalidates the hash."""
+    log_id = uuid.uuid4()
+    req_id = uuid.uuid4()
+
+    data: dict[str, Any] = {
+        "id": log_id,
+        "request_id": req_id,
+        "root_request_id": req_id,
+        "timestamp": datetime.now(timezone.utc),
+        "actor": "admin",
+        "action": "override_policy",
+        "outcome": "success",
+        "safety_metadata": {"reason": "valid"},
+        "previous_hash": None
+    }
+
+    initial_hash = compute_audit_hash(data)
+    log = AuditLog(**data, integrity_hash=initial_hash)
+
+    # Create a tampered log with different metadata but same hash
+    tampered_log = AuditLog(
+        id=log.id,
+        request_id=log.request_id,
+        root_request_id=log.root_request_id,
+        timestamp=log.timestamp,
+        actor=log.actor,
+        action=log.action,
+        outcome=log.outcome,
+        previous_hash=log.previous_hash,
+        safety_metadata={"reason": "malicious"}, # Tampered
+        integrity_hash=log.integrity_hash
+    )
+
+    # Verify chain should fail
+    assert verify_chain([tampered_log]) is False


### PR DESCRIPTION
Added `safety_metadata` to `AuditLog` model to fix integrity hash mismatch issue. Verified with new regression tests.

---
*PR created automatically by Jules for task [2850133056284627](https://jules.google.com/task/2850133056284627) started by @gowthamrao*