### PR TITLE
docs: Organize and index missing documentation

### DIFF
--- a/docs/cap/specification.md
+++ b/docs/cap/specification.md
@@ -66,7 +66,7 @@ The `definitions` section is a polymorphic key-value map where you can define re
 *   `capabilities`: Feature flags and capabilities.
 
 ### Agent Capabilities (`AgentCapabilities`)
-Used within an `AgentDefinition` to declare supported features.
+Used within an `AgentDefinition` to declare supported features. See [Explicit Streaming Contracts](streaming_contracts.md) for detailed definitions.
 
 *   `type`: The architectural complexity of the agent.
     *   Values: `atomic` (Simple, linear), `graph` (Complex workflow).

--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -97,7 +97,7 @@ Used for streaming partial results or events during execution. The packet struct
 | Op (`op`) | Payload (`p`) Type | Description |
 | :--- | :--- | :--- |
 | `delta` | `str` | A partial text chunk (token). |
-| `event` | `Dict[str, Any]` | A structured event (e.g., tool usage, state change). Ideally adheres to `PresentationEvent` schemas. |
+| `event` | `Dict[str, Any]` | A structured event (e.g., tool usage, state change). Ideally adheres to [PresentationEvent schemas](../presentation_schemas.md). |
 | `error` | `StreamError` | A strict error object. |
 | `close` | `None` | Stream termination signal. |
 
@@ -174,7 +174,7 @@ Represents a single message in a conversation history.
 
 ### PresentationEvent
 
-Polymorphic events for UI rendering (referenced in `StreamPacket` `op=event`). This is a single container with a `type` discriminator and polymorphic `data` payload.
+Polymorphic events for UI rendering (referenced in `StreamPacket` `op=event`). This is a single container with a `type` discriminator and polymorphic `data` payload. See [Standardized Presentation Schemas](../presentation_schemas.md) for full details.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Coreason Agent Protocol (CAP) Wire Format](cap/wire_protocol.md)**
     *   Defines the runtime wire protocol, including standard request/response envelopes (`ServiceRequest`, `ServiceResponse`) and streaming contracts (`StreamPacket`).
 
+*   **[Explicit Streaming Contracts](cap/streaming_contracts.md)**
+    *   Defines the contracts for Agent execution (`atomic`, `graph`) and delivery modes (`request_response`, `server_sent_events`).
+
 *   **[Stream Identity & Lifecycle](cap/stream_lifecycle.md)**
     *   Protocols and data structures for explicit, multiplexed output streams (`STREAM_START`, `STREAM_END`).
 
@@ -47,6 +50,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 
 *   **[Audit Hashing & Integrity](audit_hashing.md)**
     *   Specifications for the "Tamper-Evident" audit logging system, including the `AuditLog` model and SHA-256 chain verification algorithms.
+
+*   **[Standardized Presentation Schemas](presentation_schemas.md)**
+    *   Enforces strictly typed Pydantic models for UI events (`PresentationEvent`) like citations, progress indicators, and media carousels.
 
 *   **[Frontend Integration & Graph Events](frontend_integration.md)**
     *   Defines the strict `GraphEvent` hierarchy for internal engine state and the migration strategy to standard `CloudEvent` formats.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,16 +11,20 @@ nav:
   - Specifications & Protocols:
     - CAM Specification: cap/specification.md
     - CAP Wire Protocol: cap/wire_protocol.md
+    - Explicit Streaming Contracts: cap/streaming_contracts.md
     - Stream Identity & Lifecycle: cap/stream_lifecycle.md
     - Memory Governance: memory_governance.md
     - Session Management: session_management.md
+    - Active Memory Interface: active_memory_interface.md
     - Evaluation Metadata: evaluation_metadata.md
     - Request Lineage Implementation: request_lineage_implementation.md
     - Observability & Tracing: observability.md
     - Audit Hashing & Integrity: audit_hashing.md
+    - Standardized Presentation Schemas: presentation_schemas.md
     - Frontend Integration & Graph Events: frontend_integration.md
     - Event Content Types: event_content_types.md
     - Semantic Error Handling: error_handling_standards.md
+    - Middleware Extension Interfaces: middleware_extension_interfaces.md
   - Architecture & Rationale:
     - Product Requirements: product_requirements.md
     - Package Structure & Architecture: package_structure.md


### PR DESCRIPTION
This PR improves the organization of the documentation by ensuring all specification and protocol documents are indexed in `mkdocs.yml` and `docs/index.md`. It also adds cross-links between related documents to facilitate navigation and discovery. specifically, it addresses the lack of visibility for Streaming Contracts, Presentation Schemas, Active Memory Interface, and Middleware Extension Interfaces.

---
*PR created automatically by Jules for task [8853802738950845744](https://jules.google.com/task/8853802738950845744) started by @gowthamrao*