### PR TITLE
feat: verify evaluation metadata and fix license compliance

### DIFF
--- a/src/coreason_manifest/spec/v2/evaluation.py
+++ b/src/coreason_manifest/spec/v2/evaluation.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from pydantic import ConfigDict, Field
 
 from coreason_manifest.spec.common_base import CoReasonBaseModel

--- a/tests/test_evaluation_metadata.py
+++ b/tests/test_evaluation_metadata.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 


### PR DESCRIPTION
Work Package V: Evaluation-Ready Metadata

This submission verifies the implementation of the "Self-Describing Quality" capability.
The required models (`SuccessCriterion`, `EvaluationProfile`) were found to be correctly implemented in `src/coreason_manifest/spec/v2/evaluation.py` but lacked the standard license header.
The `AgentDefinition` was already updated to include the `evaluation` field.
The exports in `__init__.py` were correct.
The test suite `tests/test_evaluation_metadata.py` was present but lacked the license header.

Actions taken:
1. Validated the existing implementation against the requirements.
2. Added the mandatory CoReason license header to `src/coreason_manifest/spec/v2/evaluation.py` and `tests/test_evaluation_metadata.py`.
3. Executed the test suite to ensure correctness (100% pass).


---
*PR created automatically by Jules for task [10283158522928646868](https://jules.google.com/task/10283158522928646868) started by @gowthamrao*