### PR TITLE
Implement Agent Card Generator (Work Package BB)

### DIFF
--- a/docs/agent_card_generator.md
+++ b/docs/agent_card_generator.md
@@ -1,0 +1,78 @@
+# Agent Card Generator
+
+The Agent Card Generator is a utility within `coreason-manifest` designed to bridge the gap between technical definitions and human-readable documentation. It adheres to the "Glass Box" philosophy, ensuring that the transparency of an Agent's configuration is accessible to non-technical stakeholders such as Compliance Officers, Product Managers, and End Users.
+
+By generating a standardized Markdown "Agent Card" directly from the `ManifestV2` object, this tool guarantees that the documentation never drifts from the actual code.
+
+## Key Features
+
+*   **Automated Generation:** Converts `ManifestV2` objects into formatted Markdown.
+*   **Standardized Sections:** Automatically populates sections for Metadata, Financials, Governance, and API Contracts.
+*   **Robustness:** Gracefully handles missing optional fields (e.g., Resources, Evaluation metrics).
+*   **Zero Dependencies:** Implemented using standard Python string manipulation, keeping the package lightweight.
+
+## Usage
+
+The utility is exported as `render_agent_card` from the root package.
+
+```python
+from coreason_manifest import render_agent_card, load
+
+# 1. Load your manifest (e.g., from a YAML file)
+manifest = load("my_agent.yaml")
+
+# 2. Generate the card
+markdown_card = render_agent_card(manifest)
+
+# 3. Save or display the markdown
+print(markdown_card)
+```
+
+## Output Structure
+
+The generated Agent Card includes the following sections:
+
+1.  **Header:** Agent Name, Version, Role, and Creation Date.
+2.  **Description:** The Agent's backstory or description, formatted as a blockquote.
+3.  **Resource & Cost Profile:** (Optional) Details on the Model ID, Pricing (Input/Output costs), and Context Window size.
+4.  **Governance & Safety:** (Optional) Risk Level and a list of active policies enforced on the Agent.
+5.  **API Interface:** Markdown tables detailing the Input and Output schemas, including field names, types, requirements, and descriptions.
+6.  **Evaluation Standards:** (Optional) Grading rubrics and Service Level Agreements (SLAs) defined for the agent.
+
+## Example Output
+
+```markdown
+# ResearchAssistant (v1.0.0)
+**Role:** Senior Researcher | **Created:** 2023-10-27
+
+> You are an expert researcher capable of finding detailed information on any topic.
+
+## 💰 Resource & Cost Profile
+- **Model:** openai/gpt-4
+- **Pricing:** $10.0 / 1M Input | $30.0 / 1M Output
+- **Context Window:** 128000 tokens
+
+## 🛡️ Governance & Safety
+- **Risk Level:** standard
+- **Active Policies:**
+  - No PII allowed in output
+  - Must cite sources
+
+## 🔌 API Interface
+
+### Inputs
+| Field Name | Type | Required? | Description |
+| --- | --- | --- | --- |
+| `query` | `string` | Yes | The research topic |
+| `depth` | `integer` | No | Search depth (1-5) |
+
+### Outputs
+| Field Name | Type | Required? | Description |
+| --- | --- | --- | --- |
+| `summary` | `string` | No | A summary of findings |
+
+## 🧪 Evaluation Standards
+- **Grading Rubric:**
+  - **accuracy:** Must be factual (Threshold: 0.9)
+- **SLA:** 5000ms latency
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Governance & Policy Enforcement](governance_policy_enforcement.md)**
     *   Details the Governance module for defining and enforcing organizational rules, risk levels, and compliance policies on agents and tools.
 
+*   **[Agent Card Generator](agent_card_generator.md)**
+    *   Guide for using the automated documentation utility to generate standardized "Agent Cards" from Manifest definitions.
+
 ## Specifications & Protocols
 
 *   **[Coreason Agent Manifest (CAM) Specification](cap/specification.md)**

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
     - Builder SDK: builder_sdk.md
     - Secure Composition: composition.md
     - Governance & Policy: governance_policy_enforcement.md
+    - Agent Card Generator: agent_card_generator.md
   - Specifications & Protocols:
     - CAM Specification: cap/specification.md
     - CAP Wire Protocol: cap/wire_protocol.md

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -88,6 +88,7 @@ from .spec.v2.resources import (
     ResourceConstraints,
 )
 from .utils.audit import compute_audit_hash, verify_chain
+from .utils.docs import render_agent_card
 from .utils.migration import migrate_graph_event_to_cloud_event
 from .utils.service import ServiceContract
 from .utils.v2.governance import check_compliance_v2
@@ -185,6 +186,7 @@ __all__ = [
     "dump",
     "load",
     "migrate_graph_event_to_cloud_event",
+    "render_agent_card",
     "validate_integrity",
     "validate_loose",
     "verify_chain",

--- a/src/coreason_manifest/utils/docs.py
+++ b/src/coreason_manifest/utils/docs.py
@@ -1,0 +1,179 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import textwrap
+from typing import Any
+
+from coreason_manifest.spec.v2.definitions import AgentDefinition, ManifestV2
+from coreason_manifest.spec.v2.resources import ModelProfile
+
+
+def render_agent_card(agent: ManifestV2) -> str:
+    """
+    Render a standardized Markdown "Agent Card" from a ManifestV2 object.
+
+    Args:
+        agent: The Agent Manifest to render. Must contain at least one AgentDefinition.
+
+    Returns:
+        A Markdown string formatted with Metadata, Financials, Governance, and API Interface.
+    """
+    # 1. Component Extraction
+    manifest = agent
+    metadata = manifest.metadata
+
+    # Find the AgentDefinition
+    # Priority:
+    # 1. Definition matching the manifest name
+    # 2. The first AgentDefinition found in definitions
+    agent_def: AgentDefinition | None = None
+
+    if metadata.name in manifest.definitions:
+        candidate = manifest.definitions[metadata.name]
+        if isinstance(candidate, AgentDefinition):
+            agent_def = candidate
+
+    if not agent_def:
+        for definition in manifest.definitions.values():
+            if isinstance(definition, AgentDefinition):
+                agent_def = definition
+                break
+
+    # 2. Header Section
+    # Check for version in extra fields of metadata
+    version = getattr(metadata, "version", "0.0.0")
+    if not isinstance(version, str):
+        version = str(version)
+
+    output = [f"# {metadata.name} (v{version})"]
+
+    # Metadata Block
+    role = agent_def.role if agent_def else "Unknown Role"
+    created = getattr(metadata, "created", None)
+
+    meta_parts = [f"**Role:** {role}"]
+    if created:
+        meta_parts.append(f" | **Created:** {created}")
+
+    output.append("\n" + "".join(meta_parts))
+
+    # Description
+    description = None
+    if agent_def and agent_def.backstory:
+        # Quote the backstory
+        description = "\n".join(f"> {line}" for line in agent_def.backstory.splitlines())
+    elif agent_def and hasattr(agent_def, "description") and agent_def.description:
+        description = agent_def.description
+
+    if description:
+        output.append("\n" + description)
+
+    # 3. Financials (If resources exist)
+    if agent_def and agent_def.resources:
+        res: ModelProfile = agent_def.resources
+        output.append("\n## 💰 Resource & Cost Profile")
+        output.append(f"- **Model:** {res.provider}/{res.model_id}")
+
+        if res.pricing:
+            p = res.pricing
+            # Fallback for display if unit is enum
+            unit_str = p.unit.value if hasattr(p.unit, "value") else str(p.unit)
+            # Simplify TOKEN_1M to "1M" for display if it matches
+            if unit_str == "TOKEN_1M":
+                display_unit = "1M"
+            elif unit_str == "TOKEN_1K":
+                display_unit = "1k"
+            else:
+                display_unit = unit_str
+
+            output.append(f"- **Pricing:** ${p.input_cost} / {display_unit} Input | ${p.output_cost} / {display_unit} Output")
+
+        if res.constraints:
+            output.append(f"- **Context Window:** {res.constraints.context_window_size} tokens")
+
+    # 4. Governance (If agent.governance exists)
+    # Check for 'governance' attribute on the manifest object (duck typing/extra)
+    # This supports cases where the manifest object might be wrapped or extended.
+    governance = getattr(manifest, "governance", None)
+
+    # Also check if policy indicates risks or if we have critical tools
+    # For now, we strictly follow instructions: "If agent.governance exists"
+    if governance:
+        output.append("\n## 🛡️ Governance & Safety")
+
+        risk = getattr(governance, "risk_level", None)
+        if risk:
+            output.append(f"- **Risk Level:** {risk}")
+
+        # "List all active policies" - assuming governance has a 'policies' list or similar
+        policies = getattr(governance, "policies", [])
+        if policies:
+            output.append("- **Active Policies:**")
+            for policy in policies:
+                output.append(f"  - {policy}")
+
+    # 5. Interface Contract
+    output.append("\n## 🔌 API Interface")
+
+    # Inputs
+    inputs_schema = manifest.interface.inputs
+    output.append("\n### Inputs")
+    output.append(_render_schema_table(inputs_schema))
+
+    # Outputs
+    outputs_schema = manifest.interface.outputs
+    output.append("\n### Outputs")
+    output.append(_render_schema_table(outputs_schema))
+
+    # 6. Quality Assurance (If agent.evaluation exists)
+    if agent_def and agent_def.evaluation:
+        eval_profile = agent_def.evaluation
+        output.append("\n## 🧪 Evaluation Standards")
+
+        if eval_profile.grading_rubric:
+            output.append("- **Grading Rubric:**")
+            for criterion in eval_profile.grading_rubric:
+                # Criterion is SuccessCriterion object
+                output.append(f"  - **{criterion.name}:** {criterion.description} (Threshold: {criterion.threshold})")
+
+        if eval_profile.expected_latency_ms:
+            output.append(f"- **SLA:** {eval_profile.expected_latency_ms}ms latency")
+
+    return "\n".join(output)
+
+
+def _render_schema_table(schema: dict[str, Any]) -> str:
+    """Helper to render a JSON Schema properties table in Markdown."""
+    if not schema or "properties" not in schema or not schema["properties"]:
+        return "_No fields defined._"
+
+    headers = ["Field Name", "Type", "Required?", "Description"]
+    # Markdown table header
+    lines = ["| " + " | ".join(headers) + " |"]
+    # Markdown table separator
+    lines.append("| " + " | ".join(["---"] * len(headers)) + " |")
+
+    properties = schema.get("properties", {})
+    required_set = set(schema.get("required", []))
+
+    # Sort properties for consistent output
+    sorted_props = sorted(properties.items())
+
+    for name, prop in sorted_props:
+        type_ = prop.get("type", "any")
+        req = "Yes" if name in required_set else "No"
+        desc = prop.get("description", "").replace("\n", " ").strip()
+        if not desc:
+            desc = "-"
+
+        row = [f"`{name}`", f"`{type_}`", req, desc]
+        lines.append("| " + " | ".join(row) + " |")
+
+    return "\n".join(lines)

--- a/src/coreason_manifest/utils/docs.py
+++ b/src/coreason_manifest/utils/docs.py
@@ -8,11 +8,12 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-import textwrap
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from coreason_manifest.spec.v2.definitions import AgentDefinition, ManifestV2
-from coreason_manifest.spec.v2.resources import ModelProfile
+
+if TYPE_CHECKING:
+    from coreason_manifest.spec.v2.resources import ModelProfile
 
 
 def render_agent_card(agent: ManifestV2) -> str:
@@ -93,7 +94,9 @@ def render_agent_card(agent: ManifestV2) -> str:
             else:
                 display_unit = unit_str
 
-            output.append(f"- **Pricing:** ${p.input_cost} / {display_unit} Input | ${p.output_cost} / {display_unit} Output")
+            output.append(
+                f"- **Pricing:** ${p.input_cost} / {display_unit} Input | ${p.output_cost} / {display_unit} Output"
+            )
 
         if res.constraints:
             output.append(f"- **Context Window:** {res.constraints.context_window_size} tokens")

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -1,0 +1,188 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from coreason_manifest import (
+    AgentDefinition,
+    AgentStep,
+    EvaluationProfile,
+    InterfaceDefinition,
+    ManifestMetadata,
+    ManifestV2,
+    ModelProfile,
+    PricingUnit,
+    RateCard,
+    ResourceConstraints,
+    SuccessCriterion,
+    Workflow,
+    render_agent_card,
+)
+
+
+def test_render_full_agent() -> None:
+    # 1. Create components
+    resources = ModelProfile(
+        provider="openai",
+        model_id="gpt-4",
+        pricing=RateCard(
+            unit=PricingUnit.TOKEN_1M,
+            input_cost=10.0,
+            output_cost=30.0,
+            currency="USD",
+        ),
+        constraints=ResourceConstraints(
+            context_window_size=128000,
+        ),
+    )
+
+    evaluation = EvaluationProfile(
+        expected_latency_ms=2000,
+        grading_rubric=[
+            SuccessCriterion(
+                name="accuracy",
+                description="Must be accurate",
+                threshold=0.9,
+            )
+        ],
+    )
+
+    agent_def = AgentDefinition(
+        id="researcher",
+        name="Researcher",
+        role="Research Assistant",
+        goal="Find information",
+        backstory="You are a diligent researcher.\nYou cite sources.",
+        resources=resources,
+        evaluation=evaluation,
+    )
+
+    metadata = ManifestMetadata(
+        name="Researcher",
+        version="1.0.0",  # Extra field
+    )
+
+    interface = InterfaceDefinition(
+        inputs={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string", "description": "Search query"},
+                "depth": {"type": "integer", "description": "Search depth"},
+            },
+            "required": ["query"],
+        },
+        outputs={
+            "type": "object",
+            "properties": {
+                "summary": {"type": "string", "description": "Result summary"},
+            },
+        },
+    )
+
+    manifest = ManifestV2(
+        kind="Agent",
+        metadata=metadata,
+        interface=interface,
+        definitions={"Researcher": agent_def},
+        workflow=Workflow(start="main", steps={"main": AgentStep(id="main", agent="Researcher")}),
+    )
+
+    card = render_agent_card(manifest)
+
+    # Assertions
+    assert "# Researcher (v1.0.0)" in card
+    assert "**Role:** Research Assistant" in card
+    assert "> You are a diligent researcher." in card
+
+    assert "## 💰 Resource & Cost Profile" in card
+    assert "**Model:** openai/gpt-4" in card
+    assert "**Pricing:** $10.0 / 1M Input | $30.0 / 1M Output" in card
+    assert "**Context Window:** 128000 tokens" in card
+
+    assert "## 🔌 API Interface" in card
+    assert "| `query` | `string` | Yes | Search query |" in card
+    assert "| `depth` | `integer` | No | Search depth |" in card
+    assert "| `summary` | `string` | No | Result summary |" in card
+
+    assert "## 🧪 Evaluation Standards" in card
+    assert "**accuracy:** Must be accurate (Threshold: 0.9)" in card
+    assert "**SLA:** 2000ms latency" in card
+
+
+def test_render_minimal_agent() -> None:
+    agent_def = AgentDefinition(
+        id="minimal",
+        name="Minimal",
+        role="Minion",
+        goal="Do little",
+    )
+
+    manifest = ManifestV2(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Minimal"),
+        workflow=Workflow(start="main", steps={"main": AgentStep(id="main", agent="Minimal")}),
+        definitions={"Minimal": agent_def},
+    )
+
+    card = render_agent_card(manifest)
+
+    assert "# Minimal (v0.0.0)" in card
+    assert "**Role:** Minion" in card
+    assert "## 💰 Resource & Cost Profile" not in card
+    assert "## 🧪 Evaluation Standards" not in card
+    assert "## 🔌 API Interface" in card
+    assert "_No fields defined._" in card
+
+
+def test_schema_parsing() -> None:
+    interface = InterfaceDefinition(
+        inputs={
+            "type": "object",
+            "properties": {
+                "field_a": {"type": "string"},
+                "field_b": {"type": "number"},
+            },
+            "required": ["field_b"],
+        }
+    )
+
+    manifest = ManifestV2(
+        kind="Agent",
+        metadata=ManifestMetadata(name="SchemaTest"),
+        workflow=Workflow(start="main", steps={"main": AgentStep(id="main", agent="SchemaTest")}),
+        interface=interface,
+    )
+
+    card = render_agent_card(manifest)
+
+    assert "| `field_a` | `string` | No | - |" in card
+    assert "| `field_b` | `number` | Yes | - |" in card
+
+
+class MockGovernance:
+    risk_level = "standard"
+    policies = ["No rude language"]
+
+
+class MockManifest:
+    def __init__(self) -> None:
+        self.metadata = ManifestMetadata(name="GovBot")
+        self.definitions = {}  # type: ignore
+        self.interface = InterfaceDefinition()
+        self.governance = MockGovernance()
+
+
+def test_governance_render() -> None:
+    # We need to cast to ManifestV2 for typing but at runtime it works
+    manifest = MockManifest()
+
+    card = render_agent_card(manifest)  # type: ignore
+
+    assert "## 🛡️ Governance & Safety" in card
+    assert "**Risk Level:** standard" in card
+    assert "- No rude language" in card

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -9,7 +9,6 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from typing import ClassVar
-from unittest.mock import Mock
 
 from coreason_manifest import (
     AgentDefinition,
@@ -234,14 +233,14 @@ def test_render_metadata_variants() -> None:
     from pydantic import ConfigDict
 
     class ExtendedAgentDefinition(AgentDefinition):
-        model_config = ConfigDict(extra="allow") # type: ignore
+        model_config = ConfigDict(extra="allow")
 
     agent_def = ExtendedAgentDefinition(
         id="describer",
         name="Describer",
         role="Scribe",
         goal="Write",
-        description="I describe things.", # This is now allowed
+        description="I describe things.",  # This is now allowed
     )
 
     metadata = ManifestMetadata(

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -15,8 +15,8 @@ from coreason_manifest import (
     AgentStep,
     EvaluationProfile,
     InterfaceDefinition,
+    Manifest,
     ManifestMetadata,
-    ManifestV2,
     ModelProfile,
     PricingUnit,
     RateCard,
@@ -86,7 +86,7 @@ def test_render_full_agent() -> None:
         },
     )
 
-    manifest = ManifestV2(
+    manifest = Manifest(
         kind="Agent",
         metadata=metadata,
         interface=interface,
@@ -124,7 +124,7 @@ def test_render_minimal_agent() -> None:
         goal="Do little",
     )
 
-    manifest = ManifestV2(
+    manifest = Manifest(
         kind="Agent",
         metadata=ManifestMetadata(name="Minimal"),
         workflow=Workflow(start="main", steps={"main": AgentStep(id="main", agent="Minimal")}),
@@ -153,7 +153,7 @@ def test_schema_parsing() -> None:
         }
     )
 
-    manifest = ManifestV2(
+    manifest = Manifest(
         kind="Agent",
         metadata=ManifestMetadata(name="SchemaTest"),
         workflow=Workflow(start="main", steps={"main": AgentStep(id="main", agent="SchemaTest")}),

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -8,6 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from typing import ClassVar
+
 from coreason_manifest import (
     AgentDefinition,
     AgentStep,
@@ -165,8 +167,8 @@ def test_schema_parsing() -> None:
 
 
 class MockGovernance:
-    risk_level = "standard"
-    policies = ["No rude language"]
+    risk_level: ClassVar[str] = "standard"
+    policies: ClassVar[list[str]] = ["No rude language"]
 
 
 class MockManifest:


### PR DESCRIPTION
Implemented the Agent Card Generator as part of Work Package BB. 
The `render_agent_card` function takes a `ManifestV2` object and produces a formatted Markdown string. 
This implementation correctly handles the distribution of data between the top-level Manifest (metadata, interface) and the internal AgentDefinition (resources, evaluation).
Included robust handling for optional fields and a test suite covering full and minimal agent configurations.


---
*PR created automatically by Jules for task [7451071954238463794](https://jules.google.com/task/7451071954238463794) started by @gowthamrao*