### PR TITLE
Add Mock Data Factory and OpenAPI Generation Documentation

### DIFF
--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -239,3 +239,23 @@ Payload is a dictionary (see Semantic Error Handling for standard fields).
 #### Thought Trace (`type: thought_trace`)
 
 Payload is a dictionary containing reasoning steps.
+
+## OpenAPI Generation
+
+The `coreason_manifest` package provides a utility to generate an OpenAPI 3.1 Path Item Object that strictly adheres to the Service Request/Response contracts defined above.
+
+This is useful for exposing Agents as standard REST APIs.
+
+### Usage
+
+```python
+import json
+from coreason_manifest import ServiceContract
+
+# Generate the OpenAPI Path Item
+openapi_spec = ServiceContract.generate_openapi()
+
+print(json.dumps(openapi_spec, indent=2))
+```
+
+This generates a definition for a `POST` operation that accepts a `ServiceRequest` and returns a `ServiceResponse`.

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Agent Card Generator](agent_card_generator.md)**
     *   Guide for using the automated documentation utility to generate standardized "Agent Cards" from Manifest definitions.
 
+*   **[Mock Data Factory](mock_factory.md)**
+    *   Utility for generating deterministic, schema-compliant synthetic data for Agent outputs and testing.
+
 ## Specifications & Protocols
 
 *   **[Coreason Agent Manifest (CAM) Specification](cap/specification.md)**

--- a/docs/mock_factory.md
+++ b/docs/mock_factory.md
@@ -1,0 +1,80 @@
+# Mock Data Factory
+
+The **Mock Data Factory** (`src/coreason_manifest/utils/mock.py`) provides a utility to programmatically generate deterministic, schema-compliant synthetic data for Agents.
+
+This is essential for testing, simulating agent outputs, and validating downstream systems without running actual LLM inference.
+
+## Overview
+
+The factory parses the `output` schema of an `AgentDefinition` and recursively generates a Python dictionary that satisfies all constraints (types, enums, formats).
+
+Key features:
+*   **Deterministic:** Supports seeding for reproducible test cases.
+*   **Schema Compliant:** Respects JSON Schema keywords like `enum`, `const`, `allOf`, `anyOf`, `oneOf`.
+*   **Safe:** Handles recursive schemas (e.g., self-referencing definitions) with depth limits.
+*   **Zero Dependency:** Uses only Python standard library.
+
+## Usage
+
+```python
+from coreason_manifest import generate_mock_output, Manifest
+from coreason_manifest.spec.v2.definitions import AgentDefinition, InterfaceDefinition
+
+# 1. Define an Agent with an Output Schema
+agent = AgentDefinition(
+    id="weather-agent",
+    description="Gets weather",
+    interface=InterfaceDefinition(
+        inputs={"location": {"type": "string"}},
+        outputs={
+            "type": "object",
+            "properties": {
+                "temperature": {"type": "integer", "minimum": -50, "maximum": 50},
+                "condition": {"type": "string", "enum": ["sunny", "cloudy", "rainy"]},
+                "timestamp": {"type": "string", "format": "date-time"}
+            },
+            "required": ["temperature", "condition"]
+        }
+    )
+)
+
+# 2. Generate Mock Data
+# Use a seed for reproducibility
+mock_data = generate_mock_output(agent, seed=42)
+
+print(mock_data)
+# Output might look like:
+# {
+#   "temperature": 12,
+#   "condition": "cloudy",
+#   "timestamp": "2023-10-27T10:00:00Z"
+# }
+```
+
+## MockGenerator Logic
+
+The utility uses the `MockGenerator` class internally to traverse the schema.
+
+### Type Support
+
+| Type | Generator Behavior |
+| :--- | :--- |
+| `string` | Random alphanumeric string. Supports `format: uuid` and `format: date-time`. |
+| `integer` | Random integer within range (default 0-100). |
+| `number` | Random float. |
+| `boolean` | Random `True` or `False`. |
+| `array` | List of items (length 1-3). |
+| `object` | Dictionary with properties generated recursively. |
+| `null` | Returns `None`. |
+
+### Advanced Keywords
+
+*   **`$ref`**: Resolves local definitions (`$defs` or `definitions`) and recurses.
+*   **`enum`**: Randomly selects one of the allowed values.
+*   **`const`**: Returns the exact constant value.
+*   **`allOf`**: Merges properties from all sub-schemas.
+*   **`anyOf` / `oneOf`**: Randomly selects one sub-schema to generate from.
+
+### Safety Mechanisms
+
+To prevent infinite recursion in circular schemas (e.g., a Person object containing a list of Friends, who are also People), the generator enforces a strict recursion depth limit (default: 10). When the limit is reached, it returns `None` or an empty container to terminate the branch safely.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -11,6 +11,7 @@ nav:
     - Governance & Policy: governance_policy_enforcement.md
     - Semantic Diffing: semantic_diffing.md
     - Agent Card Generator: agent_card_generator.md
+    - Mock Data Factory: mock_factory.md
   - Specifications & Protocols:
     - CAM Specification: cap/specification.md
     - CAP Wire Protocol: cap/wire_protocol.md


### PR DESCRIPTION
This PR addresses documentation cohesiveness by adding missing documentation for the `generate_mock_output` utility and the `ServiceContract` OpenAPI generator. It ensures all public utilities are documented and linked in the central index and navigation. Changes were verified by running relevant tests and building the docs.

---
*PR created automatically by Jules for task [382131393540680605](https://jules.google.com/task/382131393540680605) started by @gowthamrao*