### PR TITLE
Clarify Governance Scope: Static Validation vs Runtime Enforcement

### DIFF
--- a/src/coreason_manifest/spec/governance.py
+++ b/src/coreason_manifest/spec/governance.py
@@ -21,13 +21,18 @@ from coreason_manifest.spec.common_base import CoReasonBaseModel, ToolRiskLevel
 class GovernanceConfig(CoReasonBaseModel):
     """Configuration for governance rules.
 
+    NOTE: This configuration defines policies for STATIC validation of the Manifest.
+    It ensures that the agent's definition claims compliance with these rules.
+    It does NOT provide runtime enforcement (e.g., firewalling, auth challenges),
+    which is the responsibility of the Execution Engine.
+
     Attributes:
         allowed_domains: List of allowed domains for tool URIs.
         max_risk_level: Maximum allowed risk level for tools.
         require_auth_for_critical_tools: Whether authentication is required for agents using CRITICAL tools.
         allow_inline_tools: Whether to allow inline tool definitions (which lack risk scoring).
         allow_custom_logic: Whether to allow LogicNodes and conditional Edges with custom code.
-        strict_url_validation: Enforce strict, normalized URL validation.
+        strict_url_validation: Enforce strict, normalized URL matching.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
@@ -46,7 +51,10 @@ class GovernanceConfig(CoReasonBaseModel):
     allow_custom_logic: bool = Field(
         False, description="Whether to allow LogicNodes and conditional Edges with custom code."
     )
-    strict_url_validation: bool = Field(True, description="Enforce strict, normalized URL validation.")
+    strict_url_validation: bool = Field(
+        True,
+        description="Enforce strict, normalized URL matching against allowed_domains (not a network security control).",
+    )
 
 
 class ComplianceViolation(CoReasonBaseModel):

--- a/src/coreason_manifest/utils/v2/governance.py
+++ b/src/coreason_manifest/utils/v2/governance.py
@@ -38,11 +38,15 @@ def _risk_score(level: ToolRiskLevel) -> int:
 
 
 def check_compliance_v2(manifest: ManifestV2, config: GovernanceConfig) -> ComplianceReport:
-    """Enforce policy on V2 Manifest before compilation.
+    """Perform STATIC policy compliance checking on a V2 Manifest.
+
+    This function validates that the manifest's definition complies with the
+    governance configuration. It does NOT enforce these rules at runtime;
+    it only checks that the manifest is written in a compliant way.
 
     Validates:
     - Tool risk levels against allowed maximums.
-    - Tool URIs against allowed domains.
+    - Tool URIs against allowed domains (using normalization if strict_url_validation is True).
     - Presence of custom logic (LogicStep, complex SwitchStep) if restricted.
 
     Args:


### PR DESCRIPTION
This PR addresses the "Security Theater" concern by clarifying that the Governance module provides static policy validation for the manifest, not runtime security enforcement.

Changes:
1.  **Documentation Refactor (`docs/governance_policy_enforcement.md`)**:
    *   Renamed title to "Governance & Policy Validation".
    *   Added a "Scope & Security Model" section explicitly distinguishing between static validation (this library) and runtime enforcement (Execution Engine).
    *   Clarified that `strict_url_validation` is for robust policy matching, not network security.
2.  **Code Docstring Updates**:
    *   `GovernanceConfig`: Added a note about static validation vs. runtime enforcement.
    *   `check_compliance_v2`: Updated description to "STATIC policy compliance checking".
    *   `strict_url_validation`: Clarified it is not a network security control.

Verification:
*   Ran `tests/test_validation_governance.py` and `tests/test_governance_spec.py`, all passed.
*   Verified that no functional logic was changed, only documentation and docstrings.

---
*PR created automatically by Jules for task [3873552381635166557](https://jules.google.com/task/3873552381635166557) started by @gowthamrao*