### PR TITLE
Enforce Shared Kernel Boundaries to avoid Distributed Monolith

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ It provides the **"Blueprint"** that all other services (Builder, Engine, Simula
 ### Standards Clarification
 *Note: The "Coreason Agent Manifest" (CAM) is a proprietary, strict governance schema designed for the CoReason Platform. It is distinct from the Oracle/Linux Foundation "Open Agent Specification," though we aim for future interoperability via adapters.*
 
+## Architecture & Boundaries
+
+To avoid the "Distributed Monolith" trap, this library strictly separates **Data** from **Logic**:
+
+*   **`coreason_manifest.spec` (The Kernel):** Contains **pure Pydantic models (DTOs)**. It has zero dependencies on business logic and is safe to import anywhere.
+*   **`coreason_manifest.utils` (The Toolbelt):** Contains **optional reference implementations** for Visualization, Audit Hashing, and Governance Enforcement.
+
+These components are co-located for developer convenience but are architecturally decoupled. The Core Spec **never** imports from Utils. See [ADR-001](docs/architecture/ADR-001-shared-kernel-boundaries.md) and [Package Structure](docs/package_structure.md) for details.
+
 ## Features
 
 *   **Coreason Agent Manifest (CAM):** Strict Pydantic models for Agent definitions (`AgentDefinition`) and Recipes (`Recipe`).

--- a/docs/architecture/ADR-001-shared-kernel-boundaries.md
+++ b/docs/architecture/ADR-001-shared-kernel-boundaries.md
@@ -1,0 +1,23 @@
+# ADR 001: Strict Separation of Shared Kernel and Utilities
+
+## Context
+The `coreason_manifest` library serves as the "Shared Kernel" for the Coreason ecosystem. A concern was raised that bundling logic (Governance, Visualization, Audit) with the kernel creates a "Distributed Monolith", forcing services (like the Engine) to redeploy for unrelated changes (like Visualization bug fixes).
+
+## Decision
+We will maintain the physical co-location of `spec` (DTOs) and `utils` (Logic) in the same Python package for developer ergonomics and semantic consistency, **BUT** we strictly enforce an architectural boundary:
+
+**The Core Specification (`spec`) MUST NOT depend on the Utilities (`utils`).**
+
+## Rationale
+1.  **Pure Data Kernel**: The `spec` package defines the language. It is pure data (Pydantic models). It has minimal dependencies.
+2.  **Optional Batteries**: The `utils` package provides "Reference Implementations" and "Standard Tools". Consumers (like the Engine) that only need the *language* can import `coreason_manifest.spec` without being logically coupled to the implementation of the visualization or governance logic.
+3.  **One-Way Dependency**: By enforcing `utils -> spec` (and forbidding `spec -> utils`), we ensure that changes in `utils` do not pollute the ABI or stability of `spec`.
+4.  **Version Stability**: While the package version bumps for any change, the *stability* of the `spec` module is guaranteed by the one-way dependency. A change in `viz.py` does not alter the `AgentDefinition` class.
+
+## Enforcement
+A regression test (`tests/test_architecture.py`) has been added to the CI pipeline. It scans all modules in `coreason_manifest.spec` and asserts that none of them import `coreason_manifest.utils`.
+
+## Consequences
+*   **Positive**: Consumers can trust that importing `ManifestV2` does not drag in heavy logic or side effects.
+*   **Positive**: The project remains easy to install (`pip install coreason-manifest`).
+*   **Negative**: A new release of the package is still required for utility fixes, which technically triggers a dependency update for consumers, even if they don't use the affected utility. This is accepted as a trade-off for simplicity over managing multi-package release trains (`coreason-spec`, `coreason-viz`, etc.) at this stage.

--- a/src/coreason_manifest/spec/governance.py
+++ b/src/coreason_manifest/spec/governance.py
@@ -8,9 +8,13 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-"""Governance and Policy Enforcement module for Coreason Agents.
+"""Governance Configuration Definitions (DTOs).
 
-This module provides tools to validate an AgentDefinition against a set of organizational rules.
+This module defines the data structures (`GovernanceConfig`, `ComplianceReport`) used to configure
+and report on governance policies.
+
+NOTE: This module contains PURE DATA only. The actual enforcement logic is located in
+`coreason_manifest.utils.v2.governance`.
 """
 
 from pydantic import ConfigDict, Field

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,9 +1,11 @@
 import importlib
 import pkgutil
 import sys
+
 import coreason_manifest.spec
 
-def test_spec_does_not_import_utils():
+
+def test_spec_does_not_import_utils() -> None:
     """
     Ensures that the Core Spec (shared kernel) does NOT import from the Utils package.
     This prevents the 'Distributed Monolith' trap by ensuring the DTOs are clean.
@@ -11,7 +13,7 @@ def test_spec_does_not_import_utils():
     package = coreason_manifest.spec
     prefix = package.__name__ + "."
 
-    for importer, modname, ispkg in pkgutil.walk_packages(package.__path__, prefix):
+    for _importer, modname, _ispkg in pkgutil.walk_packages(package.__path__, prefix):
         # Import the module
         try:
             module = importlib.import_module(modname)
@@ -29,11 +31,21 @@ def test_spec_does_not_import_utils():
             attr = getattr(module, name)
 
             # Check if it is a module
-            if hasattr(attr, "__name__") and isinstance(attr, type(sys)):
-                if attr.__name__.startswith("coreason_manifest.utils"):
-                    raise AssertionError(f"Module '{modname}' imports '{attr.__name__}'. Core Spec must not depend on Utils.")
+            if (
+                hasattr(attr, "__name__")
+                and isinstance(attr, type(sys))
+                and attr.__name__.startswith("coreason_manifest.utils")
+            ):
+                raise AssertionError(
+                    f"Module '{modname}' imports '{attr.__name__}'. Core Spec must not depend on Utils."
+                )
 
             # Check if it is an object (class, func) from a module
-            if hasattr(attr, "__module__") and attr.__module__:
-                 if attr.__module__.startswith("coreason_manifest.utils"):
-                    raise AssertionError(f"Module '{modname}' uses '{name}' from '{attr.__module__}'. Core Spec must not depend on Utils.")
+            if (
+                hasattr(attr, "__module__")
+                and attr.__module__
+                and attr.__module__.startswith("coreason_manifest.utils")
+            ):
+                raise AssertionError(
+                    f"Module '{modname}' uses '{name}' from '{attr.__module__}'. Core Spec must not depend on Utils."
+                )

--- a/tests/test_architecture.py
+++ b/tests/test_architecture.py
@@ -1,0 +1,39 @@
+import importlib
+import pkgutil
+import sys
+import coreason_manifest.spec
+
+def test_spec_does_not_import_utils():
+    """
+    Ensures that the Core Spec (shared kernel) does NOT import from the Utils package.
+    This prevents the 'Distributed Monolith' trap by ensuring the DTOs are clean.
+    """
+    package = coreason_manifest.spec
+    prefix = package.__name__ + "."
+
+    for importer, modname, ispkg in pkgutil.walk_packages(package.__path__, prefix):
+        # Import the module
+        try:
+            module = importlib.import_module(modname)
+        except ImportError as e:
+            # Skip if strict dependency is missing (should not happen in dev)
+            print(f"Skipping {modname} due to ImportError: {e}")
+            continue
+
+        # Check attributes
+        for name in dir(module):
+            # Skip internal attributes
+            if name.startswith("__"):
+                continue
+
+            attr = getattr(module, name)
+
+            # Check if it is a module
+            if hasattr(attr, "__name__") and isinstance(attr, type(sys)):
+                if attr.__name__.startswith("coreason_manifest.utils"):
+                    raise AssertionError(f"Module '{modname}' imports '{attr.__name__}'. Core Spec must not depend on Utils.")
+
+            # Check if it is an object (class, func) from a module
+            if hasattr(attr, "__module__") and attr.__module__:
+                 if attr.__module__.startswith("coreason_manifest.utils"):
+                    raise AssertionError(f"Module '{modname}' uses '{name}' from '{attr.__module__}'. Core Spec must not depend on Utils.")


### PR DESCRIPTION
Add strict architectural test to ensure `coreason_manifest.spec` (DTOs) never imports from `coreason_manifest.utils` (Logic).
Add ADR-001 documentation explaining the "Pure Data Kernel" vs "Optional Utils" strategy.
Update README.md to clarify the architectural separation.
Update `spec/governance.py` docstring to clarify its role as a DTO container.
This addresses concerns about the "Distributed Monolith" pattern without breaking changes.

---
*PR created automatically by Jules for task [12727122368959540808](https://jules.google.com/task/12727122368959540808) started by @gowthamrao*