### PR TITLE
Expose MCP adapter symbols via coreason_manifest.interop

### DIFF
--- a/src/coreason_manifest/interop/__init__.py
+++ b/src/coreason_manifest/interop/__init__.py
@@ -7,3 +7,7 @@
 # Commercial use beyond a 30-day trial requires a separate license.
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from .mcp import CoreasonMCPServer, create_mcp_tool_definition
+
+__all__ = ["CoreasonMCPServer", "create_mcp_tool_definition"]


### PR DESCRIPTION
Expose MCP adapter symbols via coreason_manifest.interop to fix missing exports issue.

---
*PR created automatically by Jules for task [976679484780823496](https://jules.google.com/task/976679484780823496) started by @gowthamrao*