### PR TITLE
feat: Add simple_agent shortcut for better DX

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,28 @@ pip install coreason-manifest
 
 ## Usage
 
-This library is used to define and validate Agent configurations programmatically.
+### Quick Start
+
+Create a fully compliant agent manifest in just a few lines of code:
+
+```python
+from coreason_manifest import simple_agent
+
+# Create a "Hello World" agent
+manifest = simple_agent(
+    name="HelloAgent",
+    prompt="You are a helpful assistant.",
+    model="gpt-4o",
+    inputs={"user_message": {"type": "string"}},
+    outputs={"reply": {"type": "string"}}
+)
+
+print(f"Agent '{manifest.metadata.name}' created successfully!")
+```
+
+### Advanced Usage (Manual Construction)
+
+For granular control, you can instantiate the strict Pydantic models directly:
 
 ```python
 from coreason_manifest import (

--- a/poetry.lock
+++ b/poetry.lock
@@ -345,12 +345,12 @@ version = "0.4.6"
 description = "Cross-platform colored terminal text."
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*,>=2.7"
-groups = ["main", "dev", "mcp"]
+groups = ["dev", "mcp"]
 files = [
     {file = "colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"},
     {file = "colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44"},
 ]
-markers = {main = "sys_platform == \"win32\"", mcp = "sys_platform != \"emscripten\" and platform_system == \"Windows\""}
+markers = {mcp = "sys_platform != \"emscripten\" and platform_system == \"Windows\""}
 
 [[package]]
 name = "coverage"
@@ -2142,4 +2142,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12, <3.15"
-content-hash = "69d74ef9fe45dbc19f39e90c45baddb1da471b7adde298adba3bb438010102fa"
+content-hash = "6b3e1a937a31e64dd0c5bc48864a8512fa7cd3fa736dc6cea7b6044e63f0979a"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -11,6 +11,7 @@
 # Builder SDK exports
 from .builder import AgentBuilder, TypedCapability
 from .interop.mcp import CoreasonMCPServer, create_mcp_tool_definition
+from .shortcuts import simple_agent
 from .spec.cap import (
     AgentRequest,
     ErrorSeverity,
@@ -199,6 +200,7 @@ __all__ = [
     "load",
     "migrate_graph_event_to_cloud_event",
     "render_agent_card",
+    "simple_agent",
     "validate_integrity",
     "validate_loose",
     "verify_chain",

--- a/src/coreason_manifest/shortcuts.py
+++ b/src/coreason_manifest/shortcuts.py
@@ -64,6 +64,6 @@ def simple_agent(
         if "type" in outputs and isinstance(outputs["type"], str):
             builder.interface_outputs = outputs
         else:
-            builder.interface_outputs["properties"] = outputs
+            builder.interface_outputs["properties"] = outputs  # pragma: no cover
 
     return builder.build()

--- a/src/coreason_manifest/shortcuts.py
+++ b/src/coreason_manifest/shortcuts.py
@@ -64,6 +64,6 @@ def simple_agent(
         if "type" in outputs and isinstance(outputs["type"], str):
             builder.interface_outputs = outputs
         else:
-            builder.interface_outputs["properties"] = outputs  # pragma: no cover
+            builder.interface_outputs["properties"] = outputs
 
     return builder.build()

--- a/src/coreason_manifest/shortcuts.py
+++ b/src/coreason_manifest/shortcuts.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any
+
+from coreason_manifest.builder import AgentBuilder
+from coreason_manifest.spec.v2.definitions import ManifestV2
+
+
+def simple_agent(
+    name: str,
+    prompt: str = "You are a helpful assistant.",
+    model: str | None = None,
+    tools: list[str] | None = None,
+    knowledge: list[str] | None = None,
+    inputs: dict[str, Any] | None = None,
+    outputs: dict[str, Any] | None = None,
+) -> ManifestV2:
+    """
+    Create a simple agent manifest in a single function call.
+
+    Args:
+        name: The name of the agent (and ID).
+        prompt: The system prompt/backstory.
+        model: The LLM model to use.
+        tools: List of tool IDs to enable.
+        knowledge: List of knowledge sources.
+        inputs: Dictionary defining input schema (optional).
+                Can be a full JSON Schema object or a simple properties map.
+        outputs: Dictionary defining output schema (optional).
+                 Can be a full JSON Schema object or a simple properties map.
+
+    Returns:
+        A complete ManifestV2 object ready for serialization.
+    """
+    builder = AgentBuilder(name=name)
+    builder.with_system_prompt(prompt)
+
+    if model:
+        builder.with_model(model)
+
+    if tools:
+        for tool in tools:
+            builder.with_tool(tool)
+
+    if knowledge:
+        for k in knowledge:
+            builder.with_knowledge(k)
+
+    if inputs:
+        if "type" in inputs and isinstance(inputs["type"], str):
+            builder.interface_inputs = inputs
+        else:
+            builder.interface_inputs["properties"] = inputs
+
+    if outputs:
+        if "type" in outputs and isinstance(outputs["type"], str):
+            builder.interface_outputs = outputs
+        else:
+            builder.interface_outputs["properties"] = outputs
+
+    return builder.build()

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,6 +1,6 @@
+import pytest
 from coreason_manifest import simple_agent
-from coreason_manifest.spec.v2.definitions import AgentDefinition, ManifestV2
-
+from coreason_manifest.spec.v2.definitions import ManifestV2, AgentDefinition
 
 def test_simple_agent_minimal() -> None:
     manifest = simple_agent(name="TestAgent")
@@ -10,8 +10,7 @@ def test_simple_agent_minimal() -> None:
     agent = manifest.definitions["TestAgent"]
     assert isinstance(agent, AgentDefinition)
     assert agent.id == "TestAgent"
-    assert agent.goal == "Help the user"  # default from AgentBuilder
-
+    assert agent.goal == "Help the user" # default from AgentBuilder
 
 def test_simple_agent_full_options() -> None:
     manifest = simple_agent(
@@ -40,13 +39,28 @@ def test_simple_agent_full_options() -> None:
     assert manifest.interface.outputs["type"] == "object"
     assert "report" in manifest.interface.outputs["properties"]
 
-
 def test_simple_agent_raw_schema() -> None:
     # Pass full schema with "type": "object"
-    schema = {"type": "object", "properties": {"foo": {"type": "integer"}}, "required": ["foo"]}
+    schema = {
+        "type": "object",
+        "properties": {"foo": {"type": "integer"}},
+        "required": ["foo"]
+    }
     manifest = simple_agent(name="SchemaAgent", inputs=schema)
 
     # Should use the schema directly
     assert manifest.interface.inputs == schema
     assert manifest.interface.inputs["type"] == "object"
     assert manifest.interface.inputs["required"] == ["foo"]
+
+def test_simple_agent_raw_output_schema() -> None:
+    # Pass full schema for outputs with "type": "object"
+    # This should hit the IF branch: if "type" in outputs...
+    schema = {
+        "type": "object",
+        "properties": {"bar": {"type": "string"}},
+    }
+    manifest = simple_agent(name="OutputSchemaAgent", outputs=schema)
+
+    assert manifest.interface.outputs == schema
+    assert manifest.interface.outputs["type"] == "object"

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,6 +1,6 @@
-import pytest
 from coreason_manifest import simple_agent
-from coreason_manifest.spec.v2.definitions import ManifestV2, AgentDefinition
+from coreason_manifest.spec.v2.definitions import AgentDefinition, ManifestV2
+
 
 def test_simple_agent_minimal() -> None:
     manifest = simple_agent(name="TestAgent")
@@ -10,7 +10,8 @@ def test_simple_agent_minimal() -> None:
     agent = manifest.definitions["TestAgent"]
     assert isinstance(agent, AgentDefinition)
     assert agent.id == "TestAgent"
-    assert agent.goal == "Help the user" # default from AgentBuilder
+    assert agent.goal == "Help the user"  # default from AgentBuilder
+
 
 def test_simple_agent_full_options() -> None:
     manifest = simple_agent(
@@ -39,19 +40,17 @@ def test_simple_agent_full_options() -> None:
     assert manifest.interface.outputs["type"] == "object"
     assert "report" in manifest.interface.outputs["properties"]
 
+
 def test_simple_agent_raw_schema() -> None:
     # Pass full schema with "type": "object"
-    schema = {
-        "type": "object",
-        "properties": {"foo": {"type": "integer"}},
-        "required": ["foo"]
-    }
+    schema = {"type": "object", "properties": {"foo": {"type": "integer"}}, "required": ["foo"]}
     manifest = simple_agent(name="SchemaAgent", inputs=schema)
 
     # Should use the schema directly
     assert manifest.interface.inputs == schema
     assert manifest.interface.inputs["type"] == "object"
     assert manifest.interface.inputs["required"] == ["foo"]
+
 
 def test_simple_agent_raw_output_schema() -> None:
     # Pass full schema for outputs with "type": "object"

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,8 +1,8 @@
-import pytest
 from coreason_manifest import simple_agent
-from coreason_manifest.spec.v2.definitions import ManifestV2, AgentDefinition
+from coreason_manifest.spec.v2.definitions import AgentDefinition, ManifestV2
 
-def test_simple_agent_minimal():
+
+def test_simple_agent_minimal() -> None:
     manifest = simple_agent(name="TestAgent")
     assert isinstance(manifest, ManifestV2)
     assert manifest.metadata.name == "TestAgent"
@@ -10,9 +10,10 @@ def test_simple_agent_minimal():
     agent = manifest.definitions["TestAgent"]
     assert isinstance(agent, AgentDefinition)
     assert agent.id == "TestAgent"
-    assert agent.goal == "Help the user" # default from AgentBuilder
+    assert agent.goal == "Help the user"  # default from AgentBuilder
 
-def test_simple_agent_full_options():
+
+def test_simple_agent_full_options() -> None:
     manifest = simple_agent(
         name="Researcher",
         prompt="You are a research assistant.",
@@ -24,6 +25,7 @@ def test_simple_agent_full_options():
     )
 
     agent = manifest.definitions["Researcher"]
+    assert isinstance(agent, AgentDefinition)
     assert agent.backstory == "You are a research assistant."
     assert agent.model == "gpt-4"
     assert agent.tools == ["search-tool"]
@@ -38,13 +40,10 @@ def test_simple_agent_full_options():
     assert manifest.interface.outputs["type"] == "object"
     assert "report" in manifest.interface.outputs["properties"]
 
-def test_simple_agent_raw_schema():
+
+def test_simple_agent_raw_schema() -> None:
     # Pass full schema with "type": "object"
-    schema = {
-        "type": "object",
-        "properties": {"foo": {"type": "integer"}},
-        "required": ["foo"]
-    }
+    schema = {"type": "object", "properties": {"foo": {"type": "integer"}}, "required": ["foo"]}
     manifest = simple_agent(name="SchemaAgent", inputs=schema)
 
     # Should use the schema directly

--- a/tests/test_shortcuts.py
+++ b/tests/test_shortcuts.py
@@ -1,0 +1,53 @@
+import pytest
+from coreason_manifest import simple_agent
+from coreason_manifest.spec.v2.definitions import ManifestV2, AgentDefinition
+
+def test_simple_agent_minimal():
+    manifest = simple_agent(name="TestAgent")
+    assert isinstance(manifest, ManifestV2)
+    assert manifest.metadata.name == "TestAgent"
+    assert "TestAgent" in manifest.definitions
+    agent = manifest.definitions["TestAgent"]
+    assert isinstance(agent, AgentDefinition)
+    assert agent.id == "TestAgent"
+    assert agent.goal == "Help the user" # default from AgentBuilder
+
+def test_simple_agent_full_options():
+    manifest = simple_agent(
+        name="Researcher",
+        prompt="You are a research assistant.",
+        model="gpt-4",
+        tools=["search-tool"],
+        knowledge=["docs/info.txt"],
+        inputs={"topic": {"type": "string"}},
+        outputs={"report": {"type": "string"}},
+    )
+
+    agent = manifest.definitions["Researcher"]
+    assert agent.backstory == "You are a research assistant."
+    assert agent.model == "gpt-4"
+    assert agent.tools == ["search-tool"]
+    assert agent.knowledge == ["docs/info.txt"]
+
+    # Check interface inputs - it should be wrapped in object/properties because we passed a dict without "type"
+    assert manifest.interface.inputs["type"] == "object"
+    assert "topic" in manifest.interface.inputs["properties"]
+    assert manifest.interface.inputs["properties"]["topic"]["type"] == "string"
+
+    # Check interface outputs
+    assert manifest.interface.outputs["type"] == "object"
+    assert "report" in manifest.interface.outputs["properties"]
+
+def test_simple_agent_raw_schema():
+    # Pass full schema with "type": "object"
+    schema = {
+        "type": "object",
+        "properties": {"foo": {"type": "integer"}},
+        "required": ["foo"]
+    }
+    manifest = simple_agent(name="SchemaAgent", inputs=schema)
+
+    # Should use the schema directly
+    assert manifest.interface.inputs == schema
+    assert manifest.interface.inputs["type"] == "object"
+    assert manifest.interface.inputs["required"] == ["foo"]


### PR DESCRIPTION
Addressed the reviewer concern about hostile DX by introducing a `simple_agent` shortcut function that allows defining a complete agent manifest in ~5 lines of code. This significantly reduces the boilerplate compared to the raw Pydantic model instantiation.

- `src/coreason_manifest/shortcuts.py`: New file containing the `simple_agent` function.
- `src/coreason_manifest/__init__.py`: Exported the new function.
- `tests/test_shortcuts.py`: Added tests covering various usage scenarios (minimal, full options, raw schema inputs).
- `README.md`: Updated to prioritize the "Quick Start" approach.


---
*PR created automatically by Jules for task [6740173679405670968](https://jules.google.com/task/6740173679405670968) started by @gowthamrao*