### PR TITLE
Audit and clean up test warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,7 @@ plugins = ["pydantic.mypy"]
 addopts = "--cov=src --cov-report=term-missing --cov-fail-under=100"
 testpaths = ["tests"]
 asyncio_mode = "auto"
+filterwarnings = ["ignore:Pydantic serializer warnings:UserWarning"]
 
 [tool.coverage.run]
 omit = ["tests/*", "/tmp/*"]


### PR DESCRIPTION
Performed a pre-release audit of the `coreason-manifest` package.

**Audit Findings:**
1.  **Codebase Integrity:** All tests pass with 100% coverage.
2.  **Configuration:** `pyproject.toml` uses a hybrid `[tool.poetry]` and `[project]` configuration. While this generates deprecation warnings in Poetry (due to duplicate metadata and custom license handling), strict migration to PEP 621 only was found to risk compatibility with older build tools or break the build due to custom license metadata. The current configuration is deemed the most robust compromise.
3.  **Documentation:** `README.md`, `AGENTS.md`, and `docs/` are complete and correct.
4.  **Licensing:** License headers and files are verified.

**Changes Applied:**
- Modified `pyproject.toml` to add `filterwarnings` to `[tool.pytest.ini_options]`. This suppresses `UserWarning: Pydantic serializer warnings` during tests, which are expected when testing invalid object states via `model_construct`.

This ensures a clean test run for CI/CD and developers.

---
*PR created automatically by Jules for task [17651381479627636945](https://jules.google.com/task/17651381479627636945) started by @gowthamrao*