### PR TITLE
feat: Add 'validate' command to CLI for static analysis

### DIFF
--- a/docs/cli_validation.md
+++ b/docs/cli_validation.md
@@ -1,0 +1,62 @@
+# CLI Validation Command
+
+The `validate` command is a static analysis tool included in the `coreason-manifest` CLI. It allows developers and CI/CD pipelines to verify that agent definition files conform to the strict Coreason Agent Manifest (CAM) schema without executing the agent.
+
+## Usage
+
+```bash
+coreason validate <file_path> [options]
+```
+
+### Arguments
+
+*   `file_path`: Path to the static definition file. Supported extensions are `.json`, `.yaml`, and `.yml`.
+
+### Options
+
+*   `--json`: If specified, the command will output the validated, normalized JSON structure of the agent to `stdout` upon success. This is useful for piping the valid definition to other tools.
+
+## Validation Logic
+
+The command employs an intelligent validation strategy:
+
+1.  **Format Detection:** It loads the file using the appropriate parser (`json` or `PyYAML`).
+2.  **Schema Detection:**
+    *   If the root object contains an `apiVersion` key, it validates against the full **`ManifestV2`** schema (including workflow, policy, etc.).
+    *   Otherwise, it attempts to validate against the standalone **`AgentDefinition`** schema.
+3.  **Strict Validation:** It uses Pydantic to enforce type safety, required fields, and constraints.
+
+## Output & Exit Codes
+
+### Success
+If validation succeeds, the command prints a success message to `stdout` and exits with code **0**.
+
+```text
+✅ Valid Agent: ResearchAssistant (v1.0.0)
+```
+
+If `--json` is used, the full JSON object follows.
+
+### Failure
+If validation fails, the command prints formatted error messages to `stdout` and exits with code **1**.
+
+```text
+❌ Validation Failed:
+  • workflow -> steps -> step-1: Input tag 'unknown_type' found using 'type' does not match any of the expected tags: 'agent', 'logic', 'council', 'switch'
+```
+
+### Errors
+For file not found, permission errors, or malformed JSON/YAML (parsing errors), the command prints an error message to `stderr` and exits with code **1**.
+
+## CI/CD Integration
+
+The `validate` command is designed for use in CI pipelines (e.g., GitHub Actions, GitLab CI).
+
+Example GitHub Action step:
+
+```yaml
+- name: Validate Agent Manifests
+  run: |
+    pip install coreason-manifest
+    coreason validate agent.yaml
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,6 +28,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[CLI & Interop Layer](cli_interop.md)**
     *   Documentation for the `coreason` CLI tool (`inspect`, `viz`, `run`) and dynamic loader utility.
 
+*   **[CLI Validation Command](cli_validation.md)**
+    *   Documentation for the `coreason validate` command for static analysis of manifest files.
+
 ## Specifications & Protocols
 
 *   **[Coreason Agent Manifest (CAM) Specification](cap/specification.md)**

--- a/src/coreason_manifest/cli.py
+++ b/src/coreason_manifest/cli.py
@@ -11,6 +11,9 @@
 import argparse
 import json
 import sys
+from pathlib import Path
+
+from pydantic import ValidationError
 
 from coreason_manifest.spec.v2.definitions import (
     AgentDefinition,
@@ -49,7 +52,16 @@ def main() -> None:
     # For 'run', it's redundant as we output NDJSON events, but we support it for compliance.
     run_parser.add_argument("--json", action="store_true", help="Output JSON events")
 
+    # Validate
+    validate_parser = subparsers.add_parser("validate", help="Validate a static agent definition file")
+    validate_parser.add_argument("file", help="Path to the .yaml or .json file")
+    validate_parser.add_argument("--json", action="store_true", help="Output JSON structure on success")
+
     args = parser.parse_args()
+
+    if args.command == "validate":
+        handle_validate(args)
+        return
 
     try:
         agent = load_agent_from_ref(args.ref)
@@ -77,6 +89,67 @@ def main() -> None:
             sys.exit(1)
 
         _run_simulation(agent, args.mock)
+
+
+def handle_validate(args: argparse.Namespace) -> None:
+    file_path = Path(args.file)
+    if not file_path.exists():
+        sys.stderr.write(f"Error: File not found: {file_path}\n")
+        sys.exit(1)
+
+    # Lazy import yaml
+    try:
+        import yaml
+    except ImportError:
+        sys.stderr.write("Error: PyYAML is required for validation. Please install it with 'pip install PyYAML'.\n")
+        sys.exit(1)
+
+    try:
+        with file_path.open("r", encoding="utf-8") as f:
+            if file_path.suffix.lower() == ".json":
+                data = json.load(f)
+            elif file_path.suffix.lower() in [".yaml", ".yml"]:
+                data = yaml.safe_load(f)
+            else:
+                sys.stderr.write(f"Error: Unsupported file extension: {file_path.suffix}\n")
+                sys.exit(1)
+
+        # Validation Logic
+        agent = None
+        is_manifest = False
+
+        if isinstance(data, dict) and "apiVersion" in data:
+            # It's likely a ManifestV2
+            agent = ManifestV2.model_validate(data)
+            is_manifest = True
+        else:
+            # Fallback to AgentDefinition
+            agent = AgentDefinition.model_validate(data)
+
+        # Success Output
+        name = getattr(agent, "name", "Unknown")
+        version = "?"
+        if is_manifest:
+            # agent is ManifestV2
+            # ManifestV2 has metadata which has name
+            name = agent.metadata.name  # type: ignore # Pydantic model
+            # Try to get version from metadata extra fields
+            if agent.metadata.model_extra and "version" in agent.metadata.model_extra:
+                version = str(agent.metadata.model_extra["version"])
+
+        print(f"✅ Valid Agent: {name} (v{version})")
+        if args.json:
+            print(agent.model_dump_json(indent=2, by_alias=True, exclude_none=True))
+
+    except ValidationError as e:
+        print("❌ Validation Failed:")
+        for err in e.errors():
+            loc = " -> ".join(str(l) for l in err['loc'])
+            print(f"  • {loc}: {err['msg']}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Error: {str(e)}")
+        sys.exit(1)
 
 
 def _run_simulation(agent: ManifestV2, mock: bool) -> None:

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1,0 +1,165 @@
+
+import json
+import sys
+import pytest
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from coreason_manifest.cli import main
+
+def test_validate_manifest_success(tmp_path, capsys):
+    manifest_content = """
+apiVersion: coreason.ai/v2
+kind: Recipe
+metadata:
+  name: "Test Agent"
+  x-design:
+    x: 0
+    y: 0
+workflow:
+  start: "step-1"
+  steps:
+    step-1:
+      type: "logic"
+      id: "step-1"
+      code: "print('Hello')"
+"""
+    f = tmp_path / "valid_manifest.yaml"
+    f.write_text(manifest_content)
+
+    with patch("sys.argv", ["coreason", "validate", str(f)]):
+        try:
+            main()
+        except SystemExit as e:
+            # Should exit with 0 (implicit return) or not exit
+            if e.code != 0:
+                raise
+
+    captured = capsys.readouterr()
+    assert "✅ Valid Agent: Test Agent (v?)" in captured.out
+
+def test_validate_manifest_with_version(tmp_path, capsys):
+    manifest_content = """
+apiVersion: coreason.ai/v2
+kind: Recipe
+metadata:
+  name: "Test Agent"
+  version: "1.0.0"
+  x-design:
+    x: 0
+    y: 0
+workflow:
+  start: "step-1"
+  steps:
+    step-1:
+      type: "logic"
+      id: "step-1"
+      code: "print('Hello')"
+"""
+    f = tmp_path / "valid_manifest_v1.yaml"
+    f.write_text(manifest_content)
+
+    with patch("sys.argv", ["coreason", "validate", str(f)]):
+        main()
+
+    captured = capsys.readouterr()
+    assert "✅ Valid Agent: Test Agent (v1.0.0)" in captured.out
+
+def test_validate_agent_definition_success(tmp_path, capsys):
+    agent_def = {
+        "type": "agent",
+        "id": "agent-1",
+        "name": "My Agent",
+        "role": "Assistant",
+        "goal": "Help user",
+        "backstory": "I am helpful",
+        "model": "gpt-4",
+        "tools": [],
+        "knowledge": [],
+        "interface": {},
+        "capabilities": {}
+    }
+    f = tmp_path / "valid_agent.json"
+    f.write_text(json.dumps(agent_def))
+
+    with patch("sys.argv", ["coreason", "validate", str(f)]):
+        main()
+
+    captured = capsys.readouterr()
+    assert "✅ Valid Agent: My Agent (v?)" in captured.out
+
+def test_validate_failure(tmp_path, capsys):
+    manifest_content = """
+apiVersion: coreason.ai/v2
+kind: Recipe
+metadata:
+  name: "Test Agent"
+  x-design:
+    x: 0
+    y: 0
+workflow:
+  start: "step-1"
+  steps:
+    step-1:
+      type: "unknown_type"
+      id: "step-1"
+"""
+    f = tmp_path / "invalid_manifest.yaml"
+    f.write_text(manifest_content)
+
+    with patch("sys.argv", ["coreason", "validate", str(f)]):
+        with pytest.raises(SystemExit) as e:
+            main()
+        assert e.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "❌ Validation Failed:" in captured.out
+    # Pydantic error message might vary slightly
+    assert "Input tag 'unknown_type' found using 'type' does not match any of the expected tags" in captured.out
+
+def test_file_not_found(capsys):
+    with patch("sys.argv", ["coreason", "validate", "non_existent.yaml"]):
+        with pytest.raises(SystemExit) as e:
+            main()
+        assert e.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "Error: File not found" in captured.err
+
+def test_invalid_extension(tmp_path, capsys):
+    f = tmp_path / "test.txt"
+    f.write_text("content")
+
+    with patch("sys.argv", ["coreason", "validate", str(f)]):
+        with pytest.raises(SystemExit) as e:
+            main()
+        assert e.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "Error: Unsupported file extension: .txt" in captured.err
+
+def test_missing_pyyaml(tmp_path, capsys):
+    f = tmp_path / "test.yaml"
+    f.touch()
+
+    # Mock import failure
+    import builtins
+    original_import = builtins.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if name == "yaml":
+            raise ImportError("No module named 'yaml'")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        # We also need to patch sys.modules to remove yaml if it's already there
+        with patch.dict("sys.modules"):
+            if "yaml" in sys.modules:
+                del sys.modules["yaml"]
+
+            with patch("sys.argv", ["coreason", "validate", str(f)]):
+                with pytest.raises(SystemExit) as e:
+                    main()
+                assert e.value.code == 1
+
+    captured = capsys.readouterr()
+    assert "Error: PyYAML is required" in captured.err

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1,4 +1,3 @@
-
 import json
 import sys
 from pathlib import Path
@@ -6,7 +5,9 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+
 from coreason_manifest.cli import main
+
 
 def test_validate_manifest_success(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     manifest_content = """
@@ -39,6 +40,7 @@ workflow:
     captured = capsys.readouterr()
     assert "✅ Valid Agent: Test Agent (v?)" in captured.out
 
+
 def test_validate_manifest_with_version(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     manifest_content = """
 apiVersion: coreason.ai/v2
@@ -66,6 +68,7 @@ workflow:
     captured = capsys.readouterr()
     assert "✅ Valid Agent: Test Agent (v1.0.0)" in captured.out
 
+
 def test_validate_agent_definition_success(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     agent_def = {
         "type": "agent",
@@ -78,7 +81,7 @@ def test_validate_agent_definition_success(tmp_path: Path, capsys: pytest.Captur
         "tools": [],
         "knowledge": [],
         "interface": {},
-        "capabilities": {}
+        "capabilities": {},
     }
     f = tmp_path / "valid_agent.json"
     f.write_text(json.dumps(agent_def))
@@ -88,6 +91,7 @@ def test_validate_agent_definition_success(tmp_path: Path, capsys: pytest.Captur
 
     captured = capsys.readouterr()
     assert "✅ Valid Agent: My Agent (v?)" in captured.out
+
 
 def test_validate_failure(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     manifest_content = """
@@ -118,6 +122,7 @@ workflow:
     # Pydantic error message might vary slightly
     assert "Input tag 'unknown_type' found using 'type' does not match any of the expected tags" in captured.out
 
+
 def test_file_not_found(capsys: pytest.CaptureFixture[str]) -> None:
     with patch("sys.argv", ["coreason", "validate", "non_existent.yaml"]), pytest.raises(SystemExit) as e:
         main()
@@ -125,6 +130,7 @@ def test_file_not_found(capsys: pytest.CaptureFixture[str]) -> None:
 
     captured = capsys.readouterr()
     assert "Error: File not found" in captured.err
+
 
 def test_invalid_extension(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     f = tmp_path / "test.txt"
@@ -138,12 +144,14 @@ def test_invalid_extension(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -
     captured = capsys.readouterr()
     assert "Error: Unsupported file extension: .txt" in captured.err
 
+
 def test_missing_pyyaml(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     f = tmp_path / "test.yaml"
     f.touch()
 
     # Mock import failure
     import builtins
+
     original_import = builtins.__import__
 
     def mock_import(name: str, *args: Any, **kwargs: Any) -> Any:


### PR DESCRIPTION
Implemented a new 'validate' subcommand in the coreason CLI to verify static agent definition files (.json, .yaml) against the ManifestV2 or AgentDefinition schema. This command uses Pydantic validation and lazy-loads PyYAML.

---
*PR created automatically by Jules for task [6194937299477920131](https://jules.google.com/task/6194937299477920131) started by @gowthamrao*