### PR TITLE
Implement CLI `validate` Command

### DIFF
--- a/src/coreason_manifest/cli.py
+++ b/src/coreason_manifest/cli.py
@@ -211,7 +211,7 @@ def handle_validate(args: argparse.Namespace) -> None:
     except ValidationError as e:
         print("❌ Validation Failed:")
         for err in e.errors():
-            loc = " -> ".join(str(l) for l in err["loc"])
+            loc = " -> ".join(str(part) for part in err["loc"])
             msg = err["msg"]
             print(f"  • {loc}: {msg}")
         sys.exit(1)

--- a/src/coreason_manifest/cli.py
+++ b/src/coreason_manifest/cli.py
@@ -14,6 +14,9 @@ import sys
 import textwrap
 from pathlib import Path
 
+import yaml
+from pydantic import ValidationError
+
 from coreason_manifest.spec.v2.definitions import (
     AgentDefinition,
     AgentStep,
@@ -176,6 +179,44 @@ def handle_init(args: argparse.Namespace) -> None:
     print("   3. Open 'agent.py' and press F5 to run!")
 
 
+def handle_validate(args: argparse.Namespace) -> None:
+    file_path = Path(args.file)
+    if not file_path.exists():
+        print(f"❌ Error: File '{args.file}' not found.")
+        sys.exit(1)
+
+    try:
+        content = file_path.read_text(encoding="utf-8")
+        if file_path.suffix.lower() in [".yaml", ".yml"]:
+            data = yaml.safe_load(content)
+        elif file_path.suffix.lower() == ".json":
+            data = json.loads(content)
+        else:
+            print(f"❌ Error: Unsupported file extension '{file_path.suffix}'. Use .json, .yaml, or .yml.")
+            sys.exit(1)
+    except (json.JSONDecodeError, yaml.YAMLError) as e:
+        print(f"❌ Error: Malformed file: {e}")
+        sys.exit(1)
+    except Exception as e:
+        print(f"❌ Error reading file: {e}")
+        sys.exit(1)
+
+    try:
+        agent = AgentDefinition.model_validate(data)
+        if args.json:
+            print(json.dumps({"status": "valid", "name": agent.name}))
+        else:
+            print(f"✅ Valid Agent: {agent.name}")
+        sys.exit(0)
+    except ValidationError as e:
+        print("❌ Validation Failed:")
+        for err in e.errors():
+            loc = " -> ".join(str(l) for l in err["loc"])
+            msg = err["msg"]
+            print(f"  • {loc}: {msg}")
+        sys.exit(1)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(prog="coreason", description="CoReason Manifest CLI")
     subparsers = parser.add_subparsers(dest="command", required=True)
@@ -204,11 +245,19 @@ def main() -> None:
     init_parser = subparsers.add_parser("init", help="Initialize a new CoReason agent project")
     init_parser.add_argument("name", help="Name of the agent/directory (e.g., my_first_agent)")
 
+    # Validate
+    validate_parser = subparsers.add_parser("validate", help="Validate a static agent definition file")
+    validate_parser.add_argument("file", help="Path to the .yaml or .json file")
+    validate_parser.add_argument("--json", action="store_true", help="Output validation result as JSON")
+
     args = parser.parse_args()
 
     if args.command == "init":
         handle_init(args)
-        # handle_init calls sys.exit(0) so we don't need return here, but for safety:
+        return
+
+    if args.command == "validate":
+        handle_validate(args)
         return
 
     try:

--- a/src/coreason_manifest/cli.py
+++ b/src/coreason_manifest/cli.py
@@ -207,7 +207,6 @@ def handle_validate(args: argparse.Namespace) -> None:
             print(json.dumps({"status": "valid", "name": agent.name}))
         else:
             print(f"✅ Valid Agent: {agent.name}")
-        sys.exit(0)
     except ValidationError as e:
         print("❌ Validation Failed:")
         for err in e.errors():

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -116,11 +116,13 @@ def test_validate_read_error(tmp_path: Path, capsys: pytest.CaptureFixture[str])
     agent_file = tmp_path / "read_error.json"
     agent_file.write_text("{}")
 
-    with patch.object(sys, "argv", ["coreason", "validate", str(agent_file)]):
-        with patch("pathlib.Path.read_text", side_effect=PermissionError("Boom")):
-            with pytest.raises(SystemExit) as exc:
-                main()
-            assert exc.value.code == 1
+    with (
+        patch.object(sys, "argv", ["coreason", "validate", str(agent_file)]),
+        patch("pathlib.Path.read_text", side_effect=PermissionError("Boom")),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
 
     captured = capsys.readouterr()
     assert "❌ Error reading file: Boom" in captured.out


### PR DESCRIPTION
Implemented the `validate` CLI command to allow static validation of agent definition files against the `AgentDefinition` schema. Supports JSON and YAML formats and provides detailed error reporting.

---
*PR created automatically by Jules for task [17810275595776244943](https://jules.google.com/task/17810275595776244943) started by @gowthamrao*