### PR TITLE
feat: Implement Transport Layer AgentRequest Envelope

### DIFF
--- a/docs/architecture/transport_layer.md
+++ b/docs/architecture/transport_layer.md
@@ -1,0 +1,77 @@
+# Transport Layer: The AgentRequest Envelope
+
+The **Transport Layer** in the CoReason ecosystem ensures that all interactions between agents, nodes, and services are encapsulated in a standardized, immutable envelope called `AgentRequest`.
+
+This envelope is responsible for:
+1.  **Distributed Tracing**: enforcing strict lineage (Root -> Parent -> Child).
+2.  **Context Propagation**: carrying session IDs and metadata across boundaries.
+3.  **Immutability**: preventing modification of requests once they enter the graph.
+
+## The AgentRequest Model
+
+The `AgentRequest` model is the fundamental unit of work. It is defined in `coreason_manifest.spec.common.request`.
+
+```python
+class AgentRequest(CoReasonBaseModel):
+    request_id: UUID          # Unique ID for this specific operation
+    session_id: UUID          # Mandatory user session ID
+    root_request_id: UUID     # The start of the trace
+    parent_request_id: UUID?  # The immediate caller (optional)
+    payload: Dict[str, Any]   # The actual business logic arguments
+    metadata: Dict[str, Any]  # Context (e.g., auth, locale)
+    created_at: datetime      # Timestamp
+```
+
+### Trace Lineage Rules
+
+To maintain a coherent distributed trace, the Transport Layer enforces the following rules at runtime:
+
+1.  **Auto-Rooting**: If a request is created without a `root_request_id`, it is considered a new trace. The `root_request_id` is automatically set to the `request_id`.
+2.  **Broken Trace Prevention**: You cannot specify a `parent_request_id` without also specifying a `root_request_id`. This prevents "orphaned" branches that cannot be traced back to their origin.
+    *   *Violation*: `ValueError("Broken Trace: parent_request_id provided without root_request_id.")`
+3.  **Immutability**: Fields cannot be modified after instantiation. To modify a request (e.g., to add middleware headers), you must create a new instance (copy-on-write).
+
+### Usage Pattern
+
+#### Starting a New Trace
+When a request enters the system (e.g., from an API Gateway), a new trace is started.
+
+```python
+# A new user request
+req = AgentRequest(
+    session_id=user_session_id,
+    payload={"query": "Hello world"}
+)
+# req.root_request_id == req.request_id
+```
+
+#### Propagating Context (Child Requests)
+When an agent calls another agent or tool, it must create a **child request**. This preserves the `root_request_id` and links the new request to the current one.
+
+```python
+# Inside an agent, calling a sub-agent
+child_req = current_req.create_child(
+    payload={"task": "analyze_data"},
+    metadata={"priority": "high"}
+)
+# child_req.root_request_id == current_req.root_request_id
+# child_req.parent_request_id == current_req.request_id
+```
+
+## JSON Serialization
+
+The envelope serializes to a standard JSON structure, ensuring interoperability across languages and transport mechanisms (HTTP, Queues).
+
+```json
+{
+  "request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "session_id": "7136511c-2c93-4556-9609-f643f3287611",
+  "root_request_id": "550e8400-e29b-41d4-a716-446655440000",
+  "parent_request_id": null,
+  "payload": {
+    "query": "Hello world"
+  },
+  "metadata": {},
+  "created_at": "2023-10-27T10:00:00Z"
+}
+```

--- a/docs/cap/wire_protocol.md
+++ b/docs/cap/wire_protocol.md
@@ -29,9 +29,16 @@ The standard envelope for sending instructions to an Agent.
     }
   },
   "payload": {
-    "query": "What is the status of the project?",
-    "files": [],
-    "conversation_id": "conv_123"
+    "request_id": "550e8400-e29b-41d4-a716-446655440000",
+    "session_id": "sess_abc",
+    "root_request_id": "550e8400-e29b-41d4-a716-446655440000",
+    "parent_request_id": null,
+    "payload": {
+        "query": "What is the status of the project?"
+    },
+    "metadata": {
+        "user_locale": "en-US"
+    }
   }
 }
 ```
@@ -48,14 +55,16 @@ Strict context containing authentication and session details.
 
 ### AgentRequest
 
-The strict payload schema used within `ServiceRequest`.
+The strict transport envelope used for all interactions.
 
 | Field | Type | Description |
 | :--- | :--- | :--- |
-| `query` | `str` | The user's primary input/instruction. |
-| `files` | `List[str]` | List of file URIs or references (default: `[]`). |
-| `conversation_id` | `Optional[str]` | ID for continuing a session (default: `None`). |
-| `meta` | `Dict[str, Any]` | Extra context like timezone (default: `{}`). |
+| `request_id` | `UUID` | Unique operation ID. |
+| `session_id` | `UUID` | Mandatory session ID. |
+| `root_request_id` | `UUID` | Start of the trace (auto-filled). |
+| `parent_request_id` | `UUID?` | Immediate caller (optional). |
+| `payload` | `Dict[str, Any]` | The actual business logic arguments. |
+| `metadata` | `Dict[str, Any]` | Extra context like locale, auth scope (default: `{}`). |
 
 ### ServiceResponse
 

--- a/docs/middleware_extension_interfaces.md
+++ b/docs/middleware_extension_interfaces.md
@@ -69,10 +69,19 @@ class PIIRedactor:
         request: AgentRequest
     ) -> AgentRequest:
         # Simple example: Redact generic credit card numbers in query
-        if "4000-1234" in request.query:
+        query = request.payload.get("query", "")
+        if "4000-1234" in query:
             # Create a modified copy (AgentRequest is immutable)
-            return request.model_copy(
-                update={"query": request.query.replace("4000-1234", "XXXX-XXXX")}
+            new_payload = request.payload.copy()
+            new_payload["query"] = query.replace("4000-1234", "XXXX-XXXX")
+
+            # Since AgentRequest is frozen, we use helper or constructor
+            return AgentRequest(
+                session_id=request.session_id,
+                root_request_id=request.root_request_id,
+                parent_request_id=request.parent_request_id,
+                payload=new_payload,
+                metadata=request.metadata
             )
         return request
 ```

--- a/docs/request_lineage_implementation.md
+++ b/docs/request_lineage_implementation.md
@@ -27,8 +27,10 @@ The primary payload for agent services.
 ```python
 class AgentRequest(CoReasonBaseModel):
     request_id: UUID = Field(default_factory=uuid4)
+    session_id: UUID  # Mandatory
     root_request_id: Optional[UUID] = None  # Auto-filled if None
     parent_request_id: Optional[UUID] = None
+    payload: Dict[str, Any]
     ...
 ```
 

--- a/docs/session_management.md
+++ b/docs/session_management.md
@@ -48,12 +48,12 @@ save_session(new_state)
 ## Integration
 
 ### Agent Request
-The `AgentRequest` envelope includes an optional `session_id` field to correlate stateless requests with their persistent session context.
+The `AgentRequest` envelope includes a mandatory `session_id` field to correlate stateless requests with their persistent session context.
 
 ```python
 class AgentRequest(CoReasonBaseModel):
-    query: str
-    session_id: str | None = None
+    session_id: UUID
+    payload: Dict[str, Any]
     # ...
 ```
 

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -13,7 +13,6 @@ from .builder import AgentBuilder, TypedCapability
 from .interop.mcp import CoreasonMCPServer, create_mcp_tool_definition
 from .shortcuts import simple_agent
 from .spec.cap import (
-    AgentRequest,
     ErrorSeverity,
     HealthCheckResponse,
     HealthCheckStatus,
@@ -48,6 +47,7 @@ from .spec.common.observability import (
     EventContentType,
     ReasoningTrace,
 )
+from .spec.common.request import AgentRequest
 from .spec.common.presentation import (
     CitationBlock,
     CitationItem,

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -16,6 +16,7 @@ from uuid import UUID, uuid4
 from pydantic import ConfigDict, Field, model_validator
 
 from coreason_manifest.spec.common.identity import Identity
+from coreason_manifest.spec.common.request import AgentRequest
 from coreason_manifest.spec.common_base import CoReasonBaseModel
 
 
@@ -93,41 +94,6 @@ class ServiceResponse(CoReasonBaseModel):
     created_at: datetime
     output: dict[str, Any]
     metrics: dict[str, Any] | None = None
-
-
-class AgentRequest(CoReasonBaseModel):
-    """Strictly typed payload inside a ServiceRequest."""
-
-    model_config = ConfigDict(frozen=True)
-
-    request_id: UUID = Field(default_factory=uuid4)
-    root_request_id: UUID | None = Field(
-        default=None, description="The ID of the original user request. Must always be present."
-    )
-    parent_request_id: UUID | None = Field(default=None, description="The ID of the immediate caller.")
-
-    query: str
-    files: list[str] = Field(default_factory=list)
-    conversation_id: str | None = None
-    session_id: str | None = None
-    meta: dict[str, Any] = Field(default_factory=dict)
-
-    @model_validator(mode="before")
-    @classmethod
-    def enforce_lineage(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            # Ensure request_id is present (needed for auto-rooting)
-            if "request_id" not in data:
-                data["request_id"] = uuid4()
-
-            # Check for Broken Chain FIRST
-            if data.get("parent_request_id") is not None and data.get("root_request_id") is None:
-                raise ValueError("Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present.")
-
-            # Auto-rooting (Only if no parent)
-            if data.get("root_request_id") is None:
-                data["root_request_id"] = data["request_id"]
-        return data
 
 
 class SessionContext(CoReasonBaseModel):

--- a/src/coreason_manifest/spec/common/request.py
+++ b/src/coreason_manifest/spec/common/request.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import ConfigDict, Field, model_validator
+
+from coreason_manifest.spec.common_base import CoReasonBaseModel
+
+
+class AgentRequest(CoReasonBaseModel):
+    """Transport Envelope for all communication within the CoReason ecosystem.
+
+    Ensures strict validation of trace lineage and context propagation.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    request_id: UUID = Field(default_factory=uuid4)
+    session_id: UUID
+    root_request_id: UUID | None = None
+    parent_request_id: UUID | None = None
+    payload: dict[str, Any]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_lineage(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            # 1. Ensure request_id is present (needed for auto-rooting reference)
+            if "request_id" not in data or data["request_id"] is None:
+                data["request_id"] = uuid4()
+
+            req_id = data["request_id"]
+            parent_id = data.get("parent_request_id")
+            root_id = data.get("root_request_id")
+
+            # 2. Lineage Enforcement
+            if parent_id is not None and root_id is None:
+                raise ValueError("Broken Trace: parent_request_id provided without root_request_id.")
+
+            # 3. Auto-Rooting
+            if root_id is None:
+                data["root_request_id"] = req_id
+
+        return data
+
+    def create_child(self, payload: dict[str, Any], **kwargs: Any) -> "AgentRequest":
+        """Create a child request that preserves trace context."""
+        return AgentRequest(
+            session_id=self.session_id,
+            root_request_id=self.root_request_id,
+            parent_request_id=self.request_id,
+            payload=payload,
+            **kwargs
+        )

--- a/tests/test_lineage_security.py
+++ b/tests/test_lineage_security.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import pytest
+from uuid import uuid4
 from pydantic import ValidationError
 
 from coreason_manifest.spec.cap import AgentRequest
@@ -22,7 +23,7 @@ def test_uuid_field_dos_protection() -> None:
 
     with pytest.raises(ValidationError) as excinfo:
         # Pydantic should fail fast on length or format for UUID coercion
-        AgentRequest(query="test", request_id=massive_string)
+        AgentRequest(payload={"query": "test"}, request_id=massive_string, session_id=uuid4())
 
     # Ensure it's a value error related to UUID parsing
     assert "uuid" in str(excinfo.value).lower() or "input" in str(excinfo.value).lower()

--- a/tests/test_middleware_interface.py
+++ b/tests/test_middleware_interface.py
@@ -43,10 +43,12 @@ class PIIRedactionInterceptor:
         _context: InterceptorContext,
         request: AgentRequest,
     ) -> AgentRequest:
-        if "secret" in request.query:
-            new_query = request.query.replace("secret", "******")
+        query = request.payload.get("query", "")
+        if "secret" in query:
+            new_payload = request.payload.copy()
+            new_payload["query"] = query.replace("secret", "******")
             # Create new request as AgentRequest is frozen
-            return request.model_copy(update={"query": new_query})
+            return request.model_copy(update={"payload": new_payload})
         return request
 
 
@@ -55,11 +57,11 @@ async def test_pii_redaction_interceptor() -> None:
     """Test modification of request data."""
     interceptor = PIIRedactionInterceptor()
     context = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC), metadata={})
-    request = AgentRequest(query="This is a secret message.")
+    request = AgentRequest(payload={"query": "This is a secret message."}, session_id=uuid4())
 
     processed_request = await interceptor.intercept_request(context, request)
 
-    assert processed_request.query == "This is a ****** message."
+    assert processed_request.payload["query"] == "This is a ****** message."
     assert processed_request.request_id == request.request_id
 
 
@@ -80,7 +82,7 @@ class PolicyInterceptor:
 async def test_policy_rejection_interceptor() -> None:
     """Test blocking of requests."""
     interceptor = PolicyInterceptor()
-    request = AgentRequest(query="Hello")
+    request = AgentRequest(payload={"query": "Hello"}, session_id=uuid4())
 
     # Allowed
     context_allowed = InterceptorContext(request_id=uuid4(), start_time=datetime.now(UTC), metadata={"block": False})

--- a/tests/test_service_contract.py
+++ b/tests/test_service_contract.py
@@ -1,16 +1,18 @@
 import pytest
+from uuid import uuid4
 from pydantic import ValidationError
 
 from coreason_manifest import AgentRequest, ServiceContract
 
 
 def test_agent_request_serialization() -> None:
-    req = AgentRequest(query="Hello", conversation_id="123")
+    session_id = uuid4()
+    req = AgentRequest(payload={"query": "Hello", "conversation_id": "123"}, session_id=session_id)
     dump = req.dump()
-    assert dump["query"] == "Hello"
-    assert dump["conversation_id"] == "123"
-    assert dump["files"] == []
-    assert dump["meta"] == {}
+    assert dump["payload"]["query"] == "Hello"
+    assert dump["payload"]["conversation_id"] == "123"
+    assert dump["session_id"] == str(session_id)
+    assert dump["metadata"] == {}
 
 
 def test_service_contract_generation() -> None:
@@ -38,27 +40,24 @@ def test_service_contract_generation() -> None:
 
 def test_agent_request_defaults() -> None:
     """Test that default values are correctly populated."""
-    req = AgentRequest(query="Just checking")
-    assert req.files == []
-    assert req.conversation_id is None
-    assert req.meta == {}
+    req = AgentRequest(payload={"query": "Just checking"}, session_id=uuid4())
+    assert req.metadata == {}
+    # Payload is stored as is
+    assert req.payload == {"query": "Just checking"}
 
     dump = req.dump()
-    assert dump["files"] == []
-    # None fields are excluded by CoReasonBaseModel.dump(exclude_none=True)
-    assert "conversation_id" not in dump
-    assert dump["meta"] == {}
+    assert dump["metadata"] == {}
 
 
 def test_agent_request_immutability() -> None:
     """Test that AgentRequest is frozen/immutable."""
-    req = AgentRequest(query="Immutable?")
+    req = AgentRequest(payload={"query": "Immutable?"}, session_id=uuid4())
     with pytest.raises(ValidationError):
         # Mypy will complain about assignment to frozen field, so we use setattr
         # or just suppress the static error if running mypy, but here we run pytest.
         # But python sees it as attribute error if using slots, or validation error if pydantic.
         # Pydantic v2 raises ValidationError.
-        req.query = "Changed"  # type: ignore
+        req.payload = {"query": "Changed"}  # type: ignore
 
 
 def test_agent_request_complex_meta() -> None:
@@ -68,19 +67,19 @@ def test_agent_request_complex_meta() -> None:
         "history": [1, 2, 3],
         "flags": {"experimental": True},
     }
-    req = AgentRequest(query="Complex", meta=meta)
+    req = AgentRequest(payload={"query": "Complex"}, metadata=meta, session_id=uuid4())
     dump = req.dump()
-    assert dump["meta"]["user_info"]["timezone"] == "UTC"
-    assert dump["meta"]["history"] == [1, 2, 3]
+    assert dump["metadata"]["user_info"]["timezone"] == "UTC"
+    assert dump["metadata"]["history"] == [1, 2, 3]
 
 
 def test_agent_request_with_files() -> None:
     """Test AgentRequest with files list."""
     files = ["s3://bucket/file1.txt", "http://example.com/image.png"]
-    req = AgentRequest(query="Analyze this", files=files)
+    req = AgentRequest(payload={"query": "Analyze this", "files": files}, session_id=uuid4())
     dump = req.dump()
-    assert len(dump["files"]) == 2
-    assert dump["files"][0] == "s3://bucket/file1.txt"
+    assert len(dump["payload"]["files"]) == 2
+    assert dump["payload"]["files"][0] == "s3://bucket/file1.txt"
 
 
 def test_service_contract_schema_details() -> None:

--- a/tests/test_transport_request.py
+++ b/tests/test_transport_request.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+import json
+from uuid import uuid4, UUID
+from datetime import datetime
+from pydantic import ValidationError
+from coreason_manifest.spec.common.request import AgentRequest
+
+# --- Standard Cases ---
+
+def test_new_trace_auto_rooting() -> None:
+    session_id = uuid4()
+    payload = {"query": "foo"}
+    req = AgentRequest(session_id=session_id, payload=payload)
+
+    assert isinstance(req.request_id, UUID)
+    assert req.root_request_id == req.request_id
+    assert req.parent_request_id is None
+    assert req.session_id == session_id
+    assert req.payload == payload
+    assert isinstance(req.created_at, datetime)
+
+def test_trace_continuity_child_creation() -> None:
+    root = AgentRequest(session_id=uuid4(), payload={"step": "root"})
+    child = root.create_child({"step": "child"})
+
+    assert child.root_request_id == root.root_request_id
+    assert child.parent_request_id == root.request_id
+    assert child.session_id == root.session_id
+    assert child.payload == {"step": "child"}
+    assert child.request_id != root.request_id
+    assert isinstance(child.request_id, UUID)
+
+def test_broken_trace_validation() -> None:
+    parent_id = uuid4()
+    session_id = uuid4()
+
+    with pytest.raises(ValueError, match="Broken Trace"):
+        AgentRequest(
+            session_id=session_id,
+            payload={},
+            parent_request_id=parent_id
+            # Missing root_request_id
+        )
+
+def test_valid_trace_explicit_root() -> None:
+    root_id = uuid4()
+    parent_id = uuid4()
+    session_id = uuid4()
+
+    req = AgentRequest(
+        session_id=session_id,
+        payload={},
+        root_request_id=root_id,
+        parent_request_id=parent_id
+    )
+
+    assert req.root_request_id == root_id
+    assert req.parent_request_id == parent_id
+
+def test_immutability() -> None:
+    req = AgentRequest(session_id=uuid4(), payload={"a": 1})
+
+    # Pydantic v2 frozen model raises ValidationError on assignment
+    with pytest.raises(ValidationError):
+        req.payload = {"b": 2} # type: ignore
+
+def test_serialization() -> None:
+    session_id = uuid4()
+    req = AgentRequest(session_id=session_id, payload={"key": "val"})
+
+    json_str = req.model_dump_json()
+    assert str(session_id) in json_str
+    assert "key" in json_str
+    assert "val" in json_str
+    assert str(req.request_id) in json_str
+
+# --- Edge Cases ---
+
+def test_missing_session_id() -> None:
+    """Edge Case: session_id is mandatory."""
+    with pytest.raises(ValidationError) as excinfo:
+        AgentRequest(payload={"foo": "bar"}) # type: ignore
+    assert "session_id" in str(excinfo.value)
+
+def test_invalid_uuid_strings() -> None:
+    """Edge Case: Invalid UUID strings should fail validation."""
+    with pytest.raises(ValidationError):
+        AgentRequest(
+            session_id="not-a-uuid", # type: ignore
+            payload={}
+        )
+
+def test_root_provided_without_parent() -> None:
+    """Edge Case: Explicit root provided, but no parent.
+    This represents a valid state (e.g., a detached task linked to a root trace).
+    """
+    root_id = uuid4()
+    session_id = uuid4()
+    req = AgentRequest(
+        session_id=session_id,
+        payload={},
+        root_request_id=root_id,
+        parent_request_id=None
+    )
+
+    assert req.root_request_id == root_id
+    assert req.parent_request_id is None
+    # request_id should be auto-generated
+    assert isinstance(req.request_id, UUID)
+    assert req.request_id != root_id
+
+def test_metadata_default() -> None:
+    """Edge Case: Metadata defaults to empty dict."""
+    req = AgentRequest(session_id=uuid4(), payload={})
+    assert req.metadata == {}
+
+# --- Complex Cases ---
+
+def test_deep_lineage_chain() -> None:
+    """Complex Case: verify lineage over 5 generations."""
+    root = AgentRequest(session_id=uuid4(), payload={"gen": 0})
+
+    current = root
+    chain = [root]
+
+    for i in range(1, 5):
+        current = current.create_child({"gen": i})
+        chain.append(current)
+
+    assert len(chain) == 5
+
+    # Verify strict lineage
+    for i in range(1, 5):
+        child = chain[i]
+        parent = chain[i-1]
+
+        assert child.root_request_id == root.request_id
+        assert child.parent_request_id == parent.request_id
+        assert child.session_id == root.session_id
+        assert child.payload["gen"] == i
+
+def test_round_trip_serialization() -> None:
+    """Complex Case: Full serialization and deserialization."""
+    original = AgentRequest(
+        session_id=uuid4(),
+        payload={"complex": {"nested": [1, 2, 3]}},
+        metadata={"source": "test"}
+    )
+
+    # 1. Dump to JSON string
+    json_str = original.model_dump_json()
+
+    # 2. Parse back to dict
+    data = json.loads(json_str)
+
+    # 3. Reconstruct object
+    reconstructed = AgentRequest(**data)
+
+    assert reconstructed.request_id == original.request_id
+    assert reconstructed.session_id == original.session_id
+    assert reconstructed.root_request_id == original.root_request_id
+    assert reconstructed.payload == original.payload
+    assert reconstructed.metadata == original.metadata
+    assert reconstructed.created_at == original.created_at
+
+def test_child_creation_overrides() -> None:
+    """Complex Case: create_child with metadata overrides."""
+    root = AgentRequest(session_id=uuid4(), payload={}, metadata={"a": 1})
+    child = root.create_child({"p": 2}, metadata={"b": 2})
+
+    assert child.metadata == {"b": 2} # Completely replaces, does not merge
+    assert child.session_id == root.session_id


### PR DESCRIPTION
Implemented Work Package GG: The Transport Layer. This introduces a standardized `AgentRequest` envelope for all agent interactions, enforcing strict distributed tracing rules (Auto-Rooting, Broken Trace Prevention) and context propagation (Session ID).

Key changes:
- **New Model:** `AgentRequest` in `src/coreason_manifest/spec/common/request.py`.
- **Breaking Change:** `AgentRequest` now requires `session_id` (UUID) and encapsulates arguments in `payload` (Dict). `query` field is moved to `payload['query']`.
- **Refactoring:** Updated `spec/cap.py` and all dependent tests to align with the new schema.
- **Documentation:** Added `docs/architecture/transport_layer.md` and updated existing protocol docs.

---
*PR created automatically by Jules for task [4852396728695010761](https://jules.google.com/task/4852396728695010761) started by @gowthamrao*