### PR TITLE
feat: Implement validate CLI command for static agent validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ Core definitions (e.g., `Manifest`, `Workflow`, `AgentDefinition`) inherit from 
 pip install coreason-manifest
 ```
 
+## CLI
+
+The `coreason` CLI is your primary tool for managing agent manifests.
+
+*   `init`: Scaffold a new project.
+*   `run`: Simulate execution locally.
+*   `viz`: Visualize workflow topology.
+*   `validate`: Statically validate JSON/YAML files against the schema.
+*   `inspect`: View full canonical JSON.
+*   `hash`: Compute integrity hashes.
+
+See [CLI Documentation](docs/cli.md) for full details.
+
 ## Usage
 
 ### Quick Start

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -91,10 +91,46 @@ coreason inspect agent.py:agent
 
 ### `validate`
 
-Validates a manifest file (YAML/JSON) against the schema.
+Validates a static agent definition file (YAML or JSON) against the strict CoReason schema.
+
+This command is crucial for CI/CD pipelines to ensure that manifest files committed to the repository are structurally correct and adhere to the policy before they are deployed or run.
 
 ```bash
-coreason validate <path_to_file>
+coreason validate <path_to_file> [--json]
+```
+
+**Arguments:**
+* `<path_to_file>`: Path to the `.yaml`, `.yml`, or `.json` file to validate.
+* `--json`: If the file is valid, output the full validated JSON model to stdout. This is useful for canonicalizing input (e.g., converting YAML to JSON) or piping to other tools.
+
+**Supported Schemas:**
+*   **ManifestV2:** Detected automatically if the file contains `apiVersion: coreason.ai/v2`. This validates the entire recipe, including metadata, definitions, and workflows.
+*   **AgentDefinition:** Fallback if no `apiVersion` is present. Validates a single Agent object.
+
+**Output:**
+*   **Success:** Prints `✅ Valid Agent: <Name> (v<Version>)` and exits with code 0.
+*   **Failure:** Prints `❌ Validation Failed:` followed by a detailed list of errors (Field Path -> Error Message) and exits with code 1.
+
+**Examples:**
+
+*Validate a YAML file:*
+```bash
+coreason validate agent.yaml
+# Output: ✅ Valid Agent: ResearchBot (v1.0.0)
+```
+
+*Validate and export as canonical JSON:*
+```bash
+coreason validate agent.yaml --json > agent.json
+```
+
+*Validation Failure:*
+```bash
+coreason validate invalid.json
+# Output:
+# ❌ Validation Failed:
+#   • metadata -> name: Field required
+#   • workflow -> start: Input should be a valid string
 ```
 
 ---

--- a/src/coreason_manifest/cli.py
+++ b/src/coreason_manifest/cli.py
@@ -187,6 +187,7 @@ def handle_validate(args: argparse.Namespace) -> None:
     yaml_module = None
     try:
         import yaml
+
         yaml_module = yaml
     except ImportError:
         pass
@@ -219,7 +220,7 @@ def handle_validate(args: argparse.Namespace) -> None:
     try:
         name = "Unknown"
         version = "Unknown"
-        agent_obj = None
+        agent_obj: ManifestV2 | AgentDefinition
 
         if isinstance(data, dict) and "apiVersion" in data:
             agent_obj = ManifestV2.model_validate(data)

--- a/src/coreason_manifest/cli.py
+++ b/src/coreason_manifest/cli.py
@@ -14,7 +14,6 @@ import sys
 import textwrap
 from pathlib import Path
 
-import yaml
 from pydantic import ValidationError
 
 from coreason_manifest.spec.v2.definitions import (
@@ -185,28 +184,60 @@ def handle_validate(args: argparse.Namespace) -> None:
         print(f"❌ Error: File '{args.file}' not found.")
         sys.exit(1)
 
+    yaml_module = None
+    try:
+        import yaml
+        yaml_module = yaml
+    except ImportError:
+        pass
+
+    if file_path.suffix.lower() in [".yaml", ".yml"] and yaml_module is None:
+        print("❌ Error: PyYAML is not installed. Please install it to validate YAML files.")
+        print("  pip install PyYAML")
+        sys.exit(1)
+
     try:
         content = file_path.read_text(encoding="utf-8")
         if file_path.suffix.lower() in [".yaml", ".yml"]:
-            data = yaml.safe_load(content)
+            # We already checked yaml_module is not None if extension is yaml
+            data = yaml_module.safe_load(content)  # type: ignore
         elif file_path.suffix.lower() == ".json":
             data = json.loads(content)
         else:
             print(f"❌ Error: Unsupported file extension '{file_path.suffix}'. Use .json, .yaml, or .yml.")
             sys.exit(1)
-    except (json.JSONDecodeError, yaml.YAMLError) as e:
-        print(f"❌ Error: Malformed file: {e}")
+    except json.JSONDecodeError as e:
+        print(f"❌ Error: Malformed JSON file: {e}")
         sys.exit(1)
     except Exception as e:
+        if yaml_module and isinstance(e, yaml_module.YAMLError):
+            print(f"❌ Error: Malformed YAML file: {e}")
+            sys.exit(1)
         print(f"❌ Error reading file: {e}")
         sys.exit(1)
 
     try:
-        agent = AgentDefinition.model_validate(data)
-        if args.json:
-            print(json.dumps({"status": "valid", "name": agent.name}))
+        name = "Unknown"
+        version = "Unknown"
+        agent_obj = None
+
+        if isinstance(data, dict) and "apiVersion" in data:
+            agent_obj = ManifestV2.model_validate(data)
+            name = agent_obj.metadata.name
+            # Try to get version from metadata (it allows extra fields)
+            # We use getattr because it's dynamic
+            version = getattr(agent_obj.metadata, "version", "Unknown")
         else:
-            print(f"✅ Valid Agent: {agent.name}")
+            agent_obj = AgentDefinition.model_validate(data)
+            name = agent_obj.name
+            version = "Unknown"
+
+        if args.json:
+            # Output full JSON representation
+            print(agent_obj.model_dump_json(indent=2))
+        else:
+            print(f"✅ Valid Agent: {name} (v{version})")
+
     except ValidationError as e:
         print("❌ Validation Failed:")
         for err in e.errors():

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -37,20 +37,8 @@ def test_validate_manifest_v2_success(tmp_path: Path, capsys: pytest.CaptureFixt
     agent_data = {
         "apiVersion": "coreason.ai/v2",
         "kind": "Agent",
-        "metadata": {
-            "name": "Manifest Agent",
-            "version": "1.0.0"
-        },
-        "workflow": {
-            "start": "step1",
-            "steps": {
-                "step1": {
-                    "type": "logic",
-                    "id": "step1",
-                    "code": "print('hello')"
-                }
-            }
-        }
+        "metadata": {"name": "Manifest Agent", "version": "1.0.0"},
+        "workflow": {"start": "step1", "steps": {"step1": {"type": "logic", "id": "step1", "code": "print('hello')"}}},
     }
     agent_file.write_text(yaml.dump(agent_data))
 
@@ -67,19 +55,8 @@ def test_validate_manifest_v2_no_version(tmp_path: Path, capsys: pytest.CaptureF
     agent_data = {
         "apiVersion": "coreason.ai/v2",
         "kind": "Agent",
-        "metadata": {
-            "name": "Manifest Agent NoVer"
-        },
-        "workflow": {
-            "start": "step1",
-            "steps": {
-                "step1": {
-                    "type": "logic",
-                    "id": "step1",
-                    "code": "print('hello')"
-                }
-            }
-        }
+        "metadata": {"name": "Manifest Agent NoVer"},
+        "workflow": {"start": "step1", "steps": {"step1": {"type": "logic", "id": "step1", "code": "print('hello')"}}},
     }
     agent_file.write_text(yaml.dump(agent_data))
 

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -186,11 +186,13 @@ def test_validate_missing_pyyaml(tmp_path: Path, capsys: pytest.CaptureFixture[s
     agent_file.touch()
 
     # Simulate missing yaml module
-    with patch.dict(sys.modules, {"yaml": None}):
-        with patch.object(sys, "argv", ["coreason", "validate", str(agent_file)]):
-            with pytest.raises(SystemExit) as exc:
-                main()
-            assert exc.value.code == 1
+    with (
+        patch.dict(sys.modules, {"yaml": None}),
+        patch.object(sys, "argv", ["coreason", "validate", str(agent_file)]),
+    ):
+        with pytest.raises(SystemExit) as exc:
+            main()
+        assert exc.value.code == 1
 
     captured = capsys.readouterr()
     assert "❌ Error: PyYAML is not installed" in captured.out


### PR DESCRIPTION
Implemented the `validate` CLI command to allow users to statically check agent definition files against the schema.

Key features:
-   **Multi-format Support**: Validates both `.json` and `.yaml` files.
-   **Schema Priority**: Automatically detects `ManifestV2` (via `apiVersion`) or falls back to `AgentDefinition`.
-   **Robust Reporting**:
    -   Success: `✅ Valid Agent: {name} (v{version})`
    -   Failure: Detailed list of Pydantic validation errors (Path -> Message).
    -   JSON Mode: Outputs the full validated model as JSON (useful for pipelines).
-   **Lazy Dependency**: `PyYAML` is imported only when validating YAML files, providing a helpful error message if missing.
-   **Testing**: Added `tests/test_cli_validate.py` covering various scenarios including valid/invalid inputs, file missing, and format errors.


---
*PR created automatically by Jules for task [6991169178938539850](https://jules.google.com/task/6991169178938539850) started by @gowthamrao*