### PR TITLE
Work Package GG: Transport Layer (AgentRequest)

### DIFF
--- a/docs/middleware_extension_interfaces.md
+++ b/docs/middleware_extension_interfaces.md
@@ -69,11 +69,15 @@ class PIIRedactor:
         request: AgentRequest
     ) -> AgentRequest:
         # Simple example: Redact generic credit card numbers in query
-        if "4000-1234" in request.query:
+        # Access payload dictionary
+        query = str(request.payload.get("query", ""))
+
+        if "4000-1234" in query:
+            new_payload = request.payload.copy()
+            new_payload["query"] = query.replace("4000-1234", "XXXX-XXXX")
+
             # Create a modified copy (AgentRequest is immutable)
-            return request.model_copy(
-                update={"query": request.query.replace("4000-1234", "XXXX-XXXX")}
-            )
+            return request.model_copy(update={"payload": new_payload})
         return request
 ```
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -6,6 +6,10 @@
 
 We use the [CloudEvents 1.0 JSON Format](https://github.com/cloudevents/spec/blob/v1.0.2/cloudevents/formats/json-format.md) for all system notifications and asynchronous events.
 
+## Transport Layer
+
+For distributed tracing and request context propagation across the agent graph, see the **[Transport Layer](transport_layer.md)** documentation. It details the `AgentRequest` model which enforces strict lineage (Root/Parent IDs).
+
 ### Model: `CloudEvent`
 
 A strict Pydantic model representing a CloudEvent.

--- a/docs/transport_layer.md
+++ b/docs/transport_layer.md
@@ -1,0 +1,83 @@
+# Transport Layer
+
+The **Transport Layer** defines the fundamental envelope for all communication within the CoReason ecosystem. It ensures that every interaction—whether a user request, an inter-agent call, or a system event—carries the necessary context for **Distributed Tracing**, **Session Management**, and **Audit Logging**.
+
+## The Transport Envelope: `AgentRequest`
+
+The core model is `AgentRequest`, which acts as a strictly typed, immutable envelope.
+
+**Import:**
+```python
+from coreason_manifest import AgentRequest
+```
+
+### Fields
+
+| Field | Type | Description | Required | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `request_id` | `UUID` | Unique ID for *this specific operation*. | Yes | `uuid4()` |
+| `session_id` | `UUID` | Groups requests into a coherent user session. | **Yes** | - |
+| `root_request_id` | `UUID` | The ID of the original request that started the trace. | Yes | `request_id` (Auto-rooting) |
+| `parent_request_id` | `Optional[UUID]` | The ID of the immediate caller (for nested traces). | No | `None` |
+| `payload` | `Dict[str, Any]` | The actual business logic arguments (e.g., `{"query": "hello"}`). | Yes | - |
+| `metadata` | `Dict[str, Any]` | Contextual metadata (e.g., locale, auth scope). | No | `{}` |
+| `created_at` | `datetime` | Creation timestamp (UTC). | Yes | `now()` |
+
+### Key Features
+
+#### 1. Auto-Rooting (Trace Initiation)
+When a new request is created without a `root_request_id`, the system automatically assigns the current `request_id` as the root. This marks the start of a new trace.
+
+```python
+from uuid import uuid4
+from coreason_manifest import AgentRequest
+
+# Start a new trace
+req = AgentRequest(
+    session_id=uuid4(),
+    payload={"query": "Start process"}
+)
+
+assert req.root_request_id == req.request_id  # Auto-rooted
+assert req.parent_request_id is None
+```
+
+#### 2. Trace Continuity (Child Creation)
+To propagate context, use the `create_child()` method. This ensures lineage integrity by setting the parent and root IDs correctly.
+
+```python
+# Create a child request (e.g., Agent A calls Agent B)
+child_req = req.create_child(
+    payload={"task": "sub-task"}
+)
+
+assert child_req.root_request_id == req.root_request_id  # Same trace
+assert child_req.parent_request_id == req.request_id     # Parent link established
+assert child_req.session_id == req.session_id            # Session preserved
+```
+
+#### 3. Lineage Validation
+The model enforces strict validation to prevent broken traces. You cannot provide a `parent_request_id` without a `root_request_id`.
+
+```python
+# This raises ValueError: Broken Trace
+try:
+    AgentRequest(
+        session_id=uuid4(),
+        payload={},
+        parent_request_id=uuid4()  # Missing root!
+    )
+except ValueError as e:
+    print(e)
+```
+
+#### 4. Immutability
+`AgentRequest` instances are frozen. To modify data (e.g., in middleware), use `model_copy`.
+
+```python
+# Middleware example: Redact PII
+new_payload = req.payload.copy()
+new_payload["query"] = "***"
+
+safe_req = req.model_copy(update={"payload": new_payload})
+```

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -47,7 +47,6 @@ from .spec.common.observability import (
     EventContentType,
     ReasoningTrace,
 )
-from .spec.common.request import AgentRequest
 from .spec.common.presentation import (
     CitationBlock,
     CitationItem,
@@ -58,6 +57,7 @@ from .spec.common.presentation import (
     PresentationEventType,
     ProgressUpdate,
 )
+from .spec.common.request import AgentRequest
 from .spec.common.session import MemoryStrategy, SessionState
 from .spec.common.stream import StreamReference, StreamState
 from .spec.common_base import ToolRiskLevel

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -13,7 +13,6 @@ from .builder import AgentBuilder, TypedCapability
 from .interop.mcp import CoreasonMCPServer, create_mcp_tool_definition
 from .shortcuts import simple_agent
 from .spec.cap import (
-    AgentRequest,
     ErrorSeverity,
     HealthCheckResponse,
     HealthCheckStatus,
@@ -48,6 +47,7 @@ from .spec.common.observability import (
     EventContentType,
     ReasoningTrace,
 )
+from .spec.common.request import AgentRequest
 from .spec.common.presentation import (
     CitationBlock,
     CitationItem,

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -16,6 +16,7 @@ from uuid import UUID, uuid4
 from pydantic import ConfigDict, Field, model_validator
 
 from coreason_manifest.spec.common.identity import Identity
+from coreason_manifest.spec.common.request import AgentRequest
 from coreason_manifest.spec.common_base import CoReasonBaseModel
 
 
@@ -93,41 +94,6 @@ class ServiceResponse(CoReasonBaseModel):
     created_at: datetime
     output: dict[str, Any]
     metrics: dict[str, Any] | None = None
-
-
-class AgentRequest(CoReasonBaseModel):
-    """Strictly typed payload inside a ServiceRequest."""
-
-    model_config = ConfigDict(frozen=True)
-
-    request_id: UUID = Field(default_factory=uuid4)
-    root_request_id: UUID | None = Field(
-        default=None, description="The ID of the original user request. Must always be present."
-    )
-    parent_request_id: UUID | None = Field(default=None, description="The ID of the immediate caller.")
-
-    query: str
-    files: list[str] = Field(default_factory=list)
-    conversation_id: str | None = None
-    session_id: str | None = None
-    meta: dict[str, Any] = Field(default_factory=dict)
-
-    @model_validator(mode="before")
-    @classmethod
-    def enforce_lineage(cls, data: Any) -> Any:
-        if isinstance(data, dict):
-            # Ensure request_id is present (needed for auto-rooting)
-            if "request_id" not in data:
-                data["request_id"] = uuid4()
-
-            # Check for Broken Chain FIRST
-            if data.get("parent_request_id") is not None and data.get("root_request_id") is None:
-                raise ValueError("Broken Lineage: 'root_request_id' is required when 'parent_request_id' is present.")
-
-            # Auto-rooting (Only if no parent)
-            if data.get("root_request_id") is None:
-                data["root_request_id"] = data["request_id"]
-        return data
 
 
 class SessionContext(CoReasonBaseModel):

--- a/src/coreason_manifest/spec/cap.py
+++ b/src/coreason_manifest/spec/cap.py
@@ -11,12 +11,12 @@
 from datetime import datetime
 from enum import StrEnum
 from typing import Any
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from pydantic import ConfigDict, Field, model_validator
 
 from coreason_manifest.spec.common.identity import Identity
-from coreason_manifest.spec.common.request import AgentRequest
+from coreason_manifest.spec.common.request import AgentRequest as AgentRequest
 from coreason_manifest.spec.common_base import CoReasonBaseModel
 
 

--- a/src/coreason_manifest/spec/common/request.py
+++ b/src/coreason_manifest/spec/common/request.py
@@ -1,0 +1,71 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import UTC, datetime
+from typing import Any
+from uuid import UUID, uuid4
+
+from pydantic import ConfigDict, Field, model_validator
+
+from coreason_manifest.spec.common_base import CoReasonBaseModel
+
+
+class AgentRequest(CoReasonBaseModel):
+    """Transport Envelope for all communication within the CoReason ecosystem.
+
+    Ensures strict validation of trace lineage and context propagation.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    request_id: UUID = Field(default_factory=uuid4)
+    session_id: UUID
+    root_request_id: UUID | None = Field(default=None)
+    parent_request_id: UUID | None = Field(default=None)
+    payload: dict[str, Any]
+    metadata: dict[str, Any] = Field(default_factory=dict)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+    @model_validator(mode="before")
+    @classmethod
+    def validate_trace_and_defaults(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            # Ensure request_id is present (needed for auto-rooting if missing)
+            if "request_id" not in data or data["request_id"] is None:
+                data["request_id"] = uuid4()
+
+            req_id = data["request_id"]
+            root = data.get("root_request_id")
+            parent = data.get("parent_request_id")
+
+            # Trace Integrity: If parent exists, root MUST exist.
+            if parent is not None and root is None:
+                raise ValueError("Broken Trace: parent_request_id provided without root_request_id.")
+
+            # Auto-Rooting: If root is missing, default to current request_id (start new trace).
+            if root is None:
+                data["root_request_id"] = req_id
+
+        return data
+
+    def create_child(self, payload: dict[str, Any], **kwargs: Any) -> "AgentRequest":
+        """Create a child request inheriting trace context."""
+        # Propagate metadata unless overridden
+        meta = kwargs.get("metadata", self.metadata.copy())
+
+        return AgentRequest(
+            request_id=uuid4(),
+            session_id=self.session_id,
+            root_request_id=self.root_request_id,
+            parent_request_id=self.request_id,
+            payload=payload,
+            metadata=meta,
+            created_at=datetime.now(UTC),
+        )

--- a/tests/test_lineage.py
+++ b/tests/test_lineage.py
@@ -22,7 +22,7 @@ from coreason_manifest.spec.common.session import Interaction, LineageMetadata
 
 def test_agent_request_auto_rooting() -> None:
     """Verify that an AgentRequest without a root becomes its own root."""
-    req = AgentRequest(query="test")  # request_id auto-generated
+    req = AgentRequest(session_id=uuid4(), payload={"query": "test"})  # request_id auto-generated
 
     assert isinstance(req.request_id, UUID)
     assert isinstance(req.root_request_id, UUID)
@@ -32,7 +32,7 @@ def test_agent_request_auto_rooting() -> None:
 
 def test_agent_request_explicit_none_root() -> None:
     """Verify that passing None to root_request_id triggers auto-rooting."""
-    req = AgentRequest(query="test", root_request_id=None)
+    req = AgentRequest(session_id=uuid4(), payload={"query": "test"}, root_request_id=None)
 
     assert isinstance(req.root_request_id, UUID)
     assert req.root_request_id == req.request_id
@@ -41,7 +41,7 @@ def test_agent_request_explicit_none_root() -> None:
 def test_agent_request_with_explicit_request_id_auto_root() -> None:
     """Verify auto-rooting works when request_id is manually provided."""
     uid = uuid4()
-    req = AgentRequest(query="test", request_id=uid)
+    req = AgentRequest(session_id=uuid4(), payload={"query": "test"}, request_id=uid)
 
     assert req.request_id == uid
     assert req.root_request_id == uid
@@ -53,13 +53,13 @@ def test_agent_request_validation_error() -> None:
     # We force a type mismatch to check runtime validation.
     bad_id: Any = "not-a-uuid"
     with pytest.raises(ValidationError):
-        AgentRequest(query="test", request_id=bad_id)
+        AgentRequest(session_id=uuid4(), payload={"query": "test"}, request_id=bad_id)
 
 
 def test_agent_request_auto_rooting_with_explicit_id() -> None:
     """Verify that auto-rooting works when request_id is provided."""
     uid = uuid4()
-    req = AgentRequest(request_id=uid, query="test")
+    req = AgentRequest(request_id=uid, session_id=uuid4(), payload={"query": "test"})
 
     assert req.request_id == uid
     assert req.root_request_id == uid
@@ -70,7 +70,13 @@ def test_agent_request_explicit_root() -> None:
     root_id = uuid4()
     child_id = uuid4()
 
-    req = AgentRequest(request_id=child_id, root_request_id=root_id, parent_request_id=root_id, query="test")
+    req = AgentRequest(
+        request_id=child_id,
+        session_id=uuid4(),
+        root_request_id=root_id,
+        parent_request_id=root_id,
+        payload={"query": "test"},
+    )
 
     assert req.request_id == child_id
     assert req.root_request_id == root_id
@@ -195,8 +201,8 @@ def test_broken_chain_prevention() -> None:
     parent_id = uuid4()
 
     # AgentRequest: Parent provided, Root missing -> Error
-    with pytest.raises(ValueError, match="Broken Lineage"):
-        AgentRequest(query="test", parent_request_id=parent_id)
+    with pytest.raises(ValueError, match="Broken Trace"):
+        AgentRequest(session_id=uuid4(), payload={"query": "test"}, parent_request_id=parent_id)
 
     # ReasoningTrace: Parent provided, Root missing -> Error
     with pytest.raises(ValueError, match="Broken Lineage"):
@@ -211,10 +217,15 @@ def test_broken_chain_prevention() -> None:
 
     # AgentRequest: Valid case (Parent + Root) -> Success
     root_id = uuid4()
-    req = AgentRequest(query="test", root_request_id=root_id, parent_request_id=parent_id)
+    req = AgentRequest(
+        session_id=uuid4(),
+        payload={"query": "test"},
+        root_request_id=root_id,
+        parent_request_id=parent_id,
+    )
     assert req.root_request_id == root_id
     assert req.parent_request_id == parent_id
 
     # AgentRequest: Valid case (No Parent, No Root) -> Auto-root
-    req_auto = AgentRequest(query="test")
+    req_auto = AgentRequest(session_id=uuid4(), payload={"query": "test"})
     assert req_auto.root_request_id == req_auto.request_id

--- a/tests/test_lineage_security.py
+++ b/tests/test_lineage_security.py
@@ -8,6 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from uuid import uuid4
+
 import pytest
 from pydantic import ValidationError
 
@@ -22,7 +24,7 @@ def test_uuid_field_dos_protection() -> None:
 
     with pytest.raises(ValidationError) as excinfo:
         # Pydantic should fail fast on length or format for UUID coercion
-        AgentRequest(query="test", request_id=massive_string)
+        AgentRequest(session_id=uuid4(), payload={"query": "test"}, request_id=massive_string)
 
     # Ensure it's a value error related to UUID parsing
     assert "uuid" in str(excinfo.value).lower() or "input" in str(excinfo.value).lower()

--- a/tests/test_transport_complex.py
+++ b/tests/test_transport_complex.py
@@ -68,18 +68,11 @@ def test_nested_envelope_interop() -> None:
     inner_req = AgentRequest(session_id=uuid4(), payload={"msg": "inner"})
 
     # Wrap in another request (as payload data)
-    outer_req = AgentRequest(
-        session_id=inner_req.session_id,
-        payload={"wrapped_request": inner_req.model_dump()}
-    )
+    outer_req = AgentRequest(session_id=inner_req.session_id, payload={"wrapped_request": inner_req.model_dump()})
 
     # Wrap in ServiceRequest
     ctx = SessionContext(session_id="s1", user=Identity.anonymous())
-    svc_req = ServiceRequest(
-        request_id=uuid4(),
-        context=ctx,
-        payload=outer_req
-    )
+    svc_req = ServiceRequest(request_id=uuid4(), context=ctx, payload=outer_req)
 
     # Verify nesting structure
     dump = svc_req.dump()
@@ -95,16 +88,12 @@ def test_metadata_merge_conflict_resolution() -> None:
     # Default behavior is usually shallow copy or overwrite.
     # create_child takes kwargs.
 
-    root = AgentRequest(
-        session_id=uuid4(),
-        payload={},
-        metadata={"a": 1, "b": 2}
-    )
+    root = AgentRequest(session_id=uuid4(), payload={}, metadata={"a": 1, "b": 2})
 
     # Override 'b', add 'c'
     child = root.create_child(
         payload={},
-        metadata={"b": 99, "c": 3} # This fully replaces metadata unless create_child merges
+        metadata={"b": 99, "c": 3},  # This fully replaces metadata unless create_child merges
     )
 
     # Current implementation in create_child:
@@ -118,8 +107,5 @@ def test_metadata_merge_conflict_resolution() -> None:
     merged_meta = root.metadata.copy()
     merged_meta.update({"b": 99, "c": 3})
 
-    child_merged = root.create_child(
-        payload={},
-        metadata=merged_meta
-    )
+    child_merged = root.create_child(payload={}, metadata=merged_meta)
     assert child_merged.metadata == {"a": 1, "b": 99, "c": 3}

--- a/tests/test_transport_complex.py
+++ b/tests/test_transport_complex.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from uuid import uuid4
+
+from coreason_manifest.spec.cap import ServiceRequest, SessionContext
+from coreason_manifest.spec.common.identity import Identity
+from coreason_manifest.spec.common.request import AgentRequest
+
+
+def test_long_request_chain() -> None:
+    """Verify trace integrity over a long chain of requests (A -> B -> C -> D)."""
+    # A
+    root = AgentRequest(session_id=uuid4(), payload={"step": "A"})
+
+    # B
+    req_b = root.create_child(payload={"step": "B"})
+
+    # C
+    req_c = req_b.create_child(payload={"step": "C"})
+
+    # D
+    req_d = req_c.create_child(payload={"step": "D"})
+
+    # All share same root
+    assert root.root_request_id == req_b.root_request_id
+    assert root.root_request_id == req_c.root_request_id
+    assert root.root_request_id == req_d.root_request_id
+
+    # Parents are correct
+    assert req_d.parent_request_id == req_c.request_id
+    assert req_c.parent_request_id == req_b.request_id
+    assert req_b.parent_request_id == root.request_id
+    assert root.parent_request_id is None
+
+
+def test_forked_traces() -> None:
+    """Verify multiple children from same parent (A -> B, A -> C)."""
+    root = AgentRequest(session_id=uuid4(), payload={"step": "Root"})
+
+    child1 = root.create_child(payload={"step": "Branch 1"})
+    child2 = root.create_child(payload={"step": "Branch 2"})
+
+    # Independent children
+    assert child1.request_id != child2.request_id
+
+    # Same parent
+    assert child1.parent_request_id == root.request_id
+    assert child2.parent_request_id == root.request_id
+
+    # Same root
+    assert child1.root_request_id == root.root_request_id
+    assert child2.root_request_id == root.root_request_id
+
+
+def test_nested_envelope_interop() -> None:
+    """Verify ServiceRequest wrapping AgentRequest wrapping another AgentRequest (meta-programming)."""
+    # This happens when an agent calls another agent via an API that accepts ServiceRequest,
+    # and passes the original request as payload content.
+
+    inner_req = AgentRequest(session_id=uuid4(), payload={"msg": "inner"})
+
+    # Wrap in another request (as payload data)
+    outer_req = AgentRequest(
+        session_id=inner_req.session_id,
+        payload={"wrapped_request": inner_req.model_dump()}
+    )
+
+    # Wrap in ServiceRequest
+    ctx = SessionContext(session_id="s1", user=Identity.anonymous())
+    svc_req = ServiceRequest(
+        request_id=uuid4(),
+        context=ctx,
+        payload=outer_req
+    )
+
+    # Verify nesting structure
+    dump = svc_req.dump()
+    assert dump["payload"]["payload"]["wrapped_request"]["payload"]["msg"] == "inner"
+
+    # The inner request is just data at this point, but its lineage is preserved
+    inner_data = dump["payload"]["payload"]["wrapped_request"]
+    assert inner_data["root_request_id"] == str(inner_req.root_request_id)
+
+
+def test_metadata_merge_conflict_resolution() -> None:
+    """Verify metadata merging strategy (overwrite vs preserve)."""
+    # Default behavior is usually shallow copy or overwrite.
+    # create_child takes kwargs.
+
+    root = AgentRequest(
+        session_id=uuid4(),
+        payload={},
+        metadata={"a": 1, "b": 2}
+    )
+
+    # Override 'b', add 'c'
+    child = root.create_child(
+        payload={},
+        metadata={"b": 99, "c": 3} # This fully replaces metadata unless create_child merges
+    )
+
+    # Current implementation in create_child:
+    # meta = kwargs.get("metadata", self.metadata.copy())
+    # So if metadata IS provided, it replaces entirely.
+
+    assert child.metadata == {"b": 99, "c": 3}
+    assert "a" not in child.metadata
+
+    # If we want to MERGE, user must do it manually before calling create_child
+    merged_meta = root.metadata.copy()
+    merged_meta.update({"b": 99, "c": 3})
+
+    child_merged = root.create_child(
+        payload={},
+        metadata=merged_meta
+    )
+    assert child_merged.metadata == {"a": 1, "b": 99, "c": 3}

--- a/tests/test_transport_edge_cases.py
+++ b/tests/test_transport_edge_cases.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import contextlib
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.common.request import AgentRequest
+
+
+def test_circular_lineage() -> None:
+    """Verify behavior when a request is its own parent (pathological case)."""
+    # The validator doesn't explicitly forbid this (as it's just UUID checks),
+    # but it shouldn't crash.
+    req_id = uuid4()
+
+    # Self-parenting
+    req = AgentRequest(
+        request_id=req_id,
+        session_id=uuid4(),
+        root_request_id=req_id,  # Valid: root can be self
+        parent_request_id=req_id, # Valid: parent can technically be self in a graph cycle
+        payload={}
+    )
+
+    assert req.request_id == req.parent_request_id
+    assert req.request_id == req.root_request_id
+
+
+def test_uuid_collision_simulation() -> None:
+    """Simulate a UUID collision (extremely unlikely but good to check equality logic)."""
+    uid = uuid4()
+
+    req1 = AgentRequest(request_id=uid, session_id=uuid4(), payload={"q": 1})
+    req2 = AgentRequest(request_id=uid, session_id=uuid4(), payload={"q": 2})
+
+    # They have same ID but different content.
+    # Equality depends on CoReasonBaseModel/Pydantic implementation.
+    # Usually pydantic models are equal if all fields are equal.
+    assert req1 != req2
+    assert req1.request_id == req2.request_id
+
+
+def test_payload_complex_types() -> None:
+    """Verify payload handles complex python types that might fail JSON serialization."""
+    # Sets are not standard JSON. Pydantic's model_dump(mode='json') handles them by converting to list.
+    payload = {
+        "tags": {"a", "b", "c"},
+        "tuple": (1, 2),
+    }
+
+    req = AgentRequest(session_id=uuid4(), payload=payload)
+
+    # Dump should handle sets/tuples (convert to list)
+    dump = req.dump()
+    assert set(dump["payload"]["tags"]) == {"a", "b", "c"} # serialized as list
+    assert dump["payload"]["tuple"] == [1, 2] # serialized as list
+
+
+def test_deep_recursion_payload() -> None:
+    """Verify deep recursion in payload doesn't crash validation, though serialization might fail."""
+    deep_dict = {}
+    curr = deep_dict
+    for _ in range(2000): # Exceeds default recursion limit usually
+        curr["n"] = {}
+        curr = curr["n"]
+
+    req = AgentRequest(session_id=uuid4(), payload=deep_dict)
+
+    # Validation passes because dict is just a reference
+    assert isinstance(req, AgentRequest)
+
+    # Serialization might fail
+    with contextlib.suppress(RecursionError, ValueError):
+        req.dump()
+
+
+def test_concurrent_modification_attempt() -> None:
+    """Verify that despite payload being a mutable dict reference, the model instance is frozen."""
+    payload = {"count": 0}
+    req = AgentRequest(session_id=uuid4(), payload=payload)
+
+    # Modifying the external dict reference effects the model's view of data
+    # (since Pydantic shallow copies or keeps reference depending on config).
+    # By default, it might keep reference.
+    payload["count"] = 1
+
+    # This is an important behavior to document/test: The envelope is frozen, but the payload content
+    # (if strictly a reference) is mutable via the original reference.
+    # Ideally, we'd want deep copy, but performance usually dictates reference.
+    # UPDATE: Pydantic V2/CoReasonBaseModel seemingly makes a copy during validation, isolating the model.
+    # This is safer behavior.
+    assert req.payload["count"] == 0
+
+
+def test_invalid_payload_keys() -> None:
+    """Test payload with non-string keys (JSON requirements)."""
+    # Pydantic Dict[str, Any] expects string keys.
+    # If we pass int keys, Pydantic coercion might convert them to strings or fail.
+
+    payload = {123: "value"} # type: ignore
+
+    # CoReasonBaseModel / Pydantic V2 often coerces keys to strings for Dict[str, Any]
+    # But it seems strict validation rejects int keys here.
+    with pytest.raises(ValidationError):
+        AgentRequest(session_id=uuid4(), payload=payload) # type: ignore

--- a/tests/test_transport_edge_cases.py
+++ b/tests/test_transport_edge_cases.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import contextlib
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -28,8 +29,8 @@ def test_circular_lineage() -> None:
         request_id=req_id,
         session_id=uuid4(),
         root_request_id=req_id,  # Valid: root can be self
-        parent_request_id=req_id, # Valid: parent can technically be self in a graph cycle
-        payload={}
+        parent_request_id=req_id,  # Valid: parent can technically be self in a graph cycle
+        payload={},
     )
 
     assert req.request_id == req.parent_request_id
@@ -62,15 +63,15 @@ def test_payload_complex_types() -> None:
 
     # Dump should handle sets/tuples (convert to list)
     dump = req.dump()
-    assert set(dump["payload"]["tags"]) == {"a", "b", "c"} # serialized as list
-    assert dump["payload"]["tuple"] == [1, 2] # serialized as list
+    assert set(dump["payload"]["tags"]) == {"a", "b", "c"}  # serialized as list
+    assert dump["payload"]["tuple"] == [1, 2]  # serialized as list
 
 
 def test_deep_recursion_payload() -> None:
     """Verify deep recursion in payload doesn't crash validation, though serialization might fail."""
-    deep_dict = {}
+    deep_dict: dict[str, Any] = {}
     curr = deep_dict
-    for _ in range(2000): # Exceeds default recursion limit usually
+    for _ in range(2000):  # Exceeds default recursion limit usually
         curr["n"] = {}
         curr = curr["n"]
 
@@ -107,9 +108,9 @@ def test_invalid_payload_keys() -> None:
     # Pydantic Dict[str, Any] expects string keys.
     # If we pass int keys, Pydantic coercion might convert them to strings or fail.
 
-    payload = {123: "value"} # type: ignore
+    payload = {123: "value"}
 
     # CoReasonBaseModel / Pydantic V2 often coerces keys to strings for Dict[str, Any]
     # But it seems strict validation rejects int keys here.
     with pytest.raises(ValidationError):
-        AgentRequest(session_id=uuid4(), payload=payload) # type: ignore
+        AgentRequest(session_id=uuid4(), payload=payload)

--- a/tests/test_transport_request.py
+++ b/tests/test_transport_request.py
@@ -73,7 +73,7 @@ def test_broken_trace_prevention() -> None:
         AgentRequest(
             session_id=uuid4(),
             payload={},
-            parent_request_id=parent_id
+            parent_request_id=parent_id,
             # root_request_id missing -> defaults to None initially, validator catches it
         )
 

--- a/tests/test_transport_request.py
+++ b/tests/test_transport_request.py
@@ -1,0 +1,98 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import json
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.common.request import AgentRequest
+
+
+def test_new_trace_auto_rooting() -> None:
+    """Verify that a new request becomes the root of its own trace."""
+    session_id = uuid4()
+    payload = {"query": "start"}
+
+    req = AgentRequest(session_id=session_id, payload=payload)
+
+    assert isinstance(req.request_id, UUID)
+    assert req.request_id == req.root_request_id
+    assert req.parent_request_id is None
+    assert req.session_id == session_id
+    assert req.payload == payload
+
+
+def test_trace_continuity_child_creation() -> None:
+    """Verify strict lineage inheritance in child requests."""
+    root = AgentRequest(session_id=uuid4(), payload={"step": 1})
+
+    child_payload = {"step": 2}
+    child = root.create_child(payload=child_payload)
+
+    # Trace context
+    assert child.root_request_id == root.root_request_id
+    assert child.parent_request_id == root.request_id
+
+    # Session context
+    assert child.session_id == root.session_id
+
+    # New identifiers
+    assert child.request_id != root.request_id
+    assert isinstance(child.request_id, UUID)
+
+    # Payload
+    assert child.payload == child_payload
+
+    # Metadata copy behavior (default: copy)
+    root_meta = AgentRequest(session_id=uuid4(), payload={}, metadata={"foo": "bar"})
+    child_meta = root_meta.create_child(payload={})
+    assert child_meta.metadata == {"foo": "bar"}
+    # Ensure it's a copy
+    assert child_meta.metadata is not root_meta.metadata
+
+    # Metadata override behavior
+    child_override = root_meta.create_child(payload={}, metadata={"baz": "qux"})
+    assert child_override.metadata == {"baz": "qux"}
+
+
+def test_broken_trace_prevention() -> None:
+    """Verify validation logic catches broken traces."""
+    parent_id = uuid4()
+
+    # Case: Parent exists, Root missing -> Error
+    with pytest.raises(ValueError, match="Broken Trace"):
+        AgentRequest(
+            session_id=uuid4(),
+            payload={},
+            parent_request_id=parent_id
+            # root_request_id missing -> defaults to None initially, validator catches it
+        )
+
+
+def test_immutability_and_serialization() -> None:
+    """Verify the request envelope is immutable and serializes correctly."""
+    req = AgentRequest(session_id=uuid4(), payload={"query": "test"})
+
+    # Immutability
+    with pytest.raises(ValidationError):
+        req.payload = {"query": "hacked"}  # type: ignore
+
+    # Serialization
+    json_str = req.to_json()
+    data = json.loads(json_str)
+
+    assert data["request_id"] == str(req.request_id)
+    assert data["root_request_id"] == str(req.root_request_id)
+    assert data["session_id"] == str(req.session_id)
+    assert data["payload"] == {"query": "test"}
+    # Check datetime format (ISO 8601)
+    assert "created_at" in data


### PR DESCRIPTION
Implemented the `AgentRequest` model as a standardized transport envelope for all communication within the CoReason ecosystem. This model enforces strict distributed tracing lineage (root/parent IDs) and context propagation. It replaces the previous `AgentRequest` definition and refactors all usages in the codebase to align with the new schema (mandatory session_id, payload dictionary). New tests were added to verify trace integrity and immutability.

---
*PR created automatically by Jules for task [937706633306346713](https://jules.google.com/task/937706633306346713) started by @gowthamrao*