### PR TITLE
feat: Implement ATIF Simulation Schemas

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -69,6 +69,16 @@ from .spec.interfaces.middleware import (
 )
 from .spec.interfaces.session import SessionHandle
 from .spec.interfaces.stream import IStreamEmitter
+from .spec.simulation import (
+    AdversaryProfile,
+    ChaosConfig,
+    SimulationRequest,
+    SimulationScenario,
+    SimulationStep,
+    SimulationTrace,
+    StepType,
+    ValidationLogic,
+)
 from .spec.v2.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
 from .spec.v2.definitions import (
     AgentDefinition,
@@ -108,6 +118,7 @@ load = load_from_yaml
 dump = dump_to_yaml
 
 __all__ = [
+    "AdversaryProfile",
     "AgentBuilder",
     "AgentCapabilities",
     "AgentDefinition",
@@ -117,6 +128,7 @@ __all__ = [
     "AuditLog",
     "CapabilityType",
     "ChangeCategory",
+    "ChaosConfig",
     "ChatMessage",
     "CitationBlock",
     "CitationItem",
@@ -176,8 +188,13 @@ __all__ = [
     "SessionContext",
     "SessionHandle",
     "SessionState",
+    "SimulationRequest",
+    "SimulationScenario",
+    "SimulationStep",
+    "SimulationTrace",
     "StateDefinition",
     "Step",
+    "StepType",
     "StreamError",
     "StreamOpCode",
     "StreamPacket",
@@ -188,6 +205,7 @@ __all__ = [
     "ToolDefinition",
     "ToolRiskLevel",
     "TypedCapability",
+    "ValidationLogic",
     "Workflow",
     "__version__",
     "check_compliance_v2",

--- a/src/coreason_manifest/spec/simulation.py
+++ b/src/coreason_manifest/spec/simulation.py
@@ -1,0 +1,99 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any, Dict, List, Optional
+from uuid import UUID, uuid4
+
+from pydantic import Field
+
+from .common_base import CoReasonBaseModel
+
+
+class StepType(str, Enum):
+    """Enumeration of step types in a simulation trace."""
+
+    INTERACTION = "interaction"
+    SYSTEM_EVENT = "system_event"
+    TOOL_EXECUTION = "tool_execution"
+    REASONING = "reasoning"
+    ERROR = "error"
+
+
+class ValidationLogic(str, Enum):
+    """Enumeration of validation logic types for simulation scenarios."""
+
+    EXACT_MATCH = "exact_match"
+    FUZZY = "fuzzy"
+    CODE_EVAL = "code_eval"
+    LLM_JUDGE = "llm_judge"
+
+
+class SimulationStep(CoReasonBaseModel):
+    """The atomic unit of execution history."""
+
+    step_id: UUID = Field(default_factory=uuid4)
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    type: StepType
+    node_id: str
+    inputs: Dict[str, Any] = Field(default_factory=dict)
+    thought: Optional[str] = None
+    action: Optional[Dict[str, Any]] = None
+    observation: Optional[Dict[str, Any]] = None
+    snapshot: Dict[str, Any] = Field(default_factory=dict)
+
+
+class SimulationTrace(CoReasonBaseModel):
+    """The full recording of a session."""
+
+    trace_id: UUID = Field(default_factory=uuid4)
+    agent_id: str
+    agent_version: str
+    steps: List[SimulationStep] = Field(default_factory=list)
+    outcome: Optional[Dict[str, Any]] = None
+    score: Optional[float] = None
+    metadata: Dict[str, Any] = Field(default_factory=dict)
+
+
+class AdversaryProfile(CoReasonBaseModel):
+    """Configuration for the Red Team agent."""
+
+    name: str
+    goal: str
+    strategy_model: str
+    attack_model: str
+    persona: Optional[Dict[str, Any]] = None
+
+
+class ChaosConfig(CoReasonBaseModel):
+    """Configuration for infrastructure faults."""
+
+    latency_ms: int = 0
+    error_rate: float = 0.0
+    token_throttle: bool = False
+
+
+class SimulationScenario(CoReasonBaseModel):
+    """The test case definition."""
+
+    id: str
+    description: str
+    inputs: Dict[str, Any]
+    expected_output: Optional[Dict[str, Any]] = None
+    validation_logic: ValidationLogic
+
+
+class SimulationRequest(CoReasonBaseModel):
+    """The trigger payload sent to the runner."""
+
+    scenario: SimulationScenario
+    profile: Optional[AdversaryProfile] = None
+    chaos_config: Optional[ChaosConfig] = None

--- a/src/coreason_manifest/spec/simulation.py
+++ b/src/coreason_manifest/spec/simulation.py
@@ -8,9 +8,9 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any
 from uuid import UUID, uuid4
 
 from pydantic import Field
@@ -41,14 +41,14 @@ class SimulationStep(CoReasonBaseModel):
     """The atomic unit of execution history."""
 
     step_id: UUID = Field(default_factory=uuid4)
-    timestamp: datetime = Field(default_factory=lambda: datetime.now(timezone.utc))
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
     type: StepType
     node_id: str
-    inputs: Dict[str, Any] = Field(default_factory=dict)
-    thought: Optional[str] = None
-    action: Optional[Dict[str, Any]] = None
-    observation: Optional[Dict[str, Any]] = None
-    snapshot: Dict[str, Any] = Field(default_factory=dict)
+    inputs: dict[str, Any] = Field(default_factory=dict)
+    thought: str | None = None
+    action: dict[str, Any] | None = None
+    observation: dict[str, Any] | None = None
+    snapshot: dict[str, Any] = Field(default_factory=dict)
 
 
 class SimulationTrace(CoReasonBaseModel):
@@ -57,10 +57,10 @@ class SimulationTrace(CoReasonBaseModel):
     trace_id: UUID = Field(default_factory=uuid4)
     agent_id: str
     agent_version: str
-    steps: List[SimulationStep] = Field(default_factory=list)
-    outcome: Optional[Dict[str, Any]] = None
-    score: Optional[float] = None
-    metadata: Dict[str, Any] = Field(default_factory=dict)
+    steps: list[SimulationStep] = Field(default_factory=list)
+    outcome: dict[str, Any] | None = None
+    score: float | None = None
+    metadata: dict[str, Any] = Field(default_factory=dict)
 
 
 class AdversaryProfile(CoReasonBaseModel):
@@ -70,7 +70,7 @@ class AdversaryProfile(CoReasonBaseModel):
     goal: str
     strategy_model: str
     attack_model: str
-    persona: Optional[Dict[str, Any]] = None
+    persona: dict[str, Any] | None = None
 
 
 class ChaosConfig(CoReasonBaseModel):
@@ -86,8 +86,8 @@ class SimulationScenario(CoReasonBaseModel):
 
     id: str
     description: str
-    inputs: Dict[str, Any]
-    expected_output: Optional[Dict[str, Any]] = None
+    inputs: dict[str, Any]
+    expected_output: dict[str, Any] | None = None
     validation_logic: ValidationLogic
 
 
@@ -95,5 +95,5 @@ class SimulationRequest(CoReasonBaseModel):
     """The trigger payload sent to the runner."""
 
     scenario: SimulationScenario
-    profile: Optional[AdversaryProfile] = None
-    chaos_config: Optional[ChaosConfig] = None
+    profile: AdversaryProfile | None = None
+    chaos_config: ChaosConfig | None = None

--- a/tests/test_simulation_schemas.py
+++ b/tests/test_simulation_schemas.py
@@ -1,0 +1,122 @@
+# tests/test_simulation_schemas.py
+
+import json
+from uuid import UUID
+
+from coreason_manifest import (
+    AdversaryProfile,
+    ChaosConfig,
+    SimulationRequest,
+    SimulationScenario,
+    SimulationStep,
+    SimulationTrace,
+    StepType,
+    ValidationLogic,
+)
+
+
+def test_simulation_step_serialization() -> None:
+    """Test serialization of a SimulationStep."""
+    step = SimulationStep(
+        type=StepType.REASONING,
+        node_id="node_1",
+        thought="Thinking about the problem",
+        inputs={"query": "Who is the president?"},
+    )
+
+    # Verify defaults
+    assert isinstance(step.step_id, UUID)
+    assert step.timestamp is not None
+    assert step.snapshot == {}
+
+    # Verify serialization
+    dumped = step.model_dump_json()
+    assert "step_id" in dumped
+    assert "timestamp" in dumped
+    assert "reasoning" in dumped
+
+
+def test_simulation_trace_integrity() -> None:
+    """Test trace integrity and serialization."""
+    step1 = SimulationStep(
+        type=StepType.INTERACTION,
+        node_id="start",
+        inputs={"user_input": "Hello"},
+    )
+    step2 = SimulationStep(
+        type=StepType.TOOL_EXECUTION,
+        node_id="tool_node",
+        action={"tool": "search", "args": {"q": "Hello"}},
+    )
+
+    trace = SimulationTrace(
+        agent_id="agent-007",
+        agent_version="1.0.0",
+        steps=[step1, step2],
+    )
+
+    assert len(trace.steps) == 2
+    assert trace.steps[0].node_id == "start"
+    assert trace.steps[1].node_id == "tool_node"
+
+    # Test serialization
+    json_str = trace.model_dump_json()
+    data = json.loads(json_str)
+
+    assert data["agent_id"] == "agent-007"
+    assert len(data["steps"]) == 2
+    # Check if UUIDs are serialized as strings
+    assert isinstance(data["trace_id"], str)
+    assert isinstance(data["steps"][0]["step_id"], str)
+
+
+def test_simulation_defaults() -> None:
+    """Test default values for SimulationStep."""
+    step = SimulationStep(
+        type=StepType.SYSTEM_EVENT,
+        node_id="init",
+    )
+
+    assert isinstance(step.step_id, UUID)
+    assert step.timestamp is not None
+    assert step.inputs == {}
+    assert step.snapshot == {}
+    assert step.thought is None
+
+
+def test_nesting_simulation_request() -> None:
+    """Test nesting of objects in SimulationRequest."""
+    profile = AdversaryProfile(
+        name="RedTeamer",
+        goal="Break stuff",
+        strategy_model="gpt-4",
+        attack_model="gpt-3.5",
+    )
+
+    scenario = SimulationScenario(
+        id="scenario-1",
+        description="Test basic interaction",
+        inputs={"text": "Hi"},
+        validation_logic=ValidationLogic.EXACT_MATCH,
+    )
+
+    chaos = ChaosConfig(
+        latency_ms=100,
+        error_rate=0.01,
+    )
+
+    req = SimulationRequest(
+        scenario=scenario,
+        profile=profile,
+        chaos_config=chaos,
+    )
+
+    # Serialize and deserialize
+    json_str = req.model_dump_json()
+    restored = SimulationRequest.model_validate_json(json_str)
+
+    assert restored.scenario.id == "scenario-1"
+    assert restored.profile is not None
+    assert restored.profile.name == "RedTeamer"
+    assert restored.chaos_config is not None
+    assert restored.chaos_config.latency_ms == 100


### PR DESCRIPTION
Implements the Agent Trajectory Interchange Format (ATIF) simulation and evaluation schemas in `src/coreason_manifest/spec/simulation.py`.

Includes:
- `SimulationStep`, `SimulationTrace` for execution history.
- `AdversaryProfile`, `ChaosConfig`, `SimulationScenario`, `SimulationRequest` for evaluation configuration.
- Enums: `StepType`, `ValidationLogic`.
- Updates `__init__.py` to export new classes.
- Adds `tests/test_simulation_schemas.py` to verify serialization and integrity.

---
*PR created automatically by Jules for task [12349837971544601104](https://jules.google.com/task/12349837971544601104) started by @gowthamrao*