### PR TITLE
feat: Implement Graph Recipes (Work Package JJ)

### DIFF
--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -1,0 +1,127 @@
+# Graph Recipes (Work Package JJ)
+
+The **Recipe** system is the "Brain" of the Coreason execution model. While `AgentDefinition` describes *what* an agent can do (its tools and capabilities), a `RecipeDefinition` describes *how* tasks are orchestrated.
+
+Recipes upgrade the system from simple linear lists of steps to executing complex, non-linear **Directed Cyclic Graphs (DCGs)**. This enables:
+
+*   **Loops:** "If quality < 50%, critique and revise."
+*   **Branching:** "If legal query, route to Legal Agent; else route to General Agent."
+*   **Human-in-the-Loop:** "Pause and wait for Manager Approval."
+
+## Architecture
+
+A `RecipeDefinition` is a specialized Manifest type (`kind: Recipe`) that contains a `GraphTopology`.
+
+### Graph Topology
+
+The topology consists of:
+*   **Nodes**: Units of work (Agents, Humans, Routers).
+*   **Edges**: Directed connections defining the flow of control.
+*   **Entry Point**: The ID of the node where execution begins.
+
+The system enforces strict **Graph Integrity**:
+*   The `entry_point` must exist in the node list.
+*   All edges must connect valid source and target nodes (no dangling pointers).
+*   Cycles (loops) are explicitly allowed and supported.
+
+## Node Types
+
+Nodes are polymorphic and identified by their `type` field.
+
+### 1. Agent Node (`type: agent`)
+Executes an AI Agent.
+
+```yaml
+type: agent
+id: "research-step"
+agent_ref: "researcher-agent-v1"
+system_prompt_override: "Focus on recent news."
+inputs_map:
+  topic: "user_query"
+```
+
+### 2. Human Node (`type: human`)
+Pauses execution and waits for external human intervention.
+
+```yaml
+type: human
+id: "manager-approval"
+prompt: "Please review the draft."
+timeout_seconds: 3600
+required_role: "editor"
+```
+
+### 3. Router Node (`type: router`)
+Evaluates a variable and routes execution to different paths.
+
+```yaml
+type: router
+id: "quality-gate"
+input_key: "score"
+routes:
+  high: "publish-step"
+  low: "revise-step"
+default_route: "manual-review"
+```
+
+## Example Recipe
+
+Here is a complete example of a Recipe that includes a loop and human approval.
+
+```yaml
+apiVersion: coreason.ai/v2
+kind: Recipe
+metadata:
+  name: "Blog Post Workflow"
+topology:
+  entry_point: "draft"
+  nodes:
+    - type: agent
+      id: "draft"
+      agent_ref: "writer-agent"
+
+    - type: agent
+      id: "critique"
+      agent_ref: "editor-agent"
+
+    - type: router
+      id: "check-quality"
+      input_key: "score"
+      routes:
+        pass: "human-approve"
+      default_route: "draft"  # Loop back to draft if quality fails
+
+    - type: human
+      id: "human-approve"
+      prompt: "Approve for publication?"
+
+    - type: agent
+      id: "publish"
+      agent_ref: "publisher-agent"
+
+  edges:
+    - source: "draft"
+      target: "critique"
+    - source: "critique"
+      target: "check-quality"
+    # Router logic handles the next steps dynamically, but edges can visualize the flow
+    - source: "check-quality"
+      target: "draft"
+      condition: "default (fail)"
+    - source: "check-quality"
+      target: "human-approve"
+      condition: "pass"
+    - source: "human-approve"
+      target: "publish"
+```
+
+## Validation
+
+The `coreason-manifest` library includes strict Pydantic validation for Recipes.
+
+```python
+from coreason_manifest import RecipeDefinition, GraphTopology
+
+# This will raise ValidationError if integrity checks fail
+recipe = RecipeDefinition.model_validate(data)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Coreason Agent Protocol (CAP) Wire Format](cap/wire_protocol.md)**
     *   Defines the runtime wire protocol, including standard request/response envelopes (`ServiceRequest`, `ServiceResponse`) and streaming contracts (`StreamPacket`).
 
+*   **[Graph Recipes (Work Package JJ)](graph_recipes.md)**
+    *   Describes the system for non-linear, cyclic graph execution using `RecipeDefinition` and `GraphTopology`.
+
 *   **[Explicit Streaming Contracts](cap/streaming_contracts.md)**
     *   Defines the contracts for Agent execution (`atomic`, `graph`) and delivery modes (`request_response`, `server_sent_events`).
 

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -93,6 +93,13 @@ from .spec.v2.definitions import (
     Workflow,
 )
 from .spec.v2.evaluation import EvaluationProfile, SuccessCriterion
+from .spec.v2.recipe import (
+    AgentNode,
+    GraphTopology,
+    HumanNode,
+    RecipeDefinition,
+    RouterNode,
+)
 from .spec.v2.resources import (
     ModelProfile,
     PricingUnit,
@@ -113,7 +120,7 @@ from .utils.viz import generate_mermaid_graph
 __version__ = "0.19.0"
 
 Manifest = ManifestV2
-Recipe = ManifestV2
+Recipe = RecipeDefinition
 load = load_from_yaml
 dump = dump_to_yaml
 
@@ -122,6 +129,7 @@ __all__ = [
     "AgentBuilder",
     "AgentCapabilities",
     "AgentDefinition",
+    "AgentNode",
     "AgentRequest",
     "AgentRuntimeConfig",
     "AgentStep",
@@ -154,8 +162,10 @@ __all__ = [
     "GraphEventNodeStream",
     "GraphEventStreamEnd",
     "GraphEventStreamStart",
+    "GraphTopology",
     "HealthCheckResponse",
     "HealthCheckStatus",
+    "HumanNode",
     "IRequestInterceptor",
     "IResponseInterceptor",
     "IStreamEmitter",
@@ -180,8 +190,10 @@ __all__ = [
     "RateCard",
     "ReasoningTrace",
     "Recipe",
+    "RecipeDefinition",
     "ResourceConstraints",
     "Role",
+    "RouterNode",
     "ServiceContract",
     "ServiceRequest",
     "ServiceResponse",

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Annotated, Any, Literal
+
+from pydantic import ConfigDict, Field, model_validator
+
+from coreason_manifest.spec.common_base import CoReasonBaseModel
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+
+
+class RecipeNode(CoReasonBaseModel):
+    """Base class for all nodes in a Recipe graph."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    id: str = Field(..., description="Unique identifier within the graph.")
+    metadata: dict[str, Any] = Field(default_factory=dict, description="UI layout metadata (x, y coordinates).")
+
+
+class AgentNode(RecipeNode):
+    """A node that executes an AI Agent."""
+
+    type: Literal["agent"] = "agent"
+    agent_ref: str = Field(..., description="The ID or URI of the Agent Definition to execute.")
+    system_prompt_override: str | None = Field(None, description="Context-specific instructions.")
+    inputs_map: dict[str, str] = Field(
+        default_factory=dict, description="Mapping parent outputs to agent inputs."
+    )
+
+
+class HumanNode(RecipeNode):
+    """A node that pauses execution for human input/approval."""
+
+    type: Literal["human"] = "human"
+    prompt: str = Field(..., description="Instruction for the human user.")
+    timeout_seconds: int | None = Field(None, description="SLA for approval.")
+    required_role: str | None = Field(None, description="Role required to approve (e.g., manager).")
+
+
+class RouterNode(RecipeNode):
+    """A node that routes execution based on a variable."""
+
+    type: Literal["router"] = "router"
+    input_key: str = Field(..., description="The variable to evaluate (e.g., 'classification').")
+    routes: dict[str, str] = Field(..., description="Map of value -> target_node_id.")
+    default_route: str = Field(..., description="Fallback target_node_id.")
+
+
+class GraphEdge(CoReasonBaseModel):
+    """A directed edge between two nodes."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    source: str = Field(..., description="Source Node ID.")
+    target: str = Field(..., description="Target Node ID.")
+    condition: str | None = Field(None, description="Label for visualization (e.g., 'approved').")
+
+
+class GraphTopology(CoReasonBaseModel):
+    """The directed cyclic graph structure defining the control flow."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    nodes: list[Annotated[AgentNode | HumanNode | RouterNode, Field(discriminator="type")]] = Field(
+        ..., description="List of nodes in the graph."
+    )
+    edges: list[GraphEdge] = Field(..., description="List of directed edges.")
+    entry_point: str = Field(..., description="ID of the start node.")
+
+    @model_validator(mode="after")
+    def validate_integrity(self) -> "GraphTopology":
+        """Verify graph integrity (entry point exists, no dangling edges)."""
+        valid_ids = {node.id for node in self.nodes}
+
+        # 1. Check entry point
+        if self.entry_point not in valid_ids:
+            raise ValueError(f"Entry point '{self.entry_point}' not found in nodes: {valid_ids}")
+
+        # 2. Check edges
+        for edge in self.edges:
+            if edge.source not in valid_ids:
+                raise ValueError(f"Dangling edge source: {edge.source} -> {edge.target}")
+            if edge.target not in valid_ids:
+                raise ValueError(f"Dangling edge target: {edge.source} -> {edge.target}")
+
+        return self
+
+
+class RecipeDefinition(CoReasonBaseModel):
+    """Definition of a Recipe (Graph-based Workflow)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    apiVersion: Literal["coreason.ai/v2"] = Field("coreason.ai/v2", description="API Version.")
+    kind: Literal["Recipe"] = Field("Recipe", description="Kind of the object.")
+    metadata: ManifestMetadata = Field(..., description="Metadata including name and design info.")
+    topology: GraphTopology = Field(..., description="The execution graph topology.")

--- a/tests/test_v2_exports.py
+++ b/tests/test_v2_exports.py
@@ -2,12 +2,13 @@ import pytest
 
 import coreason_manifest as cm
 from coreason_manifest.spec.v2.definitions import ManifestV2
+from coreason_manifest.spec.v2.recipe import RecipeDefinition
 from coreason_manifest.utils.v2.io import load_from_yaml
 
 
 def test_v2_defaults() -> None:
     assert cm.Manifest is ManifestV2
-    assert cm.Recipe is ManifestV2
+    assert cm.Recipe is RecipeDefinition
     assert cm.load is load_from_yaml
 
 

--- a/tests/test_v2_recipe.py
+++ b/tests/test_v2_recipe.py
@@ -1,0 +1,160 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GraphTopology,
+    HumanNode,
+    RecipeDefinition,
+    RouterNode,
+)
+
+
+def test_polymorphic_deserialization() -> None:
+    """Test that nodes are correctly deserialized into their specific types."""
+    data = {
+        "nodes": [
+            {
+                "type": "agent",
+                "id": "agent-1",
+                "agent_ref": "agent-a",
+                "metadata": {"x": 10, "y": 20},
+            },
+            {
+                "type": "human",
+                "id": "human-1",
+                "prompt": "Approve?",
+                "metadata": {"x": 100, "y": 20},
+            },
+            {
+                "type": "router",
+                "id": "router-1",
+                "input_key": "score",
+                "routes": {"high": "agent-1"},
+                "default_route": "human-1",
+                "metadata": {"x": 50, "y": 50},
+            },
+        ],
+        "edges": [],
+        "entry_point": "agent-1",
+    }
+
+    topology = GraphTopology.model_validate(data)
+
+    assert len(topology.nodes) == 3
+    assert isinstance(topology.nodes[0], AgentNode)
+    assert topology.nodes[0].id == "agent-1"
+    assert topology.nodes[0].agent_ref == "agent-a"
+
+    assert isinstance(topology.nodes[1], HumanNode)
+    assert topology.nodes[1].id == "human-1"
+    assert topology.nodes[1].prompt == "Approve?"
+
+    assert isinstance(topology.nodes[2], RouterNode)
+    assert topology.nodes[2].id == "router-1"
+    assert topology.nodes[2].input_key == "score"
+
+
+def test_integrity_validation_success() -> None:
+    """Test valid graph structure."""
+    data = {
+        "nodes": [
+            {"type": "agent", "id": "A", "agent_ref": "ref-a"},
+            {"type": "agent", "id": "B", "agent_ref": "ref-b"},
+        ],
+        "edges": [{"source": "A", "target": "B"}],
+        "entry_point": "A",
+    }
+    topology = GraphTopology.model_validate(data)
+    assert topology.entry_point == "A"
+    assert len(topology.edges) == 1
+
+
+def test_integrity_validation_failure_dangling_edge() -> None:
+    """Test validation failure for dangling edges."""
+    data = {
+        "nodes": [
+            {"type": "agent", "id": "A", "agent_ref": "ref-a"},
+        ],
+        "edges": [{"source": "A", "target": "B"}],  # B missing
+        "entry_point": "A",
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        GraphTopology.model_validate(data)
+
+    assert "Dangling edge" in str(excinfo.value)
+    assert "A -> B" in str(excinfo.value)
+
+    # Test dangling source
+    data2 = {
+        "nodes": [
+            {"type": "agent", "id": "B", "agent_ref": "ref-b"},
+        ],
+        "edges": [{"source": "A", "target": "B"}],  # A missing
+        "entry_point": "B",
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        GraphTopology.model_validate(data2)
+
+    assert "Dangling edge" in str(excinfo.value)
+    assert "A -> B" in str(excinfo.value)
+
+
+def test_integrity_validation_failure_bad_entry_point() -> None:
+    """Test validation failure for invalid entry point."""
+    data = {
+        "nodes": [
+            {"type": "agent", "id": "A", "agent_ref": "ref-a"},
+        ],
+        "edges": [],
+        "entry_point": "Z",
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        GraphTopology.model_validate(data)
+
+    assert "Entry point 'Z' not found" in str(excinfo.value)
+
+
+def test_full_manifest_roundtrip() -> None:
+    """Test serialization and deserialization of the full RecipeDefinition."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(
+            name="Test Recipe",
+            x_design=None,
+        ),
+        topology=GraphTopology(
+            nodes=[
+                AgentNode(id="start", agent_ref="agent-1"),
+                HumanNode(id="approval", prompt="Is this ok?"),
+            ],
+            edges=[
+                {"source": "start", "target": "approval", "condition": None},
+            ],
+            entry_point="start",
+        ),
+    )
+
+    json_str = recipe.to_json()
+    loaded = RecipeDefinition.model_validate_json(json_str)
+
+    assert loaded.metadata.name == "Test Recipe"
+    assert len(loaded.topology.nodes) == 2
+    assert loaded.topology.entry_point == "start"
+    assert loaded.topology.edges[0].source == "start"
+    assert loaded.topology.edges[0].target == "approval"
+
+    # Check dumping
+    dumped = loaded.dump()
+    assert dumped["kind"] == "Recipe"
+    assert dumped["apiVersion"] == "coreason.ai/v2"

--- a/tests/test_v2_recipe.py
+++ b/tests/test_v2_recipe.py
@@ -195,7 +195,10 @@ def test_edge_case_cycle() -> None:
 
 
 def test_edge_case_disconnected_node() -> None:
-    """Test that unreachable nodes are permitted (though technically 'dangling' in graph theory, they are valid definitions)."""
+    """Test that unreachable nodes are permitted.
+
+    Though technically 'dangling' in graph theory, they are valid definitions.
+    """
     data = {
         "nodes": [
             {"type": "agent", "id": "A", "agent_ref": "ref-a"},


### PR DESCRIPTION
This PR implements Work Package JJ: Graph Recipes, introducing a declarative graph-based workflow model ("Recipe") to support complex orchestration with loops, branching, and human-in-the-loop workflows.

Changes:
- **New Specification**: Created `src/coreason_manifest/spec/v2/recipe.py` defining:
    - `RecipeNode` (base), `AgentNode`, `HumanNode`, `RouterNode` (concrete).
    - `GraphEdge` and `GraphTopology` with integrity validation.
    - `RecipeDefinition` as the root manifest for recipes.
- **Exports**: Updated `src/coreason_manifest/__init__.py` to expose the new models and alias `Recipe` to `RecipeDefinition`.
- **Testing**: Added `tests/test_v2_recipe.py` verifying polymorphic deserialization, graph integrity checks, and full manifest round-tripping.


---
*PR created automatically by Jules for task [14867079587118116884](https://jules.google.com/task/14867079587118116884) started by @gowthamrao*