### PR TITLE
Bump minor version to 0.20.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.19.0"
+version = "0.20.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -38,7 +38,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.19.0"
+version = "0.20.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -117,7 +117,7 @@ from .utils.v2.io import dump_to_yaml, load_from_yaml
 from .utils.v2.validator import validate_integrity, validate_loose
 from .utils.viz import generate_mermaid_graph
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"
 
 Manifest = ManifestV2
 Recipe = RecipeDefinition

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,22 @@
+import tomllib
+from pathlib import Path
+
+import coreason_manifest
+
+
+def test_version() -> None:
+    """Verify that the package version matches pyproject.toml."""
+    pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+    with open(pyproject_path, "rb") as f:
+        pyproject_data = tomllib.load(f)
+
+    poetry_version = pyproject_data["tool"]["poetry"]["version"]
+    project_version = pyproject_data["project"]["version"]
+    package_version = coreason_manifest.__version__
+
+    assert poetry_version == package_version, (
+        f"Poetry version {poetry_version} does not match package version {package_version}"
+    )
+    assert project_version == package_version, (
+        f"Project version {project_version} does not match package version {package_version}"
+    )


### PR DESCRIPTION
Bumps the package minor version from 0.19.0 to 0.20.0. Added a test to verify that the version in `pyproject.toml` matches the version in `__init__.py` to prevent future inconsistencies.

---
*PR created automatically by Jules for task [3698434893569457232](https://jules.google.com/task/3698434893569457232) started by @gowthamrao*