### PR TITLE
Update RecipeDefinition in v2 spec with Interface, State, and Policy

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -45,45 +45,47 @@ You can also construct the object directly using Python classes.
 
 ```python
 from coreason_manifest import (
-    Recipe,
+    RecipeDefinition,
     ManifestMetadata,
-    InterfaceDefinition,
+    RecipeInterface,
     StateDefinition,
-    PolicyDefinition,
-    Workflow,
-    AgentStep
+    PolicyConfig,
+    GraphTopology,
+    AgentNode
 )
 
 # 1. Define Metadata
 metadata = ManifestMetadata(
-    name="Research Agent",
-    version="1.0.0"
+    name="Research Recipe"
 )
 
-# 2. Define Workflow
-workflow = Workflow(
-    start="step1",
-    steps={
-        "step1": AgentStep(
+# 2. Define Topology
+topology = GraphTopology(
+    entry_point="step1",
+    nodes=[
+        AgentNode(
             id="step1",
-            agent="gpt-4-researcher",
-            next="step2"
+            agent_ref="researcher-agent",
         ),
-        # ... define other steps
-    }
+        # ... define other nodes
+    ],
+    edges=[]
 )
 
 # 3. Instantiate Manifest
-manifest = Recipe(
+manifest = RecipeDefinition(
     kind="Recipe",
     metadata=metadata,
-    interface=InterfaceDefinition(
+    interface=RecipeInterface(
         inputs={"topic": {"type": "string"}},
         outputs={"summary": {"type": "string"}}
     ),
-    state=StateDefinition(),
-    policy=PolicyDefinition(max_retries=3),
-    workflow=workflow
+    state=StateDefinition(
+        properties={"notes": {"type": "string"}},
+        persistence="redis"
+    ),
+    policy=PolicyConfig(max_retries=3),
+    topology=topology
 )
 
 print(f"Manifest '{manifest.metadata.name}' created successfully.")

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -19,18 +19,17 @@ from coreason_manifest.spec.v2.definitions import ManifestMetadata
 # 1. Configuration Schemas (New)
 # ==========================================
 
+
 class RecipeInterface(CoReasonBaseModel):
     """Defines the Input/Output contract for the Recipe using JSON Schema."""
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     inputs: dict[str, Any] = Field(
-        default_factory=dict,
-        description="JSON Schema defining the expected input arguments."
+        default_factory=dict, description="JSON Schema defining the expected input arguments."
     )
     outputs: dict[str, Any] = Field(
-        default_factory=dict,
-        description="JSON Schema defining the structure of the final result."
+        default_factory=dict, description="JSON Schema defining the structure of the final result."
     )
 
 
@@ -39,13 +38,9 @@ class StateDefinition(CoReasonBaseModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
-    properties: dict[str, Any] = Field(
-        ...,
-        description="JSON Schema properties for the shared state variables."
-    )
+    properties: dict[str, Any] = Field(..., description="JSON Schema properties for the shared state variables.")
     persistence: Literal["ephemeral", "redis", "postgres"] = Field(
-        "ephemeral",
-        description="How the state should be stored across steps."
+        "ephemeral", description="How the state should be stored across steps."
     )
 
 
@@ -57,14 +52,14 @@ class PolicyConfig(CoReasonBaseModel):
     max_retries: int = Field(0, description="Global retry limit for failed steps.")
     timeout_seconds: int | None = Field(None, description="Global execution timeout.")
     execution_mode: Literal["sequential", "parallel"] = Field(
-        "sequential",
-        description="Default execution strategy for independent branches."
+        "sequential", description="Default execution strategy for independent branches."
     )
 
 
 # ==========================================
 # 2. Node Definitions
 # ==========================================
+
 
 class RecipeNode(CoReasonBaseModel):
     """Base class for all nodes in a Recipe graph."""

--- a/tests/test_docs_updated.py
+++ b/tests/test_docs_updated.py
@@ -1,0 +1,151 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GraphTopology,
+    PolicyConfig,
+    RecipeDefinition,
+    RecipeInterface,
+    StateDefinition,
+)
+
+
+def test_usage_doc_example() -> None:
+    """Verify the example code in docs/usage.md works as expected."""
+    # 1. Define Metadata
+    metadata = ManifestMetadata(name="Research Recipe")
+
+    # 2. Define Topology
+    topology = GraphTopology(
+        entry_point="step1",
+        nodes=[
+            AgentNode(
+                id="step1",
+                agent_ref="researcher-agent",
+            ),
+        ],
+        edges=[],
+    )
+
+    # 3. Instantiate Manifest
+    manifest = RecipeDefinition(
+        kind="Recipe",
+        metadata=metadata,
+        interface=RecipeInterface(inputs={"topic": {"type": "string"}}, outputs={"summary": {"type": "string"}}),
+        state=StateDefinition(properties={"notes": {"type": "string"}}, persistence="redis"),
+        policy=PolicyConfig(max_retries=3),
+        topology=topology,
+    )
+
+    assert manifest.metadata.name == "Research Recipe"
+    assert manifest.interface.inputs["topic"]["type"] == "string"
+    assert manifest.state is not None
+    assert manifest.state.persistence == "redis"
+    assert manifest.policy is not None
+    assert manifest.policy.max_retries == 3
+
+
+def test_graph_recipes_doc_example() -> None:
+    """Verify the example YAML structure in docs/graph_recipes.md."""
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "Blog Post Workflow"},
+        "interface": {"inputs": {"topic": {"type": "string"}}, "outputs": {"final_post": {"type": "string"}}},
+        "state": {
+            "properties": {"draft": {"type": "string"}, "status": {"type": "string"}},
+            "persistence": "ephemeral",
+        },
+        "policy": {"max_retries": 2, "timeout_seconds": 600},
+        "topology": {
+            "entry_point": "draft",
+            "nodes": [{"type": "agent", "id": "draft", "agent_ref": "writer-agent"}],
+            "edges": [],
+        },
+    }
+
+    recipe = RecipeDefinition.model_validate(data)
+    assert recipe.metadata.name == "Blog Post Workflow"
+    assert recipe.interface.inputs["topic"]["type"] == "string"
+    assert recipe.state is not None
+    assert recipe.state.persistence == "ephemeral"
+    assert recipe.policy is not None
+    assert recipe.policy.max_retries == 2
+
+
+def test_edge_case_empty_interface() -> None:
+    """Test Recipe with default empty interface."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Empty Interface Recipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(entry_point="start", nodes=[AgentNode(id="start", agent_ref="agent-1")], edges=[]),
+    )
+    assert recipe.interface.inputs == {}
+    assert recipe.interface.outputs == {}
+
+
+def test_edge_case_state_defaults() -> None:
+    """Test StateDefinition defaults (persistence='ephemeral')."""
+    state = StateDefinition(properties={})
+    assert state.persistence == "ephemeral"
+
+
+def test_edge_case_policy_defaults() -> None:
+    """Test PolicyConfig defaults."""
+    policy = PolicyConfig()
+    assert policy.max_retries == 0
+    assert policy.timeout_seconds is None
+    assert policy.execution_mode == "sequential"
+
+
+def test_complex_case_full_stack() -> None:
+    """Test a complex recipe with all optional fields and detailed configuration."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Complex Recipe"),
+        interface=RecipeInterface(
+            inputs={"query": {"type": "string"}, "limit": {"type": "integer", "default": 10}},
+            outputs={"results": {"type": "array", "items": {"type": "object"}}},
+        ),
+        state=StateDefinition(
+            properties={"counter": {"type": "integer"}, "logs": {"type": "array"}}, persistence="postgres"
+        ),
+        policy=PolicyConfig(max_retries=5, timeout_seconds=3600, execution_mode="parallel"),
+        topology=GraphTopology(
+            entry_point="start",
+            nodes=[
+                AgentNode(id="start", agent_ref="agent-1"),
+                AgentNode(id="worker1", agent_ref="agent-2"),
+                AgentNode(id="worker2", agent_ref="agent-3"),
+            ],
+            edges=[
+                {"source": "start", "target": "worker1"},
+                {"source": "start", "target": "worker2"},
+            ],
+        ),
+    )
+
+    assert recipe.interface.inputs["limit"]["default"] == 10
+    assert recipe.state is not None
+    assert recipe.state.persistence == "postgres"
+    assert recipe.policy is not None
+    assert recipe.policy.execution_mode == "parallel"
+    assert len(recipe.topology.edges) == 2
+
+
+def test_validation_state_persistence_enum() -> None:
+    """Test that invalid persistence options raise ValidationError."""
+    with pytest.raises(ValidationError):
+        StateDefinition(
+            properties={},
+            persistence="invalid_db",
+        )
+
+
+def test_validation_policy_execution_mode_enum() -> None:
+    """Test that invalid execution modes raise ValidationError."""
+    with pytest.raises(ValidationError):
+        PolicyConfig(execution_mode="random")

--- a/tests/test_v2_recipe.py
+++ b/tests/test_v2_recipe.py
@@ -17,6 +17,7 @@ from coreason_manifest.spec.v2.recipe import (
     GraphTopology,
     HumanNode,
     RecipeDefinition,
+    RecipeInterface,
     RouterNode,
 )
 
@@ -133,6 +134,7 @@ def test_full_manifest_roundtrip() -> None:
             name="Test Recipe",
             x_design=None,
         ),
+        interface=RecipeInterface(),
         topology=GraphTopology(
             nodes=[
                 AgentNode(id="start", agent_ref="agent-1"),

--- a/tests/test_v2_recipe_extensions.py
+++ b/tests/test_v2_recipe_extensions.py
@@ -23,10 +23,7 @@ def test_recipe_interface_defaults() -> None:
 
 def test_recipe_interface_validation() -> None:
     """Test RecipeInterface validation."""
-    interface = RecipeInterface(
-        inputs={"arg": {"type": "string"}},
-        outputs={"result": {"type": "integer"}}
-    )
+    interface = RecipeInterface(inputs={"arg": {"type": "string"}}, outputs={"result": {"type": "integer"}})
     assert interface.inputs["arg"]["type"] == "string"
     assert interface.outputs["result"]["type"] == "integer"
 
@@ -38,10 +35,7 @@ def test_recipe_interface_validation() -> None:
 def test_state_definition_validation() -> None:
     """Test StateDefinition validation."""
     # Test valid
-    state = StateDefinition(
-        properties={"count": {"type": "integer"}},
-        persistence="redis"
-    )
+    state = StateDefinition(properties={"count": {"type": "integer"}}, persistence="redis")
     assert state.persistence == "redis"
     assert state.properties["count"]["type"] == "integer"
 
@@ -68,11 +62,7 @@ def test_policy_config_defaults() -> None:
 
 def test_policy_config_validation() -> None:
     """Test PolicyConfig validation."""
-    policy = PolicyConfig(
-        max_retries=5,
-        timeout_seconds=30,
-        execution_mode="parallel"
-    )
+    policy = PolicyConfig(max_retries=5, timeout_seconds=30, execution_mode="parallel")
     assert policy.max_retries == 5
     assert policy.timeout_seconds == 30
     assert policy.execution_mode == "parallel"
@@ -86,18 +76,9 @@ def test_full_recipe_with_extensions() -> None:
     """Test RecipeDefinition with all new components."""
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="Extended Recipe"),
-        interface=RecipeInterface(
-            inputs={"query": {"type": "string"}},
-            outputs={"answer": {"type": "string"}}
-        ),
-        state=StateDefinition(
-            properties={"memory": {"type": "array"}},
-            persistence="postgres"
-        ),
-        policy=PolicyConfig(
-            max_retries=3,
-            timeout_seconds=60
-        ),
+        interface=RecipeInterface(inputs={"query": {"type": "string"}}, outputs={"answer": {"type": "string"}}),
+        state=StateDefinition(properties={"memory": {"type": "array"}}, persistence="postgres"),
+        policy=PolicyConfig(max_retries=3, timeout_seconds=60),
         topology=GraphTopology(
             nodes=[
                 AgentNode(id="start", agent_ref="agent-1"),

--- a/tests/test_v2_recipe_extensions.py
+++ b/tests/test_v2_recipe_extensions.py
@@ -1,0 +1,120 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GraphTopology,
+    PolicyConfig,
+    RecipeDefinition,
+    RecipeInterface,
+    StateDefinition,
+)
+
+
+def test_recipe_interface_defaults() -> None:
+    """Test that RecipeInterface defaults to empty dicts."""
+    interface = RecipeInterface()
+    assert interface.inputs == {}
+    assert interface.outputs == {}
+
+
+def test_recipe_interface_validation() -> None:
+    """Test RecipeInterface validation."""
+    interface = RecipeInterface(
+        inputs={"arg": {"type": "string"}},
+        outputs={"result": {"type": "integer"}}
+    )
+    assert interface.inputs["arg"]["type"] == "string"
+    assert interface.outputs["result"]["type"] == "integer"
+
+    # Test extra fields forbidden
+    with pytest.raises(ValidationError):
+        RecipeInterface(extra_field="invalid")  # type: ignore[call-arg]
+
+
+def test_state_definition_validation() -> None:
+    """Test StateDefinition validation."""
+    # Test valid
+    state = StateDefinition(
+        properties={"count": {"type": "integer"}},
+        persistence="redis"
+    )
+    assert state.persistence == "redis"
+    assert state.properties["count"]["type"] == "integer"
+
+    # Test default persistence
+    state_default = StateDefinition(properties={})
+    assert state_default.persistence == "ephemeral"
+
+    # Test invalid persistence
+    with pytest.raises(ValidationError):
+        StateDefinition(properties={}, persistence="invalid_mode")
+
+    # Test missing properties
+    with pytest.raises(ValidationError):
+        StateDefinition(persistence="ephemeral")  # type: ignore[call-arg]
+
+
+def test_policy_config_defaults() -> None:
+    """Test PolicyConfig defaults."""
+    policy = PolicyConfig()
+    assert policy.max_retries == 0
+    assert policy.timeout_seconds is None
+    assert policy.execution_mode == "sequential"
+
+
+def test_policy_config_validation() -> None:
+    """Test PolicyConfig validation."""
+    policy = PolicyConfig(
+        max_retries=5,
+        timeout_seconds=30,
+        execution_mode="parallel"
+    )
+    assert policy.max_retries == 5
+    assert policy.timeout_seconds == 30
+    assert policy.execution_mode == "parallel"
+
+    # Test invalid execution_mode
+    with pytest.raises(ValidationError):
+        PolicyConfig(execution_mode="random")
+
+
+def test_full_recipe_with_extensions() -> None:
+    """Test RecipeDefinition with all new components."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Extended Recipe"),
+        interface=RecipeInterface(
+            inputs={"query": {"type": "string"}},
+            outputs={"answer": {"type": "string"}}
+        ),
+        state=StateDefinition(
+            properties={"memory": {"type": "array"}},
+            persistence="postgres"
+        ),
+        policy=PolicyConfig(
+            max_retries=3,
+            timeout_seconds=60
+        ),
+        topology=GraphTopology(
+            nodes=[
+                AgentNode(id="start", agent_ref="agent-1"),
+            ],
+            edges=[],
+            entry_point="start",
+        ),
+    )
+
+    assert recipe.interface.inputs["query"]["type"] == "string"
+    assert recipe.state is not None
+    assert recipe.state.persistence == "postgres"
+    assert recipe.policy is not None
+    assert recipe.policy.max_retries == 3
+
+    # Test serialization
+    dumped = recipe.dump()
+    assert dumped["interface"]["inputs"]["query"]["type"] == "string"
+    assert dumped["state"]["persistence"] == "postgres"
+    assert dumped["policy"]["max_retries"] == 3


### PR DESCRIPTION
This change updates 'src/coreason_manifest/spec/v2/recipe.py' to include 'RecipeInterface', 'StateDefinition', and 'PolicyConfig' as requested. It also updates 'RecipeDefinition' to use these new components, making 'interface' a required field. 'tests/test_v2_recipe.py' was updated to reflect this breaking change, and 'tests/test_v2_recipe_extensions.py' was added to test the new components.

---
*PR created automatically by Jules for task [14702575906979637518](https://jules.google.com/task/14702575906979637518) started by @gowthamrao*