### PR TITLE
docs: Overhaul documentation for v0.20.0 (Work Package OO)

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ To enable robust Enterprise Agentic Systems, this library implements four critic
 | **🤖 Behavior** | **Protocols (`IAgentRuntime`)** | Hexagonal architecture interfaces for portable agents. Defines the Input/Output contract. |
 | **🧪 Simulation** | **ATIF (`SimulationTrace`)** | The "Flight Recorder" schema for auditing, red-teaming, and evaluation scenarios. |
 
+### Shared Kernel Boundaries
+
+To avoid the "Distributed Monolith" trap, this library strictly separates **Data** from **Logic**:
+
+*   **`coreason_manifest.spec` (The Kernel):** Contains **pure Pydantic models (DTOs)**. It has zero dependencies on business logic and is safe to import anywhere.
+*   **`coreason_manifest.utils` (The Toolbelt):** Contains **optional reference implementations** for Visualization, Audit Hashing, and Governance Enforcement.
+
+These components are co-located for developer convenience but are architecturally decoupled. The Core Spec **never** imports from Utils. See [Package Structure](docs/package_structure.md) for details.
+
 ## Installation
 
 ```bash
@@ -103,6 +112,20 @@ child_request = root_request.create_child(
 print(f"Child Parent ID: {child_request.parent_request_id} (Should match Root Request ID)")
 print(f"Child Root ID:   {child_request.root_request_id}   (Should match Root Request ID)")
 ```
+
+### 3. Builder SDK (Optional)
+
+For a fluent, Pythonic API to construct manifests (especially useful for tooling), use the `ManifestBuilder`.
+
+```python
+from coreason_manifest.builder import AgentBuilder
+
+agent = AgentBuilder("ResearchAgent") \
+    .with_model("gpt-4-turbo") \
+    .with_system_prompt("You are a helpful researcher.") \
+    .build_definition()
+```
+See [Builder SDK](docs/builder_sdk.md) for details.
 
 ## CLI
 

--- a/docs/behavior.md
+++ b/docs/behavior.md
@@ -1,0 +1,13 @@
+# Runtime Protocol (Behavior)
+
+The Runtime Protocol defines the interfaces for Agent execution and interaction within the Coreason ecosystem.
+
+## IAgentRuntime
+
+The `IAgentRuntime` interface (conceptually) defines the contract for an Agent's execution environment. It abstracts away the underlying infrastructure (local process, container, serverless function) and provides a consistent API for:
+
+1.  **Lifecycle Management**: Starting, stopping, and pausing agents.
+2.  **State Persistence**: Loading and saving agent state.
+3.  **I/O Handling**: Processing inputs and emitting outputs.
+
+*Note: This specification is currently under active development and will be formalized in future releases.*

--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -13,6 +13,46 @@ A Topology is a collection of **Nodes** connected by **Edges**.
 
 This structure allows for **Cycles** (loops), enabling agents to self-correct or retry tasks until a condition is met.
 
+## Recipe Components
+
+A `RecipeDefinition` is composed of four key layers:
+
+1.  **Interface (Contract)**: Defines inputs and outputs.
+2.  **State (Memory)**: Defines shared variables.
+3.  **Policy (Governance)**: Defines execution limits.
+4.  **Topology (Logic)**: Defines the graph structure.
+
+### 1. The Interface Layer
+Defines the input/output contract for the Recipe using JSON Schema.
+
+```python
+interface=InterfaceDefinition(
+    inputs={"user_input": {"type": "string"}},
+    outputs={"final_report": {"type": "string"}}
+)
+```
+
+### 2. The State Layer (Blackboard)
+Defines the shared memory structure and persistence strategy.
+
+```python
+state=StateDefinition(
+    properties={"draft": {"type": "string"}},
+    persistence="ephemeral" # or "redis", "postgres"
+)
+```
+
+### 3. The Policy Layer
+Sets execution limits and error handling strategies.
+
+```python
+policy=PolicyConfig(
+    max_retries=3,
+    timeout_seconds=3600,
+    execution_mode="sequential"
+)
+```
+
 ## The Graph Topology Schema
 
 The `GraphTopology` enforces structural integrity. It requires a list of `nodes`, a list of `edges`, and a valid `entry_point`.

--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -1,252 +1,86 @@
-# Graph Recipes (Work Package JJ)
+# Orchestration: Graph Recipes
 
-The **Recipe** system is the "Brain" of the Coreason execution model. While `AgentDefinition` describes *what* an agent can do (its tools and capabilities), a `RecipeDefinition` describes *how* tasks are orchestrated.
+Coreason V2 introduces **Graph Recipes**, replacing linear workflows with a robust **Directed Cyclic Graph (DCG)** architecture. This allows for complex orchestration patterns including loops, conditional branching, and human-in-the-loop interactions.
 
-Recipes upgrade the system from simple linear lists of steps to executing complex, non-linear **Directed Cyclic Graphs (DCGs)**. This enables:
+## Concept: Graphs, Not Lists
 
-*   **Loops:** "If quality < 50%, critique and revise."
-*   **Branching:** "If legal query, route to Legal Agent; else route to General Agent."
-*   **Human-in-the-Loop:** "Pause and wait for Manager Approval."
+In V1, workflows were simple lists of steps. In V2, a `RecipeDefinition` contains a `GraphTopology`.
+A Topology is a collection of **Nodes** connected by **Edges**.
 
-## Architecture
+*   **Nodes**: The "Workers" (Agents, Humans, Routers).
+*   **Edges**: The "Control Flow" (Next Step).
+*   **Entry Point**: Where execution begins.
 
-A `RecipeDefinition` is a specialized Manifest type (`kind: Recipe`) that contains a `GraphTopology` along with other key components:
+This structure allows for **Cycles** (loops), enabling agents to self-correct or retry tasks until a condition is met.
 
-### 1. The Interface Layer (Contract)
+## The Graph Topology Schema
 
-Defines the input/output contract for the Recipe using JSON Schema.
+The `GraphTopology` enforces structural integrity. It requires a list of `nodes`, a list of `edges`, and a valid `entry_point`.
 
-```yaml
-interface:
-  inputs:
-    topic:
-      type: string
-  outputs:
-    summary:
-      type: string
+### JSON Example: Agent -> Human Handover
+
+Here is a raw JSON example of a topology where an AI Agent performs a task, and then a Human Manager must approve it.
+
+```json
+{
+  "entry_point": "research-task",
+  "nodes": [
+    {
+      "type": "agent",
+      "id": "research-task",
+      "agent_ref": "researcher-v1",
+      "inputs_map": {
+        "topic": "user_query"
+      }
+    },
+    {
+      "type": "human",
+      "id": "manager-approval",
+      "prompt": "Review the research report. Approve to proceed?",
+      "timeout_seconds": 86400,
+      "required_role": "manager"
+    }
+  ],
+  "edges": [
+    {
+      "source": "research-task",
+      "target": "manager-approval",
+      "condition": "on_success"
+    }
+  ]
+}
 ```
 
-### 2. The State Layer (Memory)
+### Node Types
 
-Defines the shared memory (Blackboard) schema and persistence strategy.
+1.  **`AgentNode`**: Executes an AI Agent.
+2.  **`HumanNode`**: Suspends execution until a human provides input or approval.
+3.  **`RouterNode`**: Evaluates a variable and branches execution to different target nodes.
 
-```yaml
-state:
-  properties:
-    draft_content:
-      type: string
-    vote_count:
-      type: integer
-  persistence: "redis" # Options: ephemeral, redis, postgres
-```
+## Integrity Validation
 
-### 3. The Policy Layer (Governance)
+The `coreason-manifest` library performs strict validation on the graph topology to prevent runtime errors.
 
-Sets execution limits and error handling strategies.
+### 1. Dangling Edge Check
+Every `source` and `target` in the `edges` list must correspond to a valid Node ID. If you try to connect to a node that doesn't exist, the validator will raise a `ValueError`.
 
-```yaml
-policy:
-  max_retries: 5
-  timeout_seconds: 3600
-  execution_mode: "parallel" # Options: sequential, parallel
-```
+### 2. Entry Point Check
+The `entry_point` ID must exist in the `nodes` list. You cannot start a graph at a non-existent node.
 
-### 4. Graph Topology
-
-The topology consists of:
-*   **Nodes**: Units of work (Agents, Humans, Routers).
-*   **Edges**: Directed connections defining the flow of control.
-*   **Entry Point**: The ID of the node where execution begins.
-
-The system enforces strict **Graph Integrity**:
-*   The `entry_point` must exist in the node list.
-*   All edges must connect valid source and target nodes (no dangling pointers).
-*   Cycles (loops) are explicitly allowed and supported.
-
-## Node Types
-
-Nodes are polymorphic and identified by their `type` field.
-
-### 1. Agent Node (`type: agent`)
-Executes an AI Agent.
-
-```yaml
-type: agent
-id: "research-step"
-agent_ref: "researcher-agent-v1"
-system_prompt_override: "Focus on recent news."
-inputs_map:
-  topic: "user_query"
-```
-
-### 2. Human Node (`type: human`)
-Pauses execution and waits for external human intervention.
-
-```yaml
-type: human
-id: "manager-approval"
-prompt: "Please review the draft."
-timeout_seconds: 3600
-required_role: "editor"
-```
-
-### 3. Router Node (`type: router`)
-Evaluates a variable and routes execution to different paths.
-
-```yaml
-type: router
-id: "quality-gate"
-input_key: "score"
-routes:
-  high: "publish-step"
-  low: "revise-step"
-default_route: "manual-review"
-```
-
-## Visual Presentation
-
-Every node supports a strictly typed `presentation` field for controlling its layout and appearance in the Visual Builder.
-
-```yaml
-type: agent
-id: "research-step"
-agent_ref: "researcher-agent-v1"
-presentation:
-  x: 100.5
-  y: 200.0
-  label: "Deep Research"
-  color: "#FF5733"
-  icon: "lucide:search"
-  z_index: 10
-```
-
-*   **x, y**: Mandatory coordinates.
-*   **color**: Optional 6-character hex code (e.g. `#FF0000`).
-*   **icon**: Optional icon identifier.
-*   **z_index**: Optional rendering order (default 0).
-
-## Example Recipe
-
-Here is a complete example of a Recipe that includes a loop, human approval, state, and policy.
-
-```yaml
-apiVersion: coreason.ai/v2
-kind: Recipe
-metadata:
-  name: "Blog Post Workflow"
-
-interface:
-  inputs:
-    topic: {type: string}
-  outputs:
-    final_post: {type: string}
-
-state:
-  properties:
-    draft: {type: string}
-    status: {type: string}
-  persistence: "ephemeral"
-
-policy:
-  max_retries: 2
-  timeout_seconds: 600
-
-topology:
-  entry_point: "draft"
-  nodes:
-    - type: agent
-      id: "draft"
-      agent_ref: "writer-agent"
-
-    - type: agent
-      id: "critique"
-      agent_ref: "editor-agent"
-
-    - type: router
-      id: "check-quality"
-      input_key: "score"
-      routes:
-        pass: "human-approve"
-      default_route: "draft"  # Loop back to draft if quality fails
-
-    - type: human
-      id: "human-approve"
-      prompt: "Approve for publication?"
-
-    - type: agent
-      id: "publish"
-      agent_ref: "publisher-agent"
-
-  edges:
-    - source: "draft"
-      target: "critique"
-    - source: "critique"
-      target: "check-quality"
-    # Router logic handles the next steps dynamically, but edges can visualize the flow
-    - source: "check-quality"
-      target: "draft"
-      condition: "default (fail)"
-    - source: "check-quality"
-      target: "human-approve"
-      condition: "pass"
-    - source: "human-approve"
-      target: "publish"
-```
-
-## Advanced Patterns
-
-### Self-Refining Loop (Recursive)
-
-A common pattern is an agent that critiques and improves its own work until a quality threshold is met.
-
-```yaml
-topology:
-  entry_point: "generate"
-  nodes:
-    - type: agent
-      id: "generate"
-      agent_ref: "coder-agent"
-      # Agent takes 'feedback' as input; on first run it might be empty
-      inputs_map:
-        feedback: "critique_output"
-
-    - type: agent
-      id: "evaluate"
-      agent_ref: "qa-agent"
-      inputs_map:
-        code: "generate_output"
-
-    - type: router
-      id: "check-score"
-      input_key: "quality_score"
-      routes:
-        pass: "deploy"
-      default_route: "generate" # Recursive loop back to start
-
-    - type: agent
-      id: "deploy"
-      agent_ref: "ops-agent"
-
-  edges:
-    - source: "generate"
-      target: "evaluate"
-    - source: "evaluate"
-      target: "check-score"
-    - source: "check-score"
-      target: "generate"
-      condition: "fail (loop)"
-    - source: "check-score"
-      target: "deploy"
-      condition: "pass"
-```
-
-## Validation
-
-The `coreason-manifest` library includes strict Pydantic validation for Recipes.
+### 3. Duplicate ID Check
+All Node IDs must be unique within the topology.
 
 ```python
-from coreason_manifest import RecipeDefinition, GraphTopology
+from coreason_manifest.spec.v2.recipe import GraphTopology, AgentNode, GraphEdge
 
-# This will raise ValidationError if integrity checks fail
-recipe = RecipeDefinition.model_validate(data)
+try:
+    # This will fail because 'phantom-node' does not exist
+    topology = GraphTopology(
+        entry_point="node-1",
+        nodes=[AgentNode(id="node-1", agent_ref="agent-a")],
+        edges=[GraphEdge(source="node-1", target="phantom-node")]
+    )
+except ValueError as e:
+    print(f"Validation Error: {e}")
+    # Output: Dangling edge target: node-1 -> phantom-node
 ```

--- a/docs/presentation_schemas.md
+++ b/docs/presentation_schemas.md
@@ -1,54 +1,71 @@
-# Standardized Presentation Schemas (V2)
+# Presentation Schemas: The Visual Contract
 
-The Coreason Presentation Layer (V2) enforces strictly typed, immutable Pydantic models for all user interface events. This ensures that the Frontend can deterministically render complex agent outputs such as citations, progress bars, and media carousels.
+Coreason V2 defines a strict **Visual Contract** between the Backend (Runtime) and the Frontend (Builder/Chat). This ensures that while the Runtime executes logic, the Builder can persistently store layout information without polluting the execution model.
 
-All presentation events are wrapped in a `PresentationEvent` container and discriminated by the `type` field.
+## 1. Graph Layout (`NodePresentation`)
 
-## Core Concepts
+When defining a `Recipe`, the Runtime only cares about the topology (nodes and edges). However, the Visual Builder needs to know where to place these nodes on the canvas.
 
-*   **Strict Typing:** Uses `pydantic.AnyUrl` for URIs, `uuid.UUID` for IDs, and `Literal` for status fields.
-*   **Immutability:** All models are `frozen=True`.
-*   **Polymorphism:** The `PresentationEvent.data` field is a polymorphic union of specific payload models.
+The `presentation` field in `RecipeNode` is the dedicated container for this metadata.
 
-## The Container: `PresentationEvent`
+### The Contract
+*   **Runtime ignores it:** The engine will not fail if `x/y` are missing (though they are required by schema).
+*   **Builder owns it:** The UI is the source of truth for these coordinates.
 
-Every event emitted to the UI follows this structure:
+### Schema
+
+```python
+class NodePresentation(CoReasonBaseModel):
+    x: float          # Canvas X coordinate
+    y: float          # Canvas Y coordinate
+    label: str | None # Optional override for display name
+    color: str | None # Hex code (e.g. #FF0000)
+    icon: str | None  # Icon identifier (e.g. lucide:brain)
+    z_index: int      # Rendering layer order
+```
+
+### Example: Recipe Node with Layout
+
+```python
+from coreason_manifest.spec.v2.recipe import AgentNode
+from coreason_manifest.spec.common.presentation import NodePresentation
+
+node = AgentNode(
+    id="research-step",
+    agent_ref="researcher-v1",
+    presentation=NodePresentation(
+        x=100.5,
+        y=200.0,
+        label="Deep Research Phase",
+        color="#33FF57",
+        icon="lucide:microscope"
+    )
+)
+```
+
+## 2. Runtime Events (`PresentationEvent`)
+
+During execution, Agents emit "Presentation Events" to render rich UI elements like citations, artifacts, and progress bars. These are strictly typed to ensure the Frontend can render them deterministically.
+
+### Core Container
 
 ```python
 class PresentationEvent(CoReasonBaseModel):
     id: UUID
     timestamp: datetime
     type: PresentationEventType
-    data: Union[CitationBlock, ProgressUpdate, MediaCarousel, MarkdownBlock, dict[str, Any]]
+    data: Union[CitationBlock, ProgressUpdate, MediaCarousel, MarkdownBlock]
 ```
 
-### Event Types (`PresentationEventType`)
+### Supported Event Types
 
-*   `"thought_trace"`
-*   `"citation_block"`
-*   `"progress_indicator"`
-*   `"media_carousel"`
-*   `"markdown_block"`
-*   `"user_error"`
+*   **`citation_block`**: List of source references with snippets.
+*   **`progress_indicator`**: Loading bars with status and percentage.
+*   **`media_carousel`**: Gallery of images or files.
+*   **`markdown_block`**: Standard rich text.
 
-## Payloads
+### Example: Emitting a Citation
 
-### 1. Citation Block (`citation_block`)
-
-Used to display a list of source references.
-
-```python
-class CitationItem(CoReasonBaseModel):
-    source_id: str
-    uri: AnyUrl
-    title: str
-    snippet: str | None = None
-
-class CitationBlock(CoReasonBaseModel):
-    items: list[CitationItem]
-```
-
-**JSON Example:**
 ```json
 {
   "type": "citation_block",
@@ -61,83 +78,6 @@ class CitationBlock(CoReasonBaseModel):
         "snippet": "Revenue grew by 20%..."
       }
     ]
-  }
-}
-```
-
-### 2. Progress Indicator (`progress_indicator`)
-
-Used to show the status of a long-running operation.
-
-```python
-class ProgressUpdate(CoReasonBaseModel):
-    label: str
-    status: Literal["running", "complete", "failed"]
-    progress_percent: float | None = Field(None, ge=0.0, le=1.0)
-```
-
-**JSON Example:**
-```json
-{
-  "type": "progress_indicator",
-  "data": {
-    "label": "Analyzing documents...",
-    "status": "running",
-    "progress_percent": 0.45
-  }
-}
-```
-
-### 3. Media Carousel (`media_carousel`)
-
-Used to display a gallery of images or other media.
-
-```python
-class MediaItem(CoReasonBaseModel):
-    url: AnyUrl
-    mime_type: str
-    alt_text: str | None = None
-
-class MediaCarousel(CoReasonBaseModel):
-    items: list[MediaItem]
-```
-
-**JSON Example:**
-```json
-{
-  "type": "media_carousel",
-  "data": {
-    "items": [
-      {
-        "url": "https://example.com/chart.png",
-        "mime_type": "image/png",
-        "alt_text": "Q3 Sales Chart"
-      }
-    ]
-  }
-}
-```
-
-### 4. Markdown Block (`markdown_block`)
-
-Used for rich text content.
-
-```python
-class MarkdownBlock(CoReasonBaseModel):
-    content: str
-```
-
-### 5. User Error (`user_error`)
-
-Used for generic error reporting. The payload is a flexible dictionary (`dict[str, Any]`).
-
-**JSON Example:**
-```json
-{
-  "type": "user_error",
-  "data": {
-    "code": "rate_limit_exceeded",
-    "message": "You have exceeded your daily quota."
   }
 }
 ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,35 +3,16 @@ theme:
   name: material
 nav:
   - Home: index.md
-  - Core Documentation:
-    - Usage Guide: usage.md
-    - Builder SDK: builder_sdk.md
-    - Visualization Tools: visualization.md
-    - Secure Composition: composition.md
-    - Governance & Policy: governance_policy_enforcement.md
-    - Semantic Diffing: semantic_diffing.md
-    - Agent Card Generator: agent_card_generator.md
-    - Mock Data Factory: mock_factory.md
-    - MCP Adapter: interop/mcp_adapter.md
-  - Specifications & Protocols:
-    - Agent Trajectory (ATIF): simulation.md
-    - CAM Specification: cap/specification.md
-    - CAP Wire Protocol: cap/wire_protocol.md
-    - Explicit Streaming Contracts: cap/streaming_contracts.md
-    - Stream Identity & Lifecycle: cap/stream_lifecycle.md
-    - Memory Governance: memory_governance.md
-    - Session Management: session_management.md
-    - Active Memory Interface: active_memory_interface.md
-    - Evaluation Metadata: evaluation_metadata.md
-    - Request Lineage Implementation: request_lineage_implementation.md
-    - Observability & Tracing: observability.md
-    - Audit Hashing & Integrity: audit_hashing.md
-    - Standardized Presentation Schemas: presentation_schemas.md
-    - Frontend Integration & Graph Events: frontend_integration.md
-    - Event Content Types: event_content_types.md
-    - Semantic Error Handling: error_handling_standards.md
-    - Middleware Extension Interfaces: middleware_extension_interfaces.md
-  - Architecture & Rationale:
-    - Product Requirements: product_requirements.md
-    - Package Structure & Architecture: package_structure.md
-    - Base Model Rationale: coreason_base_model_rationale.md
+  - Usage: usage.md
+  - Specifications:
+      - "Orchestration (Recipes)": graph_recipes.md
+      - "Agent Definitions (V2)": cap/specification.md
+      - "Inline Tools": inline_tools.md
+      - "Transport & Tracing": transport_layer.md
+      - "Simulation & Eval": simulation.md
+      - "Visualization (UI)": presentation_schemas.md
+  - Interfaces:
+      - "Runtime Protocol": behavior.md
+      - "Middleware": middleware_extension_interfaces.md
+  - Architecture:
+      - "Shared Kernel": architecture/ADR-001-shared-kernel-boundaries.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -16,3 +16,30 @@ nav:
       - "Middleware": middleware_extension_interfaces.md
   - Architecture:
       - "Shared Kernel": architecture/ADR-001-shared-kernel-boundaries.md
+      - "Package Structure": package_structure.md
+      - "Base Model Rationale": coreason_base_model_rationale.md
+      - "Product Requirements": product_requirements.md
+  - Advanced / Reference:
+      - "Builder SDK": builder_sdk.md
+      - "CLI Reference": cli.md
+      - "Governance & Policy": governance_policy_enforcement.md
+      - "Active Memory Interface": active_memory_interface.md
+      - "Audit Hashing": audit_hashing.md
+      - "Semantic Diffing": semantic_diffing.md
+      - "Memory Governance": memory_governance.md
+      - "Session Management": session_management.md
+      - "Observability": observability.md
+      - "Mock Factory": mock_factory.md
+      - "Error Handling": error_handling_standards.md
+      - "Evaluation Metadata": evaluation_metadata.md
+      - "Event Content Types": event_content_types.md
+      - "Frontend Integration": frontend_integration.md
+      - "Request Lineage (Impl)": request_lineage_implementation.md
+      - "Agent Card Generator": agent_card_generator.md
+      - "Composition": composition.md
+      - "CLI Interop": cli_interop.md
+      - "Visualization (Reference)": visualization.md
+      - "CAP Wire Protocol": cap/wire_protocol.md
+      - "Stream Lifecycle": cap/stream_lifecycle.md
+      - "Streaming Contracts": cap/streaming_contracts.md
+      - "MCP Adapter": interop/mcp_adapter.md


### PR DESCRIPTION
This PR overhauls the documentation to reflect the v0.20.0 capabilities of the `coreason-manifest` library. 

It transforms the documentation from a simple schema library description to a comprehensive platform overview, covering:
1.  **Orchestration**: Graph Recipes (`GraphTopology`).
2.  **Transport**: Distributed Tracing (`AgentRequest`).
3.  **Behavior**: Inline Tools (`InlineToolDefinition`) and Interfaces.
4.  **Simulation**: ATIF references.
5.  **Visualization**: Presentation Metadata (`NodePresentation`).

It also restructures `mkdocs.yml` to improve navigation and align with the "OS Layers" concept.
Verification: Ran `mkdocs build` and verified imports in code snippets.

---
*PR created automatically by Jules for task [8584710891835432186](https://jules.google.com/task/8584710891835432186) started by @gowthamrao*