### PR TITLE
Bump minor version to 0.21.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "coreason_manifest"
-version = "0.20.0"
+version = "0.21.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 authors = ["Gowtham A Rao <gowtham.rao@coreason.ai>"]
 license = "Prosperity-3.0"
@@ -38,7 +38,7 @@ build-backend = "poetry.core.masonry.api"
 
 [project]
 name = "coreason_manifest"
-version = "0.20.0"
+version = "0.21.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -120,7 +120,7 @@ from .utils.v2.io import dump_to_yaml, load_from_yaml
 from .utils.v2.validator import validate_integrity, validate_loose
 from .utils.viz import generate_mermaid_graph
 
-__version__ = "0.20.0"
+__version__ = "0.21.0"
 
 Manifest = ManifestV2
 Recipe = RecipeDefinition


### PR DESCRIPTION
Bumps the version of `coreason_manifest` to `0.21.0` in `pyproject.toml` (both `[tool.poetry]` and `[project]` sections) and `src/coreason_manifest/__init__.py`. Verified by running `tests/test_version.py`.

---
*PR created automatically by Jules for task [17947765802218482335](https://jules.google.com/task/17947765802218482335) started by @gowthamrao*