### PR TITLE
Add EvaluatorNode to Recipe v2 spec

### DIFF
--- a/docs/evaluator_optimizer.md
+++ b/docs/evaluator_optimizer.md
@@ -1,0 +1,97 @@
+# Evaluator-Optimizer Pattern
+
+The **Evaluator-Optimizer** pattern is a core orchestration strategy in Coreason V2, designed to significantly improve the quality of AI-generated content through an iterative feedback loop. This pattern is inspired by the research in the [Anthropic Claude Cookbook](https://github.com/anthropics/claude-cookbook).
+
+## Mental Model
+
+Instead of relying on a single "zero-shot" generation from an LLM, this pattern introduces a two-step cycle:
+
+1.  **Generate**: An Agent produces a draft.
+2.  **Evaluate**: A separate "Judge" Agent critiques the draft against specific criteria and assigns a score.
+3.  **Refine**: If the score is below a threshold, the critique is fed back to the Generator, which produces an improved draft.
+
+This loop continues until the quality threshold is met or a maximum number of retries is reached.
+
+## The `EvaluatorNode`
+
+Coreason V2 simplifies this complex logic into a single declarative node type: `EvaluatorNode`.
+
+### Schema Definition
+
+```python
+class EvaluatorNode(RecipeNode):
+    type: Literal["evaluator"] = "evaluator"
+
+    # What to grade
+    target_variable: str
+
+    # Who grades it
+    evaluator_agent_ref: str
+    evaluation_profile: EvaluationProfile | str
+
+    # Logic
+    pass_threshold: float
+    max_refinements: int
+
+    # Feedback Output
+    feedback_variable: str
+
+    # Flow Control
+    pass_route: str
+    fail_route: str
+```
+
+### Configuration Fields
+
+*   **`target_variable`**: The key in the shared state (Blackboard) containing the content to be evaluated (e.g., `draft_body`).
+*   **`evaluator_agent_ref`**: The ID of the Agent Definition that will act as the judge. This agent should be prompted to analyze content and produce structured critiques.
+*   **`evaluation_profile`**: Defines the criteria for success. Can be an inline `EvaluationProfile` object or a reference ID string to a stored profile.
+*   **`pass_threshold`**: A float between 0.0 and 1.0. If the evaluator's score is greater than or equal to this value, execution proceeds to `pass_route`.
+*   **`max_refinements`**: The safety limit for the loop. If the threshold is not met after this many attempts, the flow will force a break (or a specific fallback if configured).
+*   **`feedback_variable`**: The key where the critique text will be written. The Generator node *must* subscribe to this variable to incorporate the feedback.
+
+## Example Usage
+
+### YAML Recipe
+
+```yaml
+topology:
+  nodes:
+    # 1. The Generator (Writer)
+    - type: agent
+      id: "writer"
+      agent_ref: "copywriter-v1"
+      inputs_map:
+        topic: "user_topic"
+        # Crucial: This input allows the writer to see previous feedback
+        critique: "critique_history"
+
+    # 2. The Judge (Editor)
+    - type: evaluator
+      id: "editor-check"
+      target_variable: "writer_output"
+      evaluator_agent_ref: "editor-llm"
+
+      # Criteria
+      evaluation_profile: "marketing-compliance-v1"
+      pass_threshold: 0.95
+      max_refinements: 3
+
+      # Feedback Loop
+      feedback_variable: "critique_history"
+
+      # Routing
+      pass_route: "publish"
+      fail_route: "writer" # Loop back
+
+    # 3. Success
+    - type: agent
+      id: "publish"
+      agent_ref: "publisher-v1"
+```
+
+## Best Practices
+
+1.  **Strict Criteria**: The `evaluator_agent_ref` should use a system prompt that encourages critical, detailed feedback rather than generic praise.
+2.  **History Awareness**: Ensure your Generator agent (e.g., "writer") is capable of understanding "critique" as an input argument.
+3.  **Fallback Strategy**: While `EvaluatorNode` currently forces a loop, consider using a `RouterNode` after a maximum retry failure if you need a specific "give up" path (future feature).

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -107,7 +107,9 @@ class EvaluatorNode(RecipeNode):
     target_variable: str = Field(
         ..., description="The key in the shared state/blackboard containing the content to evaluate."
     )
-    evaluator_agent_ref: str = Field(..., description="Reference to the Agent Definition ID that will act as the judge.")
+    evaluator_agent_ref: str = Field(
+        ..., description="Reference to the Agent Definition ID that will act as the judge."
+    )
     evaluation_profile: EvaluationProfile | str = Field(
         ..., description="Inline criteria definition or a reference to a preset profile."
     )
@@ -137,9 +139,9 @@ class GraphTopology(CoReasonBaseModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
-    nodes: list[
-        Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode, Field(discriminator="type")]
-    ] = Field(..., description="List of nodes in the graph.")
+    nodes: list[Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode, Field(discriminator="type")]] = Field(
+        ..., description="List of nodes in the graph."
+    )
     edges: list[GraphEdge] = Field(..., description="List of directed edges.")
     entry_point: str = Field(..., description="ID of the start node.")
 

--- a/tests/test_evaluator_node.py
+++ b/tests/test_evaluator_node.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.recipe import EvaluatorNode, GraphTopology
+from coreason_manifest.spec.v2.evaluation import EvaluationProfile
+
+
+def test_evaluator_node_instantiation() -> None:
+    """Test that EvaluatorNode can be instantiated with valid fields."""
+    node = EvaluatorNode(
+        id="editor-check",
+        target_variable="writer_output",
+        evaluator_agent_ref="editor-llm",
+        evaluation_profile="standard-critique",
+        pass_threshold=0.9,
+        max_refinements=3,
+        pass_route="publish",
+        fail_route="writer",
+        feedback_variable="critique_history",
+    )
+    assert node.type == "evaluator"
+    assert node.id == "editor-check"
+    assert node.target_variable == "writer_output"
+    assert node.evaluator_agent_ref == "editor-llm"
+    assert node.pass_threshold == 0.9
+    assert node.max_refinements == 3
+    assert node.pass_route == "publish"
+    assert node.fail_route == "writer"
+    assert node.feedback_variable == "critique_history"
+
+
+def test_evaluator_node_instantiation_with_profile_object() -> None:
+    """Test that EvaluatorNode can be instantiated with an EvaluationProfile object."""
+    profile = EvaluationProfile(
+        expected_latency_ms=1000,
+        grading_rubric=[],
+    )
+    node = EvaluatorNode(
+        id="editor-check",
+        target_variable="writer_output",
+        evaluator_agent_ref="editor-llm",
+        evaluation_profile=profile,
+        pass_threshold=0.9,
+        max_refinements=3,
+        pass_route="publish",
+        fail_route="writer",
+        feedback_variable="critique_history",
+    )
+    assert isinstance(node.evaluation_profile, EvaluationProfile)
+    assert node.evaluation_profile.expected_latency_ms == 1000
+
+
+def test_evaluator_node_validation() -> None:
+    """Test that missing required fields raise ValidationError."""
+    with pytest.raises(ValidationError) as excinfo:
+        EvaluatorNode(
+            id="editor-check",
+            # Missing target_variable
+            evaluator_agent_ref="editor-llm",
+            evaluation_profile="standard-critique",
+            pass_threshold=0.9,
+            max_refinements=3,
+            pass_route="publish",
+            fail_route="writer",
+            feedback_variable="critique_history",
+        ) # type: ignore[call-arg]
+    assert "target_variable" in str(excinfo.value)
+
+
+def test_graph_with_evaluator() -> None:
+    """Test parsing the example graph with an EvaluatorNode."""
+    data = {
+        "nodes": [
+            # 1. The Generator
+            {
+                "type": "agent",
+                "id": "writer",
+                "agent_ref": "copywriter-v1",
+                "inputs_map": {
+                    "topic": "user_topic",
+                    "critique": "critique_history",
+                },
+            },
+            # 2. The Evaluator-Optimizer (The New Node)
+            {
+                "type": "evaluator",
+                "id": "editor-check",
+                "target_variable": "writer_output",
+                "evaluator_agent_ref": "editor-llm",
+                "pass_threshold": 0.9,
+                "max_refinements": 3,
+                "feedback_variable": "critique_history",
+                "pass_route": "publish",
+                "fail_route": "writer",
+                "evaluation_profile": "standard-critique", # Added this as it is required but missing in example YAML in prompt if assumed implicit? Actually the prompt example has `evaluation_profile` mentioned in text but maybe missing in YAML block?
+                # Ah, checking the prompt example YAML again.
+            },
+            # 3. Success State
+            {
+                "type": "agent",
+                "id": "publish",
+                "agent_ref": "publisher-v1",
+            },
+        ],
+        "edges": [], # The prompt example YAML didn't show edges, but they are required in GraphTopology.
+                     # However, EvaluatorNode implies edges via pass_route/fail_route.
+                     # But GraphTopology validation requires explicit edges if it checks connectivity?
+                     # Wait, GraphTopology validation checks dangling edges in `edges` list.
+                     # It does not check if nodes are reachable if edges list is empty (test_edge_case_disconnected_node passed).
+        "entry_point": "writer",
+    }
+
+    # The prompt example YAML:
+    #     # 2. The Evaluator-Optimizer (The New Node)
+    #     - type: evaluator
+    #       id: "editor-check"
+    #       target_variable: "writer_output"
+    #       evaluator_agent_ref: "editor-llm"
+    #
+    #       # The Criteria
+    #       pass_threshold: 0.9
+    #       max_refinements: 3
+    #
+    #       # The Output
+    #       feedback_variable: "critique_history"
+    #
+    #       # The Loop
+    #       pass_route: "publish"
+    #       fail_route: "writer" # <--- The Loop Back
+
+    # Wait, the prompt example YAML *does not* include `evaluation_profile`.
+    # But the requirements say:
+    # "evaluator_agent_ref": "str" ...
+    # "evaluation_profile": "EvaluationProfile OR str" (Inline criteria definition or a reference to a preset profile).
+
+    # Let me check the prompt example YAML again.
+    # It lists: target_variable, evaluator_agent_ref, pass_threshold, max_refinements, feedback_variable, pass_route, fail_route.
+    # It seems `evaluation_profile` is missing in the YAML example block provided in the prompt?
+    # Or maybe "The Criteria" comment implies it?
+    # "The Criteria" section has `pass_threshold` and `max_refinements`.
+    # But `evaluation_profile` is listed in "The Judge (Who grades it)" section of requirements.
+    # If the YAML example is the "Definition of Done", and it misses `evaluation_profile`, does it mean it's optional?
+    # Requirements say: "evaluation_profile: EvaluationProfile OR str". It does not say Optional.
+    # Let's assume it IS required based on the schema definition I wrote (no default value).
+    # I will add it to the test data. If the user strictly wants the YAML example to work as is, I would need to make it optional.
+    # But "The Judge" section lists it as a field.
+    # I'll stick to making it required as per my schema. I'll add a dummy profile to the test data.
+
+    # Also, GraphTopology requires `edges` and `entry_point`. The YAML example is partial `topology: nodes: ...`.
+    # I'll construct a valid GraphTopology wrapper around the nodes.
+
+    topology = GraphTopology.model_validate(data)
+    assert len(topology.nodes) == 3
+
+    evaluator = next(n for n in topology.nodes if n.id == "editor-check")
+    assert isinstance(evaluator, EvaluatorNode)
+    assert evaluator.target_variable == "writer_output"
+    assert evaluator.pass_route == "publish"

--- a/tests/test_evaluator_node_complex.py
+++ b/tests/test_evaluator_node_complex.py
@@ -1,0 +1,229 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.recipe import EvaluatorNode, GraphTopology
+from coreason_manifest.spec.v2.evaluation import EvaluationProfile
+
+
+def test_edge_case_zero_max_refinements() -> None:
+    """Test that max_refinements can be 0 (fail immediately on first reject)."""
+    node = EvaluatorNode(
+        id="strict-judge",
+        target_variable="content",
+        evaluator_agent_ref="judge-v1",
+        evaluation_profile="strict-profile",
+        pass_threshold=0.9,
+        max_refinements=0,
+        pass_route="success",
+        fail_route="failure",
+        feedback_variable="critique",
+    )
+    assert node.max_refinements == 0
+
+
+def test_edge_case_boundary_thresholds() -> None:
+    """Test that pass_threshold accepts 0.0 and 1.0."""
+    node_low = EvaluatorNode(
+        id="easy-judge",
+        target_variable="content",
+        evaluator_agent_ref="judge-v1",
+        evaluation_profile="easy-profile",
+        pass_threshold=0.0,
+        max_refinements=1,
+        pass_route="success",
+        fail_route="failure",
+        feedback_variable="critique",
+    )
+    assert node_low.pass_threshold == 0.0
+
+    node_high = EvaluatorNode(
+        id="impossible-judge",
+        target_variable="content",
+        evaluator_agent_ref="judge-v1",
+        evaluation_profile="hard-profile",
+        pass_threshold=1.0,
+        max_refinements=1,
+        pass_route="success",
+        fail_route="failure",
+        feedback_variable="critique",
+    )
+    assert node_high.pass_threshold == 1.0
+
+
+def test_complex_circular_dependency() -> None:
+    """Test a valid circular dependency: Generator -> Evaluator -> Generator."""
+    data = {
+        "nodes": [
+            {
+                "type": "agent",
+                "id": "gen",
+                "agent_ref": "writer",
+                "inputs_map": {"feedback": "critique"},
+            },
+            {
+                "type": "evaluator",
+                "id": "eval",
+                "target_variable": "draft",
+                "evaluator_agent_ref": "judge",
+                "evaluation_profile": "profile-1",
+                "pass_threshold": 0.8,
+                "max_refinements": 5,
+                "pass_route": "end",
+                "fail_route": "gen",  # Cycle back
+                "feedback_variable": "critique",
+            },
+            {
+                "type": "agent",
+                "id": "end",
+                "agent_ref": "publisher",
+            },
+        ],
+        "edges": [],
+        "entry_point": "gen",
+    }
+    topology = GraphTopology.model_validate(data)
+    assert len(topology.nodes) == 3
+
+
+def test_complex_two_stage_evaluation() -> None:
+    """Test a linear chain of two evaluators: Gen -> Eval1 -> Eval2 -> End."""
+    data = {
+        "nodes": [
+            {
+                "type": "agent",
+                "id": "gen",
+                "agent_ref": "writer",
+            },
+            {
+                "type": "evaluator",
+                "id": "eval-grammar",
+                "target_variable": "draft",
+                "evaluator_agent_ref": "grammar-check",
+                "evaluation_profile": "grammar-strict",
+                "pass_threshold": 0.9,
+                "max_refinements": 2,
+                "pass_route": "eval-tone",
+                "fail_route": "gen",
+                "feedback_variable": "grammar_errors",
+            },
+            {
+                "type": "evaluator",
+                "id": "eval-tone",
+                "target_variable": "draft",
+                "evaluator_agent_ref": "tone-check",
+                "evaluation_profile": "tone-friendly",
+                "pass_threshold": 0.8,
+                "max_refinements": 2,
+                "pass_route": "end",
+                "fail_route": "gen",
+                "feedback_variable": "tone_feedback",
+            },
+            {
+                "type": "agent",
+                "id": "end",
+                "agent_ref": "publisher",
+            },
+        ],
+        "edges": [],
+        "entry_point": "gen",
+    }
+    topology = GraphTopology.model_validate(data)
+    assert len(topology.nodes) == 4
+
+    eval1 = next(n for n in topology.nodes if n.id == "eval-grammar")
+    assert isinstance(eval1, EvaluatorNode)
+    assert eval1.pass_route == "eval-tone"
+
+
+def test_complex_branching_evaluation() -> None:
+    """Test branching logic before evaluation: Gen -> Router -> (Eval A | Eval B)."""
+    data = {
+        "nodes": [
+            {
+                "type": "agent",
+                "id": "gen",
+                "agent_ref": "writer",
+            },
+            {
+                "type": "router",
+                "id": "router",
+                "input_key": "content_type",
+                "routes": {
+                    "technical": "eval-tech",
+                    "creative": "eval-creative",
+                },
+                "default_route": "eval-creative",
+            },
+            {
+                "type": "evaluator",
+                "id": "eval-tech",
+                "target_variable": "draft",
+                "evaluator_agent_ref": "tech-judge",
+                "evaluation_profile": "tech-specs",
+                "pass_threshold": 0.95,
+                "max_refinements": 3,
+                "pass_route": "end",
+                "fail_route": "gen",
+                "feedback_variable": "tech_critique",
+            },
+            {
+                "type": "evaluator",
+                "id": "eval-creative",
+                "target_variable": "draft",
+                "evaluator_agent_ref": "creative-judge",
+                "evaluation_profile": "creative-flow",
+                "pass_threshold": 0.8,
+                "max_refinements": 5,
+                "pass_route": "end",
+                "fail_route": "gen",
+                "feedback_variable": "creative_critique",
+            },
+            {
+                "type": "agent",
+                "id": "end",
+                "agent_ref": "publisher",
+            },
+        ],
+        "edges": [
+            {"source": "gen", "target": "router"},
+            # Edges from router are implicit in routes, but GraphTopology validator might check explicit edges.
+            # Wait, GraphTopology validation checks dangling edges in `edges` list.
+            # It does NOT check if all `routes` targets are connected via explicit `edges`.
+            # But let's add them for completeness if needed.
+            # Actually, `routes` targets are just node IDs.
+            # The `edges` list is optional for flow definition but mandatory for visualization if used.
+            # I will add router->eval edges to be safe.
+            {"source": "router", "target": "eval-tech"},
+            {"source": "router", "target": "eval-creative"},
+        ],
+        "entry_point": "gen",
+    }
+    topology = GraphTopology.model_validate(data)
+    assert len(topology.nodes) == 5
+
+
+def test_invalid_evaluation_profile_type() -> None:
+    """Test that evaluation_profile rejects invalid types (e.g. integer)."""
+    with pytest.raises(ValidationError) as excinfo:
+        EvaluatorNode(
+            id="bad-profile",
+            target_variable="content",
+            evaluator_agent_ref="judge",
+            evaluation_profile=123, # type: ignore[arg-type]
+            pass_threshold=0.9,
+            max_refinements=3,
+            pass_route="end",
+            fail_route="start",
+            feedback_variable="critique",
+        )
+    assert "evaluation_profile" in str(excinfo.value)

--- a/tests/test_evaluator_node_complex.py
+++ b/tests/test_evaluator_node_complex.py
@@ -12,7 +12,6 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.spec.v2.recipe import EvaluatorNode, GraphTopology
-from coreason_manifest.spec.v2.evaluation import EvaluationProfile
 
 
 def test_edge_case_zero_max_refinements() -> None:
@@ -219,7 +218,7 @@ def test_invalid_evaluation_profile_type() -> None:
             id="bad-profile",
             target_variable="content",
             evaluator_agent_ref="judge",
-            evaluation_profile=123, # type: ignore[arg-type]
+            evaluation_profile=123,
             pass_threshold=0.9,
             max_refinements=3,
             pass_route="end",


### PR DESCRIPTION
Implements the EvaluatorNode schema in src/coreason_manifest/spec/v2/recipe.py to support the Evaluator-Optimizer pattern. Updates GraphTopology to include the new node type.

---
*PR created automatically by Jules for task [9938384439804730339](https://jules.google.com/task/9938384439804730339) started by @gowthamrao*