### PR TITLE
Security Review: Document vulnerabilities and add CLI warning

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,51 @@
+# Security Policy
+
+## Supported Versions
+
+Use the latest version of `coreason-manifest` to ensure you have the latest security patches.
+
+| Version | Supported |
+| ------- | ------------------ |
+| 0.21.x  | :white_check_mark: |
+| < 0.21.0| :x:                |
+
+## Reporting a Vulnerability
+
+Please report security vulnerabilities to `security@coreason.ai`.
+
+## Known Security Considerations
+
+### 1. Arbitrary Code Execution (ACE) via CLI
+
+The `coreason` CLI executes Python code when loading agent definitions from `.py` files (e.g., `coreason inspect my_agent.py:agent`). This is by design to support dynamic manifest generation via `AgentBuilder`.
+
+**Risk:** Loading an untrusted Python file can execute malicious code on your machine.
+**Mitigation:** Only run `coreason` CLI commands on files you trust. Treat `.py` manifest definitions as executable code.
+
+### 2. Remote Code Execution (RCE) via Schema
+
+The `ManifestV2` schema supports defining executable logic:
+- `LogicStep`: Contains raw Python code in the `code` field.
+- `MCPServerDefinition`: Contains system commands in `command` and `args` fields.
+- `SkillDefinition`: References scripts via `scripts` field.
+
+**Risk:** If a runtime implementation blindly executes these fields from an untrusted manifest, it creates an RCE vulnerability.
+**Mitigation:** Runtime implementations must:
+- Sanitize and sandbox execution of `LogicStep` code.
+- Require explicit user approval before executing `MCPServerDefinition` commands.
+- Validate `scripts` paths against an allowlist or sandbox.
+
+### 3. Path Traversal Risks
+
+While `$ref` resolution is protected by `ReferenceResolver` (Jail), other URI fields are not automatically validated by the library:
+- `ToolRequirement.uri`
+- `ToolDefinition.uri`
+- `SkillDefinition.instructions_uri`
+
+**Risk:** An attacker could reference local files (e.g., `file:///etc/passwd`) or internal network resources.
+**Mitigation:** Runtime implementations must validate all URIs before access.
+
+### 4. Denial of Service (DoS)
+
+The `GraphTopology` allows cycles (loops). An infinite loop in a graph recipe could cause resource exhaustion.
+**Mitigation:** Runtime implementations should enforce execution limits (e.g., `max_steps`, timeouts).

--- a/src/coreason_manifest/utils/loader.py
+++ b/src/coreason_manifest/utils/loader.py
@@ -67,6 +67,11 @@ def load_agent_from_ref(reference: str) -> ManifestV2 | RecipeDefinition:
 
         module = importlib.util.module_from_spec(spec)
         sys.modules[module_name] = module
+
+        # SECURITY WARNING: This executes arbitrary code from the file.
+        sys.stderr.write(f"⚠️  SECURITY WARNING: Executing code from {file_path}\n")
+        sys.stderr.flush()
+
         spec.loader.exec_module(module)
     except Exception as e:
         raise ValueError(f"Error loading module {file_path}: {e}") from e

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,0 +1,40 @@
+import sys
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from pytest import CaptureFixture
+
+from coreason_manifest.utils.loader import load_agent_from_ref
+
+
+@pytest.fixture
+def mock_agent_file(tmp_path: Path) -> Generator[Path, None, None]:
+    """Create a temporary python file defining an agent."""
+    file_path = tmp_path / "mock_agent.py"
+    file_path.write_text(
+        """
+from coreason_manifest.builder import AgentBuilder
+agent = AgentBuilder("MockAgent").build()
+""",
+        encoding="utf-8",
+    )
+    yield file_path
+
+
+def test_load_agent_security_warning(mock_agent_file: Path, capsys: CaptureFixture[str]) -> None:
+    """Test that loading an agent from a file prints a security warning to stderr."""
+
+    # We need to ensure the module can be imported, so we might need to mess with sys.path
+    # but load_agent_from_ref handles sys.path insertion.
+
+    # Force reload if it was already loaded (unlikely in fresh test, but good practice)
+    module_name = mock_agent_file.stem
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+    load_agent_from_ref(f"{mock_agent_file}:agent")
+
+    captured = capsys.readouterr()
+    assert "⚠️  SECURITY WARNING: Executing code from" in captured.err
+    assert str(mock_agent_file) in captured.err

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -1,15 +1,13 @@
 import sys
 from pathlib import Path
-from typing import Generator
 
 import pytest
-from pytest import CaptureFixture
 
 from coreason_manifest.utils.loader import load_agent_from_ref
 
 
 @pytest.fixture
-def mock_agent_file(tmp_path: Path) -> Generator[Path, None, None]:
+def mock_agent_file(tmp_path: Path) -> Path:
     """Create a temporary python file defining an agent."""
     file_path = tmp_path / "mock_agent.py"
     file_path.write_text(
@@ -19,10 +17,10 @@ agent = AgentBuilder("MockAgent").build()
 """,
         encoding="utf-8",
     )
-    yield file_path
+    return file_path
 
 
-def test_load_agent_security_warning(mock_agent_file: Path, capsys: CaptureFixture[str]) -> None:
+def test_load_agent_security_warning(mock_agent_file: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """Test that loading an agent from a file prints a security warning to stderr."""
 
     # We need to ensure the module can be imported, so we might need to mess with sys.path


### PR DESCRIPTION
Performed a red-team security review of the `coreason-manifest` package.
Identified vulnerabilities:
1.  **Arbitrary Code Execution (ACE)**: The CLI executes Python code when loading agents from `.py` files.
2.  **Remote Code Execution (RCE)**: The Schema supports `LogicStep` and `MCPServerDefinition` which define executable code/commands.
3.  **Path Traversal**: Potential risks in URI fields not validated by `ReferenceResolver`.

Implemented mitigations:
- Added `SECURITY.md` to document these risks and advise users.
- Modified `src/coreason_manifest/utils/loader.py` to print a warning to `sys.stderr` when loading code.
- Added a test case `tests/test_cli_security.py` to verify the warning.

---
*PR created automatically by Jules for task [5857740732124450315](https://jules.google.com/task/5857740732124450315) started by @gowthamrao*