### PR TITLE
Update documentation to match V2 schema definitions

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,14 +33,14 @@ This is the central documentation index for the `coreason-manifest` project, whi
 
 ## Specifications & Protocols
 
-*   **[Coreason Agent Manifest (CAM) Specification](cap/specification.md)**
-    *   The authoritative "Human-Centric" YAML format specification for defining Agents, Recipes, Workflows, and their components.
+*   **[Coreason Agent Manifest (CAM) & Linear Workflows](cap/specification.md)**
+    *   The authoritative "Human-Centric" YAML format specification for defining Agents and simple, linear workflows (`ManifestV2`).
+
+*   **[Graph Recipes (Orchestration)](graph_recipes.md)**
+    *   Describes the system for complex, non-linear, cyclic graph execution using `RecipeDefinition` and `GraphTopology`.
 
 *   **[Coreason Agent Protocol (CAP) Wire Format](cap/wire_protocol.md)**
     *   Defines the runtime wire protocol, including standard request/response envelopes (`ServiceRequest`, `ServiceResponse`) and streaming contracts (`StreamPacket`).
-
-*   **[Graph Recipes (Work Package JJ)](graph_recipes.md)**
-    *   Describes the system for non-linear, cyclic graph execution using `RecipeDefinition` and `GraphTopology`.
 
 *   **[Agent Skills System](skills.md)**
     *   Documentation for defining and using procedural knowledge ("Skills") with `SkillDefinition` and `LoadStrategy`.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -34,6 +34,7 @@ Skills can declare dependencies on external packages or system tools, ensuring t
 | `type` | `Literal["skill"]` | Discriminator field. |
 | `id` | `str` | Unique identifier for the skill. |
 | `name` | `str` | Human-readable name. |
+| `version` | `str` | Semantic version (default: `1.0.0`). |
 | `description` | `str` | Summary for humans. |
 | `trigger_intent` | `str` | **Critical.** Semantic description for vector routing. Required if `load_strategy` is `LAZY`. |
 | `instructions` | `str` | Inline system prompt. (XOR with `instructions_uri`) |
@@ -41,6 +42,14 @@ Skills can declare dependencies on external packages or system tools, ensuring t
 | `scripts` | `dict[str, str]` | Map of script names to file paths. |
 | `dependencies` | `list[SkillDependency]` | List of required packages. |
 | `load_strategy` | `LoadStrategy` | `eager`, `lazy`, or `user`. Defaults to `lazy`. |
+
+### `SkillDependency`
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `ecosystem` | `Literal["python", "node", "system", "mcp"]` | The ecosystem of the dependency. |
+| `package` | `str` | The package name or command. |
+| `version_constraint` | `str` | Optional version constraint (e.g., `>=3.0.0`). |
 
 ### `AgentDefinition` Update
 

--- a/docs/tool_packs.md
+++ b/docs/tool_packs.md
@@ -47,6 +47,41 @@ class PackMetadata(CoReasonBaseModel):
     homepage: StrictUri | None
 ```
 
+### PackAuthor
+
+```python
+class PackAuthor(CoReasonBaseModel):
+    name: str | None
+    email: str | None
+    url: StrictUri | None
+```
+
+### MCPServerDefinition
+
+Defines a Model Context Protocol server process that provides tools or resources.
+
+```python
+class MCPServerDefinition(CoReasonBaseModel):
+    type: Literal["mcp_server"] = "mcp_server"
+    name: str  # Name of the server
+    command: str  # Command to execute
+    args: list[str]  # Arguments for the command
+    env: dict[str, str]  # Environment variables
+```
+
+### MCPResourceDefinition
+
+Defines a passive data stream or resource exposed via MCP.
+
+```python
+class MCPResourceDefinition(CoReasonBaseModel):
+    type: Literal["resource"] = "resource"
+    uri: StrictUri  # URI of the resource
+    name: str  # Name of the resource
+    mime_type: str | None  # MIME type (optional)
+    description: str | None  # Description (optional)
+```
+
 ## Usage Example
 
 Here is an example of how to define a reusable "Feature Dev Pack" and use it within a Manifest.
@@ -62,7 +97,10 @@ definitions:
       name: "feature-dev"
       version: "1.0.0"
       description: "Comprehensive feature development workflow."
-      author: "CoReason"
+      author:
+        name: "CoReason"
+        email: "support@coreason.ai"
+        url: "https://coreason.ai"
 
     # The Pack bundles specific agents and skills
     agents:
@@ -81,6 +119,14 @@ definitions:
         load_strategy: lazy
         trigger_intent: "Analyze requirements"
         instructions: "..."
+
+    mcp_servers:
+      - type: mcp_server
+        name: "filesystem"
+        command: "npx"
+        args: ["-y", "@modelcontextprotocol/server-filesystem", "/users/src"]
+        env:
+            NODE_ENV: "production"
 
   # The main agent uses the Pack (future runtime implementation)
   lead-engineer:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,8 +5,10 @@ nav:
   - Home: index.md
   - Usage: usage.md
   - Specifications:
-      - "Orchestration (Recipes)": graph_recipes.md
-      - "Agent Definitions (V2)": cap/specification.md
+      - "Graph Recipes (Orchestration)": graph_recipes.md
+      - "Agent Manifest (CAM) & Linear Workflows": cap/specification.md
+      - "Agent Skills System": skills.md
+      - "Tool Packs (Plugins)": tool_packs.md
       - "Inline Tools": inline_tools.md
       - "Transport & Tracing": transport_layer.md
       - "Simulation & Eval": simulation.md


### PR DESCRIPTION
This PR updates the documentation to align with the actual Pydantic models in the codebase, ensuring the code is the source of truth. It clarifies the distinction between the legacy/linear `ManifestV2` and the new graph-based `RecipeDefinition`, and fills in missing details for Skills and Tool Packs.

---
*PR created automatically by Jules for task [17788193287503778047](https://jules.google.com/task/17788193287503778047) started by @gowthamrao*