### PR TITLE
Add serve-mcp CLI command

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -142,3 +142,39 @@ Computes the canonical hash of an agent for audit and integrity purposes.
 ```bash
 coreason hash <reference>
 ```
+
+---
+
+### `serve-mcp`
+
+Serves a Coreason Agent as a **Model Context Protocol (MCP)** server over stdio.
+
+This command is intended for **interoperability testing** and **contract verification**. It projects the agent's interface (inputs/outputs) as an MCP Tool and serves a mock implementation that generates valid outputs based on the schema, allowing other MCP-compliant tools (like Claude Desktop or other agents) to consume and validate the integration contract without running the full agent logic.
+
+**Prerequisites:**
+You must install the optional `mcp` dependency:
+```bash
+pip install coreason-manifest[mcp]
+```
+
+**Usage:**
+```bash
+coreason serve-mcp <reference>
+```
+
+**Arguments:**
+* `<reference>`: Path to the agent object (e.g., `agent.py:agent`).
+
+**Example:**
+```bash
+# Serve the agent defined in agent.py
+coreason serve-mcp agent.py:agent
+```
+
+**How it works:**
+1.  Loads the Agent Definition.
+2.  Projects the agent as an MCP Tool named after the agent (sanitized).
+3.  Starts an MCP Server over stdio.
+4.  When the tool is called, it returns a **mocked response** generated from the agent's output schema using `coreason_manifest.utils.mock`.
+
+**Note:** This does *not* execute the agent's actual logic or LLM calls. It is strictly for verifying that the agent's interface contract is compatible with the consumer.

--- a/docs/interop/mcp_interop.md
+++ b/docs/interop/mcp_interop.md
@@ -1,0 +1,75 @@
+# Model Context Protocol (MCP) Interoperability
+
+The `coreason-manifest` library supports the [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) as a first-class citizen for interoperability. This allows Coreason Agents to be seamlessly consumed by any MCP-compliant client (e.g., Claude Desktop, IDEs, or other agents).
+
+## Overview
+
+Coreason Agents are defined by strict `inputs` and `outputs` schemas in their `InterfaceDefinition`. This contract-first approach makes them perfect candidates for MCP Tools.
+
+The library provides an **MCP Adapter** in `coreason_manifest.interop.mcp` that automatically projects an `AgentDefinition` into an MCP Tool structure.
+
+## Installation
+
+To use MCP features, you must install the optional dependency:
+
+```bash
+pip install coreason-manifest[mcp]
+```
+
+## Contract Verification (Mock Server)
+
+The CLI includes a `serve-mcp` command designed for **Contract Verification**. It serves your agent as an MCP Tool over stdio, but instead of running the actual agent logic (which might require API keys, databases, or complex state), it uses the **Mock Generator** to produce valid, schema-compliant outputs.
+
+This allows you to verify that your agent's interface is correctly understood by consumers *before* implementing the full logic.
+
+### Usage
+
+```bash
+# Serve your agent definition
+coreason serve-mcp my_agent.py:agent
+```
+
+### Example Workflow with Claude Desktop
+
+1.  Define your agent in `agent.py`.
+2.  Add the server config to `claude_desktop_config.json`:
+
+    ```json
+    {
+      "mcpServers": {
+        "my-agent": {
+          "command": "coreason",
+          "args": ["serve-mcp", "/absolute/path/to/my_agent.py:agent"]
+        }
+      }
+    }
+    ```
+
+3.  Restart Claude Desktop.
+4.  You can now "chat" with your agent definition. The tool call will return mocked data structure, proving that the input/output contract is valid.
+
+## Using the Adapter Programmatically
+
+You can also use the adapter in your own code to integrate Coreason Agents into custom MCP servers.
+
+```python
+from coreason_manifest.interop.mcp import CoreasonMCPServer, create_mcp_tool_definition
+from my_agent import agent_definition
+
+# 1. Get the raw tool schema
+tool_schema = create_mcp_tool_definition(agent_definition)
+print(tool_schema)
+
+# 2. Create a server instance (requires an async runner callback)
+async def my_runner(args: dict) -> dict:
+    # Implement your actual execution logic here!
+    return {"result": "Real execution result"}
+
+server = CoreasonMCPServer(agent_definition, my_runner)
+
+# 3. Run the server (e.g., over stdio)
+import asyncio
+asyncio.run(server.run_stdio())
+```
+
+This architecture allows the `coreason-manifest` library to remain a pure data definition library while enabling powerful runtime integrations through the toolbelt.

--- a/src/coreason_manifest/interop/mcp.py
+++ b/src/coreason_manifest/interop/mcp.py
@@ -102,3 +102,20 @@ class CoreasonMCPServer:
     def server(self) -> Any:
         """Returns the underlying MCP Server instance."""
         return self._server
+
+    async def run_stdio(self) -> None:
+        """Runs the MCP server using stdio transport."""
+        try:
+            from mcp.server.stdio import stdio_server
+        except ImportError:
+            raise ImportError(
+                "The 'mcp' package is required to use CoreasonMCPServer. "
+                "Install it with `pip install coreason-manifest[mcp]`."
+            ) from None
+
+        async with stdio_server() as (read_stream, write_stream):
+            await self._server.run(
+                read_stream,
+                write_stream,
+                self._server.create_initialization_options(),
+            )

--- a/tests/test_cli_serve_mcp.py
+++ b/tests/test_cli_serve_mcp.py
@@ -1,0 +1,121 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from _pytest.capture import CaptureFixture
+
+from coreason_manifest.cli import main
+from coreason_manifest.spec.v2.definitions import (
+    AgentDefinition,
+    AgentStep,
+    ManifestMetadata,
+    ManifestV2,
+    Workflow,
+)
+
+
+@pytest.fixture
+def mock_agent_def() -> AgentDefinition:
+    return AgentDefinition(id="test-agent", name="TestAgent", role="Tester", goal="Testing")
+
+
+@pytest.fixture
+def mock_manifest(mock_agent_def: AgentDefinition) -> ManifestV2:
+    return ManifestV2(
+        kind="Agent",
+        metadata=ManifestMetadata(name="TestAgent", version="1.0.0"),
+        definitions={"TestAgent": mock_agent_def},
+        workflow=Workflow(start="main", steps={"main": AgentStep(id="main", agent="TestAgent")}),
+    )
+
+
+def test_cli_serve_mcp_success(mock_agent_def: AgentDefinition, capsys: CaptureFixture[str]) -> None:
+    mock_server_instance = MagicMock()
+    mock_server_instance.run_stdio = AsyncMock()
+
+    with (
+        patch("coreason_manifest.cli.load_agent_from_ref", return_value=mock_agent_def),
+        patch("coreason_manifest.cli.CoreasonMCPServer", return_value=mock_server_instance) as mock_cls,
+        patch("coreason_manifest.cli.asyncio.run") as mock_run,
+        patch.object(sys, "argv", ["coreason", "serve-mcp", "dummy.py:agent"]),
+        patch.dict(sys.modules, {"mcp": MagicMock()}),
+    ):
+        main()
+
+        mock_cls.assert_called_once()
+        args, _ = mock_cls.call_args
+        assert args[0] == mock_agent_def
+
+        mock_server_instance.run_stdio.assert_called_once()
+        mock_run.assert_called_once()
+
+
+def test_cli_serve_mcp_missing_dependency(capsys: CaptureFixture[str]) -> None:
+    # We simulate mcp missing by patching sys.modules with None for 'mcp'
+    # However, since the import happens inside handle_serve_mcp, we need to make sure
+    # it fails.
+    # Note: cli.py has 'import mcp' inside try block.
+
+    with (
+        patch.dict(sys.modules, {"mcp": None}),
+        patch.object(sys, "argv", ["coreason", "serve-mcp", "dummy.py:agent"]),
+        pytest.raises(SystemExit),
+    ):
+        main()
+
+    captured = capsys.readouterr()
+    assert "'mcp' package is not installed" in captured.out
+
+
+def test_cli_serve_mcp_manifest_extraction(mock_manifest: ManifestV2, capsys: CaptureFixture[str]) -> None:
+    mock_server_instance = MagicMock()
+    mock_server_instance.run_stdio = AsyncMock()
+
+    with (
+        patch("coreason_manifest.cli.load_agent_from_ref", return_value=mock_manifest),
+        patch("coreason_manifest.cli.CoreasonMCPServer", return_value=mock_server_instance) as mock_cls,
+        patch("coreason_manifest.cli.asyncio.run"),
+        patch.object(sys, "argv", ["coreason", "serve-mcp", "dummy.py:agent"]),
+        patch.dict(sys.modules, {"mcp": MagicMock()}),
+    ):
+        main()
+
+        mock_cls.assert_called_once()
+        args, _ = mock_cls.call_args
+        assert args[0].name == "TestAgent"
+
+
+def test_cli_serve_mcp_extraction_error(mock_agent_def: AgentDefinition, capsys: CaptureFixture[str]) -> None:
+    # Case where ManifestV2 has multiple agents or mismatch
+    other_agent = AgentDefinition(id="other", name="Other", role="R", goal="G")
+    manifest = ManifestV2(
+        kind="Agent",
+        metadata=ManifestMetadata(name="TestAgent", version="1.0.0"),
+        definitions={"A1": mock_agent_def, "A2": other_agent},
+        workflow=Workflow(start="main", steps={"main": AgentStep(id="main", agent="TestAgent")}),
+    )
+
+    # This case actually succeeds because name matches, so we expect it to try to run the server.
+    # We didn't mock CoreasonMCPServer here so it would try to create it.
+    # But let's focus on the failing case.
+
+    # Name mismatch scenario:
+    manifest_fail = ManifestV2(
+        kind="Agent",
+        metadata=ManifestMetadata(name="NoMatch", version="1.0.0"),
+        definitions={"A1": mock_agent_def, "A2": other_agent},
+        workflow=Workflow(start="main", steps={"main": AgentStep(id="main", agent="TestAgent")}),
+    )
+
+    with (
+        patch("coreason_manifest.cli.load_agent_from_ref", return_value=manifest_fail),
+        patch.object(sys, "argv", ["coreason", "serve-mcp", "dummy.py:agent"]),
+        patch.dict(sys.modules, {"mcp": MagicMock()}),
+        pytest.raises(SystemExit),
+    ):
+        main()
+
+    captured = capsys.readouterr()
+    assert "Could not determine which AgentDefinition to serve" in captured.err


### PR DESCRIPTION
This PR adds a `serve-mcp` command to the `coreason` CLI, allowing users to serve their agent definitions as Model Context Protocol (MCP) servers.

Changes:
- `src/coreason_manifest/interop/mcp.py`: Added `run_stdio` method to `CoreasonMCPServer` to handle the server loop using stdio transport.
- `src/coreason_manifest/cli.py`: Added `serve-mcp` command. It loads an agent definition and starts an MCP server. Currently, it uses a mock runner callback that generates valid outputs based on the agent's schema, which is sufficient for verifying interoperability contracts.
- Tests: Added unit tests for `run_stdio` and the CLI command.

This directly addresses the need for interoperability by enabling Coreason agents to be consumed by any MCP-compliant client.

---
*PR created automatically by Jules for task [12505658428005694022](https://jules.google.com/task/12505658428005694022) started by @gowthamrao*