### PR TITLE
Implement TaskSequence logic for automatic GraphTopology compilation

### DIFF
--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -13,6 +13,37 @@ A Topology is a collection of **Nodes** connected by **Edges**.
 
 This structure allows for **Cycles** (loops), enabling agents to self-correct or retry tasks until a condition is met.
 
+## Syntactic Sugar: Task Sequences (New in 0.22.0)
+
+While Graphs are powerful, they can be verbose for simple linear workflows. To simplify this, `RecipeDefinition` supports **Task Sequences**.
+
+You can pass a simple list of nodes (or a dictionary with a `"steps"` key) to the `topology` field, and the library will automatically:
+1.  Set the first node as the `entry_point`.
+2.  Create linear edges connecting each node to the next (A -> B -> C).
+3.  Compile it into a full `GraphTopology` object.
+
+### Example: Linear Sequence
+
+```python
+from coreason_manifest.spec.v2.recipe import RecipeDefinition, AgentNode, HumanNode
+
+# Define nodes linearly
+step1 = AgentNode(id="research", agent_ref="researcher")
+step2 = HumanNode(id="approve", prompt="Approve?")
+step3 = AgentNode(id="publish", agent_ref="publisher")
+
+# Pass as a list
+recipe = RecipeDefinition(
+    ...
+    topology=[step1, step2, step3]  # Automatically converts to GraphTopology
+)
+
+# Resulting Topology:
+# Nodes: [research, approve, publish]
+# Edges: research -> approve, approve -> publish
+# Entry Point: research
+```
+
 ## Recipe Components
 
 A `RecipeDefinition` is composed of four key layers:

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -197,11 +197,10 @@ def coerce_topology(v: Any) -> Any:
         return TaskSequence(steps=v).to_graph()
 
     # 2. If topology is a dict
-    if isinstance(v, dict):
+    if isinstance(v, dict) and "steps" in v and "nodes" not in v:
         # If it has "steps", treat as TaskSequence
-        if "steps" in v and "nodes" not in v:
-            return TaskSequence.model_validate(v).to_graph()
-        # Otherwise assume it's GraphTopology structure, let Pydantic handle it
+        return TaskSequence.model_validate(v).to_graph()
+    # Otherwise assume it's GraphTopology structure, let Pydantic handle it
 
     return v
 

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -29,7 +29,7 @@ def test_topology_coercion_from_list() -> None:
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="test-recipe", version="1.0.0"),
         interface=RecipeInterface(),
-        topology=steps,  # type: ignore[arg-type] # Explicitly testing coercion
+        topology=steps,
     )
 
     assert isinstance(recipe.topology, GraphTopology)
@@ -57,7 +57,7 @@ def test_topology_coercion_from_dict_steps() -> None:
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="test-recipe", version="1.0.0"),
         interface=RecipeInterface(),
-        topology=topology_dict,  # type: ignore[arg-type]
+        topology=topology_dict,
     )
 
     assert isinstance(recipe.topology, GraphTopology)
@@ -72,11 +72,7 @@ def test_topology_direct_graph_topology() -> None:
     step1 = AgentNode(id="step1", agent_ref="agent-1")
 
     # Manual graph construction
-    graph = GraphTopology(
-        nodes=[step1],
-        edges=[],
-        entry_point="step1"
-    )
+    graph = GraphTopology(nodes=[step1], edges=[], entry_point="step1")
 
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="test-recipe", version="1.0.0"),
@@ -92,13 +88,13 @@ def test_topology_dict_passthrough() -> None:
     topo_data = {
         "nodes": [{"type": "agent", "id": "step1", "agent_ref": "agent-1"}],
         "edges": [],
-        "entry_point": "step1"
+        "entry_point": "step1",
     }
 
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="test-recipe", version="1.0.0"),
         interface=RecipeInterface(),
-        topology=topo_data,  # type: ignore[arg-type]
+        topology=topo_data,
     )
 
     assert isinstance(recipe.topology, GraphTopology)

--- a/tests/test_task_sequence.py
+++ b/tests/test_task_sequence.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GraphTopology,
+    HumanNode,
+    RecipeDefinition,
+    RecipeInterface,
+)
+
+
+def test_topology_coercion_from_list() -> None:
+    """Test initializing RecipeDefinition with a list of nodes (implicit TaskSequence)."""
+    step1 = AgentNode(id="step1", agent_ref="agent-1")
+    step2 = HumanNode(id="step2", prompt="Approve?")
+    step3 = AgentNode(id="step3", agent_ref="agent-2")
+
+    steps = [step1, step2, step3]
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="test-recipe", version="1.0.0"),
+        interface=RecipeInterface(),
+        topology=steps,  # type: ignore[arg-type] # Explicitly testing coercion
+    )
+
+    assert isinstance(recipe.topology, GraphTopology)
+    assert recipe.topology.entry_point == "step1"
+    assert len(recipe.topology.nodes) == 3
+    assert len(recipe.topology.edges) == 2
+
+    # Verify edges
+    edge1 = recipe.topology.edges[0]
+    assert edge1.source == "step1"
+    assert edge1.target == "step2"
+
+    edge2 = recipe.topology.edges[1]
+    assert edge2.source == "step2"
+    assert edge2.target == "step3"
+
+
+def test_topology_coercion_from_dict_steps() -> None:
+    """Test initializing RecipeDefinition with a dict containing 'steps'."""
+    step1 = AgentNode(id="step1", agent_ref="agent-1")
+    step2 = AgentNode(id="step2", agent_ref="agent-2")
+
+    topology_dict = {"steps": [step1, step2]}
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="test-recipe", version="1.0.0"),
+        interface=RecipeInterface(),
+        topology=topology_dict,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(recipe.topology, GraphTopology)
+    assert recipe.topology.entry_point == "step1"
+    assert len(recipe.topology.edges) == 1
+    assert recipe.topology.edges[0].source == "step1"
+    assert recipe.topology.edges[0].target == "step2"
+
+
+def test_topology_direct_graph_topology() -> None:
+    """Test initializing RecipeDefinition with an explicit GraphTopology (fallback)."""
+    step1 = AgentNode(id="step1", agent_ref="agent-1")
+
+    # Manual graph construction
+    graph = GraphTopology(
+        nodes=[step1],
+        edges=[],
+        entry_point="step1"
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="test-recipe", version="1.0.0"),
+        interface=RecipeInterface(),
+        topology=graph,
+    )
+
+    assert recipe.topology == graph
+
+
+def test_topology_dict_passthrough() -> None:
+    """Test initializing RecipeDefinition with a dict that is already a valid GraphTopology structure."""
+    topo_data = {
+        "nodes": [{"type": "agent", "id": "step1", "agent_ref": "agent-1"}],
+        "edges": [],
+        "entry_point": "step1"
+    }
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="test-recipe", version="1.0.0"),
+        interface=RecipeInterface(),
+        topology=topo_data,  # type: ignore[arg-type]
+    )
+
+    assert isinstance(recipe.topology, GraphTopology)
+    assert recipe.topology.entry_point == "step1"

--- a/tests/test_task_sequence_edge_cases.py
+++ b/tests/test_task_sequence_edge_cases.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    EvaluatorNode,
+    GraphTopology,
+    HumanNode,
+    RecipeDefinition,
+    RecipeInterface,
+    RouterNode,
+)
+
+
+def test_task_sequence_single_node() -> None:
+    """Test a sequence with only one node (valid, no edges)."""
+    step1 = AgentNode(id="solo", agent_ref="solo-agent")
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="solo-recipe", version="1.0.0"),
+        interface=RecipeInterface(),
+        topology=[step1],
+    )
+
+    assert isinstance(recipe.topology, GraphTopology)
+    assert recipe.topology.entry_point == "solo"
+    assert len(recipe.topology.nodes) == 1
+    assert len(recipe.topology.edges) == 0
+
+
+def test_task_sequence_empty_list_fails() -> None:
+    """Test that an empty list raises a ValidationError (min_length=1)."""
+    with pytest.raises(ValidationError) as excinfo:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="empty-recipe", version="1.0.0"),
+            interface=RecipeInterface(),
+            topology=[],
+        )
+    # Pydantic error for min_length
+    assert "List should have at least 1 item" in str(excinfo.value)
+
+
+def test_task_sequence_invalid_types_fails() -> None:
+    """Test that a list containing non-node objects fails validation."""
+    with pytest.raises(ValidationError) as excinfo:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="invalid-recipe", version="1.0.0"),
+            interface=RecipeInterface(),
+            topology=[{"invalid": "object"}],  # type: ignore[list-item]
+        )
+    # Pydantic V2 error for discriminated union mismatch
+    # The actual error message is: "Unable to extract tag using discriminator 'type'"
+    assert "Unable to extract tag using discriminator 'type'" in str(excinfo.value)
+
+
+def test_task_sequence_mixed_node_types() -> None:
+    """Test a sequence mixing different node types (Agent -> Human -> Router)."""
+    step1 = AgentNode(id="agent1", agent_ref="ref1")
+    step2 = HumanNode(id="human1", prompt="check")
+    # Router in a sequence is weird (where do the routes go?) but structurally valid as a node
+    # The edges will just point to the next step linearly.
+    # Logic-wise, a RouterNode usually ignores the default edge and follows its 'routes'.
+    # But for the purpose of GraphTopology construction, it should be allowed.
+    step3 = RouterNode(
+        id="router1",
+        input_key="decision",
+        routes={"yes": "agent1"}, # Circular ref just for valid schema
+        default_route="agent1"
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="mixed-recipe", version="1.0.0"),
+        interface=RecipeInterface(),
+        topology=[step1, step2, step3],
+    )
+
+    assert len(recipe.topology.nodes) == 3
+    # Edges: agent1->human1, human1->router1
+    assert len(recipe.topology.edges) == 2
+    assert recipe.topology.edges[0].source == "agent1"
+    assert recipe.topology.edges[0].target == "human1"
+    assert recipe.topology.edges[1].source == "human1"
+    assert recipe.topology.edges[1].target == "router1"
+
+
+def test_task_sequence_dict_extra_fields() -> None:
+    """Test that a dict with 'steps' ignores extra fields if configured to allow, or fails if strict."""
+    # TaskSequence has extra="forbid"
+
+    step1 = AgentNode(id="step1", agent_ref="ref1")
+
+    with pytest.raises(ValidationError) as excinfo:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="extra-recipe", version="1.0.0"),
+            interface=RecipeInterface(),
+            topology={"steps": [step1], "extra_field": "should_fail"},  # type: ignore[arg-type]
+        )
+    assert "Extra inputs are not permitted" in str(excinfo.value)
+
+
+def test_complex_evaluator_sequence() -> None:
+    """
+    Test a complex sequence involving an Evaluator node.
+    Realistically, Evaluator nodes loop back on failure.
+    A linear sequence A -> Evaluator -> B implies the evaluator
+    just passes through or B is the 'pass_route'?
+
+    The TaskSequence logic just wires (i) -> (i+1).
+    So Evaluator -> NextNode means there is an edge Evaluator -> NextNode.
+
+    The EvaluatorNode schema requires 'pass_route' and 'fail_route'.
+    If we use it in a TaskSequence, we must still provide those fields.
+    """
+    step1 = AgentNode(id="generator", agent_ref="gen-ref")
+
+    # We point pass/fail routes to valid IDs, possibly within the sequence
+    step2 = EvaluatorNode(
+        id="judge",
+        target_variable="output",
+        evaluator_agent_ref="judge-ref",
+        evaluation_profile="strict",
+        pass_threshold=0.8,
+        max_refinements=3,
+        pass_route="publisher", # Points to next step
+        fail_route="generator", # Loops back
+        feedback_variable="critique"
+    )
+
+    step3 = AgentNode(id="publisher", agent_ref="pub-ref")
+
+    # The automatic edge generation will add:
+    # generator -> judge
+    # judge -> publisher
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="eval-recipe", version="1.0.0"),
+        interface=RecipeInterface(),
+        topology=[step1, step2, step3],
+    )
+
+    topo = recipe.topology
+    assert len(topo.edges) == 2
+
+    # Verify the automatic edge judge->publisher exists
+    assert topo.edges[1].source == "judge"
+    assert topo.edges[1].target == "publisher"
+
+    # NOTE: The EvaluatorNode logic (in runtime) might use 'pass_route' instead of the generic edge.
+    # But structurally, this graph is valid.
+
+
+def test_topology_dict_no_steps_no_nodes_fails() -> None:
+    """Test that a dict without 'steps' AND without 'nodes' fails (ambiguous or invalid)."""
+    with pytest.raises(ValidationError):
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="bad-recipe", version="1.0.0"),
+            interface=RecipeInterface(),
+            topology={"something": "else"},  # type: ignore[arg-type]
+        )

--- a/tests/test_task_sequence_edge_cases.py
+++ b/tests/test_task_sequence_edge_cases.py
@@ -57,7 +57,7 @@ def test_task_sequence_invalid_types_fails() -> None:
         RecipeDefinition(
             metadata=ManifestMetadata(name="invalid-recipe", version="1.0.0"),
             interface=RecipeInterface(),
-            topology=[{"invalid": "object"}],  # type: ignore[list-item]
+            topology=[{"invalid": "object"}],
         )
     # Pydantic V2 error for discriminated union mismatch
     # The actual error message is: "Unable to extract tag using discriminator 'type'"
@@ -75,8 +75,8 @@ def test_task_sequence_mixed_node_types() -> None:
     step3 = RouterNode(
         id="router1",
         input_key="decision",
-        routes={"yes": "agent1"}, # Circular ref just for valid schema
-        default_route="agent1"
+        routes={"yes": "agent1"},  # Circular ref just for valid schema
+        default_route="agent1",
     )
 
     recipe = RecipeDefinition(
@@ -104,7 +104,7 @@ def test_task_sequence_dict_extra_fields() -> None:
         RecipeDefinition(
             metadata=ManifestMetadata(name="extra-recipe", version="1.0.0"),
             interface=RecipeInterface(),
-            topology={"steps": [step1], "extra_field": "should_fail"},  # type: ignore[arg-type]
+            topology={"steps": [step1], "extra_field": "should_fail"},
         )
     assert "Extra inputs are not permitted" in str(excinfo.value)
 
@@ -132,9 +132,9 @@ def test_complex_evaluator_sequence() -> None:
         evaluation_profile="strict",
         pass_threshold=0.8,
         max_refinements=3,
-        pass_route="publisher", # Points to next step
-        fail_route="generator", # Loops back
-        feedback_variable="critique"
+        pass_route="publisher",  # Points to next step
+        fail_route="generator",  # Loops back
+        feedback_variable="critique",
     )
 
     step3 = AgentNode(id="publisher", agent_ref="pub-ref")
@@ -166,5 +166,5 @@ def test_topology_dict_no_steps_no_nodes_fails() -> None:
         RecipeDefinition(
             metadata=ManifestMetadata(name="bad-recipe", version="1.0.0"),
             interface=RecipeInterface(),
-            topology={"something": "else"},  # type: ignore[arg-type]
+            topology={"something": "else"},
         )


### PR DESCRIPTION
Implemented `TaskSequence` to allow defining `RecipeDefinition` topology as a simple list of steps or a `{"steps": [...]}` dict. This provides syntactic sugar for AI agents and developers while preserving the strict `GraphTopology` internal representation. Used Pydantic V2 `BeforeValidator` for clean, field-scoped input coercion.

---
*PR created automatically by Jules for task [17992572232147989848](https://jules.google.com/task/17992572232147989848) started by @gowthamrao*