### PR TITLE
Add AI Provenance Fields to ManifestMetadata

### DIFF
--- a/docs/cap/specification.md
+++ b/docs/cap/specification.md
@@ -36,7 +36,7 @@ workflow:
 | :--- | :--- | :--- |
 | `apiVersion` | `Literal["coreason.ai/v2"]` | Must be `coreason.ai/v2`. |
 | `kind` | `Literal["Recipe", "Agent"]` | The type of asset being defined. |
-| `metadata` | `ManifestMetadata` | Metadata including name, version, and design info. |
+| `metadata` | `ManifestMetadata` | Metadata including name, version, design, and provenance info. |
 | `interface` | `InterfaceDefinition` | Defines the Input/Output contract. |
 | `state` | `StateDefinition` | Defines the internal memory schema. |
 | `policy` | `PolicyDefinition` | Governance and execution policy. |

--- a/docs/provenance_metadata.md
+++ b/docs/provenance_metadata.md
@@ -1,0 +1,35 @@
+# AI Provenance Metadata
+
+The `ManifestMetadata` in Coreason Manifest V2 includes specific fields to track the provenance of AI-generated workflows. These fields allow systems like `coreason-strategist` to embed reasoning, confidence scores, and original intent directly into the manifest.
+
+## Fields
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `str` | Human-readable name of the workflow/agent. (Required) |
+| `generation_rationale` | `str | None` | Reasoning behind the creation or selection of this workflow. |
+| `confidence_score` | `float | None` | A score (0.0 - 1.0) indicating the system's confidence in this workflow. |
+| `original_user_intent` | `str | None` | The original user prompt or goal that resulted in this workflow. |
+| `generated_by` | `str | None` | The model or system ID that generated this manifest (e.g., 'coreason-strategist-v1'). |
+| `design_metadata` | `DesignMetadata | None` | UI-specific metadata (aliased as `x-design`). |
+
+## Usage
+
+When generating a manifest programmatically (e.g., from an LLM planning step), populate these fields to ensure traceability.
+
+```python
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+
+metadata = ManifestMetadata(
+    name="Cloud Migration Plan",
+    generation_rationale="Selected 'Blue/Green Deployment' strategy to minimize downtime based on user constraints.",
+    confidence_score=0.92,  # Normalized from 0-100 to 0.0-1.0
+    original_user_intent="Create a safe migration plan for the payment service.",
+    generated_by="coreason-strategist-v2",
+)
+```
+
+## Validation
+
+*   **Confidence Score**: Must be between `0.0` and `1.0` inclusive.
+*   **Extra Fields**: The schema permits extra fields (`extra="allow"`) to support forward compatibility and custom metadata, but the fields above are strictly typed.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -56,7 +56,10 @@ from coreason_manifest import (
 
 # 1. Define Metadata
 metadata = ManifestMetadata(
-    name="Research Recipe"
+    name="Research Recipe",
+    # Optional provenance fields
+    confidence_score=0.95,
+    generated_by="coreason-strategist-v1"
 )
 
 # 2. Define Topology

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -230,6 +230,18 @@ class ManifestMetadata(CoReasonBaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True, frozen=True)
 
     name: str = Field(..., description="Human-readable name of the workflow/agent.")
+    generation_rationale: str | None = Field(
+        None, description="Reasoning behind the creation or selection of this workflow."
+    )
+    confidence_score: float | None = Field(
+        None, ge=0.0, le=1.0, description="A score (0.0 - 1.0) indicating the system's confidence in this workflow."
+    )
+    original_user_intent: str | None = Field(
+        None, description="The original user prompt or goal that resulted in this workflow."
+    )
+    generated_by: str | None = Field(
+        None, description="The model or system ID that generated this manifest (e.g., 'coreason-strategist-v1')."
+    )
     design_metadata: DesignMetadata | None = Field(None, alias="x-design", description="UI metadata.")
 
 

--- a/tests/test_metadata_provenance.py
+++ b/tests/test_metadata_provenance.py
@@ -1,0 +1,138 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+
+
+def test_manifest_metadata_provenance_valid():
+    """Test valid provenance fields."""
+    metadata = ManifestMetadata(
+        name="Test Workflow",
+        confidence_score=0.95,
+        generation_rationale="AI generated reasoning",
+        original_user_intent="User want a workflow",
+        generated_by="coreason-strategist-v1"
+    )
+    assert metadata.name == "Test Workflow"
+    assert metadata.confidence_score == 0.95
+    assert metadata.generation_rationale == "AI generated reasoning"
+    assert metadata.original_user_intent == "User want a workflow"
+    assert metadata.generated_by == "coreason-strategist-v1"
+
+def test_manifest_metadata_confidence_score_validation():
+    """Test confidence_score validation."""
+    # Test valid score
+    m1 = ManifestMetadata(name="Valid", confidence_score=0.0)
+    assert m1.confidence_score == 0.0
+
+    m2 = ManifestMetadata(name="Valid", confidence_score=1.0)
+    assert m2.confidence_score == 1.0
+
+    # Test invalid score > 1.0
+    with pytest.raises(ValidationError) as excinfo:
+        ManifestMetadata(name="Invalid", confidence_score=1.5)
+    # Pydantic v2 message may say '1' or '1.0'
+    assert "less than or equal to 1" in str(excinfo.value)
+
+    # Test invalid score < 0.0
+    with pytest.raises(ValidationError) as excinfo:
+        ManifestMetadata(name="Invalid", confidence_score=-0.1)
+    # Pydantic v2 message may say '0' or '0.0'
+    assert "greater than or equal to 0" in str(excinfo.value)
+
+def test_manifest_metadata_extra_fields():
+    """Test that extra fields are still allowed."""
+    # Pydantic V2 with extra='allow' stores in model_extra
+    # Access via attribute depends on __getattr__ implementation in base class
+    # but we can definitely check via dictionary access or model_dump
+    metadata = ManifestMetadata(
+        name="Test Extra",
+        unknown_field="some value"
+    )
+    assert metadata.name == "Test Extra"
+
+    # Check via model_dump
+    dump = metadata.model_dump()
+    assert dump["unknown_field"] == "some value"
+
+    # Check via direct attribute access (if supported by Pydantic V2 ConfigDict)
+    # Based on local test, it seems supported
+    assert getattr(metadata, "unknown_field", None) == "some value"
+
+def test_manifest_metadata_edge_cases():
+    """Test edge cases for provenance fields."""
+    # Empty strings
+    m = ManifestMetadata(
+        name="Empty Strings",
+        generation_rationale="",
+        original_user_intent="",
+        generated_by=""
+    )
+    assert m.generation_rationale == ""
+    assert m.original_user_intent == ""
+    assert m.generated_by == ""
+
+    # None values
+    m_none = ManifestMetadata(
+        name="None Values",
+        confidence_score=None,
+        generation_rationale=None,
+        original_user_intent=None,
+        generated_by=None
+    )
+    assert m_none.confidence_score is None
+
+    # Precision for float
+    m_prec = ManifestMetadata(
+        name="Precision",
+        confidence_score=0.999999999
+    )
+    assert m_prec.confidence_score == 0.999999999
+
+    # Minimal epsilon above 0
+    m_min = ManifestMetadata(
+        name="Min",
+        confidence_score=0.000000001
+    )
+    assert m_min.confidence_score == 0.000000001
+
+def test_manifest_metadata_complex_roundtrip():
+    """Test full serialization roundtrip."""
+    data = {
+        "name": "Complex Case",
+        "confidence_score": 0.88,
+        "generation_rationale": "Complex rationale with \n newlines and symbols !@#$",
+        "original_user_intent": "Make it so.",
+        "generated_by": "the-architect",
+        "extra_data": 123
+    }
+
+    # Create from dict
+    m = ManifestMetadata(**data)
+
+    # Verify
+    assert m.confidence_score == 0.88
+    assert m.generation_rationale == data["generation_rationale"]
+
+    # Serialize
+    json_str = m.model_dump_json()
+
+    # Deserialize
+    m2 = ManifestMetadata.model_validate_json(json_str)
+
+    # Verify equality
+    assert m2.name == m.name
+    assert m2.confidence_score == m.confidence_score
+    assert m2.generated_by == m.generated_by
+    # Extra fields should be preserved in roundtrip
+    assert getattr(m2, "extra_data", None) == 123
+
+def test_manifest_metadata_type_coercion_failure():
+    """Test strict typing where applicable."""
+    # Pydantic will try to coerce strings to floats
+    m = ManifestMetadata(name="Coercion", confidence_score="0.5")
+    assert m.confidence_score == 0.5
+
+    # Fail on invalid string for float
+    with pytest.raises(ValidationError):
+        ManifestMetadata(name="Fail", confidence_score="not-a-float")

--- a/tests/test_metadata_provenance.py
+++ b/tests/test_metadata_provenance.py
@@ -4,14 +4,14 @@ from pydantic import ValidationError
 from coreason_manifest.spec.v2.definitions import ManifestMetadata
 
 
-def test_manifest_metadata_provenance_valid():
+def test_manifest_metadata_provenance_valid() -> None:
     """Test valid provenance fields."""
     metadata = ManifestMetadata(
         name="Test Workflow",
         confidence_score=0.95,
         generation_rationale="AI generated reasoning",
         original_user_intent="User want a workflow",
-        generated_by="coreason-strategist-v1"
+        generated_by="coreason-strategist-v1",
     )
     assert metadata.name == "Test Workflow"
     assert metadata.confidence_score == 0.95
@@ -19,7 +19,8 @@ def test_manifest_metadata_provenance_valid():
     assert metadata.original_user_intent == "User want a workflow"
     assert metadata.generated_by == "coreason-strategist-v1"
 
-def test_manifest_metadata_confidence_score_validation():
+
+def test_manifest_metadata_confidence_score_validation() -> None:
     """Test confidence_score validation."""
     # Test valid score
     m1 = ManifestMetadata(name="Valid", confidence_score=0.0)
@@ -40,15 +41,13 @@ def test_manifest_metadata_confidence_score_validation():
     # Pydantic v2 message may say '0' or '0.0'
     assert "greater than or equal to 0" in str(excinfo.value)
 
-def test_manifest_metadata_extra_fields():
+
+def test_manifest_metadata_extra_fields() -> None:
     """Test that extra fields are still allowed."""
     # Pydantic V2 with extra='allow' stores in model_extra
     # Access via attribute depends on __getattr__ implementation in base class
     # but we can definitely check via dictionary access or model_dump
-    metadata = ManifestMetadata(
-        name="Test Extra",
-        unknown_field="some value"
-    )
+    metadata = ManifestMetadata(name="Test Extra", unknown_field="some value")
     assert metadata.name == "Test Extra"
 
     # Check via model_dump
@@ -59,15 +58,11 @@ def test_manifest_metadata_extra_fields():
     # Based on local test, it seems supported
     assert getattr(metadata, "unknown_field", None) == "some value"
 
-def test_manifest_metadata_edge_cases():
+
+def test_manifest_metadata_edge_cases() -> None:
     """Test edge cases for provenance fields."""
     # Empty strings
-    m = ManifestMetadata(
-        name="Empty Strings",
-        generation_rationale="",
-        original_user_intent="",
-        generated_by=""
-    )
+    m = ManifestMetadata(name="Empty Strings", generation_rationale="", original_user_intent="", generated_by="")
     assert m.generation_rationale == ""
     assert m.original_user_intent == ""
     assert m.generated_by == ""
@@ -78,25 +73,20 @@ def test_manifest_metadata_edge_cases():
         confidence_score=None,
         generation_rationale=None,
         original_user_intent=None,
-        generated_by=None
+        generated_by=None,
     )
     assert m_none.confidence_score is None
 
     # Precision for float
-    m_prec = ManifestMetadata(
-        name="Precision",
-        confidence_score=0.999999999
-    )
+    m_prec = ManifestMetadata(name="Precision", confidence_score=0.999999999)
     assert m_prec.confidence_score == 0.999999999
 
     # Minimal epsilon above 0
-    m_min = ManifestMetadata(
-        name="Min",
-        confidence_score=0.000000001
-    )
+    m_min = ManifestMetadata(name="Min", confidence_score=0.000000001)
     assert m_min.confidence_score == 0.000000001
 
-def test_manifest_metadata_complex_roundtrip():
+
+def test_manifest_metadata_complex_roundtrip() -> None:
     """Test full serialization roundtrip."""
     data = {
         "name": "Complex Case",
@@ -104,7 +94,7 @@ def test_manifest_metadata_complex_roundtrip():
         "generation_rationale": "Complex rationale with \n newlines and symbols !@#$",
         "original_user_intent": "Make it so.",
         "generated_by": "the-architect",
-        "extra_data": 123
+        "extra_data": 123,
     }
 
     # Create from dict
@@ -127,7 +117,8 @@ def test_manifest_metadata_complex_roundtrip():
     # Extra fields should be preserved in roundtrip
     assert getattr(m2, "extra_data", None) == 123
 
-def test_manifest_metadata_type_coercion_failure():
+
+def test_manifest_metadata_type_coercion_failure() -> None:
     """Test strict typing where applicable."""
     # Pydantic will try to coerce strings to floats
     m = ManifestMetadata(name="Coercion", confidence_score="0.5")


### PR DESCRIPTION
Extended `ManifestMetadata` in `src/coreason_manifest/spec/v2/definitions.py` to support AI-generated provenance fields. This includes:
1.  **New Fields**: `generation_rationale`, `confidence_score`, `original_user_intent`, `generated_by`.
2.  **Validation**: `confidence_score` is strictly validated to be between 0.0 and 1.0.
3.  **Documentation**: Added `docs/provenance_metadata.md` and updated existing docs.
4.  **Testing**: Added `tests/test_metadata_provenance.py` with valid, invalid, and edge case scenarios.

---
*PR created automatically by Jules for task [9817312426224771015](https://jules.google.com/task/9817312426224771015) started by @gowthamrao*