### PR TITLE
feat: Add OpenAI Assistant Adapter

### DIFF
--- a/docs/interop/openai_adapter.md
+++ b/docs/interop/openai_adapter.md
@@ -1,0 +1,101 @@
+# OpenAI Assistant Adapter
+
+The **OpenAI Assistant** Adapter enables any `Coreason` agent definition to be converted into an OpenAI Assistant configuration, allowing seamless integration with the OpenAI Assistants API.
+
+This implementation provides a pure data transformation layer, projecting `AgentDefinition` interfaces directly into the OpenAI Assistant `create` payload format.
+
+## Overview
+
+The adapter maps the following Coreason concepts to OpenAI Assistant concepts:
+
+| Coreason Concept | OpenAI Assistant Concept | Notes |
+| :--- | :--- | :--- |
+| `AgentDefinition.name` | `name` | Passed directly. |
+| `AgentDefinition.role`, `goal`, `backstory` | `instructions` | Concatenated into a single prompt. |
+| `AgentDefinition.model` | `model` | Defaults to `gpt-4o` if unspecified. |
+| `InlineToolDefinition` | `tools` (type: function) | Mapped directly via JSON Schema. |
+| `ToolRequirement` | (Skipped) | Remote tools are currently skipped as their schema is not locally available. |
+
+## Installation
+
+This functionality is part of the core `coreason-manifest` package and requires no additional dependencies beyond the standard installation.
+
+```bash
+pip install coreason-manifest
+```
+
+## Usage
+
+### Converting an Agent to an OpenAI Assistant
+
+You can convert a Coreason Agent Definition into a dictionary compatible with the OpenAI API `client.beta.assistants.create(**config)` method.
+
+```python
+from coreason_manifest import AgentDefinition, InlineToolDefinition
+from coreason_manifest.interop.openai import convert_to_openai_assistant
+
+# 1. Define your agent with tools
+calculator_tool = InlineToolDefinition(
+    name="calculator",
+    description="Perform basic arithmetic",
+    parameters={
+        "type": "object",
+        "properties": {
+            "expression": {"type": "string", "description": "Mathematical expression"}
+        },
+        "required": ["expression"]
+    }
+)
+
+agent = AgentDefinition(
+    id="math-tutor",
+    name="Math Tutor",
+    role="Tutor",
+    goal="Help students learn math",
+    backstory="You are a patient and encouraging math teacher.",
+    tools=[calculator_tool],
+    model="gpt-4-turbo"
+)
+
+# 2. Convert to OpenAI format
+openai_config = convert_to_openai_assistant(agent)
+
+print(openai_config)
+# Output:
+# {
+#   "name": "Math Tutor",
+#   "instructions": "Role: Tutor\n\nGoal: Help students learn math\n\nBackstory: ...",
+#   "model": "gpt-4-turbo",
+#   "tools": [
+#     {
+#       "type": "function",
+#       "function": {
+#         "name": "calculator",
+#         "description": "Perform basic arithmetic",
+#         "parameters": { ... }
+#       }
+#     }
+#   ],
+#   "metadata": { ... }
+# }
+```
+
+### Integrating with OpenAI Python Client
+
+The output dictionary can be passed directly to the OpenAI client using kwargs unpacking.
+
+```python
+from openai import OpenAI
+
+client = OpenAI()
+
+# Create the assistant
+assistant = client.beta.assistants.create(**openai_config)
+
+print(f"Created Assistant ID: {assistant.id}")
+```
+
+## Limitations
+
+*   **Remote Tools:** Currently, `ToolRequirement` (remote tools referenced by URI) are skipped because their JSON Schema definition is not available in the manifest itself. To use remote tools, you must manually resolve and attach their definitions.
+*   **Knowledge/Files:** The `knowledge` field (file paths) is currently ignored. File uploading requires stateful API calls (uploading files, getting file IDs), which is outside the scope of this stateless manifest library.

--- a/src/coreason_manifest/interop/__init__.py
+++ b/src/coreason_manifest/interop/__init__.py
@@ -9,5 +9,6 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from .mcp import CoreasonMCPServer, create_mcp_tool_definition
+from .openai import convert_to_openai_assistant
 
-__all__ = ["CoreasonMCPServer", "create_mcp_tool_definition"]
+__all__ = ["CoreasonMCPServer", "convert_to_openai_assistant", "create_mcp_tool_definition"]

--- a/src/coreason_manifest/interop/openai.py
+++ b/src/coreason_manifest/interop/openai.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any
+
+from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+
+
+def convert_to_openai_assistant(agent: AgentDefinition) -> dict[str, Any]:
+    """
+    Converts a Coreason Agent Definition into an OpenAI Assistant definition.
+
+    Args:
+        agent: The AgentDefinition to convert.
+
+    Returns:
+        A dictionary matching the OpenAI Assistant structure.
+    """
+    # 1. Instructions
+    instructions_parts = [
+        f"Role: {agent.role}",
+        f"Goal: {agent.goal}",
+    ]
+    if agent.backstory:
+        instructions_parts.append(f"Backstory: {agent.backstory}")
+
+    instructions = "\n\n".join(instructions_parts)
+
+    # 2. Tools
+    openai_tools = []
+
+    # Process tools
+    for tool in agent.tools:
+        if isinstance(tool, InlineToolDefinition):
+            # Map InlineToolDefinition to OpenAI function tool
+            openai_tools.append({
+                "type": "function",
+                "function": {
+                    "name": tool.name,
+                    "description": tool.description,
+                    "parameters": tool.parameters,
+                },
+            })
+        elif isinstance(tool, ToolRequirement):
+            # For remote tools, we can't fully define them without schema retrieval.
+            # We skip them for now.
+            pass
+
+    # 3. Model
+    # Default to a modern model if not specified
+    model = agent.model if agent.model else "gpt-4o"
+
+    return {
+        "name": agent.name,
+        "instructions": instructions,
+        "tools": openai_tools,
+        "model": model,
+        "metadata": {
+            "source": "coreason-manifest",
+            "agent_id": agent.id,
+            "version": "v2",
+        },
+    }

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from coreason_manifest.interop.openai import convert_to_openai_assistant
+from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+
+
+def test_convert_minimal_agent() -> None:
+    """Test converting a minimal agent with no tools."""
+    agent = AgentDefinition(
+        id="test-agent",
+        name="TestAgent",
+        role="Tester",
+        goal="To test things",
+        backstory="I was born to test.",
+        model="gpt-3.5-turbo",
+    )
+
+    openai_def = convert_to_openai_assistant(agent)
+
+    assert openai_def["name"] == "TestAgent"
+    assert "Role: Tester" in openai_def["instructions"]
+    assert "Goal: To test things" in openai_def["instructions"]
+    assert "Backstory: I was born to test." in openai_def["instructions"]
+    assert openai_def["model"] == "gpt-3.5-turbo"
+    assert openai_def["tools"] == []
+    assert openai_def["metadata"]["source"] == "coreason-manifest"
+
+
+def test_convert_agent_with_inline_tools() -> None:
+    """Test converting an agent with inline tools."""
+    tool = InlineToolDefinition(
+        name="calculator",
+        description="Calculates things",
+        parameters={
+            "type": "object",
+            "properties": {"expression": {"type": "string"}},
+            "required": ["expression"],
+        },
+    )
+
+    agent = AgentDefinition(
+        id="math-agent",
+        name="MathAgent",
+        role="Mathematician",
+        goal="Solve problems",
+        tools=[tool],
+    )
+
+    openai_def = convert_to_openai_assistant(agent)
+
+    assert len(openai_def["tools"]) == 1
+    t = openai_def["tools"][0]
+    assert t["type"] == "function"
+    assert t["function"]["name"] == "calculator"
+    assert t["function"]["description"] == "Calculates things"
+    assert t["function"]["parameters"] == tool.parameters
+
+
+def test_convert_agent_with_remote_tools() -> None:
+    """Test converting an agent with remote tools (should be skipped)."""
+    tool = ToolRequirement(
+        uri="https://api.example.com/tools/v1/search"
+    )
+
+    agent = AgentDefinition(
+        id="remote-agent",
+        name="RemoteAgent",
+        role="Searcher",
+        goal="Search the web",
+        tools=[tool],
+    )
+
+    openai_def = convert_to_openai_assistant(agent)
+
+    # Remote tools should be skipped
+    assert openai_def["tools"] == []
+
+
+def test_default_model() -> None:
+    """Test default model assignment."""
+    agent = AgentDefinition(
+        id="default-agent",
+        name="DefaultAgent",
+        role="Default",
+        goal="Default",
+    )
+
+    openai_def = convert_to_openai_assistant(agent)
+    assert openai_def["model"] == "gpt-4o"
+
+
+def test_knowledge_ignored() -> None:
+    """Test that knowledge (files) are ignored as OpenAI API requires file IDs."""
+    agent = AgentDefinition(
+        id="knowledge-agent",
+        name="Librarian",
+        role="Librarian",
+        goal="Manage knowledge",
+        knowledge=["/path/to/local/file.txt", "https://example.com/doc.pdf"],
+    )
+
+    openai_def = convert_to_openai_assistant(agent)
+
+    # We do NOT map knowledge to file_ids because that requires API calls
+    assert "file_ids" not in openai_def
+    assert "tool_resources" not in openai_def
+
+
+def test_multiple_complex_tools() -> None:
+    """Test converting an agent with multiple complex inline tools."""
+    tool1 = InlineToolDefinition(
+        name="complex_search",
+        description="Complex search tool",
+        parameters={
+            "type": "object",
+            "properties": {
+                "query": {"type": "string"},
+                "filters": {
+                    "type": "object",
+                    "properties": {
+                        "date_range": {"type": "string"},
+                        "tags": {"type": "array", "items": {"type": "string"}},
+                    },
+                },
+            },
+            "required": ["query"],
+        },
+    )
+
+    tool2 = InlineToolDefinition(
+        name="report_generator",
+        description="Generates reports",
+        parameters={
+            "type": "object",
+            "properties": {"format": {"type": "string", "enum": ["pdf", "html"]}},
+            "required": ["format"],
+        },
+    )
+
+    agent = AgentDefinition(
+        id="analyst",
+        name="Senior Analyst",
+        role="Analyst",
+        goal="Analyze data",
+        tools=[tool1, tool2],
+    )
+
+    openai_def = convert_to_openai_assistant(agent)
+
+    assert len(openai_def["tools"]) == 2
+
+    t1 = openai_def["tools"][0]
+    assert t1["function"]["name"] == "complex_search"
+    assert t1["function"]["parameters"]["properties"]["filters"]["type"] == "object"
+
+    t2 = openai_def["tools"][1]
+    assert t2["function"]["name"] == "report_generator"
+    assert "enum" in t2["function"]["parameters"]["properties"]["format"]
+
+
+def test_special_characters_in_name() -> None:
+    """Test handling of special characters in agent name."""
+    # OpenAI names are lenient (up to 256 chars), so we pass them through.
+    # We verify that they appear correctly in the output.
+    name = "Agent (Special Edition) #1"
+    agent = AgentDefinition(
+        id="special-agent",
+        name=name,
+        role="Specialist",
+        goal="Be special",
+    )
+
+    openai_def = convert_to_openai_assistant(agent)
+    assert openai_def["name"] == name


### PR DESCRIPTION
This PR introduces an adapter to convert Coreason Agent definitions into OpenAI Assistant configurations.

### Key Changes
- **New Module:** `src/coreason_manifest/interop/openai.py` implements `convert_to_openai_assistant(agent)`.
- **Logic:**
  - Maps `name`, `model` (defaults to `gpt-4o`).
  - Concatenates `role`, `goal`, `backstory` into `instructions`.
  - Converts `InlineToolDefinition` to OpenAI function schemas.
  - Skips `ToolRequirement` (remote tools) as schema is unavailable.
  - Ignores `knowledge` (files) as it requires stateful API calls.
- **Documentation:** Added `docs/interop/openai_adapter.md`.
- **Testing:** Added comprehensive tests covering standard and edge cases.

---
*PR created automatically by Jules for task [4093422578035773719](https://jules.google.com/task/4093422578035773719) started by @gowthamrao*