### PR TITLE
Add tested_models field to ManifestMetadata

### DIFF
--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -231,6 +231,9 @@ class ManifestMetadata(CoReasonBaseModel):
 
     name: str = Field(..., description="Human-readable name of the workflow/agent.")
     design_metadata: DesignMetadata | None = Field(None, alias="x-design", description="UI metadata.")
+    tested_models: list[str] = Field(
+        default_factory=list, description="List of LLM identifiers this manifest has been tested on."
+    )
 
 
 # Import ToolPackDefinition after definitions are declared to avoid circular import

--- a/tests/test_v2_manifest.py
+++ b/tests/test_v2_manifest.py
@@ -61,3 +61,22 @@ def test_invalid_manifest() -> None:
     }
     with pytest.raises(ValidationError):
         ManifestV2.model_validate(data)
+
+
+def test_manifest_metadata_tested_models() -> None:
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {
+            "name": "Test Workflow",
+            "tested_models": ["gpt-4", "claude-3-opus"]
+        },
+        "workflow": {
+            "start": "step-1",
+            "steps": {
+                "step-1": {"type": "logic", "id": "step-1", "code": "pass"}
+            },
+        },
+    }
+    manifest = ManifestV2.model_validate(data)
+    assert manifest.metadata.tested_models == ["gpt-4", "claude-3-opus"]

--- a/tests/test_v2_manifest.py
+++ b/tests/test_v2_manifest.py
@@ -67,15 +67,10 @@ def test_manifest_metadata_tested_models() -> None:
     data = {
         "apiVersion": "coreason.ai/v2",
         "kind": "Recipe",
-        "metadata": {
-            "name": "Test Workflow",
-            "tested_models": ["gpt-4", "claude-3-opus"]
-        },
+        "metadata": {"name": "Test Workflow", "tested_models": ["gpt-4", "claude-3-opus"]},
         "workflow": {
             "start": "step-1",
-            "steps": {
-                "step-1": {"type": "logic", "id": "step-1", "code": "pass"}
-            },
+            "steps": {"step-1": {"type": "logic", "id": "step-1", "code": "pass"}},
         },
     }
     manifest = ManifestV2.model_validate(data)


### PR DESCRIPTION
Added `tested_models` field to `ManifestMetadata` to allow tracking which LLMs a manifest has been tested on. This is an optional list of strings.

---
*PR created automatically by Jules for task [13334286052606953601](https://jules.google.com/task/13334286052606953601) started by @gowthamrao*