### PR TITLE
feat(manifest): generalize metadata with ProvenanceData

### DIFF
--- a/docs/cap/specification.md
+++ b/docs/cap/specification.md
@@ -36,7 +36,7 @@ workflow:
 | :--- | :--- | :--- |
 | `apiVersion` | `Literal["coreason.ai/v2"]` | Must be `coreason.ai/v2`. |
 | `kind` | `Literal["Recipe", "Agent"]` | The type of asset being defined. |
-| `metadata` | `ManifestMetadata` | Metadata including name, version, design, and provenance info. |
+| `metadata` | `ManifestMetadata` | Metadata: `name`, `version`, `provenance`, and design info. |
 | `interface` | `InterfaceDefinition` | Defines the Input/Output contract. |
 | `state` | `StateDefinition` | Defines the internal memory schema. |
 | `policy` | `PolicyDefinition` | Governance and execution policy. |

--- a/docs/cap/specification.md
+++ b/docs/cap/specification.md
@@ -36,7 +36,7 @@ workflow:
 | :--- | :--- | :--- |
 | `apiVersion` | `Literal["coreason.ai/v2"]` | Must be `coreason.ai/v2`. |
 | `kind` | `Literal["Recipe", "Agent"]` | The type of asset being defined. |
-| `metadata` | `ManifestMetadata` | Metadata including name, version, and design info. |
+| `metadata` | `ManifestMetadata` | Metadata including name, version, design, and provenance info. |
 | `interface` | `InterfaceDefinition` | Defines the Input/Output contract. |
 | `state` | `StateDefinition` | Defines the internal memory schema. |
 | `policy` | `PolicyDefinition` | Governance and execution policy. |
@@ -204,6 +204,11 @@ apiVersion: coreason.ai/v2
 kind: Recipe
 metadata:
   name: "Research Workflow"
+  version: "1.0.0"
+  provenance:
+    type: "human"
+    generated_by: "Alice"
+    methodology: "Manual Design"
 interface:
   inputs:
     query:

--- a/docs/provenance_metadata.md
+++ b/docs/provenance_metadata.md
@@ -1,0 +1,64 @@
+# AI Provenance Metadata
+
+The `ManifestMetadata` in Coreason Manifest V2 includes a standardized `provenance` object to track the creation and modification of workflows. This structure supports both AI-generated and human-authored artifacts, ensuring traceability and supply chain security.
+
+## Manifest Metadata
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `name` | `str` | Human-readable name. (Required) |
+| `version` | `str` | Semantic version (e.g., `1.0.0`). (Default: `0.1.0`) |
+| `provenance` | `ProvenanceData | None` | Provenance details. |
+| `design_metadata` | `DesignMetadata | None` | UI-specific metadata (aliased as `x-design`). |
+
+## Provenance Object (`ProvenanceData`)
+
+The `provenance` field captures the "who, when, and why".
+
+| Field | Type | Description |
+| :--- | :--- | :--- |
+| `type` | `Literal["ai", "human", "hybrid"]` | The primary source type. |
+| `generated_by` | `str` | The system ID (AI) or user identifier (Human). |
+| `generated_date` | `datetime | None` | Timestamp of generation. |
+| `rationale` | `str | None` | Reasoning behind the design. |
+| `original_intent` | `str | None` | The initial prompt (AI) or goal (Human). |
+| `confidence_score` | `float | None` | Confidence (0.0 - 1.0) for AI content. |
+| `methodology` | `str | None` | Technique used (e.g., `Chain-of-Thought`, `Manual Review`). |
+
+## Usage Examples
+
+### 1. AI-Generated Workflow
+
+```python
+from datetime import datetime, timezone
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.provenance import ProvenanceData
+
+metadata = ManifestMetadata(
+    name="Cloud Migration Plan",
+    version="0.1.0",
+    provenance=ProvenanceData(
+        type="ai",
+        generated_by="coreason-strategist-v2",
+        generated_date=datetime.now(timezone.utc),
+        rationale="Selected Blue/Green deployment to minimize risk.",
+        original_intent="Create a zero-downtime migration plan.",
+        confidence_score=0.95
+    )
+)
+```
+
+### 2. Human-Authored Workflow
+
+```python
+metadata = ManifestMetadata(
+    name="Manual Review Process",
+    version="1.0.0",
+    provenance=ProvenanceData(
+        type="human",
+        generated_by="alice@example.com",
+        methodology="Peer Review",
+        rationale="Standard operating procedure for Q2."
+    )
+)
+```

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -51,12 +51,19 @@ from coreason_manifest import (
     StateDefinition,
     PolicyConfig,
     GraphTopology,
-    AgentNode
+    AgentNode,
+    ProvenanceData
 )
 
 # 1. Define Metadata
 metadata = ManifestMetadata(
-    name="Research Recipe"
+    name="Research Recipe",
+    version="1.0.0",
+    provenance=ProvenanceData(
+        type="ai",
+        generated_by="coreason-strategist-v1",
+        confidence_score=0.95
+    )
 )
 
 # 2. Define Topology

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -18,6 +18,7 @@ from coreason_manifest.spec.common_base import CoReasonBaseModel, StrictUri, Too
 from coreason_manifest.spec.v2.contracts import InterfaceDefinition, PolicyDefinition, StateDefinition
 from coreason_manifest.spec.v2.evaluation import EvaluationProfile
 from coreason_manifest.spec.v2.packs import MCPResourceDefinition, ToolPackDefinition
+from coreason_manifest.spec.v2.provenance import ProvenanceData
 from coreason_manifest.spec.v2.resources import ModelProfile
 from coreason_manifest.spec.v2.skills import SkillDefinition
 
@@ -230,6 +231,8 @@ class ManifestMetadata(CoReasonBaseModel):
     model_config = ConfigDict(extra="allow", populate_by_name=True, frozen=True)
 
     name: str = Field(..., description="Human-readable name of the workflow/agent.")
+    version: str = Field("0.1.0", description="Semantic version of the workflow/agent.")
+    provenance: ProvenanceData | None = Field(None, description="Provenance details (AI or Human).")
     design_metadata: DesignMetadata | None = Field(None, alias="x-design", description="UI metadata.")
 
 

--- a/src/coreason_manifest/spec/v2/provenance.py
+++ b/src/coreason_manifest/spec/v2/provenance.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.spec.common_base import CoReasonBaseModel
+
+
+class ProvenanceData(CoReasonBaseModel):
+    """Metadata tracking the creation or modification of the manifest.
+
+    Supports both AI-generated (provenance) and human-authored workflows.
+    """
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True, frozen=True)
+
+    # Core identification
+    type: Literal["ai", "human", "hybrid"] = Field(..., description="The primary source of this manifest.")
+    generated_by: str = Field(..., description="The system ID (AI) or user identifier (Human).")
+    generated_date: datetime | None = Field(None, description="Timestamp of generation.")
+
+    # Rationale & Intent (Generalized)
+    rationale: str | None = Field(None, description="Reasoning behind the design choices.")
+    original_intent: str | None = Field(None, description="The initial prompt (AI) or design goal (Human).")
+
+    # AI Specifics
+    confidence_score: float | None = Field(
+        None, ge=0.0, le=1.0, description="Confidence score (0.0-1.0) for AI-generated content."
+    )
+
+    # Methodology (e.g., 'Chain-of-Thought', 'Manual Review', 'Peer Review')
+    methodology: str | None = Field(None, description="The specific technique or process used.")

--- a/tests/test_metadata_provenance.py
+++ b/tests/test_metadata_provenance.py
@@ -1,0 +1,118 @@
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.provenance import ProvenanceData
+
+
+def test_manifest_metadata_provenance_ai() -> None:
+    """Test AI-generated provenance."""
+    metadata = ManifestMetadata(
+        name="AI Workflow",
+        version="1.0.0",
+        provenance=ProvenanceData(
+            type="ai",
+            generated_by="coreason-strategist-v1",
+            confidence_score=0.95,
+            rationale="AI generated reasoning",
+            original_intent="User want a workflow",
+            generated_date=datetime(2023, 1, 1, tzinfo=UTC),
+        ),
+    )
+    assert metadata.name == "AI Workflow"
+    assert metadata.version == "1.0.0"
+    assert metadata.provenance is not None
+    assert metadata.provenance.type == "ai"
+    assert metadata.provenance.generated_by == "coreason-strategist-v1"
+    assert metadata.provenance.confidence_score == 0.95
+    assert metadata.provenance.rationale == "AI generated reasoning"
+    assert metadata.provenance.original_intent == "User want a workflow"
+    assert metadata.provenance.generated_date == datetime(2023, 1, 1, tzinfo=UTC)
+
+
+def test_manifest_metadata_provenance_human() -> None:
+    """Test Human-authored provenance."""
+    metadata = ManifestMetadata(
+        name="Human Workflow",
+        # version default check
+        provenance=ProvenanceData(type="human", generated_by="Alice", methodology="Manual Design"),
+    )
+    assert metadata.name == "Human Workflow"
+    assert metadata.version == "0.1.0"  # Default
+    assert metadata.provenance is not None
+    assert metadata.provenance.type == "human"
+    assert metadata.provenance.generated_by == "Alice"
+    assert metadata.provenance.methodology == "Manual Design"
+    assert metadata.provenance.confidence_score is None
+
+
+def test_manifest_metadata_confidence_score_validation() -> None:
+    """Test confidence_score validation."""
+    # Test valid score
+    p = ProvenanceData(type="ai", generated_by="sys", confidence_score=0.0)
+    assert p.confidence_score == 0.0
+
+    p2 = ProvenanceData(type="ai", generated_by="sys", confidence_score=1.0)
+    assert p2.confidence_score == 1.0
+
+    # Test invalid score > 1.0
+    with pytest.raises(ValidationError) as excinfo:
+        ProvenanceData(type="ai", generated_by="sys", confidence_score=1.5)
+    assert "less than or equal to 1" in str(excinfo.value)
+
+    # Test invalid score < 0.0
+    with pytest.raises(ValidationError) as excinfo:
+        ProvenanceData(type="ai", generated_by="sys", confidence_score=-0.1)
+    assert "greater than or equal to 0" in str(excinfo.value)
+
+
+def test_manifest_metadata_extra_fields() -> None:
+    """Test that extra fields are still allowed in Metadata and Provenance."""
+    metadata = ManifestMetadata(
+        name="Test Extra",
+        unknown_field="some value",
+        provenance=ProvenanceData(type="hybrid", generated_by="Team", extra_provenance="extra"),
+    )
+    # Check via model_dump
+    dump = metadata.model_dump()
+    assert dump["unknown_field"] == "some value"
+    assert dump["provenance"]["extra_provenance"] == "extra"
+
+
+def test_manifest_metadata_complex_roundtrip() -> None:
+    """Test full serialization roundtrip."""
+    data = {
+        "name": "Complex Case",
+        "version": "2.0.0",
+        "provenance": {
+            "type": "ai",
+            "generated_by": "the-architect",
+            "confidence_score": 0.88,
+            "rationale": "Complex rationale",
+            "original_intent": "Make it so.",
+            "generated_date": "2023-10-27T10:00:00Z",
+        },
+    }
+
+    # Create from dict
+    m = ManifestMetadata(**data)
+
+    # Verify
+    assert m.provenance is not None
+    assert m.provenance.confidence_score == 0.88
+
+    # Serialize
+    json_str = m.model_dump_json()
+
+    # Deserialize
+    m2 = ManifestMetadata.model_validate_json(json_str)
+
+    # Verify equality
+    assert m2.name == m.name
+    assert m2.version == "2.0.0"
+    assert m2.provenance is not None
+    assert m2.provenance.generated_by == "the-architect"
+    assert m2.provenance.generated_date is not None
+    assert m2.provenance.generated_date.year == 2023


### PR DESCRIPTION
- Introduced `ProvenanceData` in `src/coreason_manifest/spec/v2/provenance.py` to capture AI/Human origin, versioning, and rationale.
- Updated `ManifestMetadata` in `src/coreason_manifest/spec/v2/definitions.py` to use `ProvenanceData` and added a top-level `version` field.
- Updated documentation and tests to reflect the new structured approach.