### PR TITLE
Add OpenAI and LangChain Interoperability Adapters

### DIFF
--- a/src/coreason_manifest/utils/langchain_adapter.py
+++ b/src/coreason_manifest/utils/langchain_adapter.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any
+
+from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+
+
+def convert_to_langchain_kwargs(agent: AgentDefinition) -> dict[str, Any]:
+    """
+    Convert a Coreason AgentDefinition into LangChain initialization arguments.
+
+    This function extracts the system message (prompt) and tool schemas in a format
+    compatible with LangChain's agent initialization (e.g., for `create_openai_tools_agent`
+    or `bind_tools`).
+
+    Args:
+        agent: The agent definition to convert.
+
+    Returns:
+        A dictionary containing:
+        - `system_message`: A string containing the combined role, goal, and backstory.
+        - `tool_schemas`: A list of dictionaries representing the tool schemas (compatible with OpenAI function format).
+        - `model_name`: The name of the LLM model to use.
+    """
+    # Construct the system message
+    instructions_parts = [
+        f"You are {agent.name}.",
+        f"Role: {agent.role}",
+        f"Goal: {agent.goal}",
+    ]
+    if agent.backstory:
+        instructions_parts.append(f"Backstory: {agent.backstory}")
+
+    system_message = "\n\n".join(instructions_parts)
+
+    # Convert tools to schemas compatible with LangChain's bind_tools (which accepts OpenAI format)
+    tool_schemas = []
+    for tool in agent.tools:
+        if isinstance(tool, InlineToolDefinition):
+            tool_schemas.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.parameters,
+                    },
+                }
+            )
+        elif isinstance(tool, ToolRequirement):
+            # Remote tools are skipped as their schema is not available locally.
+            continue
+
+    return {
+        "system_message": system_message,
+        "tool_schemas": tool_schemas,
+        "model_name": agent.model or "gpt-4",  # Default to gpt-4 if not specified
+    }

--- a/src/coreason_manifest/utils/openai_adapter.py
+++ b/src/coreason_manifest/utils/openai_adapter.py
@@ -1,0 +1,66 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any
+
+from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+
+
+def convert_to_openai_assistant(agent: AgentDefinition) -> dict[str, Any]:
+    """
+    Convert a Coreason AgentDefinition into an OpenAI Assistant configuration.
+
+    This function maps the agent's identity, instructions, and tools to the format
+    expected by the OpenAI Assistants API.
+
+    Args:
+        agent: The agent definition to convert.
+
+    Returns:
+        A dictionary representing the OpenAI Assistant configuration.
+    """
+    instructions_parts = [
+        f"Role: {agent.role}",
+        f"Goal: {agent.goal}",
+    ]
+    if agent.backstory:
+        instructions_parts.append(f"Backstory: {agent.backstory}")
+
+    instructions = "\n\n".join(instructions_parts)
+
+    tools = []
+    for tool in agent.tools:
+        if isinstance(tool, InlineToolDefinition):
+            tools.append(
+                {
+                    "type": "function",
+                    "function": {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "parameters": tool.parameters,
+                    },
+                }
+            )
+        elif isinstance(tool, ToolRequirement):
+            # Remote tools (ToolRequirement) are skipped as their schema is not available locally.
+            continue
+
+    assistant_config = {
+        "name": agent.name,
+        "instructions": instructions,
+        "tools": tools,
+        "model": agent.model or "gpt-4-turbo-preview",  # Default model if not specified
+        "metadata": {
+            "coreason_agent_id": agent.id,
+            "coreason_agent_role": agent.role,
+        },
+    }
+
+    return assistant_config

--- a/src/coreason_manifest/utils/openai_adapter.py
+++ b/src/coreason_manifest/utils/openai_adapter.py
@@ -52,7 +52,7 @@ def convert_to_openai_assistant(agent: AgentDefinition) -> dict[str, Any]:
             # Remote tools (ToolRequirement) are skipped as their schema is not available locally.
             continue
 
-    assistant_config = {
+    return {
         "name": agent.name,
         "instructions": instructions,
         "tools": tools,
@@ -62,5 +62,3 @@ def convert_to_openai_assistant(agent: AgentDefinition) -> dict[str, Any]:
             "coreason_agent_role": agent.role,
         },
     }
-
-    return assistant_config

--- a/tests/test_interop_coverage.py
+++ b/tests/test_interop_coverage.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from coreason_manifest.utils.openai_adapter import convert_to_openai_assistant
+from coreason_manifest.utils.langchain_adapter import convert_to_langchain_kwargs
+from coreason_manifest.spec.v2.definitions import AgentDefinition
+
+def test_openai_conversion_with_backstory() -> None:
+    """Test conversion to OpenAI format including backstory."""
+    agent = AgentDefinition(
+        id="story-agent",
+        name="Story Agent",
+        role="Teller",
+        goal="Tell stories",
+        backstory="Once upon a time...",
+    )
+
+    result = convert_to_openai_assistant(agent)
+
+    assert "Backstory: Once upon a time..." in result["instructions"]
+
+def test_langchain_conversion_with_backstory() -> None:
+    """Test conversion to LangChain format including backstory."""
+    agent = AgentDefinition(
+        id="story-agent-lc",
+        name="Story Agent LC",
+        role="Teller",
+        goal="Tell stories",
+        backstory="In a galaxy far, far away...",
+    )
+
+    result = convert_to_langchain_kwargs(agent)
+
+    assert "Backstory: In a galaxy far, far away..." in result["system_message"]

--- a/tests/test_interop_coverage.py
+++ b/tests/test_interop_coverage.py
@@ -8,10 +8,10 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-import pytest
-from coreason_manifest.utils.openai_adapter import convert_to_openai_assistant
-from coreason_manifest.utils.langchain_adapter import convert_to_langchain_kwargs
 from coreason_manifest.spec.v2.definitions import AgentDefinition
+from coreason_manifest.utils.langchain_adapter import convert_to_langchain_kwargs
+from coreason_manifest.utils.openai_adapter import convert_to_openai_assistant
+
 
 def test_openai_conversion_with_backstory() -> None:
     """Test conversion to OpenAI format including backstory."""
@@ -26,6 +26,7 @@ def test_openai_conversion_with_backstory() -> None:
     result = convert_to_openai_assistant(agent)
 
     assert "Backstory: Once upon a time..." in result["instructions"]
+
 
 def test_langchain_conversion_with_backstory() -> None:
     """Test conversion to LangChain format including backstory."""

--- a/tests/test_langchain_adapter.py
+++ b/tests/test_langchain_adapter.py
@@ -8,9 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-import pytest
-from coreason_manifest.utils.langchain_adapter import convert_to_langchain_kwargs
 from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+from coreason_manifest.utils.langchain_adapter import convert_to_langchain_kwargs
 
 
 def test_langchain_conversion_minimal() -> None:

--- a/tests/test_langchain_adapter.py
+++ b/tests/test_langchain_adapter.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from coreason_manifest.utils.langchain_adapter import convert_to_langchain_kwargs
+from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+
+
+def test_langchain_conversion_minimal() -> None:
+    """Test converting a minimal AgentDefinition to LangChain kwargs."""
+    agent = AgentDefinition(
+        id="lc-agent",
+        name="LangChain Agent",
+        role="Prompt Engineer",
+        goal="Optimize prompts",
+    )
+
+    result = convert_to_langchain_kwargs(agent)
+
+    assert "system_message" in result
+    assert "LangChain Agent" in result["system_message"]
+    assert "Prompt Engineer" in result["system_message"]
+    assert "Optimize prompts" in result["system_message"]
+    assert result["tool_schemas"] == []
+    assert result["model_name"] == "gpt-4"  # Default
+
+
+def test_langchain_conversion_with_tools() -> None:
+    """Test converting an AgentDefinition with tools."""
+    tool = InlineToolDefinition(
+        name="search",
+        description="Search web",
+        parameters={
+            "type": "object",
+            "properties": {"query": {"type": "string"}},
+            "required": ["query"],
+        },
+    )
+
+    agent = AgentDefinition(
+        id="search-agent",
+        name="Search Bot",
+        role="Searcher",
+        goal="Find info",
+        tools=[tool],
+        model="gpt-3.5-turbo",
+    )
+
+    result = convert_to_langchain_kwargs(agent)
+
+    assert result["model_name"] == "gpt-3.5-turbo"
+    assert len(result["tool_schemas"]) == 1
+
+    schema = result["tool_schemas"][0]
+    # LangChain compatible format (OpenAI function)
+    assert schema["type"] == "function"
+    assert schema["function"]["name"] == "search"
+    assert schema["function"]["description"] == "Search web"
+    assert schema["function"]["parameters"] == tool.parameters
+
+
+def test_langchain_conversion_skips_remote_tools() -> None:
+    """Test that remote tools are skipped for LangChain conversion."""
+    inline = InlineToolDefinition(
+        name="calc",
+        description="Calculate",
+        parameters={"type": "object", "properties": {}},
+    )
+    remote = ToolRequirement(uri="http://remote/tool")
+
+    agent = AgentDefinition(
+        id="mixed-agent",
+        name="Mixed",
+        role="X",
+        goal="Y",
+        tools=[inline, remote],
+    )
+
+    result = convert_to_langchain_kwargs(agent)
+
+    assert len(result["tool_schemas"]) == 1
+    assert result["tool_schemas"][0]["function"]["name"] == "calc"

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from coreason_manifest.utils.openai_adapter import convert_to_openai_assistant
+from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+
+
+def test_openai_conversion_minimal() -> None:
+    """Test converting a minimal AgentDefinition to OpenAI format."""
+    agent = AgentDefinition(
+        id="test-agent-1",
+        name="Minimal Agent",
+        role="Assistant",
+        goal="Help the user.",
+    )
+
+    result = convert_to_openai_assistant(agent)
+
+    assert result["name"] == "Minimal Agent"
+    assert result["model"] == "gpt-4-turbo-preview"  # Default
+    assert "Assistant" in result["instructions"]
+    assert "Help the user." in result["instructions"]
+    assert result["tools"] == []
+    assert result["metadata"]["coreason_agent_id"] == "test-agent-1"
+
+
+def test_openai_conversion_with_tools() -> None:
+    """Test converting an AgentDefinition with inline tools."""
+    tool = InlineToolDefinition(
+        name="get_weather",
+        description="Get current weather",
+        parameters={
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+            "required": ["location"],
+        },
+    )
+
+    agent = AgentDefinition(
+        id="weather-agent",
+        name="Weather Bot",
+        role="Meteorologist",
+        goal="Provide weather info.",
+        tools=[tool],
+        model="gpt-3.5-turbo",
+    )
+
+    result = convert_to_openai_assistant(agent)
+
+    assert result["name"] == "Weather Bot"
+    assert result["model"] == "gpt-3.5-turbo"
+    assert len(result["tools"]) == 1
+
+    openai_tool = result["tools"][0]
+    assert openai_tool["type"] == "function"
+    assert openai_tool["function"]["name"] == "get_weather"
+    assert openai_tool["function"]["description"] == "Get current weather"
+    assert openai_tool["function"]["parameters"] == tool.parameters
+
+
+def test_openai_conversion_skips_remote_tools() -> None:
+    """Test that remote tools (ToolRequirement) are skipped during conversion."""
+    inline_tool = InlineToolDefinition(
+        name="local_tool",
+        description="Local tool",
+        parameters={"type": "object", "properties": {}},
+    )
+
+    remote_tool = ToolRequirement(uri="http://example.com/remote-tool")
+
+    agent = AgentDefinition(
+        id="hybrid-agent",
+        name="Hybrid Agent",
+        role="Worker",
+        goal="Work",
+        tools=[inline_tool, remote_tool],
+    )
+
+    result = convert_to_openai_assistant(agent)
+
+    # Only the inline tool should be present
+    assert len(result["tools"]) == 1
+    assert result["tools"][0]["function"]["name"] == "local_tool"

--- a/tests/test_openai_adapter.py
+++ b/tests/test_openai_adapter.py
@@ -8,9 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-import pytest
-from coreason_manifest.utils.openai_adapter import convert_to_openai_assistant
 from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+from coreason_manifest.utils.openai_adapter import convert_to_openai_assistant
 
 
 def test_openai_conversion_minimal() -> None:


### PR DESCRIPTION
This PR introduces interoperability adapters to translate `AgentDefinition` objects into formats compatible with OpenAI Assistants and LangChain. 

**Changes:**
- `src/coreason_manifest/utils/openai_adapter.py`: A pure function `convert_to_openai_assistant` that maps an agent definition to an OpenAI Assistant payload, handling inline tools and skipping remote ones.
- `src/coreason_manifest/utils/langchain_adapter.py`: A pure function `convert_to_langchain_kwargs` that generates system messages and tool schemas for LangChain agent initialization.
- Comprehensive unit tests ensuring correct field mapping and tool handling, including scenarios with backstories to ensure 100% code coverage.

These additions allow the `coreason-manifest` to serve as a central definition that can be easily exported to other popular agent frameworks without introducing runtime dependencies on those frameworks.


---
*PR created automatically by Jules for task [12047951223452419459](https://jules.google.com/task/12047951223452419459) started by @gowthamrao*