### PR TITLE
fix(mcp): resolve mypy untyped-decorator errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,8 +14,8 @@ repos:
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v1.18.2
+    rev: v1.19.1
     hooks:
       - id: mypy
         additional_dependencies:
-          [pydantic>=2.0, pytest, types-PyYAML]
+          [pydantic>=2.0, pytest, types-PyYAML, mcp]

--- a/src/coreason_manifest/utils/mcp_adapter.py
+++ b/src/coreason_manifest/utils/mcp_adapter.py
@@ -73,7 +73,7 @@ class CoreasonMCPServer:
         # Initialize Server
         self._server = Server(f"coreason-agent-{self.tool_def['name']}")
 
-        @self._server.list_tools()  # type: ignore[misc]
+        @self._server.list_tools()  # type: ignore[untyped-decorator]
         async def handle_list_tools() -> list[types.Tool]:
             return [
                 types.Tool(
@@ -83,7 +83,7 @@ class CoreasonMCPServer:
                 )
             ]
 
-        @self._server.call_tool()  # type: ignore[misc]
+        @self._server.call_tool()  # type: ignore[untyped-decorator]
         async def handle_call_tool(
             name: str, arguments: dict[str, Any] | None
         ) -> list[types.TextContent | types.ImageContent | types.EmbeddedResource]:


### PR DESCRIPTION
This PR addresses specific MyPy errors encountered in `src/coreason_manifest/utils/mcp_adapter.py` related to untyped decorators from the `mcp` library.

**Changes:**
- Replaced generic `# type: ignore[misc]` with specific `# type: ignore[untyped-decorator]` on `handle_list_tools` and `handle_call_tool` functions.

**Verification:**
- Validated with `mypy src/` (no errors).
- Verified `pytest` passes with 100% coverage.
- Confirmed compliance with `AGENTS.md` (Passive by Design, No Runtime Artifacts).

---
*PR created automatically by Jules for task [12021534380033582425](https://jules.google.com/task/12021534380033582425) started by @gowthamrao*