### PR TITLE
feat: Add Constraint system to RecipeDefinition

### DIFF
--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -63,7 +63,37 @@ interface=RecipeInterface(
 )
 ```
 
-### 2. The State Layer (`StateDefinition`)
+### 2. Feasibility Constraints (`Constraint`)
+
+The `RecipeDefinition` can enforce feasibility checks (logic gates) against the execution context before running. These are defined in the `requirements` list.
+
+```python
+from coreason_manifest.spec.v2.recipe import Constraint
+
+requirements=[
+    Constraint(variable="user.role", operator="eq", value="admin"),
+    Constraint(variable="data.row_count", operator="gt", value=500),
+    Constraint(
+        variable="system.mode",
+        operator="eq",
+        value="maintenance",
+        required=False, # If this fails, it logs a warning but proceeds
+        error_message="System is in maintenance mode; performance may be degraded."
+    )
+]
+```
+
+**Supported Operators:** `eq`, `neq`, `gt`, `gte`, `lt`, `lte`, `in`, `contains`.
+
+You can validate these constraints against a context dictionary using the `check_feasibility` method:
+
+```python
+is_feasible, errors = recipe.check_feasibility(context={"user": {"role": "guest"}})
+if not is_feasible:
+    print(f"Recipe cannot run: {errors}")
+```
+
+### 3. The State Layer (`StateDefinition`)
 Defines the shared memory structure (Blackboard) and persistence strategy.
 
 ```python
@@ -73,7 +103,7 @@ state=StateDefinition(
 )
 ```
 
-### 3. The Policy Layer (`PolicyConfig`)
+### 4. The Policy Layer (`PolicyConfig`)
 Sets execution limits and error handling strategies.
 
 ```python

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -269,7 +269,7 @@ class Constraint(CoReasonBaseModel):
             if self.operator == "contains":
                 return bool(self.value in resolved_value)
 
-            return False
+            return False  # pragma: no cover
         except TypeError:
             # Type mismatch (e.g., comparing str > int)
             return False

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -238,15 +238,12 @@ class Constraint(CoReasonBaseModel):
         """Evaluate the constraint against the given context."""
         # 1. Resolve Path
         current = context
-        try:
-            for part in self.variable.split("."):
-                if isinstance(current, dict) and part in current:
-                    current = current[part]
-                else:
-                    # Path not found
-                    return False
-        except (TypeError, AttributeError):
-            return False
+        for part in self.variable.split("."):
+            if isinstance(current, dict) and part in current:
+                current = current[part]
+            else:
+                # Path not found
+                return False
 
         resolved_value = current
 
@@ -272,7 +269,7 @@ class Constraint(CoReasonBaseModel):
             return False
         except TypeError:
             # Type mismatch (e.g., comparing str > int)
-            return False
+            return False  # pragma: no cover
 
 
 class RecipeDefinition(CoReasonBaseModel):

--- a/tests/test_v2_constraints.py
+++ b/tests/test_v2_constraints.py
@@ -1,8 +1,8 @@
-import pytest
-from coreason_manifest.spec.v2.recipe import Constraint, RecipeDefinition, AgentNode, GraphTopology, GraphEdge, RecipeInterface
 from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import AgentNode, Constraint, GraphTopology, RecipeDefinition, RecipeInterface
 
-def test_constraint_evaluate_operators():
+
+def test_constraint_evaluate_operators() -> None:
     """Test various operators for constraint evaluation."""
     context = {"val": 10, "list": [1, 2, 3], "str": "hello world"}
 
@@ -40,7 +40,8 @@ def test_constraint_evaluate_operators():
     assert Constraint(variable="str", operator="contains", value="world").evaluate(context) is True
     assert Constraint(variable="str", operator="contains", value="python").evaluate(context) is False
 
-def test_constraint_nested_path():
+
+def test_constraint_nested_path() -> None:
     """Test path resolution for nested dictionaries."""
     context = {"data": {"nested": {"value": 42}}}
 
@@ -54,7 +55,8 @@ def test_constraint_nested_path():
     # Path traversing non-dict
     assert Constraint(variable="data.nested.value.sub", operator="eq", value=42).evaluate(context) is False
 
-def test_constraint_type_safety():
+
+def test_constraint_type_safety() -> None:
     """Test that type mismatches do not crash."""
     context = {"val": "string"}
 
@@ -66,7 +68,7 @@ def test_constraint_type_safety():
     assert Constraint(variable="val", operator="contains", value=10).evaluate(context) is False
 
 
-def test_recipe_check_feasibility():
+def test_recipe_check_feasibility() -> None:
     """Test check_feasibility method on RecipeDefinition."""
 
     # Setup minimal valid recipe
@@ -82,8 +84,8 @@ def test_recipe_check_feasibility():
         topology=topology,
         requirements=[
             Constraint(variable="user.role", operator="eq", value="admin"),
-            Constraint(variable="system.ready", operator="eq", value=True)
-        ]
+            Constraint(variable="system.ready", operator="eq", value=True),
+        ],
     )
 
     context = {"user": {"role": "admin"}, "system": {"ready": True}}
@@ -103,9 +105,7 @@ def test_recipe_check_feasibility():
         metadata=metadata,
         interface=interface,
         topology=topology,
-        requirements=[
-            Constraint(variable="user.role", operator="eq", value="admin", required=False)
-        ]
+        requirements=[Constraint(variable="user.role", operator="eq", value="admin", required=False)],
     )
 
     feasible, errors = recipe_optional.check_feasibility(context_fail)
@@ -118,13 +118,8 @@ def test_recipe_check_feasibility():
         interface=interface,
         topology=topology,
         requirements=[
-            Constraint(
-                variable="user.role",
-                operator="eq",
-                value="admin",
-                error_message="User must be admin"
-            )
-        ]
+            Constraint(variable="user.role", operator="eq", value="admin", error_message="User must be admin")
+        ],
     )
 
     feasible, errors = recipe_custom_msg.check_feasibility(context_fail)

--- a/tests/test_v2_constraints.py
+++ b/tests/test_v2_constraints.py
@@ -1,0 +1,132 @@
+import pytest
+from coreason_manifest.spec.v2.recipe import Constraint, RecipeDefinition, AgentNode, GraphTopology, GraphEdge, RecipeInterface
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+
+def test_constraint_evaluate_operators():
+    """Test various operators for constraint evaluation."""
+    context = {"val": 10, "list": [1, 2, 3], "str": "hello world"}
+
+    # eq
+    assert Constraint(variable="val", operator="eq", value=10).evaluate(context) is True
+    assert Constraint(variable="val", operator="eq", value=5).evaluate(context) is False
+
+    # neq
+    assert Constraint(variable="val", operator="neq", value=5).evaluate(context) is True
+    assert Constraint(variable="val", operator="neq", value=10).evaluate(context) is False
+
+    # gt
+    assert Constraint(variable="val", operator="gt", value=5).evaluate(context) is True
+    assert Constraint(variable="val", operator="gt", value=10).evaluate(context) is False
+
+    # gte
+    assert Constraint(variable="val", operator="gte", value=10).evaluate(context) is True
+    assert Constraint(variable="val", operator="gte", value=11).evaluate(context) is False
+
+    # lt
+    assert Constraint(variable="val", operator="lt", value=15).evaluate(context) is True
+    assert Constraint(variable="val", operator="lt", value=10).evaluate(context) is False
+
+    # lte
+    assert Constraint(variable="val", operator="lte", value=10).evaluate(context) is True
+    assert Constraint(variable="val", operator="lte", value=9).evaluate(context) is False
+
+    # in
+    assert Constraint(variable="val", operator="in", value=[10, 20]).evaluate(context) is True
+    assert Constraint(variable="val", operator="in", value=[20, 30]).evaluate(context) is False
+
+    # contains
+    assert Constraint(variable="list", operator="contains", value=2).evaluate(context) is True
+    assert Constraint(variable="list", operator="contains", value=5).evaluate(context) is False
+    assert Constraint(variable="str", operator="contains", value="world").evaluate(context) is True
+    assert Constraint(variable="str", operator="contains", value="python").evaluate(context) is False
+
+def test_constraint_nested_path():
+    """Test path resolution for nested dictionaries."""
+    context = {"data": {"nested": {"value": 42}}}
+
+    assert Constraint(variable="data.nested.value", operator="eq", value=42).evaluate(context) is True
+    assert Constraint(variable="data.nested.value", operator="gt", value=40).evaluate(context) is True
+
+    # Path not found
+    assert Constraint(variable="data.missing.value", operator="eq", value=42).evaluate(context) is False
+    assert Constraint(variable="missing.path", operator="eq", value=42).evaluate(context) is False
+
+    # Path traversing non-dict
+    assert Constraint(variable="data.nested.value.sub", operator="eq", value=42).evaluate(context) is False
+
+def test_constraint_type_safety():
+    """Test that type mismatches do not crash."""
+    context = {"val": "string"}
+
+    # Comparing string > int should return False, not raise TypeError
+    assert Constraint(variable="val", operator="gt", value=10).evaluate(context) is False
+
+    # Comparing int in string (where string is the container but we pass int as item)
+    # 10 in "string" -> TypeError
+    assert Constraint(variable="val", operator="contains", value=10).evaluate(context) is False
+
+
+def test_recipe_check_feasibility():
+    """Test check_feasibility method on RecipeDefinition."""
+
+    # Setup minimal valid recipe
+    node = AgentNode(id="start", agent_ref="agent1")
+    topology = GraphTopology(nodes=[node], edges=[], entry_point="start")
+    interface = RecipeInterface()
+    metadata = ManifestMetadata(name="Test Recipe")
+
+    # Case 1: All constraints pass
+    recipe = RecipeDefinition(
+        metadata=metadata,
+        interface=interface,
+        topology=topology,
+        requirements=[
+            Constraint(variable="user.role", operator="eq", value="admin"),
+            Constraint(variable="system.ready", operator="eq", value=True)
+        ]
+    )
+
+    context = {"user": {"role": "admin"}, "system": {"ready": True}}
+    feasible, errors = recipe.check_feasibility(context)
+    assert feasible is True
+    assert len(errors) == 0
+
+    # Case 2: Required constraint fails
+    context_fail = {"user": {"role": "user"}, "system": {"ready": True}}
+    feasible, errors = recipe.check_feasibility(context_fail)
+    assert feasible is False
+    assert len(errors) == 1
+    assert "Constraint failed" in errors[0]
+
+    # Case 3: Optional constraint fails (should not fail feasibility)
+    recipe_optional = RecipeDefinition(
+        metadata=metadata,
+        interface=interface,
+        topology=topology,
+        requirements=[
+            Constraint(variable="user.role", operator="eq", value="admin", required=False)
+        ]
+    )
+
+    feasible, errors = recipe_optional.check_feasibility(context_fail)
+    assert feasible is True
+    assert len(errors) == 0
+
+    # Case 4: Custom error message
+    recipe_custom_msg = RecipeDefinition(
+        metadata=metadata,
+        interface=interface,
+        topology=topology,
+        requirements=[
+            Constraint(
+                variable="user.role",
+                operator="eq",
+                value="admin",
+                error_message="User must be admin"
+            )
+        ]
+    )
+
+    feasible, errors = recipe_custom_msg.check_feasibility(context_fail)
+    assert feasible is False
+    assert errors[0] == "User must be admin"

--- a/tests/test_v2_constraints.py
+++ b/tests/test_v2_constraints.py
@@ -68,6 +68,32 @@ def test_constraint_type_safety() -> None:
     assert Constraint(variable="val", operator="contains", value=10).evaluate(context) is False
 
 
+def test_constraint_edge_cases() -> None:
+    """Test various edge cases for Constraint evaluation."""
+    # 1. Empty context
+    assert Constraint(variable="any.key", operator="eq", value=1).evaluate({}) is False
+
+    # 2. Value is None
+    context = {"key": None}
+    assert Constraint(variable="key", operator="eq", value=None).evaluate(context) is True
+    assert Constraint(variable="key", operator="neq", value=1).evaluate(context) is True
+
+    # 3. Complex types in value (list of dicts)
+    context_complex = {"items": [{"id": 1}, {"id": 2}]}
+    target = [{"id": 1}, {"id": 2}]
+    assert Constraint(variable="items", operator="eq", value=target).evaluate(context_complex) is True
+
+    # 4. 'contains' with disparate types
+    context_mixed = {"tags": ["a", 1, True]}
+    assert Constraint(variable="tags", operator="contains", value="a").evaluate(context_mixed) is True
+    assert Constraint(variable="tags", operator="contains", value=1).evaluate(context_mixed) is True
+    assert Constraint(variable="tags", operator="contains", value=True).evaluate(context_mixed) is True
+
+    # 5. Deeply nested missing key
+    context_deep = {"a": {"b": {"c": 1}}}
+    assert Constraint(variable="a.b.c.d.e", operator="eq", value=1).evaluate(context_deep) is False
+
+
 def test_recipe_check_feasibility() -> None:
     """Test check_feasibility method on RecipeDefinition."""
 

--- a/tests/test_v2_constraints_complex.py
+++ b/tests/test_v2_constraints_complex.py
@@ -12,24 +12,14 @@ def test_recipe_complex_mixed_constraints() -> None:
     requirements = [
         Constraint(variable="env", operator="eq", value="prod", required=True),
         Constraint(variable="user.tier", operator="in", value=["gold", "platinum"], required=True),
-        Constraint(variable="feature.beta", operator="eq", value=True, required=False), # Optional, fails
+        Constraint(variable="feature.beta", operator="eq", value=True, required=False),  # Optional, fails
         Constraint(variable="quota.remaining", operator="gte", value=100, required=True),
     ]
 
-    recipe = RecipeDefinition(
-        metadata=metadata,
-        interface=interface,
-        topology=topology,
-        requirements=requirements
-    )
+    recipe = RecipeDefinition(metadata=metadata, interface=interface, topology=topology, requirements=requirements)
 
     # Scenario 1: All required pass, optional fails
-    context_pass = {
-        "env": "prod",
-        "user": {"tier": "gold"},
-        "feature": {"beta": False},
-        "quota": {"remaining": 500}
-    }
+    context_pass = {"env": "prod", "user": {"tier": "gold"}, "feature": {"beta": False}, "quota": {"remaining": 500}}
     feasible, errors = recipe.check_feasibility(context_pass)
     assert feasible is True
     assert len(errors) == 0
@@ -37,20 +27,24 @@ def test_recipe_complex_mixed_constraints() -> None:
     # Scenario 2: One required fails, optional fails
     context_fail = {
         "env": "prod",
-        "user": {"tier": "silver"}, # Fail
+        "user": {"tier": "silver"},  # Fail
         "feature": {"beta": False},
-        "quota": {"remaining": 500}
+        "quota": {"remaining": 500},
     }
     feasible, errors = recipe.check_feasibility(context_fail)
     assert feasible is False
     assert len(errors) == 1
-    assert "Constraint failed" in errors[0] and "user.tier" in errors[0]
+    assert "Constraint failed" in errors[0]
+    assert "user.tier" in errors[0]
+
 
 def test_constraint_mutable_context() -> None:
     """Test evaluating constraints against mutable context objects."""
+
     class MutableObj:
         def __init__(self, val: int):
             self.val = val
+
         def __eq__(self, other: object) -> bool:
             if isinstance(other, int):
                 return self.val == other
@@ -66,6 +60,7 @@ def test_constraint_mutable_context() -> None:
 
     context["obj"].val = 5
     assert Constraint(variable="obj", operator="eq", value=10).evaluate(context) is False
+
 
 def test_constraint_large_scale() -> None:
     """Test a large number of constraints."""
@@ -87,7 +82,7 @@ def test_constraint_large_scale() -> None:
         metadata=ManifestMetadata(name="Large Recipe"),
         interface=RecipeInterface(),
         topology=topology,
-        requirements=requirements
+        requirements=requirements,
     )
 
     feasible, errors = recipe.check_feasibility(context)

--- a/tests/test_v2_constraints_complex.py
+++ b/tests/test_v2_constraints_complex.py
@@ -1,0 +1,100 @@
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import AgentNode, Constraint, GraphTopology, RecipeDefinition, RecipeInterface
+
+
+def test_recipe_complex_mixed_constraints() -> None:
+    """Test complex scenario with multiple mixed required and optional constraints."""
+    node = AgentNode(id="start", agent_ref="agent1")
+    topology = GraphTopology(nodes=[node], edges=[], entry_point="start")
+    interface = RecipeInterface()
+    metadata = ManifestMetadata(name="Complex Recipe")
+
+    requirements = [
+        Constraint(variable="env", operator="eq", value="prod", required=True),
+        Constraint(variable="user.tier", operator="in", value=["gold", "platinum"], required=True),
+        Constraint(variable="feature.beta", operator="eq", value=True, required=False), # Optional, fails
+        Constraint(variable="quota.remaining", operator="gte", value=100, required=True),
+    ]
+
+    recipe = RecipeDefinition(
+        metadata=metadata,
+        interface=interface,
+        topology=topology,
+        requirements=requirements
+    )
+
+    # Scenario 1: All required pass, optional fails
+    context_pass = {
+        "env": "prod",
+        "user": {"tier": "gold"},
+        "feature": {"beta": False},
+        "quota": {"remaining": 500}
+    }
+    feasible, errors = recipe.check_feasibility(context_pass)
+    assert feasible is True
+    assert len(errors) == 0
+
+    # Scenario 2: One required fails, optional fails
+    context_fail = {
+        "env": "prod",
+        "user": {"tier": "silver"}, # Fail
+        "feature": {"beta": False},
+        "quota": {"remaining": 500}
+    }
+    feasible, errors = recipe.check_feasibility(context_fail)
+    assert feasible is False
+    assert len(errors) == 1
+    assert "Constraint failed" in errors[0] and "user.tier" in errors[0]
+
+def test_constraint_mutable_context() -> None:
+    """Test evaluating constraints against mutable context objects."""
+    class MutableObj:
+        def __init__(self, val: int):
+            self.val = val
+        def __eq__(self, other: object) -> bool:
+            if isinstance(other, int):
+                return self.val == other
+            return False
+
+    # This won't work with current logic because it expects dict traversal
+    # But if the mutable object IS the value (not the container), it should work
+    context = {"obj": MutableObj(10)}
+
+    # Resolving "obj" gets the MutableObj instance
+    # Comparing instance == 10
+    assert Constraint(variable="obj", operator="eq", value=10).evaluate(context) is True
+
+    context["obj"].val = 5
+    assert Constraint(variable="obj", operator="eq", value=10).evaluate(context) is False
+
+def test_constraint_large_scale() -> None:
+    """Test a large number of constraints."""
+    requirements = []
+    for i in range(100):
+        requirements.append(Constraint(variable=f"var_{i}", operator="eq", value=i))
+
+    context = {f"var_{i}": i for i in range(100)}
+
+    # Just checking logic doesn't choke
+    # Evaluating individual constraints
+    for req in requirements:
+        assert req.evaluate(context) is True
+
+    # Check feasibility
+    node = AgentNode(id="start", agent_ref="agent1")
+    topology = GraphTopology(nodes=[node], edges=[], entry_point="start")
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Large Recipe"),
+        interface=RecipeInterface(),
+        topology=topology,
+        requirements=requirements
+    )
+
+    feasible, errors = recipe.check_feasibility(context)
+    assert feasible is True
+
+    # Invalidate one
+    context["var_50"] = 999
+    feasible, errors = recipe.check_feasibility(context)
+    assert feasible is False
+    assert len(errors) == 1


### PR DESCRIPTION
This PR introduces a declarative `Constraint` system within `RecipeDefinition` to support feasibility checks and logic gating. It allows defining requirements like "data.row_count > 500" directly in the manifest, making recipes self-validating against a given context. The implementation includes a `Constraint` model with an `evaluate` method and a `check_feasibility` helper on `RecipeDefinition`.

---
*PR created automatically by Jules for task [3898666678612842191](https://jules.google.com/task/3898666678612842191) started by @gowthamrao*