### PR TITLE
Fix documentation examples and organize structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,10 @@ pip install coreason-manifest
 Recipes are now graphs, allowing for complex orchestration logic.
 
 ```python
-from coreason_manifest.spec.v2.recipe import RecipeDefinition, GraphTopology, AgentNode, HumanNode, GraphEdge
-from coreason_manifest.spec.v2.definitions import ManifestMetadata, InterfaceDefinition
+from coreason_manifest import (
+    RecipeDefinition, GraphTopology, AgentNode, HumanNode, GraphEdge,
+    ManifestMetadata, RecipeInterface
+)
 
 # Define the nodes
 research_node = AgentNode(
@@ -78,7 +80,7 @@ topology = GraphTopology(
 # Create the Recipe
 recipe = RecipeDefinition(
     metadata=ManifestMetadata(name="Research & Approve Workflow"),
-    interface=InterfaceDefinition(
+    interface=RecipeInterface(
         inputs={"user_input": {"type": "string"}},
         outputs={"approval_status": {"type": "string"}}
     ),
@@ -93,7 +95,7 @@ print(f"Recipe '{recipe.metadata.name}' is valid!")
 The `AgentRequest` envelope ensures that every action is traceable back to its origin.
 
 ```python
-from coreason_manifest.spec.common.request import AgentRequest
+from coreason_manifest import AgentRequest
 from uuid import uuid4
 
 # 1. Incoming Request (Root)
@@ -118,7 +120,7 @@ print(f"Child Root ID:   {child_request.root_request_id}   (Should match Root Re
 For a fluent, Pythonic API to construct manifests (especially useful for tooling), use the `ManifestBuilder`.
 
 ```python
-from coreason_manifest.builder import AgentBuilder
+from coreason_manifest import AgentBuilder
 
 agent = AgentBuilder("ResearchAgent") \
     .with_model("gpt-4-turbo") \

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 *   **[Graph Recipes (Orchestration)](graph_recipes.md)**
     *   Describes the system for complex, non-linear, cyclic graph execution using `RecipeDefinition` and `GraphTopology`.
 
+*   **[Evaluator-Optimizer Pattern](evaluator_optimizer.md)**
+    *   Documentation for the iterative "Generator-Judge-Refiner" loop pattern for high-quality content generation.
+
 *   **[Coreason Agent Protocol (CAP) Wire Format](cap/wire_protocol.md)**
     *   Defines the runtime wire protocol, including standard request/response envelopes (`ServiceRequest`, `ServiceResponse`) and streaming contracts (`StreamPacket`).
 
@@ -47,6 +50,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 
 *   **[Tool Packs (Plugins)](tool_packs.md)**
     *   Documentation for the Tool Pack architecture, enabling reusable bundles of Agents, Skills, and Tools.
+
+*   **[MCP Adapter](interop/mcp_adapter.md)**
+    *   Guide for integrating Model Context Protocol (MCP) servers as Coreason Tools.
 
 *   **[Explicit Streaming Contracts](cap/streaming_contracts.md)**
     *   Defines the contracts for Agent execution (`atomic`, `graph`) and delivery modes (`request_response`, `server_sent_events`).
@@ -62,6 +68,9 @@ This is the central documentation index for the `coreason-manifest` project, whi
 
 *   **[Evaluation Metadata](evaluation_metadata.md)**
     *   Specifications for embedding testing requirements (`EvaluationProfile`) and quality criteria (`SuccessCriterion`) directly into Agent Definitions.
+
+*   **[Provenance Metadata](provenance_metadata.md)**
+    *   Specifications for tracking AI generation lineage (`ManifestMetadata`) including confidence scores and original intent.
 
 *   **[Active Memory Interface](active_memory_interface.md)**
     *   Protocol (`SessionHandle`) for active agent interactions with storage (history, recall, persistent variables).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - Usage: usage.md
   - Specifications:
       - "Graph Recipes (Orchestration)": graph_recipes.md
+      - "Evaluator-Optimizer Pattern": evaluator_optimizer.md
       - "Agent Manifest (CAM) & Linear Workflows": cap/specification.md
       - "Agent Skills System": skills.md
       - "Tool Packs (Plugins)": tool_packs.md
@@ -34,6 +35,7 @@ nav:
       - "Mock Factory": mock_factory.md
       - "Error Handling": error_handling_standards.md
       - "Evaluation Metadata": evaluation_metadata.md
+      - "Provenance Metadata": provenance_metadata.md
       - "Event Content Types": event_content_types.md
       - "Frontend Integration": frontend_integration.md
       - "Request Lineage (Impl)": request_lineage_implementation.md

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -97,9 +97,13 @@ from .spec.v2.definitions import (
 from .spec.v2.evaluation import EvaluationProfile, SuccessCriterion
 from .spec.v2.recipe import (
     AgentNode,
+    EvaluatorNode,
+    GraphEdge,
     GraphTopology,
     HumanNode,
+    PolicyConfig,
     RecipeDefinition,
+    RecipeInterface,
     RouterNode,
 )
 from .spec.v2.resources import (
@@ -153,8 +157,10 @@ __all__ = [
     "ErrorDomain",
     "ErrorSeverity",
     "EvaluationProfile",
+    "EvaluatorNode",
     "EventContentType",
     "GovernanceConfig",
+    "GraphEdge",
     "GraphEvent",
     "GraphEventArtifactGenerated",
     "GraphEventCouncilVote",
@@ -187,6 +193,7 @@ __all__ = [
     "MemoryStrategy",
     "ModelProfile",
     "NodePresentation",
+    "PolicyConfig",
     "PolicyDefinition",
     "PresentationEvent",
     "PresentationEventType",
@@ -196,6 +203,7 @@ __all__ = [
     "ReasoningTrace",
     "Recipe",
     "RecipeDefinition",
+    "RecipeInterface",
     "ResourceConstraints",
     "Role",
     "RouterNode",


### PR DESCRIPTION
This PR addresses inconsistencies in the documentation, particularly in `README.md`, where the example for `RecipeDefinition` was using an incorrect interface type (`InterfaceDefinition` instead of `RecipeInterface`). It also improves the usability of the library by exporting necessary Recipe components from the top-level package. Additionally, it organizes the documentation by adding missing pages to `mkdocs.yml` and updating `docs/index.md`.

---
*PR created automatically by Jules for task [10557976841884646919](https://jules.google.com/task/10557976841884646919) started by @gowthamrao*