### PR TITLE
feat: implement Lifecycle Governance for Recipes

### DIFF
--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,123 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GraphEdge,
+    GraphTopology,
+    RecipeDefinition,
+    RecipeInterface,
+    RecipeStatus,
+    SemanticRef,
+)
+
+
+def test_draft_recipe_with_semantic_ref():
+    """Test that a DRAFT recipe allows SemanticRef."""
+    semantic_node = AgentNode(
+        id="planner",
+        agent_ref=SemanticRef(intent="Plan the trip"),
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Draft Recipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=[semantic_node],
+            edges=[],
+            entry_point="planner",
+            status="draft"
+        ),
+        status=RecipeStatus.DRAFT
+    )
+
+    assert recipe.status == RecipeStatus.DRAFT
+    assert isinstance(recipe.topology.nodes[0], AgentNode)
+    assert isinstance(recipe.topology.nodes[0].agent_ref, SemanticRef)
+
+
+def test_published_recipe_with_semantic_ref_fails():
+    """Test that a PUBLISHED recipe raises ValidationError if SemanticRef is present."""
+    semantic_node = AgentNode(
+        id="planner",
+        agent_ref=SemanticRef(intent="Plan the trip"),
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Published Recipe"),
+            interface=RecipeInterface(),
+            topology=GraphTopology(
+                nodes=[semantic_node],
+                edges=[],
+                entry_point="planner",
+                status="valid"
+            ),
+            status=RecipeStatus.PUBLISHED
+        )
+
+    assert "Resolve all SemanticRefs to concrete IDs" in str(exc.value)
+
+
+def test_published_recipe_with_broken_topology_fails():
+    """Test that a PUBLISHED recipe raises ValidationError if topology is incomplete."""
+    # Dangling edge scenario
+    node1 = AgentNode(id="start", agent_ref="agent-1")
+
+    # We pass status="draft" to GraphTopology so it skips its own validation,
+    # allowing us to test that RecipeDefinition catches it when status=PUBLISHED.
+
+    with pytest.raises(ValidationError) as exc:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Broken Recipe"),
+            interface=RecipeInterface(),
+            topology=GraphTopology(
+                nodes=[node1],
+                edges=[GraphEdge(source="start", target="missing")],
+                entry_point="start",
+                status="draft"
+            ),
+            status=RecipeStatus.PUBLISHED
+        )
+
+    assert "Topology is structurally invalid" in str(exc.value)
+
+
+def test_published_recipe_valid():
+    """Test that a valid PUBLISHED recipe passes validation."""
+    node1 = AgentNode(id="start", agent_ref="agent-1")
+    node2 = AgentNode(id="end", agent_ref="agent-2")
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Valid Recipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=[node1, node2],
+            edges=[GraphEdge(source="start", target="end")],
+            entry_point="start",
+            status="valid"
+        ),
+        status=RecipeStatus.PUBLISHED
+    )
+
+    assert recipe.status == RecipeStatus.PUBLISHED
+
+
+def test_draft_recipe_with_broken_topology_passes():
+    """Test that a DRAFT recipe allows broken topology."""
+    node1 = AgentNode(id="start", agent_ref="agent-1")
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Broken Draft"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=[node1],
+            edges=[GraphEdge(source="start", target="missing")],
+            entry_point="start",
+            status="draft"
+        ),
+        status=RecipeStatus.DRAFT
+    )
+
+    assert recipe.status == RecipeStatus.DRAFT

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -13,7 +13,7 @@ from coreason_manifest.spec.v2.recipe import (
 )
 
 
-def test_draft_recipe_with_semantic_ref():
+def test_draft_recipe_with_semantic_ref() -> None:
     """Test that a DRAFT recipe allows SemanticRef."""
     semantic_node = AgentNode(
         id="planner",
@@ -23,13 +23,8 @@ def test_draft_recipe_with_semantic_ref():
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="Draft Recipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=[semantic_node],
-            edges=[],
-            entry_point="planner",
-            status="draft"
-        ),
-        status=RecipeStatus.DRAFT
+        topology=GraphTopology(nodes=[semantic_node], edges=[], entry_point="planner", status="draft"),
+        status=RecipeStatus.DRAFT,
     )
 
     assert recipe.status == RecipeStatus.DRAFT
@@ -37,7 +32,7 @@ def test_draft_recipe_with_semantic_ref():
     assert isinstance(recipe.topology.nodes[0].agent_ref, SemanticRef)
 
 
-def test_published_recipe_with_semantic_ref_fails():
+def test_published_recipe_with_semantic_ref_fails() -> None:
     """Test that a PUBLISHED recipe raises ValidationError if SemanticRef is present."""
     semantic_node = AgentNode(
         id="planner",
@@ -48,19 +43,14 @@ def test_published_recipe_with_semantic_ref_fails():
         RecipeDefinition(
             metadata=ManifestMetadata(name="Published Recipe"),
             interface=RecipeInterface(),
-            topology=GraphTopology(
-                nodes=[semantic_node],
-                edges=[],
-                entry_point="planner",
-                status="valid"
-            ),
-            status=RecipeStatus.PUBLISHED
+            topology=GraphTopology(nodes=[semantic_node], edges=[], entry_point="planner", status="valid"),
+            status=RecipeStatus.PUBLISHED,
         )
 
     assert "Resolve all SemanticRefs to concrete IDs" in str(exc.value)
 
 
-def test_published_recipe_with_broken_topology_fails():
+def test_published_recipe_with_broken_topology_fails() -> None:
     """Test that a PUBLISHED recipe raises ValidationError if topology is incomplete."""
     # Dangling edge scenario
     node1 = AgentNode(id="start", agent_ref="agent-1")
@@ -73,18 +63,15 @@ def test_published_recipe_with_broken_topology_fails():
             metadata=ManifestMetadata(name="Broken Recipe"),
             interface=RecipeInterface(),
             topology=GraphTopology(
-                nodes=[node1],
-                edges=[GraphEdge(source="start", target="missing")],
-                entry_point="start",
-                status="draft"
+                nodes=[node1], edges=[GraphEdge(source="start", target="missing")], entry_point="start", status="draft"
             ),
-            status=RecipeStatus.PUBLISHED
+            status=RecipeStatus.PUBLISHED,
         )
 
     assert "Topology is structurally invalid" in str(exc.value)
 
 
-def test_published_recipe_valid():
+def test_published_recipe_valid() -> None:
     """Test that a valid PUBLISHED recipe passes validation."""
     node1 = AgentNode(id="start", agent_ref="agent-1")
     node2 = AgentNode(id="end", agent_ref="agent-2")
@@ -93,18 +80,15 @@ def test_published_recipe_valid():
         metadata=ManifestMetadata(name="Valid Recipe"),
         interface=RecipeInterface(),
         topology=GraphTopology(
-            nodes=[node1, node2],
-            edges=[GraphEdge(source="start", target="end")],
-            entry_point="start",
-            status="valid"
+            nodes=[node1, node2], edges=[GraphEdge(source="start", target="end")], entry_point="start", status="valid"
         ),
-        status=RecipeStatus.PUBLISHED
+        status=RecipeStatus.PUBLISHED,
     )
 
     assert recipe.status == RecipeStatus.PUBLISHED
 
 
-def test_draft_recipe_with_broken_topology_passes():
+def test_draft_recipe_with_broken_topology_passes() -> None:
     """Test that a DRAFT recipe allows broken topology."""
     node1 = AgentNode(id="start", agent_ref="agent-1")
 
@@ -112,12 +96,9 @@ def test_draft_recipe_with_broken_topology_passes():
         metadata=ManifestMetadata(name="Broken Draft"),
         interface=RecipeInterface(),
         topology=GraphTopology(
-            nodes=[node1],
-            edges=[GraphEdge(source="start", target="missing")],
-            entry_point="start",
-            status="draft"
+            nodes=[node1], edges=[GraphEdge(source="start", target="missing")], entry_point="start", status="draft"
         ),
-        status=RecipeStatus.DRAFT
+        status=RecipeStatus.DRAFT,
     )
 
     assert recipe.status == RecipeStatus.DRAFT

--- a/tests/test_lifecycle_extended.py
+++ b/tests/test_lifecycle_extended.py
@@ -1,0 +1,205 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GraphEdge,
+    GraphTopology,
+    HumanNode,
+    RecipeDefinition,
+    RecipeInterface,
+    RecipeStatus,
+    SemanticRef,
+)
+
+
+def test_transition_draft_to_published_mixed_nodes() -> None:
+    """
+    Test transition from Draft to Published with a mix of valid (concrete)
+    and invalid (semantic) nodes. Should fail.
+    """
+    concrete_node = AgentNode(id="step-1", agent_ref="concrete-agent")
+    semantic_node = AgentNode(id="step-2", agent_ref=SemanticRef(intent="do something"))
+
+    # 1. Start as Draft - Should be Valid
+    topology_draft = GraphTopology(
+        nodes=[concrete_node, semantic_node],
+        edges=[GraphEdge(source="step-1", target="step-2")],
+        entry_point="step-1",
+        status="draft",  # In draft, we can have semantic refs
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Hybrid Draft"),
+        interface=RecipeInterface(),
+        topology=topology_draft,
+        status=RecipeStatus.DRAFT,
+    )
+    assert recipe.status == RecipeStatus.DRAFT
+
+    # 2. Try to update to Published - Should Fail due to SemanticRef
+    # We simulate this by creating a new RecipeDefinition with the same topology but status=PUBLISHED
+    # (Pydantic models are immutable/frozen by default in this codebase, so we create new instances)
+
+    # Note: Even if we set topology.status="valid", the SemanticRef should still block it.
+    topology_valid_struct = GraphTopology(
+        nodes=[concrete_node, semantic_node],
+        edges=[GraphEdge(source="step-1", target="step-2")],
+        entry_point="step-1",
+        status="valid",
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Hybrid Published"),
+            interface=RecipeInterface(),
+            topology=topology_valid_struct,
+            status=RecipeStatus.PUBLISHED,
+        )
+    assert "Resolve all SemanticRefs" in str(exc.value)
+
+
+def test_semantic_ref_serialization() -> None:
+    """Test that SemanticRef serializes and deserializes correctly."""
+    ref = SemanticRef(intent="analyze data")
+    node = AgentNode(id="step-1", agent_ref=ref)
+
+    # Dump to dict
+    data = node.model_dump(mode="json")
+    assert data["agent_ref"] == {"intent": "analyze data"}
+
+    # Load back
+    loaded_node = AgentNode.model_validate(data)
+    assert isinstance(loaded_node.agent_ref, SemanticRef)
+    assert loaded_node.agent_ref.intent == "analyze data"
+
+
+def test_archived_status_behavior() -> None:
+    """Test that ARCHIVED status behaves permissively like DRAFT."""
+    semantic_node = AgentNode(id="step-1", agent_ref=SemanticRef(intent="legacy intent"))
+
+    # Even with a broken topology
+    topology_broken = GraphTopology(
+        nodes=[semantic_node],
+        edges=[GraphEdge(source="step-1", target="missing")],
+        entry_point="step-1",
+        status="draft",
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Archived Recipe"),
+        interface=RecipeInterface(),
+        topology=topology_broken,
+        status=RecipeStatus.ARCHIVED,
+    )
+
+    assert recipe.status == RecipeStatus.ARCHIVED
+    # Should not raise validation error
+
+
+def test_large_graph_multiple_semantic_refs() -> None:
+    """Test a larger graph with multiple semantic refs in Published mode."""
+    nodes = []
+    # Create 10 nodes, even ones are semantic
+    for i in range(10):
+        if i % 2 == 0:
+            nodes.append(AgentNode(id=f"step-{i}", agent_ref=SemanticRef(intent=f"intent-{i}")))
+        else:
+            nodes.append(AgentNode(id=f"step-{i}", agent_ref=f"agent-{i}"))
+
+    # Valid edges linearly
+    edges = [GraphEdge(source=f"step-{i}", target=f"step-{i + 1}") for i in range(9)]
+
+    topology = GraphTopology(nodes=nodes, edges=edges, entry_point="step-0", status="valid")
+
+    with pytest.raises(ValidationError) as exc:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Large Invalid"),
+            interface=RecipeInterface(),
+            topology=topology,
+            status=RecipeStatus.PUBLISHED,
+        )
+
+    # Verify error message mentions semantic refs
+    assert "Resolve all SemanticRefs" in str(exc.value)
+
+
+def test_structurally_valid_but_semantic_fail() -> None:
+    """
+    Test a graph that has perfect topology (valid edges/entry) but uses SemanticRef.
+    Must fail in PUBLISHED.
+    """
+    # A graph with 2 nodes, connected properly.
+    # But node 2 is semantic.
+    node1 = AgentNode(id="start", agent_ref="concrete-1")
+    node2 = AgentNode(id="end", agent_ref=SemanticRef(intent="finish"))
+
+    topology = GraphTopology(
+        nodes=[node1, node2], edges=[GraphEdge(source="start", target="end")], entry_point="start", status="valid"
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Structurally Valid Semantic"),
+            interface=RecipeInterface(),
+            topology=topology,
+            status=RecipeStatus.PUBLISHED,
+        )
+
+    assert "Resolve all SemanticRefs" in str(exc.value)
+
+
+def test_structurally_invalid_and_semantic_fail() -> None:
+    """
+    Test a graph that is BOTH structurally invalid AND has SemanticRef.
+    Should fail (order of check determines which error, but must fail).
+    """
+    # Semantic node
+    node1 = AgentNode(id="start", agent_ref=SemanticRef(intent="start"))
+
+    # Invalid edge to nowhere
+    topology = GraphTopology(
+        nodes=[node1],
+        edges=[GraphEdge(source="start", target="void")],
+        entry_point="start",
+        status="draft",  # Skip internal topology check to let Recipe catch it
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Double Invalid"),
+            interface=RecipeInterface(),
+            topology=topology,
+            status=RecipeStatus.PUBLISHED,
+        )
+
+    err_msg = str(exc.value)
+    # Our implementation checks SemanticRefs first (step 1), then Topology (step 2).
+    # So we expect the SemanticRef error.
+    assert "Resolve all SemanticRefs" in err_msg
+
+
+def test_mixed_node_types_with_semantic_ref() -> None:
+    """
+    Test mixed node types (Human, Agent) where Agent uses SemanticRef.
+    """
+    human_node = HumanNode(id="human-1", prompt="approve")
+    agent_node = AgentNode(id="agent-1", agent_ref=SemanticRef(intent="execute"))
+
+    topology = GraphTopology(
+        nodes=[human_node, agent_node],
+        edges=[GraphEdge(source="human-1", target="agent-1")],
+        entry_point="human-1",
+        status="valid",
+    )
+
+    # Should fail in PUBLISHED
+    with pytest.raises(ValidationError) as exc:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Mixed Nodes"),
+            interface=RecipeInterface(),
+            topology=topology,
+            status=RecipeStatus.PUBLISHED,
+        )
+    assert "Resolve all SemanticRefs" in str(exc.value)


### PR DESCRIPTION
Implemented Lifecycle Governance for Recipes to distinguish between "Draft" (Intent-based) and "Published" (Execution-ready) states.

Key changes:
- `RecipeStatus` enum: Defines DRAFT, PUBLISHED, ARCHIVED states.
- `SemanticRef`: A new model for placeholders based on intent.
- `AgentNode`: Updated `agent_ref` to support `str | SemanticRef`.
- `RecipeDefinition`: Added `status` field and validation logic.
  - `DRAFT`: Permissive, allows `SemanticRef` and partial graphs.
  - `PUBLISHED`: Strict, requires concrete agent IDs and valid/complete topology.
- Added tests covering various lifecycle scenarios.

---
*PR created automatically by Jules for task [14731796892190109070](https://jules.google.com/task/14731796892190109070) started by @gowthamrao*