### PR TITLE
Add GenerativeNode to Recipe Specification

### DIFF
--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -181,6 +181,13 @@ All nodes inherit from `RecipeNode`, which includes `id`, `metadata`, and `prese
     - `fail_route`: Node ID to go to if score < threshold.
     - `feedback_variable`: The key in the state where the critique/reasoning will be written.
 
+5.  **`GenerativeNode`** (`type: generative`): Acts as an interface definition for dynamic solvers (like ROMA) to solve a high-level goal recursively.
+    - `goal`: The high-level objective to be solved (e.g., "Research competitor pricing").
+    - `max_depth`: Recursion limit for sub-tasks (default: 3).
+    - `strategy`: Traversal strategy hint (`bfs`, `dfs`, `hybrid`).
+    - `allowed_tools`: Whitelist of Tool IDs the solver is permitted to use.
+    - `output_schema`: JSON Schema defining the expected structure of the final answer.
+
 ## Evaluator-Optimizer Workflow
 
 Coreason V2 natively supports the **Evaluator-Optimizer** pattern (popularized by Anthropic's Claude Cookbook). This pattern uses a dedicated `EvaluatorNode` to critique the output of a Generator agent and loop back for refinements until a quality threshold is met.

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -104,6 +104,23 @@ class AgentNode(RecipeNode):
     inputs_map: dict[str, str] = Field(default_factory=dict, description="Mapping parent outputs to agent inputs.")
 
 
+class GenerativeNode(RecipeNode):
+    """A node that acts as an interface definition for dynamic solvers."""
+
+    type: Literal["generative"] = "generative"
+    goal: str = Field(..., description="The high-level objective to be solved recursively.")
+    max_depth: int = Field(3, ge=1, description="Recursion limit for sub-tasks.")
+    strategy: Literal["bfs", "dfs", "hybrid"] = Field(
+        "hybrid", description="Traversal strategy hint for the solver."
+    )
+    allowed_tools: list[str] = Field(
+        default_factory=list, description="Whitelist of Tool IDs the solver is permitted to use."
+    )
+    output_schema: dict[str, Any] = Field(
+        default_factory=dict, description="JSON Schema defining the expected structure of the final answer."
+    )
+
+
 class HumanNode(RecipeNode):
     """A node that pauses execution for human input/approval."""
 
@@ -161,7 +178,7 @@ class GraphTopology(CoReasonBaseModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
-    nodes: list[Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode, Field(discriminator="type")]] = Field(
+    nodes: list[Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode | GenerativeNode, Field(discriminator="type")]] = Field(
         ..., description="List of nodes in the graph."
     )
     edges: list[GraphEdge] = Field(..., description="List of directed edges.")
@@ -213,7 +230,7 @@ class TaskSequence(CoReasonBaseModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
-    steps: list[Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode, Field(discriminator="type")]] = Field(
+    steps: list[Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode | GenerativeNode, Field(discriminator="type")]] = Field(
         ..., min_length=1, description="Ordered list of steps to execute."
     )
 

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -110,9 +110,7 @@ class GenerativeNode(RecipeNode):
     type: Literal["generative"] = "generative"
     goal: str = Field(..., description="The high-level objective to be solved recursively.")
     max_depth: int = Field(3, ge=1, description="Recursion limit for sub-tasks.")
-    strategy: Literal["bfs", "dfs", "hybrid"] = Field(
-        "hybrid", description="Traversal strategy hint for the solver."
-    )
+    strategy: Literal["bfs", "dfs", "hybrid"] = Field("hybrid", description="Traversal strategy hint for the solver.")
     allowed_tools: list[str] = Field(
         default_factory=list, description="Whitelist of Tool IDs the solver is permitted to use."
     )
@@ -178,9 +176,9 @@ class GraphTopology(CoReasonBaseModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
-    nodes: list[Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode | GenerativeNode, Field(discriminator="type")]] = Field(
-        ..., description="List of nodes in the graph."
-    )
+    nodes: list[
+        Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode | GenerativeNode, Field(discriminator="type")]
+    ] = Field(..., description="List of nodes in the graph.")
     edges: list[GraphEdge] = Field(..., description="List of directed edges.")
     entry_point: str = Field(..., description="ID of the start node.")
     status: Literal["draft", "valid"] = Field("valid", description="Validation status of the topology.")
@@ -230,9 +228,9 @@ class TaskSequence(CoReasonBaseModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
-    steps: list[Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode | GenerativeNode, Field(discriminator="type")]] = Field(
-        ..., min_length=1, description="Ordered list of steps to execute."
-    )
+    steps: list[
+        Annotated[AgentNode | HumanNode | RouterNode | EvaluatorNode | GenerativeNode, Field(discriminator="type")]
+    ] = Field(..., min_length=1, description="Ordered list of steps to execute.")
 
     def to_graph(self) -> GraphTopology:
         """Compiles the sequence into a GraphTopology."""

--- a/tests/test_v2_generative_node.py
+++ b/tests/test_v2_generative_node.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GenerativeNode,
+    GraphTopology,
+    RecipeDefinition,
+    RecipeInterface,
+    TaskSequence,
+)
+
+
+def test_generative_node_serialization() -> None:
+    """Test that a GenerativeNode correctly serializes and deserializes."""
+    node = GenerativeNode(
+        id="gen-1",
+        goal="Research competitor pricing",
+        max_depth=5,
+        strategy="bfs",
+        allowed_tools=["tool-1", "tool-2"],
+        output_schema={"type": "object", "properties": {"price": {"type": "number"}}},
+    )
+
+    # Dump to JSON (dict)
+    data = node.model_dump(by_alias=True)
+    assert data["type"] == "generative"
+    assert data["goal"] == "Research competitor pricing"
+    assert data["max_depth"] == 5
+    assert data["strategy"] == "bfs"
+    assert data["allowed_tools"] == ["tool-1", "tool-2"]
+
+    # Round-trip
+    node2 = GenerativeNode.model_validate(data)
+    assert node2.id == "gen-1"
+    assert node2.strategy == "bfs"
+
+
+def test_generative_node_defaults() -> None:
+    """Test default values for GenerativeNode."""
+    node = GenerativeNode(id="gen-default", goal="Simple goal")
+    assert node.max_depth == 3
+    assert node.strategy == "hybrid"
+    assert node.allowed_tools == []
+    assert node.output_schema == {}
+
+
+def test_generative_node_validation() -> None:
+    """Test validation constraints."""
+    # max_depth < 1 should fail
+    with pytest.raises(ValidationError) as excinfo:
+        GenerativeNode(id="bad-depth", goal="Fail", max_depth=0)
+    assert "Input should be greater than or equal to 1" in str(excinfo.value)
+
+    # Invalid strategy should fail
+    with pytest.raises(ValidationError) as excinfo:
+        GenerativeNode(
+            id="bad-strategy",
+            goal="Fail",
+            strategy="invalid_strat"  # type: ignore
+        )
+    assert "Input should be 'bfs', 'dfs' or 'hybrid'" in str(excinfo.value)
+
+
+def test_recipe_with_generative_node() -> None:
+    """Test that a RecipeDefinition can load a graph with a GenerativeNode."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Generative Recipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=[
+                GenerativeNode(id="gen-step", goal="Generate content"),
+                AgentNode(id="agent-step", agent_ref="editor-agent"),
+            ],
+            edges=[{"source": "gen-step", "target": "agent-step"}],
+            entry_point="gen-step",
+        ),
+    )
+
+    json_str = recipe.model_dump_json()
+    loaded = RecipeDefinition.model_validate_json(json_str)
+
+    assert len(loaded.topology.nodes) == 2
+    gen_node = next(n for n in loaded.topology.nodes if n.id == "gen-step")
+    assert isinstance(gen_node, GenerativeNode)
+    assert gen_node.goal == "Generate content"
+
+    agent_node = next(n for n in loaded.topology.nodes if n.id == "agent-step")
+    assert isinstance(agent_node, AgentNode)
+
+
+def test_topology_validation_with_generative_node() -> None:
+    """Test polymorphic deserialization in GraphTopology."""
+    data = {
+        "nodes": [
+            {
+                "type": "generative",
+                "id": "gen-1",
+                "goal": "Solve X",
+                "strategy": "dfs",
+            }
+        ],
+        "edges": [],
+        "entry_point": "gen-1",
+    }
+
+    topology = GraphTopology.model_validate(data)
+    assert isinstance(topology.nodes[0], GenerativeNode)
+    assert topology.nodes[0].strategy == "dfs"
+
+
+def test_task_sequence_with_generative_node() -> None:
+    """Test that TaskSequence accepts GenerativeNode."""
+    seq = TaskSequence(
+        steps=[
+            GenerativeNode(id="gen-1", goal="Goal 1"),
+            GenerativeNode(id="gen-2", goal="Goal 2"),
+        ]
+    )
+    graph = seq.to_graph()
+    assert len(graph.nodes) == 2
+    assert len(graph.edges) == 1
+    assert graph.edges[0].source == "gen-1"
+    assert graph.edges[0].target == "gen-2"


### PR DESCRIPTION
Implemented the `GenerativeNode` schema as requested. This new node type allows defining high-level goals for dynamic solvers without embedding solver logic, adhering to the passive library protocol. It includes fields for `goal`, `max_depth`, `strategy`, `allowed_tools`, and `output_schema`. Tested with a new test suite ensuring correct serialization, validation constraints (e.g., `max_depth >= 1`), and integration into `GraphTopology` and `TaskSequence`.

---
*PR created automatically by Jules for task [13620509647459408234](https://jules.google.com/task/13620509647459408234) started by @gowthamrao*