### PR TITLE
feat: add Interactive Control Plane to RecipeNode

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,8 +6,13 @@ Use the latest version of `coreason-manifest` to ensure you have the latest secu
 
 | Version | Supported |
 | ------- | ------------------ |
+<<<<<<< HEAD
 | 0.22.x  | :white_check_mark: |
 | < 0.22.0| :x:                |
+=======
+| 0.21.x  | :white_check_mark: |
+| < 0.21.0| :x:                |
+>>>>>>> 80a9ebdf3e3efdad8958e7f246bfa0d3e2bc7d6c
 
 ## Reporting a Vulnerability
 

--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -161,6 +161,8 @@ All nodes inherit from `RecipeNode`, which includes `id`, `metadata`, and `prese
     - `system_prompt_override`: Context-specific instructions (optional).
     - `inputs_map`: Mapping parent outputs to agent inputs (dict[str, str]).
 
+    **New in 0.22.0**: All nodes support `interaction` configuration for "Glass Box" steering. See [Interactive Control Plane](interactive_control_plane.md).
+
 2.  **`HumanNode`** (`type: human`): Suspends execution until a human provides input or approval.
     - `prompt`: Instruction for the human user.
     - `timeout_seconds`: SLA for approval (optional).

--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -161,8 +161,11 @@ All nodes inherit from `RecipeNode`, which includes `id`, `metadata`, and `prese
     - `system_prompt_override`: Context-specific instructions (optional).
     - `inputs_map`: Mapping parent outputs to agent inputs (dict[str, str]).
 
+<<<<<<< HEAD
     **New in 0.22.0**: All nodes support `interaction` configuration for "Glass Box" steering. See [Interactive Control Plane](interactive_control_plane.md).
 
+=======
+>>>>>>> 80a9ebdf3e3efdad8958e7f246bfa0d3e2bc7d6c
 2.  **`HumanNode`** (`type: human`): Suspends execution until a human provides input or approval.
     - `prompt`: Instruction for the human user.
     - `timeout_seconds`: SLA for approval (optional).
@@ -183,6 +186,7 @@ All nodes inherit from `RecipeNode`, which includes `id`, `metadata`, and `prese
     - `fail_route`: Node ID to go to if score < threshold.
     - `feedback_variable`: The key in the state where the critique/reasoning will be written.
 
+<<<<<<< HEAD
 5.  **`GenerativeNode`** (`type: generative`): Acts as an interface definition for dynamic solvers (like ROMA) to solve a high-level goal recursively.
     - `goal`: The high-level objective to be solved (e.g., "Research competitor pricing").
     - `max_depth`: Recursion limit for sub-tasks (default: 3).
@@ -190,6 +194,8 @@ All nodes inherit from `RecipeNode`, which includes `id`, `metadata`, and `prese
     - `allowed_tools`: Whitelist of Tool IDs the solver is permitted to use.
     - `output_schema`: JSON Schema defining the expected structure of the final answer.
 
+=======
+>>>>>>> 80a9ebdf3e3efdad8958e7f246bfa0d3e2bc7d6c
 ## Evaluator-Optimizer Workflow
 
 Coreason V2 natively supports the **Evaluator-Optimizer** pattern (popularized by Anthropic's Claude Cookbook). This pattern uses a dedicated `EvaluatorNode` to critique the output of a Generator agent and loop back for refinements until a quality threshold is met.
@@ -231,6 +237,7 @@ topology:
       agent_ref: "publisher-v1"
 ```
 
+<<<<<<< HEAD
 ## Lifecycle Governance (Draft vs. Published)
 
 The `RecipeDefinition` enforces a strict lifecycle to distinguish between "work-in-progress" (Intent-based) and "execution-ready" (Concrete) states. This is controlled by the `status` field.
@@ -309,6 +316,51 @@ except ValidationError as e:
 
 ### 3. Status: `ARCHIVED`
 Behaves similarly to `DRAFT` but indicates the recipe is deprecated or read-only.
+=======
+## Integrity Validation & Draft Mode
+
+The `coreason-manifest` library performs strict validation on the graph topology to prevent runtime errors. However, for AI Agents generating workflows (or human "work-in-progress" saves), we support a **Draft Mode**.
+
+### 1. Strict Validation (Default)
+By default (`status="valid"`), the topology enforces:
+*   **Entry Point Existence**: The `entry_point` ID must exist in the `nodes` list.
+*   **Dangling Edge Check**: Every `source` and `target` must correspond to a valid Node ID.
+*   **Duplicate ID Check**: All Node IDs must be unique.
+
+```python
+from coreason_manifest.spec.v2.recipe import GraphTopology, AgentNode, GraphEdge
+
+try:
+    # This will fail because 'phantom-node' does not exist
+    topology = GraphTopology(
+        entry_point="node-1",
+        nodes=[AgentNode(id="node-1", agent_ref="agent-a")],
+        edges=[GraphEdge(source="node-1", target="phantom-node")]
+    )
+except ValueError as e:
+    print(f"Validation Error: {e}")
+    # Output: Dangling edge target: node-1 -> phantom-node
+```
+
+### 2. Draft Mode (`status="draft"`)
+To support partial or incomplete graphs (e.g., during generation or editing), you can set `status="draft"`. This **skips** the Entry Point and Dangling Edge checks, allowing the object to be instantiated and saved.
+
+**Note:** Duplicate Node IDs are *never* allowed, even in draft mode, as they break the internal graph structure.
+
+```python
+# This IS valid in Draft Mode
+draft_topology = GraphTopology(
+    status="draft",
+    entry_point="missing-node", # Allowed
+    nodes=[AgentNode(id="node-1", agent_ref="agent-a")],
+    edges=[GraphEdge(source="node-1", target="phantom-node")] # Allowed
+)
+
+# Check if it's ready for promotion
+is_ready = draft_topology.verify_completeness()
+# Output: False
+```
+>>>>>>> 80a9ebdf3e3efdad8958e7f246bfa0d3e2bc7d6c
 
 ## Runtime Execution
 

--- a/docs/interactive_control_plane.md
+++ b/docs/interactive_control_plane.md
@@ -1,0 +1,108 @@
+# Interactive Control Plane
+
+The **Interactive Control Plane** transforms the Coreason Manifest from a static script into a "Steerable Glass Box." This architecture allows any node in a `RecipeDefinition` (Agents, Generative Solvers, etc.) to declare its level of transparency and specific points where human intervention is required or allowed.
+
+This design adheres to the **Passive by Design** principle: The Manifest defines the *configuration* for interaction, while the Runtime is responsible for the actual execution (pausing, resuming, and collecting feedback).
+
+## Core Concepts
+
+### 1. Transparency Level (`TransparencyLevel`)
+
+Defines how much internal reasoning and state is exposed to the observer.
+
+*   **`OPAQUE`** (Default): Black box execution. Only final inputs and outputs are visible. Suitable for simple utility tasks.
+*   **`OBSERVABLE`**: "Glass Box". The node emits granular thought traces, sub-plan events, and internal state changes. It does not strictly require pausing but provides rich telemetry.
+*   **`INTERACTIVE`**: "Step-Through". Implies `OBSERVABLE` behavior AND signals the runtime to expect potential intervention commands. The runtime may offer a UI for stepping through execution.
+
+### 2. Intervention Triggers (`InterventionTrigger`)
+
+Defines specific lifecycle hooks where the engine MUST pause execution and wait for a signal (e.g., human approval or edits).
+
+*   **`ON_START`**: Pause before the node begins execution. Useful for reviewing inputs or modifying the initial prompt.
+*   **`ON_PLAN_GENERATION`**: specific to `GenerativeNode`. Pause after the solver creates a plan but *before* it executes it. This is critical for "Review & Refine" workflows where a human validates the decomposition.
+*   **`ON_FAILURE`**: Pause if the node encounters an error or exception. Allows for manual recovery, editing inputs, or skipping the step.
+*   **`ON_COMPLETION`**: Pause after execution finishes but *before* passing data to the next node. Useful for output review and final sign-off.
+
+### 3. Interaction Configuration (`InteractionConfig`)
+
+This configuration object is attached to any `RecipeNode` via the `interaction` field.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `transparency` | `TransparencyLevel` | `OPAQUE` | Visibility level. |
+| `triggers` | `list[InterventionTrigger]` | `[]` | List of lifecycle hooks where execution must pause. |
+| `editable_fields` | `list[str]` | `[]` | Whitelist of fields the user is allowed to modify during an intervention (e.g., `["goal", "inputs", "solver.n_samples"]`). |
+| `guidance_hint` | `str` | `None` | Static instructions for the human on what to verify (e.g., "Ensure the plan covers all 3 competitors"). |
+
+## Examples
+
+### 1. Interactive Generative Node (Review Plan)
+
+A `GenerativeNode` that solves a complex goal. We want to review the generated plan before it executes.
+
+```python
+from coreason_manifest.spec.v2.recipe import (
+    GenerativeNode,
+    InteractionConfig,
+    TransparencyLevel,
+    InterventionTrigger
+)
+
+node = GenerativeNode(
+    id="market-research",
+    goal="Analyze competitor pricing strategies",
+    output_schema={"type": "object"},
+    interaction=InteractionConfig(
+        transparency=TransparencyLevel.INTERACTIVE,
+        triggers=[InterventionTrigger.ON_PLAN_GENERATION],
+        editable_fields=["goal", "solver.max_iterations"],
+        guidance_hint="Verify that the plan includes at least 3 distinct pricing models."
+    )
+)
+```
+
+### 2. Observable Agent with Failure Recovery
+
+An `AgentNode` that is critical. We want to see its thought process (`OBSERVABLE`) and pause only if it fails (`ON_FAILURE`).
+
+```python
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    InteractionConfig,
+    TransparencyLevel,
+    InterventionTrigger
+)
+
+node = AgentNode(
+    id="critical-task",
+    agent_ref="agent/v1/processor",
+    interaction=InteractionConfig(
+        transparency=TransparencyLevel.OBSERVABLE,
+        triggers=[InterventionTrigger.ON_FAILURE],
+        editable_fields=["inputs", "system_prompt_override"],
+        guidance_hint="If this fails, check for malformed input data."
+    )
+)
+```
+
+### 3. Human Sign-Off (Completion Trigger)
+
+An agent that generates a draft, requiring human approval before proceeding.
+
+```python
+node = AgentNode(
+    id="draft-email",
+    agent_ref="agent/v1/writer",
+    interaction=InteractionConfig(
+        transparency=TransparencyLevel.OPAQUE,
+        triggers=[InterventionTrigger.ON_COMPLETION],
+        editable_fields=["outputs"], # Allow editing the final email text
+        guidance_hint="Ensure tone is professional."
+    )
+)
+```
+
+## Architectural Notes
+
+*   **Universal Inheritance**: The `interaction` field is available on the base `RecipeNode`, meaning all node types (Agents, Humans, Routers, Evaluators, Generative) support these settings.
+*   **Runtime Responsibility**: The Manifest only declares the *intent* for interaction. The Runtime is responsible for implementing the pause/resume mechanism, exposing the state to the user, and applying edits to `editable_fields`.

--- a/docs/runtime/graph_executor.md
+++ b/docs/runtime/graph_executor.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 # Reference Graph Executor
 
 The `GraphExecutor` class (located in `coreason_manifest.utils.simulation_executor`) is a **reference implementation** of the Coreason Runtime architecture. It is designed primarily for **simulation, testing, and graph validation**, providing a working baseline for the "Passive Definition, Active Execution" principle.
@@ -74,4 +75,83 @@ trace = await executor.run()
 # 5. Inspect Trace
 for step in trace.steps:
     print(f"[{step.node_id}] {step.thought or ''}")
+=======
+# Graph Executor Architecture
+
+The `GraphExecutor` is the runtime engine responsible for traversing the `RecipeDefinition` graph and managing the execution state. It implements a **Blackboard Architecture** where all nodes share a common context.
+
+## Overview
+
+The executor operates by maintaining an execution pointer (`current_node_id`) and a state dictionary (`context`). It loops until a terminal node is reached or a safety limit (`max_steps`) is exceeded.
+
+### Key Responsibilities
+
+1.  **Graph Traversal**: Navigating nodes based on topology and routing logic.
+2.  **State Management**: Mapping inputs from the Blackboard to nodes, and merging outputs back.
+3.  **Execution Simulation**: Invoking (or mocking) the logic for each node type.
+4.  **Tracing**: Recording every step in a `SimulationTrace`.
+
+## The Blackboard Model
+
+The `context` (Blackboard) is a dictionary `dict[str, Any]` that accumulates state throughout the execution.
+
+*   **Initial State**: Populated from `recipe.interface.inputs`.
+*   **Input Mapping**: `AgentNode.inputs_map` defines how to extract data from the Blackboard for a specific agent.
+    *   Example: `{"query": "user_input"}` maps `context["user_input"]` to the agent's `query` argument.
+*   **Output Merging**: When a node completes, its entire output dictionary is updated into the Blackboard.
+    *   Example: `context.update(agent_output)`
+
+## Node Execution
+
+### AgentNode
+*   **Action**: Executes an AI Agent (simulated in the reference implementation).
+*   **Input**: Derived from Blackboard via `inputs_map`.
+*   **Output**: Merged into Blackboard.
+*   **Step Type**: `TOOL_EXECUTION`.
+
+### HumanNode
+*   **Action**: Pauses for human input (CLI prompt in reference implementation).
+*   **Input**: `prompt` string.
+*   **Output**: User response, merged into Blackboard.
+*   **Step Type**: `INTERACTION`.
+
+### RouterNode
+*   **Action**: Evaluates a variable for branching.
+*   **Input**: `input_key` from Blackboard.
+*   **Output**: Routing decision (target node ID).
+*   **Logic**:
+    1.  Read `value = context[node.input_key]`.
+    2.  Check `node.routes` for `value`.
+    3.  If match, return target ID.
+    4.  Else, return `node.default_route`.
+*   **Step Type**: `REASONING`.
+
+## Safety Mechanisms
+
+### Infinite Loop Protection
+To prevent runaway execution in cyclic graphs (loops), the executor enforces a strict `max_steps` limit (default: 50). This ensures that even if a loop condition is never met, the process will terminate.
+
+### Validation
+The executor validates the initial state against the `RecipeInterface` (if strict validation is enabled) and ensures that traversed nodes exist in the topology.
+
+## Usage
+
+```python
+from coreason_manifest.runtime.executor import GraphExecutor
+from coreason_manifest.spec.v2.recipe import RecipeDefinition
+
+# Load Recipe
+recipe = ...
+
+# Initialize State
+initial_state = {"user_input": "Hello World"}
+
+# Execute
+executor = GraphExecutor(recipe, initial_state)
+trace = await executor.run()
+
+# Inspect Result
+print(trace.steps)
+print(executor.context)
+>>>>>>> 80a9ebdf3e3efdad8958e7f246bfa0d3e2bc7d6c
 ```

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -107,6 +107,38 @@ class PolicyConfig(CoReasonBaseModel):
 # ==========================================
 
 
+class TransparencyLevel(StrEnum):
+    """How much internal reasoning is exposed."""
+
+    OPAQUE = "opaque"
+    OBSERVABLE = "observable"
+    INTERACTIVE = "interactive"
+
+
+class InterventionTrigger(StrEnum):
+    """Lifecycle hooks where the engine MUST pause."""
+
+    ON_START = "on_start"
+    ON_PLAN_GENERATION = "on_plan_generation"
+    ON_FAILURE = "on_failure"
+    ON_COMPLETION = "on_completion"
+
+
+class InteractionConfig(CoReasonBaseModel):
+    """Configuration for Human-in-the-Loop observability and steering."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    transparency: TransparencyLevel = Field(TransparencyLevel.OPAQUE, description="Visibility level.")
+    triggers: list[InterventionTrigger] = Field(
+        default_factory=list, description="Lifecycle hooks where the engine MUST pause."
+    )
+    editable_fields: list[str] = Field(
+        default_factory=list, description="Whitelist of fields the user is allowed to modify during intervention."
+    )
+    guidance_hint: str | None = Field(None, description="Static instructions for the human on what to verify.")
+
+
 class RecipeNode(CoReasonBaseModel):
     """Base class for all nodes in a Recipe graph."""
 
@@ -115,6 +147,7 @@ class RecipeNode(CoReasonBaseModel):
     id: str = Field(..., description="Unique identifier within the graph.")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Custom metadata (not for UI layout).")
     presentation: NodePresentation | None = Field(None, description="Visual layout and styling metadata.")
+    interaction: InteractionConfig | None = Field(None, description="Policies for transparency and human intervention.")
 
 
 class AgentNode(RecipeNode):

--- a/tests/test_v2_generative_node_extended.py
+++ b/tests/test_v2_generative_node_extended.py
@@ -1,0 +1,119 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    GenerativeNode,
+    GraphTopology,
+    RecipeDefinition,
+    RecipeInterface,
+    SolverConfig,
+    SolverStrategy,
+)
+
+
+def test_solver_config_serialization() -> None:
+    """Test serialization of SolverConfig."""
+    config = SolverConfig(strategy=SolverStrategy.ENSEMBLE, n_samples=5, aggregation_method="best_of_n")
+    data = config.model_dump()
+    assert data["strategy"] == "ensemble"
+    assert data["n_samples"] == 5
+
+
+def test_solver_config_validation_edge_cases() -> None:
+    """Test numeric boundaries for SolverConfig fields."""
+    with pytest.raises(ValidationError) as exc:
+        SolverConfig(depth_limit=0)
+    assert "Input should be greater than or equal to 1" in str(exc.value)
+
+
+def test_solver_config_invalid_strategy() -> None:
+    """Test invalid strategy enum value (Pydantic validation)."""
+    # Use Any cast to bypass MyPy check for invalid literal
+    invalid_strategy: Any = "invalid_strategy"
+    with pytest.raises(ValidationError) as exc:
+        SolverConfig(strategy=invalid_strategy)
+    assert "Input should be 'standard', 'tree_search' or 'ensemble'" in str(exc.value)
+
+
+def test_generative_node_with_custom_solver() -> None:
+    """Test GenerativeNode correctly embeds a custom SolverConfig."""
+    solver = SolverConfig(strategy=SolverStrategy.TREE_SEARCH, max_iterations=100, beam_width=5)
+    node = GenerativeNode(id="gen-node", goal="Solve complex logic", output_schema={}, solver=solver)
+
+    assert node.solver.strategy == SolverStrategy.TREE_SEARCH
+    assert node.solver.max_iterations == 100
+    dump = node.model_dump()
+    assert dump["solver"]["max_iterations"] == 100
+
+
+def test_full_recipe_serialization_with_complex_solver() -> None:
+    """Test full round-trip serialization of a Recipe containing advanced GenerativeNodes."""
+    node_ensemble = GenerativeNode(
+        id="step-1",
+        goal="Generate ideas",
+        output_schema={"type": "array"},
+        solver=SolverConfig(strategy=SolverStrategy.ENSEMBLE, n_samples=10, aggregation_method="weighted_merge"),
+    )
+
+    node_refine = GenerativeNode(
+        id="step-2",
+        goal="Refine best idea",
+        output_schema={"type": "string"},
+        solver=SolverConfig(strategy=SolverStrategy.TREE_SEARCH, depth_limit=10, beam_width=2),
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Complex Solver Recipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=[node_ensemble, node_refine], edges=[{"source": "step-1", "target": "step-2"}], entry_point="step-1"
+        ),
+    )
+
+    # Serialize
+    json_str = recipe.model_dump_json()
+    loaded = RecipeDefinition.model_validate_json(json_str)
+
+    nodes = {n.id: n for n in loaded.topology.nodes}
+
+    step1 = nodes["step-1"]
+    assert isinstance(step1, GenerativeNode)
+    assert step1.solver.strategy == SolverStrategy.ENSEMBLE
+    assert step1.solver.n_samples == 10
+
+    step2 = nodes["step-2"]
+    assert isinstance(step2, GenerativeNode)
+    assert step2.solver.strategy == SolverStrategy.TREE_SEARCH
+    assert step2.solver.depth_limit == 10
+
+
+def test_complex_overlapping_solver_config() -> None:
+    """
+    Test a configuration that sets parameters relevant to multiple strategies.
+    """
+    # Setting both n_samples (SPIO) and beam_width (LATS)
+    solver = SolverConfig(
+        strategy=SolverStrategy.STANDARD,  # Strategy is standard
+        n_samples=5,  # But we set SPIO param
+        beam_width=3,  # And LATS param
+        max_iterations=50,
+    )
+
+    # Should validate fine as a data structure
+    node = GenerativeNode(id="mixed-config", goal="Ambiguous task", output_schema={}, solver=solver)
+
+    assert node.solver.n_samples == 5
+    assert node.solver.beam_width == 3

--- a/tests/test_v2_interaction.py
+++ b/tests/test_v2_interaction.py
@@ -1,0 +1,213 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GenerativeNode,
+    GraphTopology,
+    InteractionConfig,
+    InterventionTrigger,
+    RecipeNode,
+    TransparencyLevel,
+    TaskSequence,
+)
+
+
+def test_interaction_primitives_exist():
+    """Verify that interaction primitives are importable and defined correctly."""
+    assert TransparencyLevel.OPAQUE == "opaque"
+    assert TransparencyLevel.OBSERVABLE == "observable"
+    assert TransparencyLevel.INTERACTIVE == "interactive"
+
+    assert InterventionTrigger.ON_START == "on_start"
+    assert InterventionTrigger.ON_PLAN_GENERATION == "on_plan_generation"
+    assert InterventionTrigger.ON_FAILURE == "on_failure"
+    assert InterventionTrigger.ON_COMPLETION == "on_completion"
+
+
+def test_interaction_config_defaults():
+    """Verify default values for InteractionConfig."""
+    config = InteractionConfig()
+    assert config.transparency == TransparencyLevel.OPAQUE
+    assert config.triggers == []
+    assert config.editable_fields == []
+    assert config.guidance_hint is None
+
+
+def test_agent_node_interaction_support():
+    """Verify AgentNode supports interaction configuration."""
+    interaction = InteractionConfig(
+        transparency=TransparencyLevel.INTERACTIVE,
+        triggers=[InterventionTrigger.ON_START, InterventionTrigger.ON_FAILURE],
+        editable_fields=["inputs", "system_prompt_override"],
+        guidance_hint="Review the inputs carefully."
+    )
+
+    node = AgentNode(
+        id="agent_1",
+        agent_ref="agent/v1/summarizer",
+        interaction=interaction
+    )
+
+    assert node.interaction is not None
+    assert node.interaction.transparency == TransparencyLevel.INTERACTIVE
+    assert InterventionTrigger.ON_START in node.interaction.triggers
+    assert "inputs" in node.interaction.editable_fields
+    assert node.interaction.guidance_hint == "Review the inputs carefully."
+
+
+def test_generative_node_interaction_support():
+    """Verify GenerativeNode supports interaction configuration."""
+    interaction = InteractionConfig(
+        transparency=TransparencyLevel.OBSERVABLE,
+        triggers=[InterventionTrigger.ON_PLAN_GENERATION],
+        editable_fields=["goal", "solver.n_samples"],
+        guidance_hint="Check if the plan covers all edge cases."
+    )
+
+    node = GenerativeNode(
+        id="gen_1",
+        goal="Generate a report",
+        output_schema={"type": "object"},
+        interaction=interaction
+    )
+
+    assert node.interaction is not None
+    assert node.interaction.transparency == TransparencyLevel.OBSERVABLE
+    assert InterventionTrigger.ON_PLAN_GENERATION in node.interaction.triggers
+    assert "solver.n_samples" in node.interaction.editable_fields
+
+
+def test_serialization():
+    """Verify that interaction config serializes correctly."""
+    interaction = InteractionConfig(
+        transparency=TransparencyLevel.INTERACTIVE,
+        triggers=[InterventionTrigger.ON_COMPLETION]
+    )
+
+    node = AgentNode(
+        id="agent_1",
+        agent_ref="agent/v1/test",
+        interaction=interaction
+    )
+
+    dumped = node.dump()
+    assert "interaction" in dumped
+    assert dumped["interaction"]["transparency"] == "interactive"
+    assert dumped["interaction"]["triggers"] == ["on_completion"]
+
+
+def test_validation_rejects_invalid_enums():
+    """Verify validation fails for invalid enum values."""
+    with pytest.raises(ValidationError) as excinfo:
+        InteractionConfig(transparency="invalid_level") # type: ignore
+    assert "Input should be 'opaque', 'observable' or 'interactive'" in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        InteractionConfig(triggers=["invalid_trigger"]) # type: ignore
+    assert "Input should be 'on_start', 'on_plan_generation', 'on_failure' or 'on_completion'" in str(excinfo.value)
+
+def test_inheritance_check():
+    """Verify that interaction field is inherited from RecipeNode."""
+    # This is implicitly tested by AgentNode and GenerativeNode usage,
+    # but we can explicitly check isinstance if we really want, or just rely on the above tests.
+    node = AgentNode(id="a1", agent_ref="ref")
+    assert isinstance(node, RecipeNode)
+    assert hasattr(node, "interaction")
+    assert node.interaction is None
+
+# --- Edge Case Tests ---
+
+def test_edge_case_empty_values():
+    """Verify that empty lists and strings are handled correctly."""
+    interaction = InteractionConfig(
+        triggers=[],
+        editable_fields=[],
+        guidance_hint=""
+    )
+    assert interaction.triggers == []
+    assert interaction.editable_fields == []
+    assert interaction.guidance_hint == ""
+
+def test_edge_case_nested_editable_fields():
+    """Verify that nested field paths are accepted (they are just strings)."""
+    interaction = InteractionConfig(
+        editable_fields=["solver.n_samples", "metadata.version", "deeply.nested.field"]
+    )
+    assert "deeply.nested.field" in interaction.editable_fields
+
+def test_edge_case_all_triggers():
+    """Verify that all triggers can be active simultaneously."""
+    triggers = [
+        InterventionTrigger.ON_START,
+        InterventionTrigger.ON_PLAN_GENERATION,
+        InterventionTrigger.ON_FAILURE,
+        InterventionTrigger.ON_COMPLETION
+    ]
+    interaction = InteractionConfig(triggers=triggers)
+    assert len(interaction.triggers) == 4
+    assert set(interaction.triggers) == set(triggers)
+
+def test_edge_case_duplicate_triggers():
+    """Verify behavior with duplicate triggers (should be allowed by list, though redundant)."""
+    # Pydantic doesn't deduplicate lists by default unless using set, but our schema says list.
+    triggers = [InterventionTrigger.ON_START, InterventionTrigger.ON_START]
+    interaction = InteractionConfig(triggers=triggers)
+    assert len(interaction.triggers) == 2
+    assert interaction.triggers[0] == InterventionTrigger.ON_START
+
+# --- Complex Case Tests ---
+
+def test_complex_graph_mixed_interactions():
+    """Verify a topology with nodes having different interaction configurations."""
+
+    # Node 1: Interactive Agent
+    agent_node = AgentNode(
+        id="agent_1",
+        agent_ref="ref_1",
+        interaction=InteractionConfig(
+            transparency=TransparencyLevel.INTERACTIVE,
+            triggers=[InterventionTrigger.ON_FAILURE]
+        )
+    )
+
+    # Node 2: Observable Generative Node
+    gen_node = GenerativeNode(
+        id="gen_1",
+        goal="Solve X",
+        output_schema={},
+        interaction=InteractionConfig(
+            transparency=TransparencyLevel.OBSERVABLE,
+            triggers=[InterventionTrigger.ON_PLAN_GENERATION]
+        )
+    )
+
+    # Node 3: Opaque Agent (Default)
+    opaque_node = AgentNode(
+        id="agent_2",
+        agent_ref="ref_2"
+        # interaction is None
+    )
+
+    # Create Topology
+    topology = TaskSequence(steps=[agent_node, gen_node, opaque_node]).to_graph()
+
+    assert len(topology.nodes) == 3
+
+    # Verify Node 1
+    n1 = next(n for n in topology.nodes if n.id == "agent_1")
+    assert n1.interaction.transparency == TransparencyLevel.INTERACTIVE
+
+    # Verify Node 2
+    n2 = next(n for n in topology.nodes if n.id == "gen_1")
+    assert n2.interaction.transparency == TransparencyLevel.OBSERVABLE
+
+    # Verify Node 3
+    n3 = next(n for n in topology.nodes if n.id == "agent_2")
+    assert n3.interaction is None
+
+def test_complex_interaction_modification_immutability():
+    """Verify that InteractionConfig is frozen (immutable)."""
+    interaction = InteractionConfig(transparency=TransparencyLevel.OPAQUE)
+    with pytest.raises(ValidationError):
+        interaction.transparency = TransparencyLevel.INTERACTIVE # type: ignore


### PR DESCRIPTION
Implemented the Interactive Control Plane schema as requested.

1.  **Schema Updates**: Modified `src/coreason_manifest/spec/v2/recipe.py` to include `InteractionConfig` on the base `RecipeNode`. This ensures universal inheritance for all node types (Agent, Generative, Human, etc.).
2.  **Configuration**:
    *   `TransparencyLevel`: Defines visibility (OPAQUE, OBSERVABLE, INTERACTIVE).
    *   `InterventionTrigger`: Defines lifecycle hooks for pausing execution (ON_START, ON_PLAN_GENERATION, ON_FAILURE, ON_COMPLETION).
    *   `InteractionConfig`: Encapsulates these settings plus `editable_fields` and `guidance_hint`.
3.  **Documentation**:
    *   Created `docs/interactive_control_plane.md` with detailed explanations and examples.
    *   Updated `docs/graph_recipes.md` to link to the new documentation.
4.  **Testing**:
    *   Created `tests/test_v2_interaction.py` covering defaults, serialization, validation, edge cases, and complex graph topologies.


---
*PR created automatically by Jules for task [10597289617023500994](https://jules.google.com/task/10597289617023500994) started by @gowthamrao*