### PR TITLE
Add Visualization and Collaboration schemas to Recipe V2

### DIFF
--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -392,3 +392,26 @@ node = AgentNode(
     *   `editable_fields`: `list[str]` (Default: `[]`). Whitelist of fields the user can modify during a pause.
     *   `enforce_contract`: `bool` (Default: `True`). If True, the runtime MUST validate the steered output against the original output_schema.
     *   `guidance_hint`: `str | None`. Optional instruction for the operator.
+
+## Cognitive Visualization & Collaboration (New in 0.23.0)
+
+Coreason V2 now supports **Human-on-the-Loop (HOTL)** and **Magentic-UI** capabilities directly in the manifest.
+
+### 1. Visualization (`PresentationHints`)
+
+The `visualization` field allows you to hint at how the node's internal reasoning should be rendered (e.g., as a Tree of Thoughts or a Kanban board).
+
+*   `style`: `VisualizationStyle` (`CHAT`, `TREE`, `KANBAN`, `DOCUMENT`).
+*   `display_title`: Friendly label.
+*   `hidden_fields`: Whitelist of internal variables to hide.
+*   `progress_indicator`: Context variable to watch for % completion.
+
+### 2. Collaboration (`CollaborationConfig`)
+
+The `collaboration` field defines the protocol for human engagement (e.g., Co-Editing a document with an agent).
+
+*   `mode`: `CollaborationMode` (`COMPLETION`, `INTERACTIVE`, `CO_EDIT`).
+*   `feedback_schema`: JSON Schema for structured feedback.
+*   `supported_commands`: Slash commands the agent understands (e.g., `/refine`).
+
+See [UX & Collaboration: Human-on-the-Loop](ux_collaboration.md) for detailed configuration examples.

--- a/docs/ux_collaboration.md
+++ b/docs/ux_collaboration.md
@@ -1,0 +1,116 @@
+# UX & Collaboration: Human-on-the-Loop
+
+Coreason V2 introduces dedicated schemas to bridge the gap between autonomous execution and human understanding. This is achieved through two new planes: **Cognitive Visualization** (How the AI thinks) and **Collaboration** (How the Human engages).
+
+## 1. Cognitive Visualization (`PresentationHints`)
+
+The `visualization` field on any `RecipeNode` allows the recipe author to hint at the most effective way to render the agent's internal state. This enables "Magentic-UI" experiences where the interface adapts to the cognitive process (e.g., displaying a research agent as a document editor, or a planning agent as a tree).
+
+### Schema
+
+```python
+class PresentationHints(CoReasonBaseModel):
+    style: VisualizationStyle = Field(VisualizationStyle.CHAT, ...)
+    display_title: str | None = Field(None, ...)
+    icon: str | None = Field(None, ...)
+    hidden_fields: list[str] = Field(default=[], ...)
+    progress_indicator: str | None = Field(None, ...)
+```
+
+### Visualization Styles (`VisualizationStyle`)
+
+1.  **`CHAT` (Default)**
+    *   **Metaphor**: Standard Linear Message Stream.
+    *   **Use Case**: Simple conversational agents, Q&A bots.
+    *   **UI Behavior**: Appends messages to a chat history.
+
+2.  **`TREE` (Tree of Thoughts)**
+    *   **Metaphor**: Interactive Node-Link Diagram.
+    *   **Use Case**: Complex reasoning, Multi-step planning, LATS/MCTS solvers.
+    *   **UI Behavior**: Visualizes the search space, allowing users to expand branches and inspect alternative thoughts.
+
+3.  **`KANBAN` (Task Board)**
+    *   **Metaphor**: Columns and Cards.
+    *   **Use Case**: Parallel sub-agents, Task decomposition, Project management.
+    *   **UI Behavior**: Displays sub-tasks as cards moving through status columns (ToDo -> Doing -> Done).
+
+4.  **`DOCUMENT` (Artifact-Centric)**
+    *   **Metaphor**: Shared Document Editor (like Google Docs).
+    *   **Use Case**: Draft & Refine workflows, Copywriting, Coding assistants.
+    *   **UI Behavior**: Focuses on the artifact (text/code) with the chat as a sidebar.
+
+### Example: Tree Search Visualization
+
+```python
+node = GenerativeNode(
+    id="planner",
+    goal="Plan trip to Tokyo",
+    output_schema=...,
+    visualization=PresentationHints(
+        style=VisualizationStyle.TREE,
+        display_title="Exploration Tree",
+        icon="lucide:network",
+        hidden_fields=["raw_search_results"] # Hide verbose data
+    )
+)
+```
+
+## 2. Collaboration (`CollaborationConfig`)
+
+The `collaboration` field defines the rules of engagement for "Human-on-the-Loop" (HOTL) scenarios. It dictates *when* and *how* a human can intervene.
+
+### Schema
+
+```python
+class CollaborationConfig(CoReasonBaseModel):
+    mode: CollaborationMode = Field(CollaborationMode.COMPLETION, ...)
+    feedback_schema: dict[str, Any] | None = Field(None, ...)
+    supported_commands: list[str] = Field(default=[], ...)
+```
+
+### Collaboration Modes (`CollaborationMode`)
+
+1.  **`COMPLETION` (Default)**
+    *   **Protocol**: Fire-and-Forget (until finish).
+    *   **Interaction**: User waits for the final output. Can only review *after* completion (unless paused by `InteractionConfig`).
+
+2.  **`INTERACTIVE` (Human-on-the-Loop)**
+    *   **Protocol**: Chat/Steering during execution.
+    *   **Interaction**: User can inject messages or commands *while* the loop is running.
+    *   **Example**: "Stop researching X, focus on Y instead."
+
+3.  **`CO_EDIT` (Magentic-UI)**
+    *   **Protocol**: Shared State Mutation.
+    *   **Interaction**: User and Agent edit a structured artifact simultaneously.
+    *   **Example**: A coding agent writes a function, and the user fixes a typo in real-time.
+
+### Example: Interactive Feedback
+
+```python
+node = AgentNode(
+    id="writer",
+    agent_ref="copywriter",
+    collaboration=CollaborationConfig(
+        mode=CollaborationMode.INTERACTIVE,
+        # Structured Feedback Form
+        feedback_schema={
+            "type": "object",
+            "properties": {
+                "rating": {"type": "integer", "minimum": 1, "maximum": 5},
+                "critique": {"type": "string"}
+            }
+        },
+        # Slash Commands
+        supported_commands=["/rewrite", "/expand", "/shorten"]
+    )
+)
+```
+
+## Integrating with Interaction Config
+
+`CollaborationConfig` (Experience) works hand-in-hand with `InteractionConfig` (Control).
+
+*   **`InteractionConfig`** handles the *mechanics* of pausing execution and allowing state mutation (the "Backend" of HOTL).
+*   **`CollaborationConfig`** handles the *protocol* and *expectations* of the user interface (the "Frontend" of HOTL).
+
+For example, a `CO_EDIT` mode implies that the UI should render a shared editor (`visualization.style="DOCUMENT"`), while `InteractionConfig.editable_fields` whitelist which parts of the state the user is actually allowed to touch.

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -136,6 +136,47 @@ class InteractionConfig(CoReasonBaseModel):
     guidance_hint: str | None = Field(None, description="Hint for the human operator.")
 
 
+class VisualizationStyle(StrEnum):
+    """How the UI should render the node's running state."""
+
+    CHAT = "chat"
+    TREE = "tree"
+    KANBAN = "kanban"
+    DOCUMENT = "document"
+
+
+class PresentationHints(CoReasonBaseModel):
+    """Directives for the frontend on how to render the internal reasoning."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    style: VisualizationStyle = Field(VisualizationStyle.CHAT, description="Visualization style.")
+    display_title: str | None = Field(None, description="Human-friendly label override.")
+    icon: str | None = Field(None, description="Icon name/emoji, e.g., 'lucide:brain'.")
+    hidden_fields: list[str] = Field(
+        default_factory=list, description="Whitelist of internal variables to hide from the non-debug UI."
+    )
+    progress_indicator: str | None = Field(None, description="Name of the context variable to watch for % completion.")
+
+
+class CollaborationMode(StrEnum):
+    """The protocol for human engagement."""
+
+    COMPLETION = "completion"
+    INTERACTIVE = "interactive"
+    CO_EDIT = "co_edit"
+
+
+class CollaborationConfig(CoReasonBaseModel):
+    """Rules for human-agent engagement."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    mode: CollaborationMode = Field(CollaborationMode.COMPLETION, description="Engagement mode.")
+    feedback_schema: dict[str, Any] | None = Field(None, description="JSON Schema for structured feedback.")
+    supported_commands: list[str] = Field(default_factory=list, description="Slash commands the agent understands.")
+
+
 class RecipeNode(CoReasonBaseModel):
     """Base class for all nodes in a Recipe graph."""
 
@@ -143,8 +184,10 @@ class RecipeNode(CoReasonBaseModel):
 
     id: str = Field(..., description="Unique identifier within the graph.")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Custom metadata (not for UI layout).")
-    presentation: NodePresentation | None = Field(None, description="Visual layout and styling metadata.")
+    presentation: NodePresentation | None = Field(None, description="Static visual layout (x, y, color).")
     interaction: InteractionConfig | None = Field(None, description="Interactive control plane configuration.")
+    visualization: PresentationHints | None = Field(None, description="Dynamic rendering hints (Glass Box).")
+    collaboration: CollaborationConfig | None = Field(None, description="Human engagement rules (Co-Pilot).")
 
 
 class AgentNode(RecipeNode):

--- a/tests/test_v2_visualization_collab.py
+++ b/tests/test_v2_visualization_collab.py
@@ -1,10 +1,16 @@
+import pytest
+from pydantic import ValidationError
+
 from coreason_manifest.spec.common.presentation import NodePresentation
 from coreason_manifest.spec.v2.recipe import (
     AgentNode,
     CollaborationConfig,
     CollaborationMode,
     GenerativeNode,
+    InteractionConfig,
+    InterventionTrigger,
     PresentationHints,
+    TransparencyLevel,
     VisualizationStyle,
 )
 
@@ -59,3 +65,102 @@ def test_conflict_avoidance() -> None:
     assert data["presentation"]["x"] == 100
     assert data["presentation"]["y"] == 200
     assert data["visualization"]["style"] == "chat"
+
+
+def test_edge_cases() -> None:
+    """Test optional fields, defaults, and validation."""
+    # 1. Test defaults
+    node = AgentNode(
+        id="minimal",
+        agent_ref="ref",
+        visualization=PresentationHints(),  # Should use default style=CHAT
+        collaboration=CollaborationConfig(),  # Should use default mode=COMPLETION
+    )
+    assert node.visualization is not None
+    assert node.visualization.style == VisualizationStyle.CHAT
+    assert node.visualization.hidden_fields == []
+    assert node.collaboration is not None
+    assert node.collaboration.mode == CollaborationMode.COMPLETION
+    assert node.collaboration.supported_commands == []
+
+    # 2. Test invalid Visualization Style
+    with pytest.raises(ValidationError) as exc:
+        PresentationHints(style="INVALID_STYLE")
+    assert "Input should be 'chat', 'tree', 'kanban' or 'document'" in str(exc.value)
+
+    # 3. Test invalid Collaboration Mode
+    with pytest.raises(ValidationError) as exc:
+        CollaborationConfig(mode="INVALID_MODE")
+    assert "Input should be 'completion', 'interactive' or 'co_edit'" in str(exc.value)
+
+    # 4. Test nullable fields
+    hints = PresentationHints(style=VisualizationStyle.KANBAN, display_title=None, icon=None, progress_indicator=None)
+    assert hints.display_title is None
+
+    # 5. Test empty hidden fields
+    hints_empty = PresentationHints(hidden_fields=[])
+    assert hints_empty.hidden_fields == []
+
+
+def test_complex_configuration() -> None:
+    """Test a node with all UX/Control planes configured."""
+    node = GenerativeNode(
+        id="complex-node",
+        goal="Do everything",
+        output_schema={"type": "object"},
+        # 1. Layout
+        presentation=NodePresentation(x=50, y=50, color="#FF0000"),
+        # 2. Visualization
+        visualization=PresentationHints(
+            style=VisualizationStyle.TREE,
+            display_title="Master Plan",
+            icon="lucide:brain-circuit",
+            hidden_fields=["internal_scratchpad"],
+            progress_indicator="percent_complete",
+        ),
+        # 3. Collaboration
+        collaboration=CollaborationConfig(
+            mode=CollaborationMode.INTERACTIVE,
+            feedback_schema={"type": "object", "properties": {"rating": {"type": "integer"}}},
+            supported_commands=["/retry", "/explain"],
+        ),
+        # 4. Interaction (Control)
+        interaction=InteractionConfig(
+            transparency=TransparencyLevel.OBSERVABLE,
+            triggers=[InterventionTrigger.ON_FAILURE],
+            editable_fields=["goal"],
+            guidance_hint="Watch closely",
+        ),
+    )
+
+    data = node.dump()
+
+    # Assertions for complex structure
+    assert data["presentation"]["color"] == "#FF0000"
+    assert data["visualization"]["icon"] == "lucide:brain-circuit"
+    assert "internal_scratchpad" in data["visualization"]["hidden_fields"]
+    assert data["collaboration"]["feedback_schema"]["properties"]["rating"]["type"] == "integer"
+    assert "/retry" in data["collaboration"]["supported_commands"]
+    assert data["interaction"]["transparency"] == "observable"
+
+
+def test_serialization_roundtrip() -> None:
+    """Ensure data integrity after dump/load cycle."""
+    original = AgentNode(
+        id="roundtrip",
+        agent_ref="ref",
+        visualization=PresentationHints(style=VisualizationStyle.KANBAN),
+        collaboration=CollaborationConfig(mode=CollaborationMode.CO_EDIT),
+    )
+
+    # Dump to dict
+    serialized = original.dump()
+
+    # Load back
+    reloaded = AgentNode.model_validate(serialized)
+
+    assert reloaded.id == original.id
+    assert reloaded.visualization is not None
+    assert reloaded.visualization.style == VisualizationStyle.KANBAN
+    assert reloaded.collaboration is not None
+    assert reloaded.collaboration.mode == CollaborationMode.CO_EDIT

--- a/tests/test_v2_visualization_collab.py
+++ b/tests/test_v2_visualization_collab.py
@@ -1,0 +1,61 @@
+from coreason_manifest.spec.common.presentation import NodePresentation
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    CollaborationConfig,
+    CollaborationMode,
+    GenerativeNode,
+    PresentationHints,
+    VisualizationStyle,
+)
+
+
+def test_sota_tree_search_configuration() -> None:
+    node = GenerativeNode(
+        id="node-1",
+        goal="Solve the problem",
+        output_schema={"type": "string"},
+        visualization=PresentationHints(
+            style=VisualizationStyle.TREE,
+            display_title="Reasoning Tree",
+        ),
+        collaboration=CollaborationConfig(
+            mode=CollaborationMode.INTERACTIVE,
+            supported_commands=["/prune"],
+        ),
+    )
+
+    data = node.dump()
+    assert data["visualization"]["style"] == "tree"
+    assert data["visualization"]["display_title"] == "Reasoning Tree"
+    assert data["collaboration"]["mode"] == "interactive"
+    assert data["collaboration"]["supported_commands"] == ["/prune"]
+
+
+def test_co_edit_agent() -> None:
+    node = AgentNode(
+        id="agent-1",
+        agent_ref="agent-ref-1",
+        visualization=PresentationHints(style=VisualizationStyle.DOCUMENT),
+        collaboration=CollaborationConfig(mode=CollaborationMode.CO_EDIT),
+    )
+
+    assert node.visualization is not None
+    assert node.visualization.style == VisualizationStyle.DOCUMENT
+    assert node.collaboration is not None
+    assert node.collaboration.mode == CollaborationMode.CO_EDIT
+
+
+def test_conflict_avoidance() -> None:
+    node = AgentNode(
+        id="agent-1",
+        agent_ref="agent-ref-1",
+        presentation=NodePresentation(x=100, y=200, color="#0000FF"),
+        visualization=PresentationHints(style=VisualizationStyle.CHAT),
+    )
+
+    data = node.dump()
+
+    # Check that both fields exist and are correct
+    assert data["presentation"]["x"] == 100
+    assert data["presentation"]["y"] == 200
+    assert data["visualization"]["style"] == "chat"


### PR DESCRIPTION
Implements Cognitive Visualization (PresentationHints, VisualizationStyle) and Collaboration (CollaborationConfig, CollaborationMode) schemas in src/coreason_manifest/spec/v2/recipe.py and adds tests in tests/test_v2_visualization_collab.py.

---
*PR created automatically by Jules for task [6953401950047204751](https://jules.google.com/task/6953401950047204751) started by @gowthamrao*