### PR TITLE
Add MCP Tool and Runtime Environment schemas

### DIFF
--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -104,7 +104,7 @@ state=StateDefinition(
 ```
 
 ### 4. The Policy Layer (`PolicyConfig`)
-Sets execution limits and error handling strategies.
+Sets execution limits and error handling strategies, including **MCP Governance**.
 
 ```python
 policy=PolicyConfig(
@@ -113,11 +113,28 @@ policy=PolicyConfig(
     execution_mode="sequential", # or "parallel"
     # New Harvesting Fields
     budget_cap_usd=50.0,
-    sensitive_tools=["buy_stock", "delete_db"]
+    sensitive_tools=["buy_stock", "delete_db"],
+    allowed_mcp_servers=["github", "brave-search"]
 )
 ```
 
-### 5. The Test Layer (`SimulationScenario`)
+### 5. The Environment Layer (`RuntimeEnvironment`)
+
+New in 0.22.0, the `environment` field allows recipes to declare their **MCP Infrastructure Requirements**.
+
+```python
+from coreason_manifest.spec.v2.resources import RuntimeEnvironment, McpServerRequirement
+
+environment=RuntimeEnvironment(
+    mcp_servers=[
+        McpServerRequirement(name="github", required_tools=["create_issue"])
+    ]
+)
+```
+
+See [MCP Runtime & Governance](mcp_runtime.md) for full details.
+
+### 6. The Test Layer (`SimulationScenario`)
 
 Recipes can now embed self-contained test scenarios (harvested from Simulacrum) for validation.
 

--- a/docs/mcp_runtime.md
+++ b/docs/mcp_runtime.md
@@ -1,0 +1,135 @@
+# MCP Runtime & Governance
+
+Coreason Manifest V2.2 (introduced in 0.22.0) adds first-class support for the **Model Context Protocol (MCP)**, allowing Recipes to declare their infrastructure requirements and govern tool access.
+
+This document describes the schema for defining **Tool Capabilities**, **Runtime Environments**, and **Governance Policies**.
+
+## 1. Tool Capabilities (`ToolDefinition`)
+
+To enable static analysis and planning, tools must be defined with a schema that describes their interface. The `ToolDefinition` schema allows you to specify inputs, descriptions, and governance metadata.
+
+```python
+from coreason_manifest.spec.v2.resources import ToolDefinition, ToolParameter
+
+tool = ToolDefinition(
+    name="brave_search",
+    description="Search the web for real-time information.",
+    parameters={
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "The search query"},
+            "count": {"type": "integer", "default": 5}
+        },
+        "required": ["query"]
+    },
+    # Critical for MCP Governance
+    is_consequential=False,
+    namespace="brave"
+)
+```
+
+### Key Fields
+*   **`name`**: The unique identifier for the tool (e.g., `github.create_issue`).
+*   **`parameters`**: A JSON Schema object defining the expected inputs.
+*   **`is_consequential`**: A boolean flag (default `False`). If `True`, the MCP Runtime MUST require human approval before executing this tool (side-effect protection).
+*   **`namespace`**: The expected MCP server namespace (e.g., `github`).
+
+## 2. Infrastructure Requirements (`RuntimeEnvironment`)
+
+A Recipe can now declare the "Hardware" (MCP Servers) it requires to run. This allows the runtime to pre-flight check that all necessary connections are available before starting execution.
+
+This is defined in the `environment` field of `RecipeDefinition`.
+
+```python
+from coreason_manifest.spec.v2.resources import RuntimeEnvironment, McpServerRequirement
+
+environment = RuntimeEnvironment(
+    mcp_servers=[
+        McpServerRequirement(
+            name="github",
+            required_tools=["create_issue", "list_pull_requests"],
+            version_constraint=">=1.0.0"
+        ),
+        McpServerRequirement(
+            name="brave-search",
+            required_tools=["search"]
+        )
+    ],
+    python_version="3.12"
+)
+```
+
+### `McpServerRequirement`
+*   **`name`**: The name of the MCP server (must match the server configuration in the runtime).
+*   **`required_tools`**: A list of tool names that *must* be available on this server.
+*   **`version_constraint`**: Semantic version string (e.g., `>=1.0`) to ensure compatibility.
+
+## 3. Governance Policy (`PolicyConfig`)
+
+The `PolicyConfig` schema has been updated to support MCP-specific governance rules. Specifically, you can whitelist which MCP servers a recipe is allowed to access.
+
+```python
+from coreason_manifest.spec.v2.recipe import PolicyConfig
+
+policy = PolicyConfig(
+    max_retries=3,
+    budget_cap_usd=10.0,
+    # Whitelist of allowed MCP servers
+    allowed_mcp_servers=["github", "brave-search"],
+    # Tools that always require human confirmation
+    sensitive_tools=["github.delete_repo"]
+)
+```
+
+### `allowed_mcp_servers`
+A list of strings representing the names of MCP servers that this recipe is permitted to access. If an agent attempts to use a tool from a server not in this list, the execution will be blocked by the governance layer.
+
+## Full Example: Recipe with MCP Support
+
+Here is a complete example of a `RecipeDefinition` that uses these new features.
+
+```python
+from coreason_manifest.spec.v2.recipe import (
+    RecipeDefinition,
+    PolicyConfig,
+    RecipeInterface,
+    AgentNode,
+    GraphTopology,
+    RecipeStatus
+)
+from coreason_manifest.spec.v2.resources import RuntimeEnvironment, McpServerRequirement
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+
+# 1. Define Environment
+env = RuntimeEnvironment(
+    mcp_servers=[
+        McpServerRequirement(name="github", required_tools=["create_issue"])
+    ]
+)
+
+# 2. Define Policy
+policy = PolicyConfig(
+    allowed_mcp_servers=["github"],
+    sensitive_tools=["github.delete_repo"] # Extra safety
+)
+
+# 3. Define Recipe
+recipe = RecipeDefinition(
+    metadata=ManifestMetadata(name="Github Issue Creator"),
+    interface=RecipeInterface(inputs={"title": {"type": "string"}}),
+    environment=env,
+    policy=policy,
+    status=RecipeStatus.DRAFT,
+    topology=GraphTopology(
+        entry_point="create-task",
+        nodes=[
+            AgentNode(
+                id="create-task",
+                agent_ref="github-agent",
+                inputs_map={"title": "title"}
+            )
+        ],
+        edges=[]
+    )
+)
+```

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -19,6 +19,7 @@ from coreason_manifest.spec.common_base import CoReasonBaseModel
 from coreason_manifest.spec.simulation import SimulationScenario
 from coreason_manifest.spec.v2.definitions import ManifestMetadata
 from coreason_manifest.spec.v2.evaluation import EvaluationProfile
+from coreason_manifest.spec.v2.resources import RuntimeEnvironment
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +119,10 @@ class PolicyConfig(CoReasonBaseModel):
     sensitive_tools: list[str] = Field(
         default_factory=list,
         description="List of tool names that ALWAYS require human confirmation (InteractionConfig override).",
+    )
+    allowed_mcp_servers: list[str] = Field(
+        default_factory=list,
+        description="Whitelist of MCP server names this recipe is allowed to access.",
     )
 
 
@@ -476,6 +481,7 @@ class RecipeDefinition(CoReasonBaseModel):
 
     # --- New Components ---
     interface: RecipeInterface = Field(..., description="Input/Output contract.")
+    environment: RuntimeEnvironment | None = Field(None, description="The infrastructure requirements for the recipe.")
 
     # --- New Harvesting Field ---
     tests: list[SimulationScenario] = Field(

--- a/src/coreason_manifest/spec/v2/resources.py
+++ b/src/coreason_manifest/spec/v2/resources.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from enum import StrEnum
+from typing import Any
 
 from pydantic import ConfigDict, Field
 
@@ -63,3 +64,47 @@ class ModelProfile(CoReasonBaseModel):
     model_id: str = Field(..., description="The technical ID (e.g. gpt-4).")
     pricing: RateCard | None = Field(None, description="Financials.")
     constraints: ResourceConstraints | None = Field(None, description="Technical limits.")
+
+
+class ToolParameter(CoReasonBaseModel):
+    """Parameter definition for a tool."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    name: str = Field(..., description="Parameter name.")
+    type: str = Field(..., description="Data type of the parameter.")
+    description: str = Field(..., description="Parameter description.")
+    required: bool = Field(True, description="Whether the parameter is required.")
+
+
+class ToolDefinition(CoReasonBaseModel):
+    """Static definition of an MCP tool capability."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    name: str = Field(..., description="The tool name (e.g., 'brave_search').")
+    description: str = Field(..., description="What the tool does.")
+    parameters: dict[str, Any] = Field(..., description="JSON Schema of inputs.")
+    is_consequential: bool = Field(
+        False, description="If True, coreason-mcp MUST require human approval before execution."
+    )
+    namespace: str | None = Field(None, description="Expected MCP server namespace (e.g., 'github').")
+
+
+class McpServerRequirement(CoReasonBaseModel):
+    """Declares that this recipe needs a specific MCP server available."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    name: str = Field(..., description="Server name.")
+    required_tools: list[str] = Field(default_factory=list, description="List of required tools.")
+    version_constraint: str | None = Field(None, description="Version constraint.")
+
+
+class RuntimeEnvironment(CoReasonBaseModel):
+    """The infrastructure requirements for the recipe."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    mcp_servers: list[McpServerRequirement] = Field(default_factory=list, description="Required MCP servers.")
+    python_version: str | None = Field("3.12", description="Required Python version.")

--- a/tests/test_v2_resources.py
+++ b/tests/test_v2_resources.py
@@ -1,0 +1,33 @@
+from coreason_manifest.spec.v2.resources import McpServerRequirement, RuntimeEnvironment, ToolDefinition, ToolParameter
+
+
+def test_tool_parameter() -> None:
+    param = ToolParameter(name="query", type="string", description="Search query")
+    assert param.name == "query"
+    assert param.type == "string"
+    assert param.required is True
+
+
+def test_tool_definition() -> None:
+    tool = ToolDefinition(
+        name="brave_search",
+        description="Search the web",
+        parameters={"properties": {"query": {"type": "string"}}},
+        is_consequential=True,
+        namespace="brave",
+    )
+    assert tool.name == "brave_search"
+    assert tool.is_consequential is True
+    assert tool.namespace == "brave"
+
+
+def test_runtime_environment() -> None:
+    mcp_req = McpServerRequirement(name="github", required_tools=["create_issue"])
+    env = RuntimeEnvironment(mcp_servers=[mcp_req], python_version="3.11")
+    assert env.mcp_servers[0].name == "github"
+    assert env.python_version == "3.11"
+
+    # Test defaults
+    env_default = RuntimeEnvironment()
+    assert env_default.mcp_servers == []
+    assert env_default.python_version == "3.12"

--- a/tests/test_v2_resources_extended.py
+++ b/tests/test_v2_resources_extended.py
@@ -1,0 +1,185 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    PolicyConfig,
+    RecipeDefinition,
+    RecipeInterface,
+)
+from coreason_manifest.spec.v2.resources import (
+    McpServerRequirement,
+    RuntimeEnvironment,
+    ToolDefinition,
+)
+
+# -----------------------------------------------------------------------------
+# 1. ToolDefinition Edge Cases & Complexity
+# -----------------------------------------------------------------------------
+
+
+def test_tool_definition_empty_params() -> None:
+    """Edge Case: ToolDefinition with empty parameters dict should be valid."""
+    tool = ToolDefinition(name="simple_tool", description="Does nothing", parameters={})
+    assert tool.parameters == {}
+    assert tool.is_consequential is False  # Default
+
+
+def test_tool_definition_complex_nested_params() -> None:
+    """Complex Case: deeply nested JSON schema in parameters."""
+    complex_schema = {
+        "type": "object",
+        "properties": {
+            "config": {"type": "object", "properties": {"nested": {"type": "array", "items": {"type": "string"}}}}
+        },
+    }
+    tool = ToolDefinition(
+        name="complex_tool",
+        description="Complex params",
+        parameters=complex_schema,
+        is_consequential=True,
+        namespace="complex-ns",
+    )
+
+    # Verify structure matches input
+    assert tool.parameters["properties"]["config"]["properties"]["nested"]["type"] == "array"
+
+    # Verify serialization
+    dumped = tool.dump()
+    assert dumped["parameters"]["type"] == "object"
+
+
+def test_tool_definition_validation_error() -> None:
+    """Validation: Missing required fields."""
+    with pytest.raises(ValidationError) as exc:
+        ToolDefinition(
+            # Missing name, description, parameters
+            is_consequential=True
+        )  # type: ignore[call-arg]
+
+    errors = exc.value.errors()
+    missing_fields = [e["loc"][0] for e in errors]
+    assert "name" in missing_fields
+    assert "description" in missing_fields
+    assert "parameters" in missing_fields
+
+
+# -----------------------------------------------------------------------------
+# 2. RuntimeEnvironment & McpServerRequirement Edge Cases
+# -----------------------------------------------------------------------------
+
+
+def test_mcp_requirement_empty_tools() -> None:
+    """Edge Case: Server requirement with no specific tools."""
+    req = McpServerRequirement(name="brave")
+    assert req.name == "brave"
+    assert req.required_tools == []
+    assert req.version_constraint is None
+
+
+def test_runtime_env_multiple_servers() -> None:
+    """Complex Case: Multiple servers with mixed constraints."""
+    req1 = McpServerRequirement(name="github", required_tools=["create_issue"], version_constraint=">=1.0.0")
+    req2 = McpServerRequirement(name="slack", required_tools=[])
+
+    env = RuntimeEnvironment(mcp_servers=[req1, req2], python_version="3.11")
+
+    assert len(env.mcp_servers) == 2
+    assert env.mcp_servers[0].name == "github"
+    assert env.mcp_servers[1].name == "slack"
+
+
+def test_runtime_env_defaults() -> None:
+    """Edge Case: Default initialization."""
+    env = RuntimeEnvironment()
+    assert env.mcp_servers == []
+    assert env.python_version == "3.12"  # Check default value
+
+
+# -----------------------------------------------------------------------------
+# 3. PolicyConfig & RecipeDefinition Integration
+# -----------------------------------------------------------------------------
+
+
+def test_policy_config_defaults() -> None:
+    """Edge Case: PolicyConfig defaults."""
+    policy = PolicyConfig()
+    assert policy.allowed_mcp_servers == []
+    assert policy.sensitive_tools == []
+
+
+def test_policy_config_explicit_empty_list() -> None:
+    """Edge Case: Explicit empty list vs None (Pydantic handles None -> list if default factory?).
+    Actually fields are usually required or have defaults.
+    """
+    policy = PolicyConfig(allowed_mcp_servers=[])
+    assert policy.allowed_mcp_servers == []
+
+
+def test_full_recipe_integration() -> None:
+    """Complex Case: Full integration of Recipe with Environment and Policy."""
+
+    # 1. Environment
+    mcp_req = McpServerRequirement(name="github", required_tools=["create_issue"])
+    env = RuntimeEnvironment(mcp_servers=[mcp_req])
+
+    # 2. Policy
+    policy = PolicyConfig(allowed_mcp_servers=["github"], sensitive_tools=["github.delete_repo"], max_retries=5)
+
+    # 3. Topology (Minimal)
+    node = AgentNode(id="step1", agent_ref="agent-v1", inputs_map={"q": "q"})
+
+    # 4. Recipe
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Integration Test Recipe"),
+        interface=RecipeInterface(inputs={"q": {"type": "string"}}),
+        environment=env,
+        policy=policy,
+        topology=[node],  # TaskSequence coercion
+    )
+
+    # Assertions
+    assert recipe.environment is not None
+    assert recipe.environment.mcp_servers[0].name == "github"
+
+    assert recipe.policy is not None
+    assert "github" in recipe.policy.allowed_mcp_servers
+    assert recipe.policy.max_retries == 5
+
+    # Test Serialization
+    dumped = recipe.dump()
+    assert dumped["environment"]["mcp_servers"][0]["name"] == "github"
+    assert dumped["policy"]["allowed_mcp_servers"] == ["github"]
+
+
+def test_recipe_hashing() -> None:
+    """Verify hash computation works with new fields."""
+    env = RuntimeEnvironment(mcp_servers=[McpServerRequirement(name="github")])
+    recipe1 = RecipeDefinition(
+        metadata=ManifestMetadata(name="Recipe"),
+        interface=RecipeInterface(),
+        topology=[AgentNode(id="a", agent_ref="b")],
+        environment=env,
+    )
+
+    # Create identical recipe
+    recipe2 = RecipeDefinition(
+        metadata=ManifestMetadata(name="Recipe"),
+        interface=RecipeInterface(),
+        topology=[AgentNode(id="a", agent_ref="b")],
+        environment=env.model_copy(),
+    )
+
+    assert recipe1.compute_hash() == recipe2.compute_hash()
+
+    # Create different recipe (different env)
+    env_diff = RuntimeEnvironment(mcp_servers=[McpServerRequirement(name="gitlab")])
+    recipe3 = RecipeDefinition(
+        metadata=ManifestMetadata(name="Recipe"),
+        interface=RecipeInterface(),
+        topology=[AgentNode(id="a", agent_ref="b")],
+        environment=env_diff,
+    )
+
+    assert recipe1.compute_hash() != recipe3.compute_hash()


### PR DESCRIPTION
Introduced schemas for defining MCP Tool Dependencies and Governance Rules.
- `ToolDefinition` allows static validation of tool inputs.
- `RuntimeEnvironment` specifies required MCP servers.
- `PolicyConfig` now includes `allowed_mcp_servers` for governance.
- `RecipeDefinition` links to `RuntimeEnvironment`.

---
*PR created automatically by Jules for task [8328670043713570722](https://jules.google.com/task/8328670043713570722) started by @gowthamrao*