### PR TITLE
Enrich Manifest with Assembler Pattern schemas

### DIFF
--- a/docs/assembler_pattern.md
+++ b/docs/assembler_pattern.md
@@ -1,0 +1,79 @@
+# The Assembler Pattern
+
+The **Assembler Pattern** transforms the Manifest from a purely passive definition into a configuration file for the **Weaver** (in `coreason-construct`). This allows you to define an agent's cognitive architecture inline, specifying its Identity, Environment, Mode, and Task.
+
+## Concept: Inline Cognitive Architecture
+
+Instead of referencing a pre-built agent by ID (`agent_ref`), you can now define the agent's "Cognitive Profile" directly within the `AgentNode`. This profile tells the Weaver how to assemble the prompt and what context to inject.
+
+### The `CognitiveProfile`
+
+The `CognitiveProfile` consists of four key components:
+
+1.  **Identity (Who)**: The role or persona (e.g., `safety_scientist`).
+2.  **Mode (How)**: The reasoning style (e.g., `standard`, `six_hats`, `socratic`).
+3.  **Environment (Where)**: Dynamic context modules (`knowledge_contexts`) to inject.
+4.  **Task (What)**: The logic primitive to apply (`task_primitive`, e.g., `extract`, `classify`).
+
+## Usage in `AgentNode`
+
+The `AgentNode` now supports a `construct` field. If provided, this inline definition takes precedence over `agent_ref`.
+
+```python
+from coreason_manifest.spec.v2.recipe import AgentNode
+from coreason_manifest.spec.v2.agent import (
+    CognitiveProfile,
+    ContextDependency,
+    ComponentPriority
+)
+
+# Define an inline agent
+profile = CognitiveProfile(
+    role="senior_editor",
+    reasoning_mode="critique",
+    knowledge_contexts=[
+        ContextDependency(
+            name="brand_guidelines",
+            priority=ComponentPriority.CRITICAL
+        ),
+        ContextDependency(
+            name="recent_articles",
+            priority=ComponentPriority.LOW,
+            parameters={"limit": 5}
+        )
+    ],
+    task_primitive="review_and_edit"
+)
+
+# Create the node
+node = AgentNode(
+    id="editor_step",
+    construct=profile,
+    # agent_ref is optional when construct is used
+)
+```
+
+## Token Optimization
+
+To support the Weaver's token optimization logic, we've added `ComponentPriority` and `token_budget`.
+
+### Context Priority
+
+Each `ContextDependency` has a `priority` level:
+*   `CRITICAL` (10): Must be included.
+*   `HIGH` (8): Should be included.
+*   `MEDIUM` (5): Standard priority.
+*   `LOW` (1): Can be pruned if the budget is tight.
+
+### Global Token Budget
+
+The `PolicyConfig` now includes a `token_budget` field. The Weaver uses this budget to decide which context modules to prune.
+
+```python
+from coreason_manifest.spec.v2.recipe import PolicyConfig
+
+policy = PolicyConfig(
+    token_budget=8000,  # Max tokens for the assembled prompt
+    budget_cap_usd=5.0
+)
+```

--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -178,6 +178,7 @@ All nodes inherit from `RecipeNode`, which includes `id`, `metadata`, and `prese
 
 1.  **`AgentNode`** (`type: agent`): Executes an AI Agent.
     - `agent_ref`: The ID or URI of the Agent Definition to execute.
+    - `construct`: (Optional) Inline definition of the agent's cognitive architecture (Assembler Pattern). See [The Assembler Pattern](assembler_pattern.md).
     - `system_prompt_override`: Context-specific instructions (optional).
     - `inputs_map`: Mapping parent outputs to agent inputs (dict[str, str]).
 

--- a/docs/v2_harvesting_features.md
+++ b/docs/v2_harvesting_features.md
@@ -60,6 +60,7 @@ The `PolicyConfig` class, part of the top-level `RecipeDefinition`, now includes
 | Field | Type | Description |
 | :--- | :--- | :--- |
 | `budget_cap_usd` | `float \| None` | Hard limit for estimated token + tool costs. Execution halts if exceeded. |
+| `token_budget` | `int \| None` | Max tokens for the assembled prompt. Low-priority contexts will be pruned if exceeded. |
 | `sensitive_tools` | `list[str]` | List of tool names that ALWAYS require human confirmation, overriding node-level interaction configs. |
 
 ### Example
@@ -68,6 +69,7 @@ The `PolicyConfig` class, part of the top-level `RecipeDefinition`, now includes
 policy = PolicyConfig(
     max_retries=3,
     budget_cap_usd=50.00,
+    token_budget=8000,
     sensitive_tools=["delete_database", "refund_payment"]
 )
 ```
@@ -101,3 +103,7 @@ recipe = RecipeDefinition(
     tests=tests
 )
 ```
+
+## 5. Cognitive Profile (Harvested from Weaver)
+
+The `AgentNode` now supports an inline `CognitiveProfile` (`construct` field) to configure the agent's identity, mode, environment, and task directly. This pattern is documented in [The Assembler Pattern](assembler_pattern.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,7 @@ nav:
   - Usage: usage.md
   - Specifications:
       - "Graph Recipes (Orchestration)": graph_recipes.md
+      - "The Assembler Pattern (Inline Agents)": assembler_pattern.md
       - "Agent Manifest (CAM) & Linear Workflows": cap/specification.md
       - "Agent Skills System": skills.md
       - "Tool Packs (Plugins)": tool_packs.md

--- a/src/coreason_manifest/spec/v2/agent.py
+++ b/src/coreason_manifest/spec/v2/agent.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import IntEnum
+from typing import Any
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.spec.common_base import CoReasonBaseModel
+
+
+class ComponentPriority(IntEnum):
+    """Priority levels for token optimization (harvested from Weaver)."""
+
+    LOW = 1
+    MEDIUM = 5
+    HIGH = 8
+    CRITICAL = 10
+
+
+class ContextDependency(CoReasonBaseModel):
+    """A reference to a context module (e.g. 'hipaa_context')."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    name: str = Field(..., description="The registry name of the context component.")
+    priority: ComponentPriority = Field(ComponentPriority.MEDIUM, description="Token optimization priority.")
+    parameters: dict[str, Any] = Field(default_factory=dict, description="Variables to inject into the context.")
+
+
+class CognitiveProfile(CoReasonBaseModel):
+    """The configuration for the Weaver to assemble a Prompt."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    # 1. Identity (Who)
+    role: str = Field(..., description="The specific Role/Persona (e.g., 'safety_scientist').")
+
+    # 2. Mode (How)
+    reasoning_mode: str | None = Field("standard", description="The thinking style (e.g., 'six_hats', 'socratic').")
+
+    # 3. Environment (Where)
+    knowledge_contexts: list[ContextDependency] = Field(
+        default_factory=list, description="Dynamic context modules to inject."
+    )
+
+    # 4. Task (What) - Maps to StructuredPrimitive
+    task_primitive: str | None = Field(
+        None, description="The logic primitive to apply (e.g., 'extract', 'classify', 'cohort')."
+    )

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -17,6 +17,7 @@ from pydantic import BeforeValidator, ConfigDict, Field, model_validator
 from coreason_manifest.spec.common.presentation import NodePresentation
 from coreason_manifest.spec.common_base import CoReasonBaseModel
 from coreason_manifest.spec.simulation import SimulationScenario
+from coreason_manifest.spec.v2.agent import CognitiveProfile
 from coreason_manifest.spec.v2.definitions import ManifestMetadata
 from coreason_manifest.spec.v2.evaluation import EvaluationProfile
 
@@ -114,6 +115,10 @@ class PolicyConfig(CoReasonBaseModel):
     # --- New Harvesting Fields ---
     budget_cap_usd: float | None = Field(
         None, description="Hard limit for estimated token + tool costs. Execution halts if exceeded."
+    )
+    token_budget: int | None = Field(
+        None,
+        description="Max tokens for the assembled prompt. Low-priority contexts will be pruned if exceeded.",
     )
     sensitive_tools: list[str] = Field(
         default_factory=list,
@@ -225,8 +230,16 @@ class AgentNode(RecipeNode):
     """A node that executes an AI Agent."""
 
     type: Literal["agent"] = "agent"
-    agent_ref: str | SemanticRef = Field(
-        ..., description="The ID or URI of the Agent Definition, or a Semantic Reference."
+
+    # New Field: Inline Definition
+    # If provided, this overrides 'agent_ref' lookup.
+    construct: CognitiveProfile | None = Field(  # type: ignore[assignment]
+        None,
+        description="Inline definition of the agent's cognitive architecture (for the Weaver).",
+    )
+
+    agent_ref: str | SemanticRef | None = Field(
+        None, description="The ID or URI of the Agent Definition, or a Semantic Reference."
     )
     system_prompt_override: str | None = Field(None, description="Context-specific instructions.")
     inputs_map: dict[str, str] = Field(default_factory=dict, description="Mapping parent outputs to agent inputs.")

--- a/tests/test_v2_construct.py
+++ b/tests/test_v2_construct.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+
+from coreason_manifest.spec.v2.agent import (
+    CognitiveProfile,
+    ComponentPriority,
+    ContextDependency,
+)
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    GraphTopology,
+    PolicyConfig,
+    RecipeDefinition,
+    RecipeInterface,
+)
+
+
+def test_cognitive_profile_creation() -> None:
+    """Test creating a CognitiveProfile."""
+    profile = CognitiveProfile(
+        role="data_analyst",
+        reasoning_mode="analytical",
+        knowledge_contexts=[ContextDependency(name="sql_knowledge", priority=ComponentPriority.HIGH)],
+        task_primitive="extract_metrics",
+    )
+    assert profile.role == "data_analyst"
+    assert profile.reasoning_mode == "analytical"
+    assert len(profile.knowledge_contexts) == 1
+    assert profile.knowledge_contexts[0].name == "sql_knowledge"
+    assert profile.knowledge_contexts[0].priority == ComponentPriority.HIGH
+    assert profile.task_primitive == "extract_metrics"
+
+
+def test_agent_node_with_construct() -> None:
+    """Test AgentNode with inline construct."""
+    profile = CognitiveProfile(role="assistant")
+    node = AgentNode(
+        id="agent-1",
+        construct=profile,
+        agent_ref=None,  # Explicitly None
+    )
+    assert node.construct == profile
+    assert node.agent_ref is None
+
+
+def test_agent_node_construct_overrides_agent_ref_in_logic() -> None:
+    """
+    The spec says 'If provided, this overrides agent_ref lookup'.
+    We just test that both can be present in the object,
+    and it's up to the runtime to prioritize.
+    """
+    profile = CognitiveProfile(role="assistant")
+    node = AgentNode(
+        id="agent-1",
+        construct=profile,
+        agent_ref="some-catalog-id",
+    )
+    assert node.construct == profile
+    assert node.agent_ref == "some-catalog-id"
+
+
+def test_policy_config_token_budget() -> None:
+    """Test new token_budget field in PolicyConfig."""
+    policy = PolicyConfig(
+        max_retries=3,
+        token_budget=10000,
+        budget_cap_usd=5.0,
+    )
+    assert policy.token_budget == 10000
+    assert policy.budget_cap_usd == 5.0
+
+
+def test_full_recipe_with_construct() -> None:
+    """Test full recipe serialization with construct."""
+    profile = CognitiveProfile(
+        role="writer",
+        knowledge_contexts=[ContextDependency(name="style_guide", priority=ComponentPriority.CRITICAL)],
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Construct Recipe"),
+        interface=RecipeInterface(),
+        policy=PolicyConfig(token_budget=5000),
+        topology=GraphTopology(
+            nodes=[
+                AgentNode(id="writer", construct=profile),
+            ],
+            edges=[],
+            entry_point="writer",
+        ),
+    )
+
+    # Roundtrip
+    json_str = recipe.to_json()
+    loaded = RecipeDefinition.model_validate_json(json_str)
+
+    node = loaded.topology.nodes[0]
+    assert isinstance(node, AgentNode)
+    assert node.construct is not None
+    assert node.construct.role == "writer"
+    assert node.construct.knowledge_contexts[0].priority == ComponentPriority.CRITICAL
+
+    assert loaded.policy is not None
+    assert loaded.policy.token_budget == 5000

--- a/tests/test_v2_construct_extended.py
+++ b/tests/test_v2_construct_extended.py
@@ -1,0 +1,197 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.agent import (
+    CognitiveProfile,
+    ComponentPriority,
+    ContextDependency,
+)
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    PolicyConfig,
+    RecipeDefinition,
+    GraphTopology,
+    RecipeInterface,
+    GraphEdge,
+    RecipeStatus,
+)
+
+# ==========================================
+# Edge Cases
+# ==========================================
+
+def test_agent_node_no_ref_no_construct() -> None:
+    """
+    Test AgentNode with neither agent_ref nor construct.
+    Technically valid by schema (both Optional), but Runtime should handle it.
+    """
+    node = AgentNode(id="ghost-agent")
+    assert node.agent_ref is None
+    assert node.construct is None
+    # This node is essentially empty, waiting for runtime logic or injection.
+
+
+def test_cognitive_profile_minimal() -> None:
+    """Test CognitiveProfile with only required fields."""
+    profile = CognitiveProfile(role="observer")
+    assert profile.role == "observer"
+    assert profile.reasoning_mode == "standard"  # Default
+    assert profile.knowledge_contexts == []      # Default
+    assert profile.task_primitive is None        # Default
+
+
+def test_context_dependency_minimal() -> None:
+    """Test ContextDependency with defaults."""
+    dep = ContextDependency(name="basic_context")
+    assert dep.name == "basic_context"
+    assert dep.priority == ComponentPriority.MEDIUM # Default
+    assert dep.parameters == {}                     # Default
+
+
+def test_policy_config_extreme_values() -> None:
+    """Test PolicyConfig with extreme/boundary values."""
+    policy = PolicyConfig(
+        token_budget=0,             # Zero budget
+        budget_cap_usd=999999.99,   # Large budget
+    )
+    assert policy.token_budget == 0
+    assert policy.budget_cap_usd == 999999.99
+
+    policy_none = PolicyConfig(token_budget=None)
+    assert policy_none.token_budget is None
+
+
+# ==========================================
+# Complex Cases
+# ==========================================
+
+def test_hybrid_recipe_topology() -> None:
+    """
+    Test a graph that mixes:
+    1. Agent with inline construct.
+    2. Agent with semantic reference.
+    3. Agent with concrete reference.
+    """
+    # 1. Inline Agent
+    node_inline = AgentNode(
+        id="step-1-inline",
+        construct=CognitiveProfile(
+            role="analyst",
+            task_primitive="analyze"
+        )
+    )
+
+    # 2. Concrete Agent
+    node_concrete = AgentNode(
+        id="step-2-concrete",
+        agent_ref="summarizer-v1"
+    )
+
+    # 3. Hybrid (Both - construct takes precedence logic wise, but both exist in model)
+    node_hybrid = AgentNode(
+        id="step-3-hybrid",
+        construct=CognitiveProfile(role="reviewer"),
+        agent_ref="reviewer-base-v1"
+    )
+
+    topology = GraphTopology(
+        nodes=[node_inline, node_concrete, node_hybrid],
+        edges=[
+            GraphEdge(source="step-1-inline", target="step-2-concrete"),
+            GraphEdge(source="step-2-concrete", target="step-3-hybrid")
+        ],
+        entry_point="step-1-inline"
+    )
+
+    assert len(topology.nodes) == 3
+    assert topology.verify_completeness()
+
+
+def test_complex_context_dependencies() -> None:
+    """Test a profile with many context dependencies and parameters."""
+    profile = CognitiveProfile(
+        role="legal_expert",
+        knowledge_contexts=[
+            ContextDependency(name="constitution", priority=ComponentPriority.CRITICAL),
+            ContextDependency(name="case_law_2024", priority=ComponentPriority.HIGH, parameters={"year": 2024, "region": "US"}),
+            ContextDependency(name="internal_memos", priority=ComponentPriority.LOW, parameters={"tags": ["confidential"]}),
+        ]
+    )
+
+    assert len(profile.knowledge_contexts) == 3
+    # Verify sorting or access
+    critical = [c for c in profile.knowledge_contexts if c.priority == ComponentPriority.CRITICAL]
+    assert len(critical) == 1
+    assert critical[0].name == "constitution"
+
+
+def test_full_recipe_serialization_roundtrip_complex() -> None:
+    """Test full serialization of a complex recipe with new features."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Complex Assembler Recipe"),
+        interface=RecipeInterface(),
+        policy=PolicyConfig(
+            token_budget=128000,
+            sensitive_tools=["exec_code"]
+        ),
+        topology=GraphTopology(
+            nodes=[
+                AgentNode(
+                    id="start",
+                    construct=CognitiveProfile(
+                        role="orchestrator",
+                        reasoning_mode="six_hats",
+                        knowledge_contexts=[
+                            ContextDependency(name="project_specs", priority=ComponentPriority.HIGH)
+                        ]
+                    )
+                ),
+                AgentNode(
+                    id="end",
+                    agent_ref="finalizer"
+                )
+            ],
+            edges=[GraphEdge(source="start", target="end")],
+            entry_point="start"
+        )
+    )
+
+    # Dump
+    json_str = recipe.to_json()
+
+    # Load
+    loaded = RecipeDefinition.model_validate_json(json_str)
+
+    # Verify
+    assert loaded.policy is not None
+    assert loaded.policy.token_budget == 128000
+
+    start_node = next(n for n in loaded.topology.nodes if n.id == "start")
+    assert isinstance(start_node, AgentNode)
+    assert start_node.construct is not None
+    assert start_node.construct.reasoning_mode == "six_hats"
+
+def test_lifecycle_validation_incomplete_node() -> None:
+    """Test that PUBLISHED status rejects nodes without agent_ref or construct."""
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "Incomplete Recipe"},
+        "interface": {},
+        "status": RecipeStatus.PUBLISHED,
+        "topology": {
+            "nodes": [
+                {"type": "agent", "id": "ghost"} # missing agent_ref and construct
+            ],
+            "edges": [],
+            "entry_point": "ghost"
+        }
+    }
+
+    with pytest.raises(ValidationError) as excinfo:
+        RecipeDefinition.model_validate(data)
+
+    assert "Nodes ['ghost'] are incomplete" in str(excinfo.value)


### PR DESCRIPTION
Enrich Manifest with Assembler Pattern schemas from coreason-construct. This allows Recipes to specify the Identity, Environment, Mode, and Task of an agent via an inline `CognitiveProfile`, effectively turning the Manifest into a configuration file for the Weaver.

Changes:
- Added `ComponentPriority`, `ContextDependency`, `CognitiveProfile` to a new module `src/coreason_manifest/spec/v2/agent.py`.
- Updated `AgentNode` to support `construct` field (CognitiveProfile) and optional `agent_ref`.
- Updated `PolicyConfig` to support `token_budget`.
- Added comprehensive tests in `tests/test_v2_construct.py`.

---
*PR created automatically by Jules for task [8899855487172530479](https://jules.google.com/task/8899855487172530479) started by @gowthamrao*