### PR TITLE
Add Compliance Requirements Schema to Recipe Manifest

### DIFF
--- a/docs/compliance_schema.md
+++ b/docs/compliance_schema.md
@@ -1,0 +1,108 @@
+# Compliance & Audit Schema
+
+Coreason V2 introduces a dedicated **Compliance Layer** (`ComplianceConfig`) to the Recipe Manifest. This schema allows a Recipe to dictate the rigor of the audit trail, instructing the `coreason-auditor` worker on what artifacts to generate (e.g., for GxP, SOC2, or casual usage).
+
+## Purpose
+
+Different workflows have different regulatory requirements:
+*   **Casual Chat:** Needs minimal logging and short retention.
+*   **Customer Support:** Needs PII scrubbing and 30-day retention.
+*   **Clinical Decision Support (GxP):** Needs full reasoning traces, cryptographic signatures, unmasked data (for clinical context), and long-term retention (7+ years).
+
+The `ComplianceConfig` schema standardizes these requirements within the manifest itself.
+
+## Configuration Reference
+
+The `ComplianceConfig` model is located at `src/coreason_manifest/spec/v2/recipe.py`.
+
+```python
+from coreason_manifest.spec.v2.recipe import (
+    ComplianceConfig,
+    AuditLevel,
+    RetentionPolicy
+)
+
+config = ComplianceConfig(
+    audit_level=AuditLevel.BASIC,
+    retention=RetentionPolicy.THIRTY_DAYS,
+    generate_aibom=False,
+    generate_pdf_report=False,
+    require_signature=False,
+    mask_pii=True
+)
+```
+
+### 1. Audit Levels (`AuditLevel`)
+
+Controls *what* is logged during execution.
+
+| Level | Value | Description | Use Case |
+| :--- | :--- | :--- | :--- |
+| **NONE** | `"none"` | No persistent logging. | Ephemeral chats, testing. |
+| **BASIC** | `"basic"` | Logs Inputs and Outputs only. | Standard SaaS features. |
+| **FULL** | `"full"` | Logs full reasoning trace (CoT), tool inputs/outputs, and intermediate steps. | Debugging, complex reasoning. |
+| **GXP** | `"gxp"` | Full trace + Signatures + Immutable Archiving + Metadata hashing. | FDA/GxP, Financial, Legal. |
+
+### 2. Retention Policy (`RetentionPolicy`)
+
+Controls *how long* the audit artifacts must be retained by the storage backend.
+
+| Policy | Value | Description |
+| :--- | :--- | :--- |
+| **EPHEMERAL** | `"ephemeral"` | Deleted immediately after the session ends. |
+| **30 DAYS** | `"30_days"` | Standard rolling window. |
+| **1 YEAR** | `"1_year"` | Annual audit compliance. |
+| **7 YEARS** | `"7_years"` | Legal/Financial standard (e.g., tax records, clinical trials). |
+
+### 3. Artifact Generation Flags
+
+| Flag | Default | Description |
+| :--- | :--- | :--- |
+| `generate_aibom` | `False` | Generates an **AI Bill of Materials** (software supply chain), listing all models, tools, and plugins used. |
+| `generate_pdf_report` | `False` | Generates a human-readable PDF summary of the session. |
+| `require_signature` | `False` | Cryptographically signs the final output using the worker's private key. |
+
+### 4. Privacy (`mask_pii`)
+
+*   `mask_pii` (bool, default `True`): If `True`, the Auditor will attempt to scrub Personally Identifiable Information (PII) from logs before archiving.
+*   **Important:** For GxP or Clinical use cases, you often set this to `False` because the patient context is critical for the audit trail and is protected by other means (HIPAA-compliant storage).
+
+## Examples
+
+### Scenario A: Casual Chatbot
+
+Minimal overhead.
+
+```python
+compliance = ComplianceConfig(
+    audit_level=AuditLevel.NONE,
+    retention=RetentionPolicy.EPHEMERAL
+)
+```
+
+### Scenario B: Financial Advisor
+
+Strict logging, long retention, but PII must be masked.
+
+```python
+compliance = ComplianceConfig(
+    audit_level=AuditLevel.FULL,
+    retention=RetentionPolicy.SEVEN_YEARS,
+    mask_pii=True,
+    require_signature=True
+)
+```
+
+### Scenario C: Clinical Trial Analysis (GxP)
+
+Maximum rigor. Data integrity is paramount, so signatures and AIBOM are required. PII masking might be disabled if the system operates within a secure enclave.
+
+```python
+compliance = ComplianceConfig(
+    audit_level=AuditLevel.GXP_COMPLIANT,
+    retention=RetentionPolicy.SEVEN_YEARS,
+    generate_aibom=True,
+    generate_pdf_report=True,
+    mask_pii=False # Keep clinical data intact
+)
+```

--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -151,6 +151,23 @@ tests=[
 ]
 ```
 
+### 7. The Compliance Layer (`ComplianceConfig`)
+
+The `compliance` field dictates the rigor of the audit trail, instructing the `coreason-auditor` worker on what artifacts to generate (GxP, SOC2, etc.).
+
+```python
+from coreason_manifest.spec.v2.recipe import ComplianceConfig, AuditLevel, RetentionPolicy
+
+compliance=ComplianceConfig(
+    audit_level=AuditLevel.GXP_COMPLIANT, # "full" trace + signatures
+    retention=RetentionPolicy.SEVEN_YEARS, # Legal hold
+    generate_aibom=True,    # Create software supply chain manifest
+    generate_pdf_report=True,
+    require_signature=True, # Cryptographically sign output
+    mask_pii=False          # Do not scrub PII (e.g., if needed for clinical records)
+)
+```
+
 ## The Graph Topology Schema (`GraphTopology`)
 
 The `GraphTopology` enforces structural integrity. It requires a list of `nodes`, a list of `edges`, and a valid `entry_point`.

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -131,6 +131,51 @@ class PolicyConfig(CoReasonBaseModel):
     )
 
 
+class AuditLevel(StrEnum):
+    """The depth of the audit trail required."""
+
+    NONE = "none"  # No persistent logging
+    BASIC = "basic"  # Inputs/Outputs only
+    FULL = "full"  # Full reasoning trace + tool inputs/outputs
+    GXP_COMPLIANT = "gxp"  # Full trace + signatures + immutable archiving
+
+
+class RetentionPolicy(StrEnum):
+    """How long the audit artifacts must be retained."""
+
+    EPHEMERAL = "ephemeral"  # Delete after session
+    THIRTY_DAYS = "30_days"
+    ONE_YEAR = "1_year"
+    SEVEN_YEARS = "7_years"  # Standard for financial/legal
+
+
+class ComplianceConfig(CoReasonBaseModel):
+    """Configuration for the Coreason Auditor."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    audit_level: AuditLevel = Field(AuditLevel.BASIC, description="Depth of logging.")
+    retention: RetentionPolicy = Field(
+        RetentionPolicy.THIRTY_DAYS, description="Data retention requirement."
+    )
+
+    # Artifact Generation Flags
+    generate_aibom: bool = Field(
+        False, description="Generate an AI Bill of Materials (software supply chain)."
+    )
+    generate_pdf_report: bool = Field(
+        False, description="Generate a human-readable PDF report of the session."
+    )
+    require_signature: bool = Field(
+        False, description="Cryptographically sign the final output."
+    )
+
+    # PII/Sensitivity
+    mask_pii: bool = Field(
+        True, description="Attempt to scrub PII from logs before archiving."
+    )
+
+
 # ==========================================
 # 2. Node Definitions
 # ==========================================
@@ -524,6 +569,11 @@ class RecipeDefinition(CoReasonBaseModel):
     state: StateDefinition | None = Field(None, description="Internal state schema.")
     policy: PolicyConfig | None = Field(None, description="Execution limits and error handling.")
     # ----------------------
+
+    # --- New Field for Auditor Support ---
+    compliance: ComplianceConfig | None = Field(
+        None, description="Directives for the Auditor worker (logging, retention, signing)."
+    )
 
     topology: Annotated[GraphTopology, BeforeValidator(coerce_topology)] = Field(
         ..., description="The execution graph topology."

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -155,25 +155,15 @@ class ComplianceConfig(CoReasonBaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     audit_level: AuditLevel = Field(AuditLevel.BASIC, description="Depth of logging.")
-    retention: RetentionPolicy = Field(
-        RetentionPolicy.THIRTY_DAYS, description="Data retention requirement."
-    )
+    retention: RetentionPolicy = Field(RetentionPolicy.THIRTY_DAYS, description="Data retention requirement.")
 
     # Artifact Generation Flags
-    generate_aibom: bool = Field(
-        False, description="Generate an AI Bill of Materials (software supply chain)."
-    )
-    generate_pdf_report: bool = Field(
-        False, description="Generate a human-readable PDF report of the session."
-    )
-    require_signature: bool = Field(
-        False, description="Cryptographically sign the final output."
-    )
+    generate_aibom: bool = Field(False, description="Generate an AI Bill of Materials (software supply chain).")
+    generate_pdf_report: bool = Field(False, description="Generate a human-readable PDF report of the session.")
+    require_signature: bool = Field(False, description="Cryptographically sign the final output.")
 
     # PII/Sensitivity
-    mask_pii: bool = Field(
-        True, description="Attempt to scrub PII from logs before archiving."
-    )
+    mask_pii: bool = Field(True, description="Attempt to scrub PII from logs before archiving.")
 
 
 # ==========================================

--- a/tests/test_compliance_schema.py
+++ b/tests/test_compliance_schema.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    AuditLevel,
+    ComplianceConfig,
+    GraphTopology,
+    RecipeDefinition,
+    RecipeInterface,
+    RetentionPolicy,
+)
+
+
+def test_compliance_defaults() -> None:
+    """Test default values for ComplianceConfig."""
+    config = ComplianceConfig()
+
+    assert config.audit_level == AuditLevel.BASIC
+    assert config.retention == RetentionPolicy.THIRTY_DAYS
+    assert config.generate_aibom is False
+    assert config.generate_pdf_report is False
+    assert config.require_signature is False
+    assert config.mask_pii is True
+
+
+def test_compliance_custom_values() -> None:
+    """Test setting custom values for ComplianceConfig."""
+    config = ComplianceConfig(
+        audit_level=AuditLevel.GXP_COMPLIANT,
+        retention=RetentionPolicy.SEVEN_YEARS,
+        generate_aibom=True,
+        require_signature=True,
+        mask_pii=False,
+    )
+
+    assert config.audit_level == AuditLevel.GXP_COMPLIANT
+    assert config.retention == RetentionPolicy.SEVEN_YEARS
+    assert config.generate_aibom is True
+    assert config.require_signature is True
+    assert config.mask_pii is False
+
+
+def test_compliance_enums() -> None:
+    """Verify enum values match the spec."""
+    assert AuditLevel.NONE == "none"
+    assert AuditLevel.BASIC == "basic"
+    assert AuditLevel.FULL == "full"
+    assert AuditLevel.GXP_COMPLIANT == "gxp"
+
+    assert RetentionPolicy.EPHEMERAL == "ephemeral"
+    assert RetentionPolicy.THIRTY_DAYS == "30_days"
+    assert RetentionPolicy.ONE_YEAR == "1_year"
+    assert RetentionPolicy.SEVEN_YEARS == "7_years"
+
+
+def test_recipe_with_compliance() -> None:
+    """Test full recipe definition with compliance config."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Compliance Test"),
+        interface=RecipeInterface(),
+        compliance=ComplianceConfig(
+            audit_level=AuditLevel.FULL,
+            retention=RetentionPolicy.ONE_YEAR,
+        ),
+        topology=GraphTopology(
+            nodes=[AgentNode(id="A", agent_ref="ref-a")],
+            edges=[],
+            entry_point="A",
+        ),
+    )
+
+    assert recipe.compliance is not None
+    assert recipe.compliance.audit_level == AuditLevel.FULL
+    assert recipe.compliance.retention == RetentionPolicy.ONE_YEAR
+
+
+def test_recipe_without_compliance() -> None:
+    """Test recipe definition without compliance config (optional)."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="No Compliance Test"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=[AgentNode(id="A", agent_ref="ref-a")],
+            edges=[],
+            entry_point="A",
+        ),
+    )
+
+    assert recipe.compliance is None
+
+
+def test_compliance_roundtrip() -> None:
+    """Test JSON serialization/deserialization."""
+    original = ComplianceConfig(
+        audit_level=AuditLevel.GXP_COMPLIANT,
+        generate_pdf_report=True,
+    )
+
+    json_str = original.model_dump_json()
+    loaded = ComplianceConfig.model_validate_json(json_str)
+
+    assert loaded == original
+    assert loaded.audit_level == AuditLevel.GXP_COMPLIANT
+    assert loaded.generate_pdf_report is True

--- a/tests/test_compliance_schema.py
+++ b/tests/test_compliance_schema.py
@@ -54,15 +54,15 @@ def test_compliance_custom_values() -> None:
 
 def test_compliance_enums() -> None:
     """Verify enum values match the spec."""
-    assert AuditLevel.NONE == "none"
-    assert AuditLevel.BASIC == "basic"
-    assert AuditLevel.FULL == "full"
-    assert AuditLevel.GXP_COMPLIANT == "gxp"
+    assert AuditLevel.NONE.value == "none"
+    assert AuditLevel.BASIC.value == "basic"
+    assert AuditLevel.FULL.value == "full"
+    assert AuditLevel.GXP_COMPLIANT.value == "gxp"
 
-    assert RetentionPolicy.EPHEMERAL == "ephemeral"
-    assert RetentionPolicy.THIRTY_DAYS == "30_days"
-    assert RetentionPolicy.ONE_YEAR == "1_year"
-    assert RetentionPolicy.SEVEN_YEARS == "7_years"
+    assert RetentionPolicy.EPHEMERAL.value == "ephemeral"
+    assert RetentionPolicy.THIRTY_DAYS.value == "30_days"
+    assert RetentionPolicy.ONE_YEAR.value == "1_year"
+    assert RetentionPolicy.SEVEN_YEARS.value == "7_years"
 
 
 def test_recipe_with_compliance() -> None:
@@ -114,3 +114,99 @@ def test_compliance_roundtrip() -> None:
     assert loaded == original
     assert loaded.audit_level == AuditLevel.GXP_COMPLIANT
     assert loaded.generate_pdf_report is True
+
+
+def test_compliance_edge_cases_invalid_enum() -> None:
+    """Test validation failure for invalid enum values."""
+    with pytest.raises(ValidationError) as excinfo:
+        ComplianceConfig.model_validate({"audit_level": "INVALID_LEVEL"})
+
+    assert "Input should be 'none', 'basic', 'full' or 'gxp'" in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        ComplianceConfig.model_validate({"retention": "100_years"})
+
+    assert "Input should be 'ephemeral', '30_days', '1_year' or '7_years'" in str(excinfo.value)
+
+
+def test_compliance_edge_cases_type_mismatch() -> None:
+    """Test validation failure for type mismatch in boolean flags."""
+    # Pydantic attempts coercion, so passing a string "true" works.
+    # But passing a dict or list should fail.
+
+    with pytest.raises(ValidationError) as excinfo:
+        ComplianceConfig.model_validate({"generate_aibom": {"nested": "dict"}})
+
+    assert "Input should be a valid boolean" in str(excinfo.value)
+
+
+def test_complex_compliance_scenario() -> None:
+    """Test a complex scenario mimicking a GxP Clinical Trial workflow."""
+
+    # 1. Define strict compliance
+    clinical_compliance = ComplianceConfig(
+        audit_level=AuditLevel.GXP_COMPLIANT,
+        retention=RetentionPolicy.SEVEN_YEARS,
+        generate_aibom=True,
+        generate_pdf_report=True,
+        require_signature=True,
+        mask_pii=False # Explicitly keeping PII for clinical records
+    )
+
+    # 2. Define recipe with this compliance
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(
+            name="Clinical Trial Analysis",
+            description="Analyzes patient data for adverse events.",
+            version="1.0.0"
+        ),
+        interface=RecipeInterface(
+            inputs={"patient_id": {"type": "string"}},
+            outputs={"risk_score": {"type": "number"}}
+        ),
+        compliance=clinical_compliance,
+        topology=GraphTopology(
+            nodes=[
+                AgentNode(id="ingest", agent_ref="ingestion-bot"),
+                AgentNode(id="analyze", agent_ref="clinical-reasoner"),
+            ],
+            edges=[
+                {"source": "ingest", "target": "analyze"}
+            ],
+            entry_point="ingest"
+        )
+    )
+
+    # 3. Serialize
+    json_output = recipe.model_dump_json()
+
+    # 4. Deserialize
+    loaded_recipe = RecipeDefinition.model_validate_json(json_output)
+
+    # 5. Verify integrity
+    assert loaded_recipe.compliance is not None
+    assert loaded_recipe.compliance.audit_level == AuditLevel.GXP_COMPLIANT
+    assert loaded_recipe.compliance.mask_pii is False
+    assert loaded_recipe.compliance.generate_aibom is True
+    assert loaded_recipe.metadata.name == "Clinical Trial Analysis"
+
+
+def test_compliance_field_alias() -> None:
+    """Test that populate_by_name works (though we use snake_case)."""
+    # Just verifying that passing arguments by name works as expected in constructor
+    config = ComplianceConfig(audit_level=AuditLevel.NONE)
+    assert config.audit_level == AuditLevel.NONE
+
+    # Verify dict instantiation
+    config_from_dict = ComplianceConfig.model_validate({"audit_level": "none"})
+    assert config_from_dict.audit_level == AuditLevel.NONE
+
+
+def test_compliance_extra_forbid() -> None:
+    """Test that extra fields are forbidden."""
+    with pytest.raises(ValidationError) as excinfo:
+        ComplianceConfig(
+            audit_level=AuditLevel.BASIC,
+            extra_field="should_fail"
+        )
+    assert "Extra inputs are not permitted" in str(excinfo.value)

--- a/tests/test_compliance_schema.py
+++ b/tests/test_compliance_schema.py
@@ -150,7 +150,7 @@ def test_complex_compliance_scenario() -> None:
         generate_aibom=True,
         generate_pdf_report=True,
         require_signature=True,
-        mask_pii=False # Explicitly keeping PII for clinical records
+        mask_pii=False,  # Explicitly keeping PII for clinical records
     )
 
     # 2. Define recipe with this compliance
@@ -158,11 +158,10 @@ def test_complex_compliance_scenario() -> None:
         metadata=ManifestMetadata(
             name="Clinical Trial Analysis",
             description="Analyzes patient data for adverse events.",
-            version="1.0.0"
+            version="1.0.0",
         ),
         interface=RecipeInterface(
-            inputs={"patient_id": {"type": "string"}},
-            outputs={"risk_score": {"type": "number"}}
+            inputs={"patient_id": {"type": "string"}}, outputs={"risk_score": {"type": "number"}}
         ),
         compliance=clinical_compliance,
         topology=GraphTopology(
@@ -170,11 +169,9 @@ def test_complex_compliance_scenario() -> None:
                 AgentNode(id="ingest", agent_ref="ingestion-bot"),
                 AgentNode(id="analyze", agent_ref="clinical-reasoner"),
             ],
-            edges=[
-                {"source": "ingest", "target": "analyze"}
-            ],
-            entry_point="ingest"
-        )
+            edges=[{"source": "ingest", "target": "analyze"}],
+            entry_point="ingest",
+        ),
     )
 
     # 3. Serialize
@@ -207,6 +204,6 @@ def test_compliance_extra_forbid() -> None:
     with pytest.raises(ValidationError) as excinfo:
         ComplianceConfig(
             audit_level=AuditLevel.BASIC,
-            extra_field="should_fail"
+            extra_field="should_fail",  # type: ignore[call-arg]
         )
     assert "Extra inputs are not permitted" in str(excinfo.value)


### PR DESCRIPTION
Implemented `ComplianceConfig` schema in `src/coreason_manifest/spec/v2/recipe.py` as requested. This allows recipes to specify audit strictness and compliance requirements. Added comprehensive tests in `tests/test_compliance_schema.py` covering enums, default values, and serialization. Verified that existing tests pass.

---
*PR created automatically by Jules for task [647596872876551144](https://jules.google.com/task/647596872876551144) started by @gowthamrao*