### PR TITLE
Add Knowledge and Retrieval schemas for RAG support

### DIFF
--- a/docs/assembler_pattern.md
+++ b/docs/assembler_pattern.md
@@ -12,7 +12,7 @@ The `CognitiveProfile` consists of four key components:
 
 1.  **Identity (Who)**: The role or persona (e.g., `safety_scientist`).
 2.  **Mode (How)**: The reasoning style (e.g., `standard`, `six_hats`, `socratic`).
-3.  **Environment (Where)**: Dynamic context modules (`knowledge_contexts`) to inject.
+3.  **Environment (Where)**: Dynamic context modules (`knowledge_contexts`) and Long-Term Memory (`memory`) to inject.
 4.  **Task (What)**: The logic primitive to apply (`task_primitive`, e.g., `extract`, `classify`).
 
 ## Usage in `AgentNode`
@@ -26,6 +26,7 @@ from coreason_manifest.spec.v2.agent import (
     ContextDependency,
     ComponentPriority
 )
+from coreason_manifest.spec.v2.knowledge import RetrievalConfig, RetrievalStrategy
 
 # Define an inline agent
 profile = CognitiveProfile(
@@ -40,6 +41,14 @@ profile = CognitiveProfile(
             name="recent_articles",
             priority=ComponentPriority.LOW,
             parameters={"limit": 5}
+        )
+    ],
+    # Access long-term memory
+    memory=[
+        RetrievalConfig(
+            strategy=RetrievalStrategy.DENSE,
+            collection_name="past_editorials",
+            top_k=3
         )
     ],
     task_primitive="review_and_edit"

--- a/docs/knowledge_retrieval.md
+++ b/docs/knowledge_retrieval.md
@@ -1,0 +1,77 @@
+# Knowledge Retrieval & Long-Term Memory (RAG)
+
+The **Knowledge & Retrieval Schema** (`coreason_manifest.spec.v2.knowledge`) defines how an agent accesses long-term memory. It allows a `Recipe` to strictly configure Retrieval-Augmented Generation (RAG) capabilities, supporting vector search, keyword search, and knowledge graph traversal.
+
+## Core Concepts
+
+### 1. Retrieval Strategy
+
+The `RetrievalStrategy` defines the algorithm used to fetch relevant context from the archive.
+
+*   `DENSE` (`"dense"`): Vector similarity search (semantic match).
+*   `SPARSE` (`"sparse"`): Keyword/BM25 search (exact term match).
+*   `HYBRID` (`"hybrid"`): A combination of Dense and Sparse search, typically re-ranked using Reciprocal Rank Fusion (RRF). This is the default.
+*   `GRAPH` (`"graph"`): Knowledge Graph traversal (following semantic links).
+*   `GRAPH_RAG` (`"graph_rag"`): A hybrid approach combining vector search with graph exploration.
+
+### 2. Knowledge Scope
+
+The `KnowledgeScope` defines the boundary of memory access, ensuring data privacy and relevance.
+
+*   `SHARED` (`"shared"`): Global organization knowledge, accessible to all users.
+*   `USER` (`"user"`): User-specific private memory (e.g., personal documents).
+*   `SESSION` (`"session"`): Ephemeral context limited to the current conversation/session.
+
+### 3. Retrieval Configuration
+
+The `RetrievalConfig` model encapsulates the RAG parameters.
+
+| Field | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `strategy` | `RetrievalStrategy` | `HYBRID` | The search algorithm to use. |
+| `collection_name` | `str` | **Required** | The ID of the vector/graph collection to query. |
+| `top_k` | `int` | `5` | Number of chunks/nodes to retrieve (must be >= 1). |
+| `score_threshold` | `float` | `0.7` | Minimum similarity score (0.0 - 1.0) to consider a match. |
+| `scope` | `KnowledgeScope` | `SHARED` | Access control boundary. |
+
+## Integration with Cognitive Profile
+
+The `CognitiveProfile` (in `coreason_manifest.spec.v2.agent`) now includes a `memory` field, which is a list of `RetrievalConfig` objects. This allows an agent to query multiple knowledge sources simultaneously.
+
+### Example: Hybrid RAG Setup
+
+```python
+from coreason_manifest.spec.v2.agent import CognitiveProfile
+from coreason_manifest.spec.v2.knowledge import (
+    RetrievalConfig,
+    RetrievalStrategy,
+    KnowledgeScope
+)
+
+# Define an agent with access to legal precedents and user notes
+legal_expert = CognitiveProfile(
+    role="legal_analyst",
+    memory=[
+        # 1. Access Shared Legal Precedents (Vector Search)
+        RetrievalConfig(
+            strategy=RetrievalStrategy.DENSE,
+            collection_name="supreme_court_cases",
+            top_k=3,
+            score_threshold=0.85,
+            scope=KnowledgeScope.SHARED
+        ),
+        # 2. Access Private Case Notes (Keyword Search)
+        RetrievalConfig(
+            strategy=RetrievalStrategy.SPARSE,
+            collection_name="case_notes",
+            top_k=5,
+            scope=KnowledgeScope.USER
+        )
+    ]
+)
+```
+
+This configuration tells the runtime to:
+1.  Perform a vector search on the "supreme_court_cases" collection.
+2.  Perform a keyword search on the user's "case_notes".
+3.  Combine and inject the retrieved context into the agent's prompt.

--- a/src/coreason_manifest/spec/v2/agent.py
+++ b/src/coreason_manifest/spec/v2/agent.py
@@ -14,6 +14,7 @@ from typing import Any
 from pydantic import ConfigDict, Field
 
 from coreason_manifest.spec.common_base import CoReasonBaseModel
+from coreason_manifest.spec.v2.knowledge import RetrievalConfig
 
 
 class ComponentPriority(IntEnum):
@@ -49,6 +50,12 @@ class CognitiveProfile(CoReasonBaseModel):
     # 3. Environment (Where)
     knowledge_contexts: list[ContextDependency] = Field(
         default_factory=list, description="Dynamic context modules to inject."
+    )
+
+    # --- New Field for Archive Support ---
+    memory: list[RetrievalConfig] = Field(
+        default_factory=list,
+        description="Configuration for Long-Term Memory (RAG) access.",
     )
 
     # 4. Task (What) - Maps to StructuredPrimitive

--- a/src/coreason_manifest/spec/v2/knowledge.py
+++ b/src/coreason_manifest/spec/v2/knowledge.py
@@ -1,0 +1,53 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import StrEnum
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.spec.common_base import CoReasonBaseModel
+
+
+class RetrievalStrategy(StrEnum):
+    """The algorithm used to fetch relevant context."""
+
+    DENSE = "dense"  # Vector similarity search
+    SPARSE = "sparse"  # Keyword/BM25 search
+    HYBRID = "hybrid"  # Combination of Dense + Sparse with RRF
+    GRAPH = "graph"  # Knowledge Graph traversal
+    GRAPH_RAG = "graph_rag"  # Hybrid Vector + Graph
+
+
+class KnowledgeScope(StrEnum):
+    """The boundary of the memory access."""
+
+    SHARED = "shared"  # Global organization knowledge
+    USER = "user"  # User-specific private memory
+    SESSION = "session"  # Ephemeral conversation context
+
+
+class RetrievalConfig(CoReasonBaseModel):
+    """Configuration for the RAG engine."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    strategy: RetrievalStrategy = Field(
+        RetrievalStrategy.HYBRID, description="Search algorithm."
+    )
+    collection_name: str = Field(
+        ..., description="The ID of the vector/graph collection to query."
+    )
+    top_k: int = Field(5, ge=1, description="Number of chunks to retrieve.")
+    score_threshold: float | None = Field(
+        0.7, ge=0.0, le=1.0, description="Minimum similarity score."
+    )
+    scope: KnowledgeScope = Field(
+        KnowledgeScope.SHARED, description="Access control scope."
+    )

--- a/src/coreason_manifest/spec/v2/knowledge.py
+++ b/src/coreason_manifest/spec/v2/knowledge.py
@@ -38,16 +38,8 @@ class RetrievalConfig(CoReasonBaseModel):
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
-    strategy: RetrievalStrategy = Field(
-        RetrievalStrategy.HYBRID, description="Search algorithm."
-    )
-    collection_name: str = Field(
-        ..., description="The ID of the vector/graph collection to query."
-    )
+    strategy: RetrievalStrategy = Field(RetrievalStrategy.HYBRID, description="Search algorithm.")
+    collection_name: str = Field(..., description="The ID of the vector/graph collection to query.")
     top_k: int = Field(5, ge=1, description="Number of chunks to retrieve.")
-    score_threshold: float | None = Field(
-        0.7, ge=0.0, le=1.0, description="Minimum similarity score."
-    )
-    scope: KnowledgeScope = Field(
-        KnowledgeScope.SHARED, description="Access control scope."
-    )
+    score_threshold: float | None = Field(0.7, ge=0.0, le=1.0, description="Minimum similarity score.")
+    scope: KnowledgeScope = Field(KnowledgeScope.SHARED, description="Access control scope.")

--- a/tests/test_v2_knowledge.py
+++ b/tests/test_v2_knowledge.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.agent import CognitiveProfile
+from coreason_manifest.spec.v2.knowledge import (
+    KnowledgeScope,
+    RetrievalConfig,
+    RetrievalStrategy,
+)
+
+
+def test_retrieval_strategy_enum() -> None:
+    """Ensure RetrievalStrategy values are correct."""
+    assert RetrievalStrategy.DENSE == "dense"
+    assert RetrievalStrategy.SPARSE == "sparse"
+    assert RetrievalStrategy.HYBRID == "hybrid"
+    assert RetrievalStrategy.GRAPH == "graph"
+    assert RetrievalStrategy.GRAPH_RAG == "graph_rag"
+
+
+def test_knowledge_scope_enum() -> None:
+    """Ensure KnowledgeScope values are correct."""
+    assert KnowledgeScope.SHARED == "shared"
+    assert KnowledgeScope.USER == "user"
+    assert KnowledgeScope.SESSION == "session"
+
+
+def test_retrieval_config_defaults() -> None:
+    """Test defaults for RetrievalConfig."""
+    config = RetrievalConfig(collection_name="test_collection")
+    assert config.strategy == RetrievalStrategy.HYBRID
+    assert config.top_k == 5
+    assert config.score_threshold == 0.7
+    assert config.scope == KnowledgeScope.SHARED
+    assert config.collection_name == "test_collection"
+
+
+def test_retrieval_config_custom() -> None:
+    """Test custom values for RetrievalConfig."""
+    config = RetrievalConfig(
+        strategy=RetrievalStrategy.GRAPH,
+        collection_name="legal_docs",
+        top_k=10,
+        score_threshold=0.5,
+        scope=KnowledgeScope.USER,
+    )
+    assert config.strategy == RetrievalStrategy.GRAPH
+    assert config.collection_name == "legal_docs"
+    assert config.top_k == 10
+    assert config.score_threshold == 0.5
+    assert config.scope == KnowledgeScope.USER
+
+
+def test_retrieval_config_validation() -> None:
+    """Test validation constraints."""
+    # Test top_k < 1
+    with pytest.raises(ValidationError) as exc:
+        RetrievalConfig(collection_name="test", top_k=0)
+    assert "Input should be greater than or equal to 1" in str(exc.value)
+
+    # Test score_threshold < 0
+    with pytest.raises(ValidationError) as exc:
+        RetrievalConfig(collection_name="test", score_threshold=-0.1)
+    assert "Input should be greater than or equal to 0" in str(exc.value)
+
+    # Test score_threshold > 1
+    with pytest.raises(ValidationError) as exc:
+        RetrievalConfig(collection_name="test", score_threshold=1.1)
+    assert "Input should be less than or equal to 1" in str(exc.value)
+
+
+def test_cognitive_profile_with_memory() -> None:
+    """Test integration of RetrievalConfig into CognitiveProfile."""
+    memory_config = RetrievalConfig(
+        strategy=RetrievalStrategy.DENSE, collection_name="history"
+    )
+    profile = CognitiveProfile(
+        role="archivist",
+        memory=[memory_config],
+    )
+    assert len(profile.memory) == 1
+    assert profile.memory[0].collection_name == "history"
+    assert profile.memory[0].strategy == RetrievalStrategy.DENSE
+
+
+def test_serialization() -> None:
+    """Test serialization of RetrievalConfig."""
+    config = RetrievalConfig(collection_name="test", top_k=3)
+    dumped = config.dump()
+    assert dumped["collection_name"] == "test"
+    assert dumped["top_k"] == 3
+    assert dumped["strategy"] == "hybrid"  # Default


### PR DESCRIPTION
Implemented `RetrievalConfig`, `RetrievalStrategy`, and `KnowledgeScope` in `src/coreason_manifest/spec/v2/knowledge.py`. Updated `CognitiveProfile` in `src/coreason_manifest/spec/v2/agent.py` to include a `memory` field for RAG configuration. Added comprehensive tests in `tests/test_v2_knowledge.py` covering enums, validation, and integration.

---
*PR created automatically by Jules for task [6583058423014319170](https://jules.google.com/task/6583058423014319170) started by @gowthamrao*