### PR TITLE
Add QoS parameters to PolicyConfig for AI Gateway

### DIFF
--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -133,9 +133,7 @@ class PolicyConfig(CoReasonBaseModel):
         None, ge=0, description="Max requests per minute allowed for this recipe execution."
     )
 
-    rate_limit_tpm: int | None = Field(
-        None, ge=0, description="Max tokens per minute allowed (input + output)."
-    )
+    rate_limit_tpm: int | None = Field(None, ge=0, description="Max tokens per minute allowed (input + output).")
 
     caching_enabled: bool = Field(
         True,

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import logging
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import Annotated, Any, Literal
 
 from pydantic import BeforeValidator, ConfigDict, Field, model_validator
@@ -104,6 +104,16 @@ class StateDefinition(CoReasonBaseModel):
     )
 
 
+class ExecutionPriority(IntEnum):
+    """Traffic priority for the AI Gateway (Load Shedding)."""
+
+    CRITICAL = 10  # Real-time user interaction (CEO bot)
+    HIGH = 8  # Standard synchronous flows
+    NORMAL = 5  # Default
+    LOW = 2  # Background tasks / Bulk processing
+    BATCH = 1  # Overnight jobs
+
+
 class PolicyConfig(CoReasonBaseModel):
     """Governance rules for execution limits (harvested from Connect)."""
 
@@ -112,6 +122,25 @@ class PolicyConfig(CoReasonBaseModel):
     max_retries: int = Field(0, description="Global retry limit for failed steps.")
     timeout_seconds: int | None = Field(None, description="Global execution timeout.")
     execution_mode: Literal["sequential", "parallel"] = Field("sequential", description="Default execution strategy.")
+
+    # --- New QoS Fields for AI Gateway ---
+    priority: ExecutionPriority = Field(
+        ExecutionPriority.NORMAL,
+        description="Traffic priority. Low priority requests may be queued or dropped during high load.",
+    )
+
+    rate_limit_rpm: int | None = Field(
+        None, ge=0, description="Max requests per minute allowed for this recipe execution."
+    )
+
+    rate_limit_tpm: int | None = Field(
+        None, ge=0, description="Max tokens per minute allowed (input + output)."
+    )
+
+    caching_enabled: bool = Field(
+        True,
+        description="Allow the Gateway to serve cached responses for identical inputs (Semantic Caching).",
+    )
 
     # --- New Harvesting Fields ---
     budget_cap_usd: float | None = Field(

--- a/tests/test_v2_gateway_qos.py
+++ b/tests/test_v2_gateway_qos.py
@@ -1,0 +1,83 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.recipe import ExecutionPriority, PolicyConfig, RecipeDefinition
+
+
+def test_policy_config_instantiation() -> None:
+    """Test instantiating PolicyConfig with new QoS fields."""
+    policy = PolicyConfig(
+        priority=ExecutionPriority.BATCH,
+        rate_limit_rpm=60,
+        rate_limit_tpm=1000,
+        caching_enabled=False
+    )
+
+    assert policy.priority == ExecutionPriority.BATCH
+    assert policy.rate_limit_rpm == 60
+    assert policy.rate_limit_tpm == 1000
+    assert policy.caching_enabled is False
+
+def test_policy_config_defaults() -> None:
+    """Test default values for PolicyConfig."""
+    policy = PolicyConfig()
+
+    assert policy.priority == ExecutionPriority.NORMAL
+    assert policy.rate_limit_rpm is None
+    assert policy.rate_limit_tpm is None
+    assert policy.caching_enabled is True
+
+def test_rate_limit_validation() -> None:
+    """Test validation for rate limits (must be non-negative)."""
+    # Should accept None
+    policy = PolicyConfig(rate_limit_rpm=None)
+    assert policy.rate_limit_rpm is None
+
+    # Should accept 0
+    policy = PolicyConfig(rate_limit_rpm=0)
+    assert policy.rate_limit_rpm == 0
+
+    # Should reject negative numbers
+    with pytest.raises(ValidationError) as excinfo:
+        PolicyConfig(rate_limit_rpm=-1)
+
+    assert "Input should be greater than or equal to 0" in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo:
+        PolicyConfig(rate_limit_tpm=-500)
+
+    assert "Input should be greater than or equal to 0" in str(excinfo.value)
+
+def test_integration_recipe_definition() -> None:
+    """Test integrating PolicyConfig with RecipeDefinition."""
+    from coreason_manifest.spec.v2.definitions import ManifestMetadata
+    from coreason_manifest.spec.v2.recipe import RecipeInterface, GraphTopology, AgentNode
+
+    policy = PolicyConfig(
+        priority=ExecutionPriority.CRITICAL,
+        rate_limit_rpm=100
+    )
+
+    # Minimal valid recipe setup
+    agent = AgentNode(id="agent1", agent_ref="my-agent")
+    topology = GraphTopology(
+        nodes=[agent],
+        edges=[],
+        entry_point="agent1"
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="test-recipe"),
+        interface=RecipeInterface(),
+        topology=topology,
+        policy=policy
+    )
+
+    assert recipe.policy is not None
+    assert recipe.policy.priority == ExecutionPriority.CRITICAL
+    assert recipe.policy.rate_limit_rpm == 100
+
+    # Check serialization
+    dump = recipe.model_dump()
+    assert dump["policy"]["priority"] == ExecutionPriority.CRITICAL
+    assert dump["policy"]["rate_limit_rpm"] == 100

--- a/tests/test_v2_gateway_qos.py
+++ b/tests/test_v2_gateway_qos.py
@@ -7,16 +7,14 @@ from coreason_manifest.spec.v2.recipe import ExecutionPriority, PolicyConfig, Re
 def test_policy_config_instantiation() -> None:
     """Test instantiating PolicyConfig with new QoS fields."""
     policy = PolicyConfig(
-        priority=ExecutionPriority.BATCH,
-        rate_limit_rpm=60,
-        rate_limit_tpm=1000,
-        caching_enabled=False
+        priority=ExecutionPriority.BATCH, rate_limit_rpm=60, rate_limit_tpm=1000, caching_enabled=False
     )
 
     assert policy.priority == ExecutionPriority.BATCH
     assert policy.rate_limit_rpm == 60
     assert policy.rate_limit_tpm == 1000
     assert policy.caching_enabled is False
+
 
 def test_policy_config_defaults() -> None:
     """Test default values for PolicyConfig."""
@@ -26,6 +24,7 @@ def test_policy_config_defaults() -> None:
     assert policy.rate_limit_rpm is None
     assert policy.rate_limit_tpm is None
     assert policy.caching_enabled is True
+
 
 def test_rate_limit_validation() -> None:
     """Test validation for rate limits (must be non-negative)."""
@@ -48,29 +47,20 @@ def test_rate_limit_validation() -> None:
 
     assert "Input should be greater than or equal to 0" in str(excinfo.value)
 
+
 def test_integration_recipe_definition() -> None:
     """Test integrating PolicyConfig with RecipeDefinition."""
     from coreason_manifest.spec.v2.definitions import ManifestMetadata
-    from coreason_manifest.spec.v2.recipe import RecipeInterface, GraphTopology, AgentNode
+    from coreason_manifest.spec.v2.recipe import AgentNode, GraphTopology, RecipeInterface
 
-    policy = PolicyConfig(
-        priority=ExecutionPriority.CRITICAL,
-        rate_limit_rpm=100
-    )
+    policy = PolicyConfig(priority=ExecutionPriority.CRITICAL, rate_limit_rpm=100)
 
     # Minimal valid recipe setup
     agent = AgentNode(id="agent1", agent_ref="my-agent")
-    topology = GraphTopology(
-        nodes=[agent],
-        edges=[],
-        entry_point="agent1"
-    )
+    topology = GraphTopology(nodes=[agent], edges=[], entry_point="agent1")
 
     recipe = RecipeDefinition(
-        metadata=ManifestMetadata(name="test-recipe"),
-        interface=RecipeInterface(),
-        topology=topology,
-        policy=policy
+        metadata=ManifestMetadata(name="test-recipe"), interface=RecipeInterface(), topology=topology, policy=policy
     )
 
     assert recipe.policy is not None


### PR DESCRIPTION
This PR updates the `PolicyConfig` schema to support Quality of Service (QoS) parameters required by the AI Gateway. It introduces an `ExecutionPriority` enum and adds fields for priority, rate limiting (RPM/TPM), and caching control. It also includes comprehensive tests for the new functionality.

---
*PR created automatically by Jules for task [2468185674051472086](https://jules.google.com/task/2468185674051472086) started by @gowthamrao*