### PR TITLE
Add Flow Governance to RecipeNode

### DIFF
--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -277,9 +277,7 @@ class RecoveryConfig(CoReasonBaseModel):
     max_retries: int | None = Field(None, description="Override global retry limit.")
     retry_delay_seconds: float = Field(1.0, description="Backoff start.")
 
-    behavior: FailureBehavior = Field(
-        FailureBehavior.FAIL_WORKFLOW, description="Strategy on final failure."
-    )
+    behavior: FailureBehavior = Field(FailureBehavior.FAIL_WORKFLOW, description="Strategy on final failure.")
 
     fallback_node_id: str | None = Field(
         None,

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -260,6 +260,37 @@ class CollaborationConfig(CoReasonBaseModel):
     )
 
 
+class FailureBehavior(StrEnum):
+    """Action to take when a node fails after retries are exhausted."""
+
+    FAIL_WORKFLOW = "fail_workflow"  # Default: Stop everything
+    CONTINUE_WITH_DEFAULT = "continue_with_default"  # Use 'default_output'
+    ROUTE_TO_FALLBACK = "route_to_fallback"  # Jump to specific node
+    IGNORE = "ignore"  # Return None and proceed
+
+
+class RecoveryConfig(CoReasonBaseModel):
+    """Configuration for node-level resilience (harvested from Maco)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
+
+    max_retries: int | None = Field(None, description="Override global retry limit.")
+    retry_delay_seconds: float = Field(1.0, description="Backoff start.")
+
+    behavior: FailureBehavior = Field(
+        FailureBehavior.FAIL_WORKFLOW, description="Strategy on final failure."
+    )
+
+    fallback_node_id: str | None = Field(
+        None,
+        description="The ID of the node to transition to if behavior is ROUTE_TO_FALLBACK.",
+    )
+    default_output: dict[str, Any] | None = Field(
+        None,
+        description="Static payload to return if behavior is CONTINUE_WITH_DEFAULT.",
+    )
+
+
 class RecipeNode(CoReasonBaseModel):
     """Base class for all nodes in a Recipe graph."""
 
@@ -268,6 +299,13 @@ class RecipeNode(CoReasonBaseModel):
     id: str = Field(..., description="Unique identifier within the graph.")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Custom metadata (not for UI layout).")
     presentation: NodePresentation | None = Field(None, description="Static visual layout (x, y, color).")
+
+    # --- New Field: Flow Governance ---
+    recovery: RecoveryConfig | None = Field(
+        None,
+        description="Error handling and resilience settings.",
+    )
+
     interaction: InteractionConfig | None = Field(None, description="Interactive control plane configuration.")
     visualization: PresentationHints | None = Field(None, description="Dynamic rendering hints (Glass Box).")
     collaboration: CollaborationConfig | None = Field(None, description="Human engagement rules (Co-Pilot).")

--- a/tests/test_v2_flow_governance.py
+++ b/tests/test_v2_flow_governance.py
@@ -1,4 +1,3 @@
-import pytest
 from coreason_manifest.spec.v2.recipe import (
     AgentNode,
     FailureBehavior,

--- a/tests/test_v2_flow_governance.py
+++ b/tests/test_v2_flow_governance.py
@@ -1,0 +1,63 @@
+import pytest
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    FailureBehavior,
+    RecoveryConfig,
+)
+
+
+def test_fallback_configuration() -> None:
+    """Test creating a node with ROUTE_TO_FALLBACK behavior."""
+    node = AgentNode(
+        id="agent-fail",
+        agent_ref="agent-a",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="fallback-agent",
+            max_retries=3,
+        ),
+    )
+
+    assert node.recovery is not None
+    assert node.recovery.behavior == FailureBehavior.ROUTE_TO_FALLBACK
+    assert node.recovery.fallback_node_id == "fallback-agent"
+    assert node.recovery.max_retries == 3
+
+
+def test_default_value_configuration() -> None:
+    """Test creating a node with CONTINUE_WITH_DEFAULT behavior."""
+    default_payload = {"status": "skipped", "reason": "timeout"}
+    node = AgentNode(
+        id="agent-skip",
+        agent_ref="agent-b",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.CONTINUE_WITH_DEFAULT,
+            default_output=default_payload,
+        ),
+    )
+
+    assert node.recovery is not None
+    assert node.recovery.behavior == FailureBehavior.CONTINUE_WITH_DEFAULT
+    assert node.recovery.default_output == default_payload
+
+
+def test_serialization() -> None:
+    """Verify that recovery fields persist correctly in the Recipe JSON."""
+    node = AgentNode(
+        id="agent-persist",
+        agent_ref="agent-c",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.IGNORE,
+            retry_delay_seconds=5.0,
+        ),
+    )
+
+    # Serialize
+    json_str = node.model_dump_json()
+
+    # Deserialize
+    restored_node = AgentNode.model_validate_json(json_str)
+
+    assert restored_node.recovery is not None
+    assert restored_node.recovery.behavior == FailureBehavior.IGNORE
+    assert restored_node.recovery.retry_delay_seconds == 5.0

--- a/tests/test_v2_governance_text_injection.py
+++ b/tests/test_v2_governance_text_injection.py
@@ -109,11 +109,7 @@ def test_complex_case_inheritance_simulation() -> None:
 
     Scenario: A parent policy exists, and a child recipe wants to override only the disclaimer.
     """
-    parent_policy = PolicyConfig(
-        safety_preamble="Parent Safety",
-        legal_disclaimer="Parent Disclaimer",
-        max_retries=3
-    )
+    parent_policy = PolicyConfig(safety_preamble="Parent Safety", legal_disclaimer="Parent Disclaimer", max_retries=3)
 
     # Child overrides disclaimer but keeps safety
     child_overrides = {"legal_disclaimer": "Child Disclaimer"}


### PR DESCRIPTION
Implemented Flow Governance features for `RecipeNode` by adding `RecoveryConfig` and `FailureBehavior`. This allows defining resilience patterns like retries, fallbacks, and default values for node failures. Added comprehensive tests to verify the new functionality.

---
*PR created automatically by Jules for task [11339424003544011333](https://jules.google.com/task/11339424003544011333) started by @gowthamrao*