### PR TITLE
feat: Add QoS parameters to PolicyConfig

### DIFF
--- a/docs/gateway_qos.md
+++ b/docs/gateway_qos.md
@@ -1,0 +1,57 @@
+# Traffic Governance & Quality of Service (QoS)
+
+Coreason V2 introduces **Traffic Governance** at the manifest level, allowing Recipes to declare their importance, resource needs, and behavior under load. These settings are consumed by the **CoReason AI Gateway** to enforce rate limits, prioritize critical traffic, and optimize costs.
+
+## Concepts
+
+### 1. Execution Priority (Load Shedding)
+
+The `ExecutionPriority` enum defines the relative importance of a Recipe's execution request. During periods of high congestion, the Gateway may delay or drop lower-priority requests to preserve capacity for critical workloads.
+
+| Level | Value | Description | Use Case |
+| :--- | :--- | :--- | :--- |
+| **CRITICAL** | 10 | Real-time, user-facing, strictly synchronous. | CEO Chatbot, Customer Support Live Agent. |
+| **HIGH** | 8 | Important but slightly tolerant of latency. | Internal Tools, Standard User Requests. |
+| **NORMAL** | 5 | Default. Standard priority. | Most background workflows. |
+| **LOW** | 2 | Latency-tolerant, can be queued. | Bulk data processing, Analysis jobs. |
+| **BATCH** | 1 | Lowest priority, overnight processing. | Daily summaries, archival tasks. |
+
+### 2. Rate Limiting
+
+Recipes can self-impose limits to prevent abuse or control costs.
+
+*   **`rate_limit_rpm` (Requests Per Minute)**: Hard cap on the number of executions started per minute.
+*   **`rate_limit_tpm` (Tokens Per Minute)**: Hard cap on the estimated token consumption (input + output).
+
+### 3. Semantic Caching
+
+*   **`caching_enabled`**: If `True` (default), the Gateway is permitted to serve a cached response for identical inputs. This saves cost and latency but may be undesirable for non-deterministic or strictly fresh data requirements.
+
+## Configuration
+
+These settings are defined in the `policy` field of the `RecipeDefinition`.
+
+```python
+from coreason_manifest.spec.v2.recipe import RecipeDefinition, PolicyConfig, ExecutionPriority
+
+recipe = RecipeDefinition(
+    # ...
+    policy=PolicyConfig(
+        priority=ExecutionPriority.BATCH, # Run overnight
+        rate_limit_rpm=100,               # Don't flood the system
+        caching_enabled=True              # Reuse results if possible
+    )
+)
+```
+
+## Gateway Behavior
+
+1.  **Admission Control**: When a request arrives, the Gateway checks the `rate_limit_rpm`. If exceeded, it returns `429 Too Many Requests`.
+2.  **Prioritization**: If the system is under heavy load (e.g., GPU saturation), the Gateway prioritizes requests with higher `priority` values. `BATCH` requests may be paused or queued until load subsides.
+3.  **Caching**: If `caching_enabled` is True, the Gateway checks its semantic cache (e.g., Redis/Vector DB) for a matching query vector. If found, it returns the cached result immediately.
+
+## Best Practices
+
+*   Use `CRITICAL` sparingly. Overuse dilutes its effectiveness.
+*   Set `rate_limit_rpm` for all public-facing or untrusted recipes.
+*   Disable `caching_enabled` only if the recipe relies on real-time external data (e.g., "What is the current stock price?").

--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -104,14 +104,24 @@ state=StateDefinition(
 ```
 
 ### 4. The Policy Layer (`PolicyConfig`)
-Sets execution limits and error handling strategies, including **MCP Governance**.
+Sets execution limits and error handling strategies, including **MCP Governance** and **Traffic Prioritization**.
 
 ```python
+from coreason_manifest.spec.v2.recipe import PolicyConfig, ExecutionPriority
+
 policy=PolicyConfig(
+    # --- Traffic Governance (QoS) ---
+    priority=ExecutionPriority.CRITICAL, # 10 (High), 5 (Normal), 2 (Low), 1 (Batch)
+    rate_limit_rpm=60,      # Max 60 requests per minute
+    rate_limit_tpm=10000,   # Max 10k tokens per minute
+    caching_enabled=True,   # Semantic Caching allowed
+
+    # --- Execution Limits ---
     max_retries=3,
     timeout_seconds=3600,
     execution_mode="sequential", # or "parallel"
-    # New Harvesting Fields
+
+    # --- Financial & Safety ---
     budget_cap_usd=50.0,
     sensitive_tools=["buy_stock", "delete_db"],
     allowed_mcp_servers=["github", "brave-search"],

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -134,9 +134,7 @@ class PolicyConfig(CoReasonBaseModel):
         None, ge=0, description="Max requests per minute allowed for this recipe execution."
     )
 
-    rate_limit_tpm: int | None = Field(
-        None, ge=0, description="Max tokens per minute allowed (input + output)."
-    )
+    rate_limit_tpm: int | None = Field(None, ge=0, description="Max tokens per minute allowed (input + output).")
 
     caching_enabled: bool = Field(
         True,

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import logging
-from enum import StrEnum
+from enum import IntEnum, StrEnum
 from typing import Annotated, Any, Literal
 
 from pydantic import BeforeValidator, ConfigDict, Field, model_validator
@@ -105,6 +105,16 @@ class StateDefinition(CoReasonBaseModel):
     )
 
 
+class ExecutionPriority(IntEnum):
+    """Traffic priority for the AI Gateway (Load Shedding)."""
+
+    CRITICAL = 10  # Real-time user interaction (CEO bot)
+    HIGH = 8  # Standard synchronous flows
+    NORMAL = 5  # Default
+    LOW = 2  # Background tasks / Bulk processing
+    BATCH = 1  # Overnight jobs
+
+
 class PolicyConfig(CoReasonBaseModel):
     """Governance rules for execution limits (harvested from Connect)."""
 
@@ -113,6 +123,25 @@ class PolicyConfig(CoReasonBaseModel):
     max_retries: int = Field(0, description="Global retry limit for failed steps.")
     timeout_seconds: int | None = Field(None, description="Global execution timeout.")
     execution_mode: Literal["sequential", "parallel"] = Field("sequential", description="Default execution strategy.")
+
+    # --- New QoS Fields for AI Gateway ---
+    priority: ExecutionPriority = Field(
+        ExecutionPriority.NORMAL,
+        description="Traffic priority. Low priority requests may be queued or dropped during high load.",
+    )
+
+    rate_limit_rpm: int | None = Field(
+        None, ge=0, description="Max requests per minute allowed for this recipe execution."
+    )
+
+    rate_limit_tpm: int | None = Field(
+        None, ge=0, description="Max tokens per minute allowed (input + output)."
+    )
+
+    caching_enabled: bool = Field(
+        True,
+        description="Allow the Gateway to serve cached responses for identical inputs (Semantic Caching).",
+    )
 
     # --- New Harvesting Fields ---
     budget_cap_usd: float | None = Field(

--- a/tests/test_v2_gateway_qos.py
+++ b/tests/test_v2_gateway_qos.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    ExecutionPriority,
+    GraphTopology,
+    PolicyConfig,
+    RecipeDefinition,
+    RecipeInterface,
+)
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+
+
+def test_policy_config_instantiation():
+    """Test standard instantiation of PolicyConfig."""
+    policy = PolicyConfig(
+        priority=ExecutionPriority.BATCH,
+        rate_limit_rpm=60,
+        rate_limit_tpm=1000,
+        caching_enabled=False,
+    )
+
+    assert policy.priority == ExecutionPriority.BATCH
+    assert policy.rate_limit_rpm == 60
+    assert policy.rate_limit_tpm == 1000
+    assert policy.caching_enabled is False
+
+
+def test_policy_config_defaults():
+    """Test default values of PolicyConfig."""
+    policy = PolicyConfig()
+
+    assert policy.priority == ExecutionPriority.NORMAL
+    assert policy.rate_limit_rpm is None
+    assert policy.rate_limit_tpm is None
+    assert policy.caching_enabled is True
+
+
+def test_policy_config_validation_negative_rpm():
+    """Test that rate_limit_rpm rejects negative numbers."""
+    with pytest.raises(ValidationError) as excinfo:
+        PolicyConfig(rate_limit_rpm=-1)
+
+    assert "Input should be greater than or equal to 0" in str(excinfo.value)
+
+
+def test_policy_config_validation_negative_tpm():
+    """Test that rate_limit_tpm rejects negative numbers."""
+    with pytest.raises(ValidationError) as excinfo:
+        PolicyConfig(rate_limit_tpm=-100)
+
+    assert "Input should be greater than or equal to 0" in str(excinfo.value)
+
+
+def test_recipe_definition_with_qos_policy():
+    """Test integration of QoS-enhanced PolicyConfig within a RecipeDefinition."""
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(
+            name="QoS Test Recipe",
+        ),
+        interface=RecipeInterface(),
+        policy=PolicyConfig(
+            priority=ExecutionPriority.CRITICAL,
+            rate_limit_rpm=120,
+        ),
+        topology=GraphTopology(
+            nodes=[
+                AgentNode(id="start", agent_ref="agent-1"),
+            ],
+            edges=[],
+            entry_point="start",
+        ),
+    )
+
+    # Dump to dict and verify
+    dumped = recipe.model_dump()
+    assert dumped["policy"]["priority"] == 10  # CRITICAL is 10
+    assert dumped["policy"]["rate_limit_rpm"] == 120
+    assert dumped["policy"]["caching_enabled"] is True  # Default
+
+    # Round-trip JSON
+    json_str = recipe.model_dump_json()
+    loaded = RecipeDefinition.model_validate_json(json_str)
+
+    assert loaded.policy is not None
+    assert loaded.policy.priority == ExecutionPriority.CRITICAL
+    assert loaded.policy.rate_limit_rpm == 120

--- a/tests/test_v2_gateway_qos.py
+++ b/tests/test_v2_gateway_qos.py
@@ -3,6 +3,7 @@
 import pytest
 from pydantic import ValidationError
 
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
 from coreason_manifest.spec.v2.recipe import (
     AgentNode,
     ExecutionPriority,
@@ -11,10 +12,9 @@ from coreason_manifest.spec.v2.recipe import (
     RecipeDefinition,
     RecipeInterface,
 )
-from coreason_manifest.spec.v2.definitions import ManifestMetadata
 
 
-def test_policy_config_instantiation():
+def test_policy_config_instantiation() -> None:
     """Test standard instantiation of PolicyConfig."""
     policy = PolicyConfig(
         priority=ExecutionPriority.BATCH,
@@ -29,7 +29,7 @@ def test_policy_config_instantiation():
     assert policy.caching_enabled is False
 
 
-def test_policy_config_defaults():
+def test_policy_config_defaults() -> None:
     """Test default values of PolicyConfig."""
     policy = PolicyConfig()
 
@@ -39,7 +39,7 @@ def test_policy_config_defaults():
     assert policy.caching_enabled is True
 
 
-def test_policy_config_validation_negative_rpm():
+def test_policy_config_validation_negative_rpm() -> None:
     """Test that rate_limit_rpm rejects negative numbers."""
     with pytest.raises(ValidationError) as excinfo:
         PolicyConfig(rate_limit_rpm=-1)
@@ -47,7 +47,7 @@ def test_policy_config_validation_negative_rpm():
     assert "Input should be greater than or equal to 0" in str(excinfo.value)
 
 
-def test_policy_config_validation_negative_tpm():
+def test_policy_config_validation_negative_tpm() -> None:
     """Test that rate_limit_tpm rejects negative numbers."""
     with pytest.raises(ValidationError) as excinfo:
         PolicyConfig(rate_limit_tpm=-100)
@@ -55,7 +55,7 @@ def test_policy_config_validation_negative_tpm():
     assert "Input should be greater than or equal to 0" in str(excinfo.value)
 
 
-def test_recipe_definition_with_qos_policy():
+def test_recipe_definition_with_qos_policy() -> None:
     """Test integration of QoS-enhanced PolicyConfig within a RecipeDefinition."""
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(

--- a/tests/test_v2_gateway_qos_extended.py
+++ b/tests/test_v2_gateway_qos_extended.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    ExecutionPriority,
+    GraphTopology,
+    PolicyConfig,
+    RecipeDefinition,
+    RecipeInterface,
+)
+
+
+def test_edge_case_zero_limits() -> None:
+    """Test that rate limits of 0 are valid (effectively blocking)."""
+    policy = PolicyConfig(rate_limit_rpm=0, rate_limit_tpm=0)
+    assert policy.rate_limit_rpm == 0
+    assert policy.rate_limit_tpm == 0
+
+
+def test_edge_case_large_limits() -> None:
+    """Test very large integer values for limits."""
+    large_val = 10**18  # Quintillion
+    policy = PolicyConfig(rate_limit_rpm=large_val)
+    assert policy.rate_limit_rpm == large_val
+
+
+def test_edge_case_invalid_priority_value() -> None:
+    """Test that priority strictly enforces Enum members (Pydantic validation)."""
+    # Passing an integer not in the Enum should fail validation
+    with pytest.raises(ValidationError) as excinfo:
+        PolicyConfig(priority=99)  # 99 is not a valid ExecutionPriority
+
+    assert "Input should be" in str(excinfo.value)
+
+
+def test_complex_case_full_recipe_serialization() -> None:
+    """Test serialization of a full Recipe with all QoS fields set."""
+    policy = PolicyConfig(
+        priority=ExecutionPriority.CRITICAL,
+        rate_limit_rpm=60,
+        rate_limit_tpm=10000,
+        caching_enabled=False,
+        max_retries=5,
+        timeout_seconds=300,
+        budget_cap_usd=100.0,
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Complex QoS Recipe"),
+        interface=RecipeInterface(),
+        policy=policy,
+        topology=GraphTopology(
+            nodes=[AgentNode(id="worker", agent_ref="worker-v1")],
+            edges=[],
+            entry_point="worker"
+        )
+    )
+
+    dumped = recipe.model_dump()
+    assert dumped["policy"]["priority"] == 10
+    assert dumped["policy"]["rate_limit_rpm"] == 60
+    assert dumped["policy"]["caching_enabled"] is False
+
+    # Verify round-trip
+    loaded = RecipeDefinition.model_validate(dumped)
+    assert loaded.policy is not None
+    assert loaded.policy.priority == ExecutionPriority.CRITICAL
+
+
+def test_complex_case_nested_structure_immutability() -> None:
+    """Test that PolicyConfig remains immutable when accessed via Recipe."""
+    policy = PolicyConfig(priority=ExecutionPriority.LOW)
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Immutable Policy"),
+        interface=RecipeInterface(),
+        policy=policy,
+        topology=GraphTopology(
+            nodes=[AgentNode(id="a", agent_ref="b")],
+            edges=[],
+            entry_point="a"
+        )
+    )
+
+    # Attempting to modify the frozen model should raise ValidationError
+    with pytest.raises(ValidationError):
+        recipe.policy.priority = ExecutionPriority.HIGH  # type: ignore
+
+
+def test_edge_case_none_vs_missing() -> None:
+    """Test distinction between explicit None and default None (should be same for Pydantic)."""
+    p1 = PolicyConfig(rate_limit_rpm=None)
+    p2 = PolicyConfig()
+
+    assert p1.rate_limit_rpm is None
+    assert p2.rate_limit_rpm is None
+    assert p1.model_dump() == p2.model_dump()

--- a/tests/test_v2_gateway_qos_extended.py
+++ b/tests/test_v2_gateway_qos_extended.py
@@ -53,11 +53,7 @@ def test_complex_case_full_recipe_serialization() -> None:
         metadata=ManifestMetadata(name="Complex QoS Recipe"),
         interface=RecipeInterface(),
         policy=policy,
-        topology=GraphTopology(
-            nodes=[AgentNode(id="worker", agent_ref="worker-v1")],
-            edges=[],
-            entry_point="worker"
-        )
+        topology=GraphTopology(nodes=[AgentNode(id="worker", agent_ref="worker-v1")], edges=[], entry_point="worker"),
     )
 
     dumped = recipe.model_dump()
@@ -78,11 +74,7 @@ def test_complex_case_nested_structure_immutability() -> None:
         metadata=ManifestMetadata(name="Immutable Policy"),
         interface=RecipeInterface(),
         policy=policy,
-        topology=GraphTopology(
-            nodes=[AgentNode(id="a", agent_ref="b")],
-            edges=[],
-            entry_point="a"
-        )
+        topology=GraphTopology(nodes=[AgentNode(id="a", agent_ref="b")], edges=[], entry_point="a"),
     )
 
     # Attempting to modify the frozen model should raise ValidationError


### PR DESCRIPTION
Enhanced PolicyConfig in src/coreason_manifest/spec/v2/recipe.py to include ExecutionPriority, rate limiting (rpm/tpm), and caching controls. Added tests/test_v2_gateway_qos.py to verify these changes.

---
*PR created automatically by Jules for task [6091827402481289170](https://jules.google.com/task/6091827402481289170) started by @gowthamrao*