### PR TITLE
Add Episteme / Meta-Cognition features

### DIFF
--- a/src/coreason_manifest/spec/v2/reasoning.py
+++ b/src/coreason_manifest/spec/v2/reasoning.py
@@ -9,40 +9,55 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from enum import StrEnum
+
 from pydantic import ConfigDict, Field
+
 from coreason_manifest.spec.common_base import CoReasonBaseModel
+
 
 class ReviewStrategy(StrEnum):
     """How the node output is critiqued."""
+
     NONE = "none"
-    BASIC = "basic"                 # Simple self-correction
-    ADVERSARIAL = "adversarial"     # Devil's Advocate persona
-    CAUSAL = "causal"               # Check logical consistency/fallacies
-    CONSENSUS = "consensus"         # Multi-model agreement
+    BASIC = "basic"  # Simple self-correction
+    ADVERSARIAL = "adversarial"  # Devil's Advocate persona
+    CAUSAL = "causal"  # Check logical consistency/fallacies
+    CONSENSUS = "consensus"  # Multi-model agreement
+
 
 class AdversarialConfig(CoReasonBaseModel):
     """Configuration for the 'Devil's Advocate' reviewer."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    persona: str = Field("skeptic", description="The persona adopted by the reviewer (e.g., 'security_auditor', 'skeptic').")
+    persona: str = Field(
+        "skeptic", description="The persona adopted by the reviewer (e.g., 'security_auditor', 'skeptic')."
+    )
     attack_vectors: list[str] = Field(
-        default_factory=list,
-        description="Specific angles of critique (e.g., 'pii_leakage', 'hallucination')."
+        default_factory=list, description="Specific angles of critique (e.g., 'pii_leakage', 'hallucination')."
     )
     temperature: float = Field(0.7, description="Creativity level of the critique.")
 
+
 class GapScanConfig(CoReasonBaseModel):
     """Configuration for Knowledge Gap detection (Episteme)."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
 
     enabled: bool = Field(False, description="If True, scans context for missing prerequisites before execution.")
-    confidence_threshold: float = Field(0.8, description="Minimum confidence to proceed without asking clarifying questions.")
+    confidence_threshold: float = Field(
+        0.8, description="Minimum confidence to proceed without asking clarifying questions."
+    )
+
 
 class ReasoningConfig(CoReasonBaseModel):
     """Container for meta-cognitive behaviors attached to a Node."""
+
     model_config = ConfigDict(extra="forbid", frozen=True)
 
-    strategy: ReviewStrategy = Field(ReviewStrategy.NONE, description="The active critique method applied to this node's output.")
+    strategy: ReviewStrategy = Field(
+        ReviewStrategy.NONE, description="The active critique method applied to this node's output."
+    )
 
     # Strategy-specific configs
     adversarial: AdversarialConfig | None = Field(None, description="Config if strategy is ADVERSARIAL.")

--- a/src/coreason_manifest/spec/v2/reasoning.py
+++ b/src/coreason_manifest/spec/v2/reasoning.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import StrEnum
+from pydantic import ConfigDict, Field
+from coreason_manifest.spec.common_base import CoReasonBaseModel
+
+class ReviewStrategy(StrEnum):
+    """How the node output is critiqued."""
+    NONE = "none"
+    BASIC = "basic"                 # Simple self-correction
+    ADVERSARIAL = "adversarial"     # Devil's Advocate persona
+    CAUSAL = "causal"               # Check logical consistency/fallacies
+    CONSENSUS = "consensus"         # Multi-model agreement
+
+class AdversarialConfig(CoReasonBaseModel):
+    """Configuration for the 'Devil's Advocate' reviewer."""
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    persona: str = Field("skeptic", description="The persona adopted by the reviewer (e.g., 'security_auditor', 'skeptic').")
+    attack_vectors: list[str] = Field(
+        default_factory=list,
+        description="Specific angles of critique (e.g., 'pii_leakage', 'hallucination')."
+    )
+    temperature: float = Field(0.7, description="Creativity level of the critique.")
+
+class GapScanConfig(CoReasonBaseModel):
+    """Configuration for Knowledge Gap detection (Episteme)."""
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    enabled: bool = Field(False, description="If True, scans context for missing prerequisites before execution.")
+    confidence_threshold: float = Field(0.8, description="Minimum confidence to proceed without asking clarifying questions.")
+
+class ReasoningConfig(CoReasonBaseModel):
+    """Container for meta-cognitive behaviors attached to a Node."""
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    strategy: ReviewStrategy = Field(ReviewStrategy.NONE, description="The active critique method applied to this node's output.")
+
+    # Strategy-specific configs
+    adversarial: AdversarialConfig | None = Field(None, description="Config if strategy is ADVERSARIAL.")
+    gap_scan: GapScanConfig | None = Field(None, description="Config for pre-execution knowledge scanning.")
+
+    max_revisions: int = Field(1, description="Maximum self-correction loops allowed if critique fails.")

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -78,8 +78,7 @@ class RecipeNode(CoReasonBaseModel):
 
     # --- New Field for Episteme ---
     reasoning: ReasoningConfig | None = Field(
-        None,
-        description="Meta-cognition settings: Review loops, gap scanning, and validation strategies."
+        None, description="Meta-cognition settings: Review loops, gap scanning, and validation strategies."
     )
 
 

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -17,6 +17,7 @@ from coreason_manifest.spec.common.presentation import NodePresentation
 from coreason_manifest.spec.common_base import CoReasonBaseModel
 from coreason_manifest.spec.v2.definitions import ManifestMetadata
 from coreason_manifest.spec.v2.evaluation import EvaluationProfile
+from coreason_manifest.spec.v2.reasoning import ReasoningConfig
 
 logger = logging.getLogger(__name__)
 
@@ -74,6 +75,12 @@ class RecipeNode(CoReasonBaseModel):
     id: str = Field(..., description="Unique identifier within the graph.")
     metadata: dict[str, Any] = Field(default_factory=dict, description="Custom metadata (not for UI layout).")
     presentation: NodePresentation | None = Field(None, description="Visual layout and styling metadata.")
+
+    # --- New Field for Episteme ---
+    reasoning: ReasoningConfig | None = Field(
+        None,
+        description="Meta-cognition settings: Review loops, gap scanning, and validation strategies."
+    )
 
 
 class AgentNode(RecipeNode):

--- a/tests/test_v2_episteme_harvest.py
+++ b/tests/test_v2_episteme_harvest.py
@@ -1,0 +1,57 @@
+import pytest
+from coreason_manifest.spec.v2.reasoning import (
+    ReviewStrategy,
+    ReasoningConfig,
+    AdversarialConfig,
+    GapScanConfig
+)
+from coreason_manifest.spec.v2.recipe import RecipeNode
+
+def test_episteme_defaults():
+    """Verify default meta-cognition settings."""
+    config = ReasoningConfig()
+    assert config.strategy == ReviewStrategy.NONE
+    assert config.max_revisions == 1
+
+def test_adversarial_configuration():
+    """Verify detailed adversarial review configuration."""
+    adv_config = AdversarialConfig(
+        persona="security_auditor",
+        attack_vectors=["prompt_injection", "pii_leak"],
+        temperature=0.5
+    )
+    reasoning = ReasoningConfig(
+        strategy=ReviewStrategy.ADVERSARIAL,
+        adversarial=adv_config,
+        max_revisions=3
+    )
+
+    assert reasoning.strategy == "adversarial"
+    # Strict MyPy: Check if reasoning.adversarial is not None before accessing attributes
+    assert reasoning.adversarial is not None
+    assert reasoning.adversarial.persona == "security_auditor"
+    assert len(reasoning.adversarial.attack_vectors) == 2
+
+def test_gap_scan_toggle():
+    """Verify knowledge gap scanning toggle."""
+    config = ReasoningConfig(
+        gap_scan=GapScanConfig(enabled=True, confidence_threshold=0.9)
+    )
+    # Strict MyPy: Check if reasoning.gap_scan is not None
+    assert config.gap_scan is not None
+    assert config.gap_scan.enabled is True
+    assert config.gap_scan.confidence_threshold == 0.9
+
+def test_node_integration():
+    """Ensure a RecipeNode can carry reasoning logic."""
+    node = RecipeNode(
+        id="step_1",
+        reasoning=ReasoningConfig(strategy=ReviewStrategy.BASIC)
+    )
+    # Strict MyPy: Check if node.reasoning is not None
+    assert node.reasoning is not None
+    assert node.reasoning.strategy == ReviewStrategy.BASIC
+
+    # Test JSON serialization
+    data = node.model_dump(mode='json')
+    assert data['reasoning']['strategy'] == 'basic'

--- a/tests/test_v2_episteme_harvest.py
+++ b/tests/test_v2_episteme_harvest.py
@@ -1,30 +1,20 @@
-import pytest
-from coreason_manifest.spec.v2.reasoning import (
-    ReviewStrategy,
-    ReasoningConfig,
-    AdversarialConfig,
-    GapScanConfig
-)
+from coreason_manifest.spec.v2.reasoning import AdversarialConfig, GapScanConfig, ReasoningConfig, ReviewStrategy
 from coreason_manifest.spec.v2.recipe import RecipeNode
 
-def test_episteme_defaults():
+
+def test_episteme_defaults() -> None:
     """Verify default meta-cognition settings."""
     config = ReasoningConfig()
     assert config.strategy == ReviewStrategy.NONE
     assert config.max_revisions == 1
 
-def test_adversarial_configuration():
+
+def test_adversarial_configuration() -> None:
     """Verify detailed adversarial review configuration."""
     adv_config = AdversarialConfig(
-        persona="security_auditor",
-        attack_vectors=["prompt_injection", "pii_leak"],
-        temperature=0.5
+        persona="security_auditor", attack_vectors=["prompt_injection", "pii_leak"], temperature=0.5
     )
-    reasoning = ReasoningConfig(
-        strategy=ReviewStrategy.ADVERSARIAL,
-        adversarial=adv_config,
-        max_revisions=3
-    )
+    reasoning = ReasoningConfig(strategy=ReviewStrategy.ADVERSARIAL, adversarial=adv_config, max_revisions=3)
 
     assert reasoning.strategy == "adversarial"
     # Strict MyPy: Check if reasoning.adversarial is not None before accessing attributes
@@ -32,26 +22,23 @@ def test_adversarial_configuration():
     assert reasoning.adversarial.persona == "security_auditor"
     assert len(reasoning.adversarial.attack_vectors) == 2
 
-def test_gap_scan_toggle():
+
+def test_gap_scan_toggle() -> None:
     """Verify knowledge gap scanning toggle."""
-    config = ReasoningConfig(
-        gap_scan=GapScanConfig(enabled=True, confidence_threshold=0.9)
-    )
+    config = ReasoningConfig(gap_scan=GapScanConfig(enabled=True, confidence_threshold=0.9))
     # Strict MyPy: Check if reasoning.gap_scan is not None
     assert config.gap_scan is not None
     assert config.gap_scan.enabled is True
     assert config.gap_scan.confidence_threshold == 0.9
 
-def test_node_integration():
+
+def test_node_integration() -> None:
     """Ensure a RecipeNode can carry reasoning logic."""
-    node = RecipeNode(
-        id="step_1",
-        reasoning=ReasoningConfig(strategy=ReviewStrategy.BASIC)
-    )
+    node = RecipeNode(id="step_1", reasoning=ReasoningConfig(strategy=ReviewStrategy.BASIC))
     # Strict MyPy: Check if node.reasoning is not None
     assert node.reasoning is not None
     assert node.reasoning.strategy == ReviewStrategy.BASIC
 
     # Test JSON serialization
-    data = node.model_dump(mode='json')
-    assert data['reasoning']['strategy'] == 'basic'
+    data = node.model_dump(mode="json")
+    assert data["reasoning"]["strategy"] == "basic"


### PR DESCRIPTION
Implemented the Episteme / Meta-Cognition feature by populating the empty logic files. 

Key changes:
1.  **Reasoning Schema**: Created `src/coreason_manifest/spec/v2/reasoning.py` with `ReviewStrategy`, `AdversarialConfig`, `GapScanConfig`, and `ReasoningConfig`.
2.  **Recipe Integration**: Updated `src/coreason_manifest/spec/v2/recipe.py` to import `ReasoningConfig` and add the `reasoning` field to `RecipeNode`.
3.  **Testing**: Created `tests/test_v2_episteme_harvest.py` with 4 test cases covering defaults, adversarial config, gap scan toggle, and node integration. Verified with pytest.

---
*PR created automatically by Jules for task [11359633310085313957](https://jules.google.com/task/11359633310085313957) started by @gowthamrao*