### PR TITLE
feat: Harvest topology validation logic to RecipeDefinition

### DIFF
--- a/docs/flow_governance.md
+++ b/docs/flow_governance.md
@@ -99,4 +99,5 @@ The `RecipeDefinition` strictly validates Flow Governance configurations:
 *   `max_retries` must be non-negative.
 *   `retry_delay_seconds` must be non-negative.
 *   If `behavior` is `route_to_fallback`, `fallback_node_id` MUST be provided and MUST exist in the graph.
+    *   **Note:** Referential integrity for `fallback_node_id` is enforced strictly upon instantiation of the `RecipeDefinition`, regardless of whether the recipe status is `DRAFT` or `PUBLISHED`.
 *   If `behavior` is `continue_with_default`, `default_output` generally should be provided (though `None` is valid).

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -667,7 +667,8 @@ class RecipeDefinition(CoReasonBaseModel):
                 target_id = node.recovery.fallback_node_id
                 if target_id not in valid_node_ids:
                     errors.append(
-                        f"Node '{node.id}' defines fallback_node_id='{target_id}', but '{target_id}' does not exist in the recipe."
+                        f"Node '{node.id}' defines fallback_node_id='{target_id}', "
+                        f"but '{target_id}' does not exist in the recipe."
                     )
 
             # Future proofing: If you add explicit 'next_step' fields later, add checks here.

--- a/tests/test_v2_validator_complex.py
+++ b/tests/test_v2_validator_complex.py
@@ -1,0 +1,190 @@
+import pytest
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.evaluation import EvaluationProfile, SuccessCriterion
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    EvaluatorNode,
+    FailureBehavior,
+    GraphEdge,
+    GraphTopology,
+    HumanNode,
+    RecipeDefinition,
+    RecipeInterface,
+    RecipeStatus,
+    RecoveryConfig,
+    RouterNode,
+)
+
+
+def test_fallback_chain() -> None:
+    """Test a chain of fallbacks: A -> B -> C."""
+    node_c = AgentNode(id="Agent_C", agent_ref="agent-3")
+    node_b = AgentNode(
+        id="Agent_B",
+        agent_ref="agent-2",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Agent_C",
+        ),
+    )
+    node_a = AgentNode(
+        id="Agent_A",
+        agent_ref="agent-1",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Agent_B",
+        ),
+    )
+
+    topology = GraphTopology(
+        nodes=[node_a, node_b, node_c],
+        edges=[],
+        entry_point="Agent_A",
+        status="valid",
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Chain Topology"),
+        interface=RecipeInterface(),
+        topology=topology,
+        status=RecipeStatus.DRAFT,
+    )
+
+    assert recipe.topology.nodes[0].recovery is not None
+    assert recipe.topology.nodes[0].recovery.fallback_node_id == "Agent_B"
+    assert recipe.topology.nodes[1].recovery is not None
+    assert recipe.topology.nodes[1].recovery.fallback_node_id == "Agent_C"
+
+
+def test_fallback_cycle() -> None:
+    """Test a fallback cycle: A -> B -> A."""
+    node_b = AgentNode(
+        id="Agent_B",
+        agent_ref="agent-2",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Agent_A",
+        ),
+    )
+    node_a = AgentNode(
+        id="Agent_A",
+        agent_ref="agent-1",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Agent_B",
+        ),
+    )
+
+    topology = GraphTopology(
+        nodes=[node_a, node_b],
+        edges=[],
+        entry_point="Agent_A",
+        status="valid",
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Cycle Topology"),
+        interface=RecipeInterface(),
+        topology=topology,
+        status=RecipeStatus.DRAFT,
+    )
+
+    assert recipe.topology.nodes[0].recovery is not None
+    assert recipe.topology.nodes[0].recovery.fallback_node_id == "Agent_B"
+
+
+def test_complex_broken_topology() -> None:
+    """Test a mix of nodes where one has a broken link."""
+    node_agent = AgentNode(id="Worker", agent_ref="worker-v1")
+    node_human = HumanNode(id="Manager", prompt="Approve?")
+
+    # Broken Router
+    node_router = RouterNode(
+        id="Decider",
+        input_key="score",
+        routes={"high": "Worker"},
+        default_route="Manager",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Missing_Node"  # This is the error
+        )
+    )
+
+    topology = GraphTopology(
+        nodes=[node_agent, node_human, node_router],
+        edges=[],
+        entry_point="Decider",
+        status="draft",
+    )
+
+    with pytest.raises(ValueError, match="Missing_Node"):
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Complex Broken"),
+            interface=RecipeInterface(),
+            topology=topology,
+            status=RecipeStatus.DRAFT,
+        )
+
+
+def test_mixed_node_types() -> None:
+    """Verify different node types with valid fallbacks."""
+    node_fallback = HumanNode(id="Human_Help", prompt="Fix it")
+
+    node_router = RouterNode(
+        id="Router",
+        input_key="x",
+        routes={},
+        default_route="Human_Help",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Human_Help"
+        )
+    )
+
+    node_evaluator = EvaluatorNode(
+        id="Judge",
+        target_variable="output",
+        evaluator_agent_ref="gpt-4",
+        evaluation_profile=EvaluationProfile(
+            grading_rubric=[
+                SuccessCriterion(
+                    name="accuracy",
+                    description="Must be accurate",
+                    threshold=0.9
+                )
+            ]
+        ),
+        pass_threshold=0.9,
+        max_refinements=1,
+        pass_route="Human_Help",
+        fail_route="Human_Help",
+        feedback_variable="feedback",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Human_Help"
+        )
+    )
+
+    topology = GraphTopology(
+        nodes=[node_fallback, node_router, node_evaluator],
+        edges=[],
+        entry_point="Router",
+        status="valid",
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Mixed Nodes"),
+        interface=RecipeInterface(),
+        topology=topology,
+        status=RecipeStatus.DRAFT,
+    )
+
+    # Check Router
+    router = next(n for n in recipe.topology.nodes if n.id == "Router")
+    assert router.recovery is not None
+    assert router.recovery.fallback_node_id == "Human_Help"
+
+    # Check Evaluator
+    evaluator = next(n for n in recipe.topology.nodes if n.id == "Judge")
+    assert evaluator.recovery is not None
+    assert evaluator.recovery.fallback_node_id == "Human_Help"

--- a/tests/test_v2_validator_complex.py
+++ b/tests/test_v2_validator_complex.py
@@ -1,11 +1,11 @@
 import pytest
+
 from coreason_manifest.spec.v2.definitions import ManifestMetadata
 from coreason_manifest.spec.v2.evaluation import EvaluationProfile, SuccessCriterion
 from coreason_manifest.spec.v2.recipe import (
     AgentNode,
     EvaluatorNode,
     FailureBehavior,
-    GraphEdge,
     GraphTopology,
     HumanNode,
     RecipeDefinition,
@@ -106,8 +106,8 @@ def test_complex_broken_topology() -> None:
         default_route="Manager",
         recovery=RecoveryConfig(
             behavior=FailureBehavior.ROUTE_TO_FALLBACK,
-            fallback_node_id="Missing_Node"  # This is the error
-        )
+            fallback_node_id="Missing_Node",  # This is the error
+        ),
     )
 
     topology = GraphTopology(
@@ -135,10 +135,7 @@ def test_mixed_node_types() -> None:
         input_key="x",
         routes={},
         default_route="Human_Help",
-        recovery=RecoveryConfig(
-            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
-            fallback_node_id="Human_Help"
-        )
+        recovery=RecoveryConfig(behavior=FailureBehavior.ROUTE_TO_FALLBACK, fallback_node_id="Human_Help"),
     )
 
     node_evaluator = EvaluatorNode(
@@ -146,23 +143,14 @@ def test_mixed_node_types() -> None:
         target_variable="output",
         evaluator_agent_ref="gpt-4",
         evaluation_profile=EvaluationProfile(
-            grading_rubric=[
-                SuccessCriterion(
-                    name="accuracy",
-                    description="Must be accurate",
-                    threshold=0.9
-                )
-            ]
+            grading_rubric=[SuccessCriterion(name="accuracy", description="Must be accurate", threshold=0.9)]
         ),
         pass_threshold=0.9,
         max_refinements=1,
         pass_route="Human_Help",
         fail_route="Human_Help",
         feedback_variable="feedback",
-        recovery=RecoveryConfig(
-            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
-            fallback_node_id="Human_Help"
-        )
+        recovery=RecoveryConfig(behavior=FailureBehavior.ROUTE_TO_FALLBACK, fallback_node_id="Human_Help"),
     )
 
     topology = GraphTopology(

--- a/tests/test_v2_validator_harvest.py
+++ b/tests/test_v2_validator_harvest.py
@@ -1,25 +1,27 @@
 import pytest
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
 from coreason_manifest.spec.v2.recipe import (
-    RecipeDefinition,
     AgentNode,
-    GraphTopology,
+    FailureBehavior,
     GraphEdge,
+    GraphTopology,
+    RecipeDefinition,
     RecipeInterface,
     RecipeStatus,
     RecoveryConfig,
-    FailureBehavior,
 )
-from coreason_manifest.spec.v2.definitions import ManifestMetadata
 
-def test_valid_topology():
+
+def test_valid_topology() -> None:
     """Test a valid topology with correct fallback reference."""
     node_a = AgentNode(
         id="Agent_A",
         agent_ref="agent-1",
         recovery=RecoveryConfig(
             behavior=FailureBehavior.ROUTE_TO_FALLBACK,
-            fallback_node_id="Agent_B"
-        )
+            fallback_node_id="Agent_B",
+        ),
     )
     node_b = AgentNode(id="Agent_B", agent_ref="agent-2")
 
@@ -27,27 +29,29 @@ def test_valid_topology():
         nodes=[node_a, node_b],
         edges=[GraphEdge(source="Agent_A", target="Agent_B")],
         entry_point="Agent_A",
-        status="valid"
+        status="valid",
     )
 
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="Valid Topology"),
         interface=RecipeInterface(),
         topology=topology,
-        status=RecipeStatus.DRAFT
+        status=RecipeStatus.DRAFT,
     )
 
+    assert recipe.topology.nodes[0].recovery is not None
     assert recipe.topology.nodes[0].recovery.fallback_node_id == "Agent_B"
 
-def test_broken_link_fallback():
+
+def test_broken_link_fallback() -> None:
     """Test a broken link where fallback node does not exist."""
     node_a = AgentNode(
         id="Agent_A",
         agent_ref="agent-1",
         recovery=RecoveryConfig(
             behavior=FailureBehavior.ROUTE_TO_FALLBACK,
-            fallback_node_id="Ghost_Node"
-        )
+            fallback_node_id="Ghost_Node",
+        ),
     )
 
     # Even if GraphTopology is draft, RecipeDefinition should catch this if we add the validator.
@@ -56,43 +60,42 @@ def test_broken_link_fallback():
         nodes=[node_a],
         edges=[],
         entry_point="Agent_A",
-        status="draft"
+        status="draft",
     )
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="Ghost_Node"):
         RecipeDefinition(
             metadata=ManifestMetadata(name="Broken Link"),
             interface=RecipeInterface(),
             topology=topology,
-            status=RecipeStatus.DRAFT
+            status=RecipeStatus.DRAFT,
         )
 
-    assert "Ghost_Node" in str(excinfo.value)
-    assert "fallback_node_id" in str(excinfo.value)
 
-def test_self_reference_fallback():
+def test_self_reference_fallback() -> None:
     """Test a node referencing itself as fallback."""
     node_a = AgentNode(
         id="Agent_A",
         agent_ref="agent-1",
         recovery=RecoveryConfig(
             behavior=FailureBehavior.ROUTE_TO_FALLBACK,
-            fallback_node_id="Agent_A"
-        )
+            fallback_node_id="Agent_A",
+        ),
     )
 
     topology = GraphTopology(
         nodes=[node_a],
         edges=[],
         entry_point="Agent_A",
-        status="valid"
+        status="valid",
     )
 
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="Self Reference"),
         interface=RecipeInterface(),
         topology=topology,
-        status=RecipeStatus.DRAFT
+        status=RecipeStatus.DRAFT,
     )
 
+    assert recipe.topology.nodes[0].recovery is not None
     assert recipe.topology.nodes[0].recovery.fallback_node_id == "Agent_A"

--- a/tests/test_v2_validator_harvest.py
+++ b/tests/test_v2_validator_harvest.py
@@ -1,0 +1,98 @@
+import pytest
+from coreason_manifest.spec.v2.recipe import (
+    RecipeDefinition,
+    AgentNode,
+    GraphTopology,
+    GraphEdge,
+    RecipeInterface,
+    RecipeStatus,
+    RecoveryConfig,
+    FailureBehavior,
+)
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+
+def test_valid_topology():
+    """Test a valid topology with correct fallback reference."""
+    node_a = AgentNode(
+        id="Agent_A",
+        agent_ref="agent-1",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Agent_B"
+        )
+    )
+    node_b = AgentNode(id="Agent_B", agent_ref="agent-2")
+
+    topology = GraphTopology(
+        nodes=[node_a, node_b],
+        edges=[GraphEdge(source="Agent_A", target="Agent_B")],
+        entry_point="Agent_A",
+        status="valid"
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Valid Topology"),
+        interface=RecipeInterface(),
+        topology=topology,
+        status=RecipeStatus.DRAFT
+    )
+
+    assert recipe.topology.nodes[0].recovery.fallback_node_id == "Agent_B"
+
+def test_broken_link_fallback():
+    """Test a broken link where fallback node does not exist."""
+    node_a = AgentNode(
+        id="Agent_A",
+        agent_ref="agent-1",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Ghost_Node"
+        )
+    )
+
+    # Even if GraphTopology is draft, RecipeDefinition should catch this if we add the validator.
+    # Note: GraphTopology skips validation if status='draft', so we rely on RecipeDefinition validator.
+    topology = GraphTopology(
+        nodes=[node_a],
+        edges=[],
+        entry_point="Agent_A",
+        status="draft"
+    )
+
+    with pytest.raises(ValueError) as excinfo:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Broken Link"),
+            interface=RecipeInterface(),
+            topology=topology,
+            status=RecipeStatus.DRAFT
+        )
+
+    assert "Ghost_Node" in str(excinfo.value)
+    assert "fallback_node_id" in str(excinfo.value)
+
+def test_self_reference_fallback():
+    """Test a node referencing itself as fallback."""
+    node_a = AgentNode(
+        id="Agent_A",
+        agent_ref="agent-1",
+        recovery=RecoveryConfig(
+            behavior=FailureBehavior.ROUTE_TO_FALLBACK,
+            fallback_node_id="Agent_A"
+        )
+    )
+
+    topology = GraphTopology(
+        nodes=[node_a],
+        edges=[],
+        entry_point="Agent_A",
+        status="valid"
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Self Reference"),
+        interface=RecipeInterface(),
+        topology=topology,
+        status=RecipeStatus.DRAFT
+    )
+
+    assert recipe.topology.nodes[0].recovery.fallback_node_id == "Agent_A"


### PR DESCRIPTION
This PR migrates the graph referential integrity validation logic from the legacy `coreason-validator` to the V2 Manifest schema.
It introduces a `model_validator` in `RecipeDefinition` that checks if all `fallback_node_id`s referenced in `RecoveryConfig` exist within the recipe's topology nodes. This prevents the instantiation of recipes with broken recovery links.
Tests are included to verify valid, broken, and self-referential topologies.


---
*PR created automatically by Jules for task [189076611711724944](https://jules.google.com/task/189076611711724944) started by @gowthamrao*