### PR TITLE
docs: SOTA Documentation Update for Coreason Manifest

### DIFF
--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, Literal
+from typing import Any, Literal, Self
 
 from pydantic import BaseModel
 
@@ -93,32 +93,70 @@ class AgentBuilder:
         self._cap_type = CapabilityType.GRAPH
         self._cap_delivery_mode = DeliveryMode.REQUEST_RESPONSE
 
-    def with_system_prompt(self, prompt: str) -> "AgentBuilder":
-        """Set the system prompt (backstory) for the agent."""
+    def with_system_prompt(self, prompt: str) -> Self:
+        """
+        Set the system prompt (backstory) for the agent.
+
+        Args:
+            prompt (str): The system prompt text.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.system_prompt = prompt
         return self
 
-    def with_model(self, model: str) -> "AgentBuilder":
-        """Set the LLM model ID."""
+    def with_model(self, model: str) -> Self:
+        """
+        Set the LLM model ID.
+
+        Args:
+            model (str): The model identifier.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.model = model
         return self
 
-    def with_tool(self, tool_id: str) -> "AgentBuilder":
-        """Add a tool ID to the agent's toolset."""
+    def with_tool(self, tool_id: str) -> Self:
+        """
+        Add a tool ID to the agent's toolset.
+
+        Args:
+            tool_id (str): The identifier of the tool.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.tools.append(tool_id)
         return self
 
-    def with_knowledge(self, uri: str) -> "AgentBuilder":
-        """Add a knowledge source URI."""
+    def with_knowledge(self, uri: str) -> Self:
+        """
+        Add a knowledge source URI.
+
+        Args:
+            uri (str): The URI of the knowledge source.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.knowledge.append(uri)
         return self
 
-    def with_capability(self, cap: TypedCapability[Any, Any]) -> "AgentBuilder":
+    def with_capability(self, cap: TypedCapability[Any, Any]) -> Self:
         """
         Add a capability to the agent.
 
         Merges the capability's input/output schemas into the agent's interface
         and updates capability flags (e.g., delivery mode).
+
+        Args:
+            cap (TypedCapability): The typed capability definition.
+
+        Returns:
+            Self: The builder instance for chaining.
         """
         # Merge input schema
         cap_input = cap.get_input_schema()
@@ -152,6 +190,9 @@ class AgentBuilder:
     def build_definition(self) -> AgentDefinition:
         """
         Build the AgentDefinition object.
+
+        Returns:
+            AgentDefinition: The constructed agent definition.
         """
         # Construct InterfaceDefinition
         interface = InterfaceDefinition(inputs=self.interface_inputs, outputs=self.interface_outputs)
@@ -182,6 +223,9 @@ class AgentBuilder:
 
         Constructs the ManifestMetadata, InterfaceDefinition, AgentCapabilities,
         AgentDefinition, and a default Workflow.
+
+        Returns:
+            ManifestV2: The fully constructed manifest.
         """
         # 1. Construct ManifestMetadata
         metadata = ManifestMetadata(name=self.name, version=self.version)
@@ -221,53 +265,135 @@ class ManifestBuilder:
         self.policy = PolicyDefinition()
         self._metadata_extras: dict[str, Any] = {}
 
-    def add_agent(self, agent: AgentDefinition) -> "ManifestBuilder":
-        """Add an AgentDefinition to the manifest."""
+    def add_agent(self, agent: AgentDefinition) -> Self:
+        """
+        Add an AgentDefinition to the manifest.
+
+        Args:
+            agent (AgentDefinition): The agent definition to add.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.definitions[agent.id] = agent
         return self
 
-    def add_tool(self, tool: ToolDefinition) -> "ManifestBuilder":
-        """Add a ToolDefinition to the manifest."""
+    def add_tool(self, tool: ToolDefinition) -> Self:
+        """
+        Add a ToolDefinition to the manifest.
+
+        Args:
+            tool (ToolDefinition): The tool definition to add.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.definitions[tool.id] = tool
         return self
 
-    def add_generic_definition(self, key: str, definition: GenericDefinition) -> "ManifestBuilder":
-        """Add a generic definition to the manifest."""
+    def add_generic_definition(self, key: str, definition: GenericDefinition) -> Self:
+        """
+        Add a generic definition to the manifest.
+
+        Args:
+            key (str): The key/id for the definition.
+            definition (GenericDefinition): The definition object.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.definitions[key] = definition
         return self
 
-    def add_step(self, step: Step) -> "ManifestBuilder":
-        """Add a workflow step."""
+    def add_step(self, step: Step) -> Self:
+        """
+        Add a workflow step.
+
+        Args:
+            step (Step): The workflow step to add.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.steps[step.id] = step
         return self
 
-    def set_start_step(self, step_id: str) -> "ManifestBuilder":
-        """Set the ID of the starting step."""
+    def set_start_step(self, step_id: str) -> Self:
+        """
+        Set the ID of the starting step.
+
+        Args:
+            step_id (str): The ID of the start step.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.start_step_id = step_id
         return self
 
-    def set_interface(self, interface: InterfaceDefinition) -> "ManifestBuilder":
-        """Set the input/output interface for the manifest."""
+    def set_interface(self, interface: InterfaceDefinition) -> Self:
+        """
+        Set the input/output interface for the manifest.
+
+        Args:
+            interface (InterfaceDefinition): The interface definition.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.interface = interface
         return self
 
-    def set_state(self, state: StateDefinition) -> "ManifestBuilder":
-        """Set the state definition."""
+    def set_state(self, state: StateDefinition) -> Self:
+        """
+        Set the state definition.
+
+        Args:
+            state (StateDefinition): The state definition.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.state = state
         return self
 
-    def set_policy(self, policy: PolicyDefinition) -> "ManifestBuilder":
-        """Set the policy definition."""
+    def set_policy(self, policy: PolicyDefinition) -> Self:
+        """
+        Set the policy definition.
+
+        Args:
+            policy (PolicyDefinition): The policy definition.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self.policy = policy
         return self
 
-    def set_metadata(self, key: str, value: Any) -> "ManifestBuilder":
-        """Set extra metadata fields."""
+    def set_metadata(self, key: str, value: Any) -> Self:
+        """
+        Set extra metadata fields.
+
+        Args:
+            key (str): The metadata key.
+            value (Any): The metadata value.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
         self._metadata_extras[key] = value
         return self
 
     def build(self) -> ManifestV2:
-        """Build the final ManifestV2 object."""
+        """
+        Build the final ManifestV2 object.
+
+        Returns:
+            ManifestV2: The fully constructed manifest.
+
+        Raises:
+            ValueError: If the start step is not specified and cannot be inferred.
+        """
         metadata = ManifestMetadata(name=self.name, version=self.version, **self._metadata_extras)
 
         if not self.start_step_id:

--- a/src/coreason_manifest/spec/v2/agent.py
+++ b/src/coreason_manifest/spec/v2/agent.py
@@ -28,7 +28,14 @@ class ComponentPriority(IntEnum):
 
 
 class ContextDependency(CoReasonBaseModel):
-    """A reference to a context module (e.g. 'hipaa_context')."""
+    """
+    A reference to a context module (e.g. 'hipaa_context').
+
+    Attributes:
+        name (str): The registry name of the context component.
+        priority (ComponentPriority): Token optimization priority. (Default: MEDIUM).
+        parameters (dict[str, Any]): Variables to inject into the context.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -38,7 +45,19 @@ class ContextDependency(CoReasonBaseModel):
 
 
 class CognitiveProfile(CoReasonBaseModel):
-    """The configuration for the Weaver to assemble a Prompt."""
+    """
+    The configuration for the Weaver to assemble a Prompt.
+
+    Attributes:
+        role (str): The specific Role/Persona (e.g., 'safety_scientist').
+        reasoning_mode (str | None): The thinking style (e.g., 'six_hats', 'socratic'). (Default: "standard").
+        reasoning (ReasoningConfig | None): System 2: Deep reasoning configuration (Episteme).
+        reflex (ReflexConfig | None): System 1: Fast response configuration (Cortex).
+        knowledge_contexts (list[ContextDependency]): Dynamic context modules to inject.
+        memory_read (list[RetrievalConfig]): Sources to read from (RAG). (Alias: 'memory').
+        memory_write (MemoryWriteConfig | None): Rules for saving new memories (Crystallization).
+        task_primitive (str | None): The logic primitive to apply (e.g., 'extract', 'classify', 'cohort').
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/spec/v2/compliance.py
+++ b/src/coreason_manifest/spec/v2/compliance.py
@@ -65,7 +65,8 @@ class IntegrityConfig(CoReasonBaseModel):
         input_mode (AuditContentMode): How to handle user/system inputs in the audit log. (Default: FULL_PAYLOAD).
         output_mode (AuditContentMode): How to handle agent outputs in the audit log. (Default: FULL_PAYLOAD).
         integrity_level (IntegrityLevel): Cryptographic proof requirement for the execution trace. (Default: NONE).
-        hash_algorithm (str): Algorithm used for generating payload references (if mode is reference_only). (Default: "sha256").
+        hash_algorithm (str): Algorithm used for generating payload references (if mode is reference_only).
+            (Default: "sha256").
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)

--- a/src/coreason_manifest/spec/v2/compliance.py
+++ b/src/coreason_manifest/spec/v2/compliance.py
@@ -58,7 +58,15 @@ class IntegrityLevel(StrEnum):
 
 
 class IntegrityConfig(CoReasonBaseModel):
-    """Configuration for Zero-Copy auditing and Verification logic."""
+    """
+    Configuration for Zero-Copy auditing and Verification logic.
+
+    Attributes:
+        input_mode (AuditContentMode): How to handle user/system inputs in the audit log. (Default: FULL_PAYLOAD).
+        output_mode (AuditContentMode): How to handle agent outputs in the audit log. (Default: FULL_PAYLOAD).
+        integrity_level (IntegrityLevel): Cryptographic proof requirement for the execution trace. (Default: NONE).
+        hash_algorithm (str): Algorithm used for generating payload references (if mode is reference_only). (Default: "sha256").
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -82,7 +90,18 @@ class IntegrityConfig(CoReasonBaseModel):
 
 
 class ComplianceConfig(CoReasonBaseModel):
-    """Configuration for the Coreason Auditor."""
+    """
+    Configuration for the Coreason Auditor.
+
+    Attributes:
+        audit_level (AuditLevel): Depth of logging. (Default: BASIC).
+        retention (RetentionPolicy): Data retention requirement. (Default: THIRTY_DAYS).
+        generate_aibom (bool): Generate an AI Bill of Materials (software supply chain). (Default: False).
+        generate_pdf_report (bool): Generate a human-readable PDF report of the session. (Default: False).
+        require_signature (bool): Cryptographically sign the final output. (Default: False).
+        mask_pii (bool): Attempt to scrub PII from logs before archiving. (Default: True).
+        integrity (IntegrityConfig): Configuration for Zero-Copy auditing and data integrity verification.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/spec/v2/contracts.py
+++ b/src/coreason_manifest/spec/v2/contracts.py
@@ -16,7 +16,13 @@ from coreason_manifest.spec.common_base import CoReasonBaseModel
 
 
 class InterfaceDefinition(CoReasonBaseModel):
-    """Defines the input/output contract."""
+    """
+    Defines the input/output contract.
+
+    Attributes:
+        inputs (dict[str, Any]): JSON Schema definitions for arguments.
+        outputs (dict[str, Any]): JSON Schema definitions for return values.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -25,7 +31,13 @@ class InterfaceDefinition(CoReasonBaseModel):
 
 
 class StateDefinition(CoReasonBaseModel):
-    """Defines the conversation memory/context structure."""
+    """
+    Defines the conversation memory/context structure.
+
+    Attributes:
+        schema_ (dict[str, Any]): The structure of the conversation memory/context. (Alias: 'schema').
+        backend (str | None): Backend storage type (e.g., 'redis', 'memory').
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -36,7 +48,15 @@ class StateDefinition(CoReasonBaseModel):
 
 
 class PolicyDefinition(CoReasonBaseModel):
-    """Defines execution policy and governance rules."""
+    """
+    Defines execution policy and governance rules.
+
+    Attributes:
+        max_steps (int | None): Execution limit on number of steps.
+        max_retries (int): Maximum number of retries. (Default: 3).
+        timeout (int | None): Timeout in seconds.
+        human_in_the_loop (bool): Whether to require human approval. (Default: False).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -152,10 +152,12 @@ class AgentDefinition(CoReasonBaseModel):
             (Validation: Normalizes string URIs or partial dicts to ToolRequirement).
         knowledge (list[str]): List of file paths or knowledge base IDs.
         skills (list[str]): List of Skill IDs to equip this agent with.
-        context_strategy (Literal["full", "compressed", "hybrid"]): Context optimization strategy for skills. (Default: "hybrid").
+        context_strategy (Literal["full", "compressed", "hybrid"]): Context optimization strategy for skills.
+            (Default: "hybrid").
         interface (InterfaceDefinition): Input/Output contract.
         capabilities (AgentCapabilities): Feature flags and capabilities for the agent.
-        runtime (AgentRuntimeConfig | None): Configuration for the agent runtime environment (e.g. environment variables).
+        runtime (AgentRuntimeConfig | None): Configuration for the agent runtime environment
+            (e.g. environment variables).
         evaluation (EvaluationProfile | None): Quality assurance and testing metadata.
         resources (ModelProfile | None): Hardware, pricing, and operational constraints for this agent.
     """
@@ -387,7 +389,8 @@ class ManifestV2(CoReasonBaseModel):
         interface (InterfaceDefinition): Input/Output contract.
         state (StateDefinition): Internal state schema.
         policy (PolicyDefinition): Policy and governance.
-        definitions (dict[str, ToolDefinition | AgentDefinition | ...]): Reusable definitions. (Polymorphic: Discriminator 'type').
+        definitions (dict[str, ToolDefinition | AgentDefinition | ...]): Reusable definitions.
+            (Polymorphic: Discriminator 'type').
         workflow (Workflow): The main workflow topology.
     """
 

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -44,7 +44,18 @@ __all__ = [
 
 
 class DesignMetadata(CoReasonBaseModel):
-    """UI-specific metadata for the visual builder."""
+    """
+    UI-specific metadata for the visual builder.
+
+    Attributes:
+        x (float): X coordinate on the canvas.
+        y (float): Y coordinate on the canvas.
+        icon (str | None): Icon name or URL.
+        color (str | None): Color code (hex/name).
+        label (str | None): Display label.
+        zoom (float | None): Zoom level.
+        collapsed (bool): Whether the node is collapsed in UI. (Default: False).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -58,7 +69,17 @@ class DesignMetadata(CoReasonBaseModel):
 
 
 class ToolDefinition(CoReasonBaseModel):
-    """Definition of an external tool."""
+    """
+    Definition of an external tool.
+
+    Attributes:
+        type (Literal["tool"]): Discriminator. (Default: "tool").
+        id (str): Unique ID for the tool within the manifest.
+        name (str): Name of the tool.
+        uri (StrictUri): The MCP endpoint URI.
+        risk_level (ToolRiskLevel): Risk level (safe, standard, critical).
+        description (str | None): Description of the tool.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -71,7 +92,14 @@ class ToolDefinition(CoReasonBaseModel):
 
 
 class ToolRequirement(CoReasonBaseModel):
-    """A requirement for a remote tool."""
+    """
+    A requirement for a remote tool.
+
+    Attributes:
+        type (Literal["remote"]): Discriminator. (Default: "remote").
+        uri (str): The URI of the tool or reference ID.
+        hash (str | None): Optional integrity hash.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -81,7 +109,16 @@ class ToolRequirement(CoReasonBaseModel):
 
 
 class InlineToolDefinition(CoReasonBaseModel):
-    """A tool defined directly within the manifest (Serverless/Local)."""
+    """
+    A tool defined directly within the manifest (Serverless/Local).
+
+    Attributes:
+        type (Literal["inline"]): Discriminator. (Default: "inline").
+        name (str): Name of the tool. (Pattern: ^[a-zA-Z0-9_-]+$).
+        description (str): Description of what the tool does.
+        parameters (dict[str, Any]): JSON Schema for arguments. (Validation: Must be type='object').
+        code_hash (str | None): Optional integrity check for implementation code.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -100,7 +137,28 @@ class InlineToolDefinition(CoReasonBaseModel):
 
 
 class AgentDefinition(CoReasonBaseModel):
-    """Definition of an Agent."""
+    """
+    Definition of an Agent.
+
+    Attributes:
+        type (Literal["agent"]): Discriminator. (Default: "agent").
+        id (str): Unique ID for the agent.
+        name (str): Name of the agent.
+        role (str): The persona/job title.
+        goal (str): Primary objective.
+        backstory (str | None): Backstory or directives.
+        model (str | None): LLM identifier.
+        tools (list[ToolRequirement | InlineToolDefinition]): List of Tool Requirements or Inline Definitions.
+            (Validation: Normalizes string URIs or partial dicts to ToolRequirement).
+        knowledge (list[str]): List of file paths or knowledge base IDs.
+        skills (list[str]): List of Skill IDs to equip this agent with.
+        context_strategy (Literal["full", "compressed", "hybrid"]): Context optimization strategy for skills. (Default: "hybrid").
+        interface (InterfaceDefinition): Input/Output contract.
+        capabilities (AgentCapabilities): Feature flags and capabilities for the agent.
+        runtime (AgentRuntimeConfig | None): Configuration for the agent runtime environment (e.g. environment variables).
+        evaluation (EvaluationProfile | None): Quality assurance and testing metadata.
+        resources (ModelProfile | None): Hardware, pricing, and operational constraints for this agent.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -157,13 +215,24 @@ class AgentDefinition(CoReasonBaseModel):
 
 
 class GenericDefinition(CoReasonBaseModel):
-    """Fallback for unknown definitions."""
+    """
+    Fallback for unknown definitions.
+
+    Allows any extra fields.
+    """
 
     model_config = ConfigDict(extra="allow", frozen=True)
 
 
 class BaseStep(CoReasonBaseModel):
-    """Base attributes for all steps."""
+    """
+    Base attributes for all steps.
+
+    Attributes:
+        id (str): Unique identifier for the step.
+        inputs (dict[str, Any]): Input arguments for the step.
+        design_metadata (DesignMetadata | None): UI metadata. (Alias: 'x-design').
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -173,7 +242,16 @@ class BaseStep(CoReasonBaseModel):
 
 
 class AgentStep(BaseStep):
-    """A step that executes an AI Agent."""
+    """
+    A step that executes an AI Agent.
+
+    Attributes:
+        type (Literal["agent"]): Discriminator. (Default: "agent").
+        agent (str): Reference to an Agent definition (by ID or name).
+        next (str | None): ID of the next step to execute.
+        system_prompt (str | None): Optional override for system prompt.
+        temporary_skills (list[str]): Skills injected into the agent ONLY for this specific step.
+    """
 
     type: Literal["agent"] = "agent"
     agent: str = Field(..., description="Reference to an Agent definition (by ID or name).")
@@ -185,7 +263,14 @@ class AgentStep(BaseStep):
 
 
 class LogicStep(BaseStep):
-    """A step that executes custom logic."""
+    """
+    A step that executes custom logic.
+
+    Attributes:
+        type (Literal["logic"]): Discriminator. (Default: "logic").
+        code (str): Python code or reference to logic to execute.
+        next (str | None): ID of the next step to execute.
+    """
 
     type: Literal["logic"] = "logic"
     code: str = Field(..., description="Python code or reference to logic to execute.")
@@ -193,7 +278,15 @@ class LogicStep(BaseStep):
 
 
 class CouncilStep(BaseStep):
-    """A step that involves multiple voters/agents."""
+    """
+    A step that involves multiple voters/agents.
+
+    Attributes:
+        type (Literal["council"]): Discriminator. (Default: "council").
+        voters (list[str]): List of voters (Agent IDs).
+        strategy (str): Voting strategy (e.g., consensus, majority). (Default: "consensus").
+        next (str | None): ID of the next step to execute.
+    """
 
     type: Literal["council"] = "council"
     voters: list[str] = Field(..., description="List of voters (Agent IDs).")
@@ -202,7 +295,14 @@ class CouncilStep(BaseStep):
 
 
 class SwitchStep(BaseStep):
-    """A step that routes execution based on conditions."""
+    """
+    A step that routes execution based on conditions.
+
+    Attributes:
+        type (Literal["switch"]): Discriminator. (Default: "switch").
+        cases (dict[str, str]): Dictionary of condition expressions to Step IDs.
+        default (str | None): Default Step ID if no cases match.
+    """
 
     type: Literal["switch"] = "switch"
     cases: dict[str, str] = Field(..., description="Dictionary of condition expressions to Step IDs.")
@@ -217,7 +317,13 @@ Step = Annotated[
 
 
 class Workflow(CoReasonBaseModel):
-    """Defines the execution topology."""
+    """
+    Defines the execution topology.
+
+    Attributes:
+        start (str): ID of the starting step.
+        steps (dict[str, Step]): Dictionary of all steps indexed by ID.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -226,7 +332,19 @@ class Workflow(CoReasonBaseModel):
 
 
 class ManifestMetadata(CoReasonBaseModel):
-    """Metadata for the manifest."""
+    """
+    Metadata for the manifest.
+
+    Attributes:
+        name (str): Human-readable name of the workflow/agent.
+        generation_rationale (str | None): Reasoning behind the creation or selection of this workflow.
+        confidence_score (float | None): A score (0.0 - 1.0) indicating the system's confidence in this workflow.
+        original_user_intent (str | None): The original user prompt or goal that resulted in this workflow.
+        generated_by (str | None): The model or system ID that generated this manifest (e.g., 'coreason-strategist-v1').
+        design_metadata (DesignMetadata | None): UI metadata. (Alias: 'x-design').
+        provenance (ProvenanceData | None): Provenance metadata.
+        tested_models (list[str]): List of LLM identifiers this manifest has been tested on.
+    """
 
     model_config = ConfigDict(extra="allow", populate_by_name=True, frozen=True)
 
@@ -259,7 +377,19 @@ ToolPackDefinition.model_rebuild(
 
 
 class ManifestV2(CoReasonBaseModel):
-    """Root object for Coreason Manifest V2."""
+    """
+    Root object for Coreason Manifest V2.
+
+    Attributes:
+        apiVersion (Literal["coreason.ai/v2"]): API Version. (Default: "coreason.ai/v2").
+        kind (Literal["Recipe", "Agent"]): Kind of the object.
+        metadata (ManifestMetadata): Metadata including name and design info.
+        interface (InterfaceDefinition): Input/Output contract.
+        state (StateDefinition): Internal state schema.
+        policy (PolicyDefinition): Policy and governance.
+        definitions (dict[str, ToolDefinition | AgentDefinition | ...]): Reusable definitions. (Polymorphic: Discriminator 'type').
+        workflow (Workflow): The main workflow topology.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/spec/v2/guardrails.py
+++ b/src/coreason_manifest/spec/v2/guardrails.py
@@ -24,7 +24,15 @@ class BreakerScope(StrEnum):
 
 
 class CircuitBreakerConfig(CoReasonBaseModel):
-    """Configuration for automated stoppage rules."""
+    """
+    Configuration for automated stoppage rules.
+
+    Attributes:
+        failure_rate_threshold (float): Error rate to trigger break. (Constraint: 0.0-1.0).
+        window_seconds (int): Time window for error calculation. (Constraint: >= 1).
+        recovery_timeout_seconds (int): Time to wait before retry. (Constraint: >= 1).
+        scope (BreakerScope): Scope of the breaker. (Default: AGENT).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -35,7 +43,14 @@ class CircuitBreakerConfig(CoReasonBaseModel):
 
 
 class DriftConfig(CoReasonBaseModel):
-    """Configuration for semantic drift detection."""
+    """
+    Configuration for semantic drift detection.
+
+    Attributes:
+        input_drift_threshold (float | None): Max allowed input semantic drift. (Constraint: 0.0-1.0).
+        output_drift_threshold (float | None): Max allowed output semantic drift. (Constraint: 0.0-1.0).
+        baseline_dataset_id (str | None): Dataset ID for baseline comparison.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -45,7 +60,14 @@ class DriftConfig(CoReasonBaseModel):
 
 
 class GuardrailsConfig(CoReasonBaseModel):
-    """Active Defense configuration."""
+    """
+    Active Defense configuration.
+
+    Attributes:
+        circuit_breaker (CircuitBreakerConfig | None): Circuit breaker settings.
+        drift_check (DriftConfig | None): Drift detection settings.
+        spot_check_rate (float | None): Probability of human spot check. (Constraint: 0.0-1.0).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/spec/v2/identity.py
+++ b/src/coreason_manifest/spec/v2/identity.py
@@ -47,7 +47,8 @@ class IdentityRequirement(CoReasonBaseModel):
         required_permissions (list[str]): List of specific permission strings (AND logic). User must have all.
         inject_user_profile (bool): If True, injects name, email, and ID into the context. (Default: False).
         inject_locale_info (bool): If True, injects timezone and locale/language preference. (Default: True).
-        anonymize_pii (bool): If True, the runtime replaces real names/emails with hashes or aliases before sending to LLM. (Default: True).
+        anonymize_pii (bool): If True, the runtime replaces real names/emails with hashes or aliases before sending
+            to LLM. (Default: True).
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)

--- a/src/coreason_manifest/spec/v2/identity.py
+++ b/src/coreason_manifest/spec/v2/identity.py
@@ -38,7 +38,17 @@ class ContextField(StrEnum):
 
 
 class IdentityRequirement(CoReasonBaseModel):
-    """RBAC and Context Injection rules for a Recipe."""
+    """
+    RBAC and Context Injection rules for a Recipe.
+
+    Attributes:
+        min_scope (AccessScope): Minimum authentication level required to execute this recipe. (Default: AUTHENTICATED).
+        required_roles (list[str]): List of mandatory roles (OR logic). User must have at least one.
+        required_permissions (list[str]): List of specific permission strings (AND logic). User must have all.
+        inject_user_profile (bool): If True, injects name, email, and ID into the context. (Default: False).
+        inject_locale_info (bool): If True, injects timezone and locale/language preference. (Default: True).
+        anonymize_pii (bool): If True, the runtime replaces real names/emails with hashes or aliases before sending to LLM. (Default: True).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/spec/v2/knowledge.py
+++ b/src/coreason_manifest/spec/v2/knowledge.py
@@ -70,7 +70,8 @@ class MemoryWriteConfig(CoReasonBaseModel):
     Attributes:
         strategy (ConsolidationStrategy): When to persist memories. (Default: SESSION_CLOSE).
         frequency_turns (int): If strategy is SUMMARY_WINDOW, how many turns trigger a write. (Default: 10).
-        destination_collection (str | None): Target vector store collection. If None, uses the primary retrieval collection.
+        destination_collection (str | None): Target vector store collection. If None, uses the primary
+            retrieval collection.
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)

--- a/src/coreason_manifest/spec/v2/knowledge.py
+++ b/src/coreason_manifest/spec/v2/knowledge.py
@@ -34,7 +34,16 @@ class KnowledgeScope(StrEnum):
 
 
 class RetrievalConfig(CoReasonBaseModel):
-    """Configuration for the RAG engine."""
+    """
+    Configuration for the RAG engine.
+
+    Attributes:
+        strategy (RetrievalStrategy): Search algorithm. (Default: HYBRID).
+        collection_name (str): The ID of the vector/graph collection to query.
+        top_k (int): Number of chunks to retrieve. (Default: 5, Constraint: >= 1).
+        score_threshold (float | None): Minimum similarity score. (Default: 0.7, Constraint: 0.0-1.0).
+        scope (KnowledgeScope): Access control scope. (Default: SHARED).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -55,7 +64,14 @@ class ConsolidationStrategy(StrEnum):
 
 
 class MemoryWriteConfig(CoReasonBaseModel):
-    """Configuration for the Cortex Crystallizer (Memory Writer)."""
+    """
+    Configuration for the Cortex Crystallizer (Memory Writer).
+
+    Attributes:
+        strategy (ConsolidationStrategy): When to persist memories. (Default: SESSION_CLOSE).
+        frequency_turns (int): If strategy is SUMMARY_WINDOW, how many turns trigger a write. (Default: 10).
+        destination_collection (str | None): Target vector store collection. If None, uses the primary retrieval collection.
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 

--- a/src/coreason_manifest/spec/v2/reasoning.py
+++ b/src/coreason_manifest/spec/v2/reasoning.py
@@ -26,7 +26,14 @@ class ReviewStrategy(StrEnum):
 
 
 class AdversarialConfig(CoReasonBaseModel):
-    """Configuration for the 'Devil's Advocate' reviewer."""
+    """
+    Configuration for the 'Devil's Advocate' reviewer.
+
+    Attributes:
+        persona (str): The persona adopted by the reviewer (e.g., 'security_auditor', 'skeptic'). (Default: "skeptic").
+        attack_vectors (list[str]): Specific angles of critique (e.g., 'pii_leakage', 'hallucination').
+        temperature (float): Creativity level of the critique. (Default: 0.7).
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -42,7 +49,13 @@ class AdversarialConfig(CoReasonBaseModel):
 
 
 class GapScanConfig(CoReasonBaseModel):
-    """Configuration for Knowledge Gap detection (Episteme)."""
+    """
+    Configuration for Knowledge Gap detection (Episteme).
+
+    Attributes:
+        enabled (bool): If True, scans context for missing prerequisites before execution. (Default: False).
+        confidence_threshold (float): Minimum confidence to proceed without asking clarifying questions. (Default: 0.8).
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -54,7 +67,15 @@ class GapScanConfig(CoReasonBaseModel):
 
 
 class ReasoningConfig(CoReasonBaseModel):
-    """Container for meta-cognitive behaviors attached to a Node."""
+    """
+    Container for meta-cognitive behaviors attached to a Node.
+
+    Attributes:
+        strategy (ReviewStrategy): The active critique method applied to this node's output. (Default: NONE).
+        adversarial (AdversarialConfig | None): Config if strategy is ADVERSARIAL.
+        gap_scan (GapScanConfig | None): Config for pre-execution knowledge scanning.
+        max_revisions (int): Maximum self-correction loops allowed if critique fails. (Default: 1).
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 
@@ -71,7 +92,14 @@ class ReasoningConfig(CoReasonBaseModel):
 
 
 class ReflexConfig(CoReasonBaseModel):
-    """Configuration for 'System 1' fast thinking (Cortex Reflex)."""
+    """
+    Configuration for 'System 1' fast thinking (Cortex Reflex).
+
+    Attributes:
+        enabled (bool): Allow fast-path responses without deep reasoning chains. (Default: True).
+        confidence_threshold (float): Minimum confidence required to bypass the solver loop. (Default: 0.9).
+        allowed_tools (list[str]): List of read-only tools that can be called in Reflex mode (e.g., 'search', 'get_time').
+    """
 
     model_config = ConfigDict(extra="forbid", frozen=True)
 

--- a/src/coreason_manifest/spec/v2/reasoning.py
+++ b/src/coreason_manifest/spec/v2/reasoning.py
@@ -98,7 +98,8 @@ class ReflexConfig(CoReasonBaseModel):
     Attributes:
         enabled (bool): Allow fast-path responses without deep reasoning chains. (Default: True).
         confidence_threshold (float): Minimum confidence required to bypass the solver loop. (Default: 0.9).
-        allowed_tools (list[str]): List of read-only tools that can be called in Reflex mode (e.g., 'search', 'get_time').
+        allowed_tools (list[str]): List of read-only tools that can be called in Reflex mode (e.g., 'search',
+            'get_time').
     """
 
     model_config = ConfigDict(extra="forbid", frozen=True)

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -68,9 +68,11 @@ class OptimizationIntent(CoReasonBaseModel):
         base_ref (str): Parent ID to fork.
         improvement_goal (str): Prompt for the optimizer (e.g., 'Reduce hallucinations').
         strategy (Literal["atomic", "parallel"]): Optimization strategy. (Default: "parallel").
-        metric_name (str): The grading function to optimize against (e.g., 'faithfulness', 'json_validity'). (Default: "exact_match").
+        metric_name (str): The grading function to optimize against (e.g., 'faithfulness', 'json_validity').
+            (Default: "exact_match").
         teacher_model (str | None): ID of a stronger model to use for bootstrapping synthetic training data.
-        max_demonstrations (int): Maximum number of few-shot examples to learn and inject. (Default: 5, Constraint: >= 0).
+        max_demonstrations (int): Maximum number of few-shot examples to learn and inject.
+            (Default: 5, Constraint: >= 0).
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
@@ -135,7 +137,8 @@ class StateDefinition(CoReasonBaseModel):
 
     Attributes:
         properties (dict[str, Any]): JSON Schema properties for the shared state variables.
-        persistence (Literal["ephemeral", "redis", "postgres"]): How the state should be stored across steps. (Default: "ephemeral").
+        persistence (Literal["ephemeral", "redis", "postgres"]): How the state should be stored across steps.
+            (Default: "ephemeral").
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
@@ -164,13 +167,17 @@ class PolicyConfig(CoReasonBaseModel):
         max_retries (int): Global retry limit for failed steps. (Default: 0).
         timeout_seconds (int | None): Global execution timeout.
         execution_mode (Literal["sequential", "parallel"]): Default execution strategy. (Default: "sequential").
-        priority (ExecutionPriority): Traffic priority. Low priority requests may be queued or dropped during high load. (Default: NORMAL).
+        priority (ExecutionPriority): Traffic priority. Low priority requests may be queued or dropped during high load.
+            (Default: NORMAL).
         rate_limit_rpm (int | None): Max requests per minute allowed for this recipe execution. (Constraint: >= 0).
         rate_limit_tpm (int | None): Max tokens per minute allowed (input + output). (Constraint: >= 0).
-        caching_enabled (bool): Allow the Gateway to serve cached responses for identical inputs (Semantic Caching). (Default: True).
+        caching_enabled (bool): Allow the Gateway to serve cached responses for identical inputs (Semantic Caching).
+            (Default: True).
         budget_cap_usd (float | None): Hard limit for estimated token + tool costs. Execution halts if exceeded.
-        token_budget (int | None): Max tokens for the assembled prompt. Low-priority contexts will be pruned if exceeded.
-        sensitive_tools (list[str]): List of tool names that ALWAYS require human confirmation (InteractionConfig override).
+        token_budget (int | None): Max tokens for the assembled prompt. Low-priority contexts will be pruned if
+            exceeded.
+        sensitive_tools (list[str]): List of tool names that ALWAYS require human confirmation (InteractionConfig
+            override).
         allowed_mcp_servers (list[str]): Whitelist of MCP server names this recipe is allowed to access.
         safety_preamble (str | None): Mandatory safety instruction injected into the system prompt.
         legal_disclaimer (str | None): Text that must be appended to the final output.
@@ -317,7 +324,8 @@ class CollaborationConfig(CoReasonBaseModel):
         supported_commands (list[str]): Slash commands the agent understands.
         channels (list[str]): Communication channels to notify (e.g., ['slack', 'email', 'mobile_push']).
         timeout_seconds (int | None): How long to wait for human input before triggering fallback.
-        fallback_behavior (Literal["fail", "proceed_with_default", "escalate"]): Action to take if the timeout is exceeded. (Default: "fail").
+        fallback_behavior (Literal["fail", "proceed_with_default", "escalate"]): Action to take if the timeout
+            is exceeded. (Default: "fail").
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
@@ -389,7 +397,8 @@ class RecipeNode(CoReasonBaseModel):
         visualization (PresentationHints | None): Dynamic rendering hints (Glass Box).
         collaboration (CollaborationConfig | None): Human engagement rules (Co-Pilot).
         recovery (RecoveryConfig | None): Error handling and resilience settings.
-        reasoning (ReasoningConfig | None): Meta-cognition settings: Review loops, gap scanning, and validation strategies.
+        reasoning (ReasoningConfig | None): Meta-cognition settings: Review loops, gap scanning, and validation
+            strategies.
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
@@ -417,9 +426,11 @@ class AgentNode(RecipeNode):
 
     Attributes:
         type (Literal["agent"]): Discriminator. (Default: "agent").
-        cognitive_profile (CognitiveProfile | None): Inline definition of the agent's cognitive architecture (for the Weaver).
+        cognitive_profile (CognitiveProfile | None): Inline definition of the agent's cognitive architecture
+            (for the Weaver).
         agent_ref (str | SemanticRef | None): The ID or URI of the Agent Definition, or a Semantic Reference.
-        model_policy (ModelSelectionPolicy | str | None): The routing policy for the LLM. Can be an inline policy or a reference to a Model ID.
+        model_policy (ModelSelectionPolicy | str | None): The routing policy for the LLM. Can be an inline policy
+            or a reference to a Model ID.
         system_prompt_override (str | None): Context-specific instructions.
         inputs_map (dict[str, str]): Mapping parent outputs to agent inputs.
     """
@@ -463,12 +474,15 @@ class SolverConfig(CoReasonBaseModel):
         strategy (SolverStrategy): The planning strategy to use. (Default: STANDARD).
         depth_limit (int): Hard limit on recursion depth. (Default: 3, Constraint: >= 1).
         n_samples (int): Council size: How many plans to generate. (Default: 1, Constraint: >= 1).
-        diversity_threshold (float | None): For Ensemble: Minimum Jaccard distance required between generated plans. (Default: 0.3, Constraint: 0.0-1.0).
+        diversity_threshold (float | None): For Ensemble: Minimum Jaccard distance required between generated plans.
+            (Default: 0.3, Constraint: 0.0-1.0).
         enable_dissenter (bool): If True, an adversarial agent will critique plans before voting. (Default: False).
-        consensus_threshold (float | None): Percentage of votes required to ratify a plan. (Default: 0.6, Constraint: 0.0-1.0).
+        consensus_threshold (float | None): Percentage of votes required to ratify a plan.
+            (Default: 0.6, Constraint: 0.0-1.0).
         beam_width (int): For LATS: How many children to expand per node. (Default: 1, Constraint: >= 1).
         max_iterations (int): For LATS: The 'Search Budget' (total simulations). (Default: 10, Constraint: >= 1).
-        aggregation_method (Literal["best_of_n", "majority_vote", "weighted_merge"] | None): How to combine results if n_samples > 1.
+        aggregation_method (Literal["best_of_n", "majority_vote", "weighted_merge"] | None): How to combine results
+            if n_samples > 1.
     """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
@@ -809,7 +823,8 @@ class RecipeDefinition(CoReasonBaseModel):
         interface (RecipeInterface): Input/Output contract.
         environment (RuntimeEnvironment | None): The infrastructure requirements for the recipe.
         default_model_policy (ModelSelectionPolicy | None): Default model selection rules for all agents in this recipe.
-        tests (list[SimulationScenario]): Self-contained test scenarios (harvested from Simulacrum) to validate this recipe.
+        tests (list[SimulationScenario]): Self-contained test scenarios (harvested from Simulacrum) to validate
+            this recipe.
         requirements (list[Constraint]): List of feasibility constraints.
         state (StateDefinition | None): Internal state schema.
         policy (PolicyConfig | None): Execution limits and error handling.

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -42,7 +42,15 @@ class RecipeStatus(StrEnum):
 
 
 class RecipeRecommendation(CoReasonBaseModel):
-    """Stores search results from the catalog."""
+    """
+    Stores search results from the catalog.
+
+    Attributes:
+        ref (str): ID of the candidate.
+        score (float): 0.0 - 1.0 score.
+        rationale (str): Rationale for the recommendation.
+        warnings (list[str]): Warnings if any.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -53,7 +61,17 @@ class RecipeRecommendation(CoReasonBaseModel):
 
 
 class OptimizationIntent(CoReasonBaseModel):
-    """Directives for 'Fork & Improve' workflows (harvested from Foundry)."""
+    """
+    Directives for 'Fork & Improve' workflows (harvested from Foundry).
+
+    Attributes:
+        base_ref (str): Parent ID to fork.
+        improvement_goal (str): Prompt for the optimizer (e.g., 'Reduce hallucinations').
+        strategy (Literal["atomic", "parallel"]): Optimization strategy. (Default: "parallel").
+        metric_name (str): The grading function to optimize against (e.g., 'faithfulness', 'json_validity'). (Default: "exact_match").
+        teacher_model (str | None): ID of a stronger model to use for bootstrapping synthetic training data.
+        max_demonstrations (int): Maximum number of few-shot examples to learn and inject. (Default: 5, Constraint: >= 0).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -74,7 +92,15 @@ class OptimizationIntent(CoReasonBaseModel):
 
 
 class SemanticRef(CoReasonBaseModel):
-    """A semantic reference (placeholder) for an agent or tool."""
+    """
+    A semantic reference (placeholder) for an agent or tool.
+
+    Attributes:
+        intent (str): The intent description for this placeholder.
+        constraints (list[str]): Hard requirements.
+        candidates (list[RecipeRecommendation]): AI suggestions.
+        optimization (OptimizationIntent | None): Optional directive.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -85,7 +111,13 @@ class SemanticRef(CoReasonBaseModel):
 
 
 class RecipeInterface(CoReasonBaseModel):
-    """Defines the Input/Output contract for the Recipe using JSON Schema."""
+    """
+    Defines the Input/Output contract for the Recipe using JSON Schema.
+
+    Attributes:
+        inputs (dict[str, Any]): JSON Schema defining the expected input arguments.
+        outputs (dict[str, Any]): JSON Schema defining the structure of the final result.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -98,7 +130,13 @@ class RecipeInterface(CoReasonBaseModel):
 
 
 class StateDefinition(CoReasonBaseModel):
-    """Defines the shared memory (Blackboard) structure and persistence."""
+    """
+    Defines the shared memory (Blackboard) structure and persistence.
+
+    Attributes:
+        properties (dict[str, Any]): JSON Schema properties for the shared state variables.
+        persistence (Literal["ephemeral", "redis", "postgres"]): How the state should be stored across steps. (Default: "ephemeral").
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -119,7 +157,24 @@ class ExecutionPriority(IntEnum):
 
 
 class PolicyConfig(CoReasonBaseModel):
-    """Governance rules for execution limits (harvested from Connect)."""
+    """
+    Governance rules for execution limits (harvested from Connect).
+
+    Attributes:
+        max_retries (int): Global retry limit for failed steps. (Default: 0).
+        timeout_seconds (int | None): Global execution timeout.
+        execution_mode (Literal["sequential", "parallel"]): Default execution strategy. (Default: "sequential").
+        priority (ExecutionPriority): Traffic priority. Low priority requests may be queued or dropped during high load. (Default: NORMAL).
+        rate_limit_rpm (int | None): Max requests per minute allowed for this recipe execution. (Constraint: >= 0).
+        rate_limit_tpm (int | None): Max tokens per minute allowed (input + output). (Constraint: >= 0).
+        caching_enabled (bool): Allow the Gateway to serve cached responses for identical inputs (Semantic Caching). (Default: True).
+        budget_cap_usd (float | None): Hard limit for estimated token + tool costs. Execution halts if exceeded.
+        token_budget (int | None): Max tokens for the assembled prompt. Low-priority contexts will be pruned if exceeded.
+        sensitive_tools (list[str]): List of tool names that ALWAYS require human confirmation (InteractionConfig override).
+        allowed_mcp_servers (list[str]): Whitelist of MCP server names this recipe is allowed to access.
+        safety_preamble (str | None): Mandatory safety instruction injected into the system prompt.
+        legal_disclaimer (str | None): Text that must be appended to the final output.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -192,7 +247,16 @@ class InterventionTrigger(StrEnum):
 
 
 class InteractionConfig(CoReasonBaseModel):
-    """Configuration for the Interactive Control Plane."""
+    """
+    Configuration for the Interactive Control Plane.
+
+    Attributes:
+        transparency (TransparencyLevel): Visibility level. (Default: OPAQUE).
+        triggers (list[InterventionTrigger]): When to pause.
+        editable_fields (list[str]): Whitelist of fields modifiable during pause.
+        enforce_contract (bool): Validate steered output against original schema. (Default: True).
+        guidance_hint (str | None): Hint for the human operator.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -213,7 +277,16 @@ class VisualizationStyle(StrEnum):
 
 
 class PresentationHints(CoReasonBaseModel):
-    """Directives for the frontend on how to render the internal reasoning."""
+    """
+    Directives for the frontend on how to render the internal reasoning.
+
+    Attributes:
+        style (VisualizationStyle): Visualization style. (Default: CHAT).
+        display_title (str | None): Human-friendly label override.
+        icon (str | None): Icon name/emoji, e.g., 'lucide:brain'.
+        hidden_fields (list[str]): Whitelist of internal variables to hide from the non-debug UI.
+        progress_indicator (str | None): Name of the context variable to watch for % completion.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -235,7 +308,17 @@ class CollaborationMode(StrEnum):
 
 
 class CollaborationConfig(CoReasonBaseModel):
-    """Rules for human-agent engagement (harvested from Human-Layer)."""
+    """
+    Rules for human-agent engagement (harvested from Human-Layer).
+
+    Attributes:
+        mode (CollaborationMode): Engagement mode. (Default: COMPLETION).
+        feedback_schema (dict[str, Any] | None): JSON Schema for structured feedback.
+        supported_commands (list[str]): Slash commands the agent understands.
+        channels (list[str]): Communication channels to notify (e.g., ['slack', 'email', 'mobile_push']).
+        timeout_seconds (int | None): How long to wait for human input before triggering fallback.
+        fallback_behavior (Literal["fail", "proceed_with_default", "escalate"]): Action to take if the timeout is exceeded. (Default: "fail").
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -266,7 +349,16 @@ class FailureBehavior(StrEnum):
 
 
 class RecoveryConfig(CoReasonBaseModel):
-    """Configuration for node-level resilience (harvested from Maco)."""
+    """
+    Configuration for node-level resilience (harvested from Maco).
+
+    Attributes:
+        max_retries (int | None): Override global retry limit.
+        retry_delay_seconds (float): Backoff start. (Default: 1.0).
+        behavior (FailureBehavior): Strategy on final failure. (Default: FAIL_WORKFLOW).
+        fallback_node_id (str | None): The ID of the node to transition to if behavior is ROUTE_TO_FALLBACK.
+        default_output (dict[str, Any] | None): Static payload to return if behavior is CONTINUE_WITH_DEFAULT.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -286,7 +378,19 @@ class RecoveryConfig(CoReasonBaseModel):
 
 
 class RecipeNode(CoReasonBaseModel):
-    """Base class for all nodes in a Recipe graph."""
+    """
+    Base class for all nodes in a Recipe graph.
+
+    Attributes:
+        id (str): Unique identifier within the graph.
+        metadata (dict[str, Any]): Custom metadata (not for UI layout).
+        presentation (NodePresentation | None): Static visual layout (x, y, color).
+        interaction (InteractionConfig | None): Interactive control plane configuration.
+        visualization (PresentationHints | None): Dynamic rendering hints (Glass Box).
+        collaboration (CollaborationConfig | None): Human engagement rules (Co-Pilot).
+        recovery (RecoveryConfig | None): Error handling and resilience settings.
+        reasoning (ReasoningConfig | None): Meta-cognition settings: Review loops, gap scanning, and validation strategies.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -308,7 +412,17 @@ class RecipeNode(CoReasonBaseModel):
 
 
 class AgentNode(RecipeNode):
-    """A node that executes an AI Agent."""
+    """
+    A node that executes an AI Agent.
+
+    Attributes:
+        type (Literal["agent"]): Discriminator. (Default: "agent").
+        cognitive_profile (CognitiveProfile | None): Inline definition of the agent's cognitive architecture (for the Weaver).
+        agent_ref (str | SemanticRef | None): The ID or URI of the Agent Definition, or a Semantic Reference.
+        model_policy (ModelSelectionPolicy | str | None): The routing policy for the LLM. Can be an inline policy or a reference to a Model ID.
+        system_prompt_override (str | None): Context-specific instructions.
+        inputs_map (dict[str, str]): Mapping parent outputs to agent inputs.
+    """
 
     type: Literal["agent"] = "agent"
 
@@ -342,7 +456,20 @@ class SolverStrategy(StrEnum):
 
 
 class SolverConfig(CoReasonBaseModel):
-    """Configuration for the autonomous planning capabilities."""
+    """
+    Configuration for the autonomous planning capabilities.
+
+    Attributes:
+        strategy (SolverStrategy): The planning strategy to use. (Default: STANDARD).
+        depth_limit (int): Hard limit on recursion depth. (Default: 3, Constraint: >= 1).
+        n_samples (int): Council size: How many plans to generate. (Default: 1, Constraint: >= 1).
+        diversity_threshold (float | None): For Ensemble: Minimum Jaccard distance required between generated plans. (Default: 0.3, Constraint: 0.0-1.0).
+        enable_dissenter (bool): If True, an adversarial agent will critique plans before voting. (Default: False).
+        consensus_threshold (float | None): Percentage of votes required to ratify a plan. (Default: 0.6, Constraint: 0.0-1.0).
+        beam_width (int): For LATS: How many children to expand per node. (Default: 1, Constraint: >= 1).
+        max_iterations (int): For LATS: The 'Search Budget' (total simulations). (Default: 10, Constraint: >= 1).
+        aggregation_method (Literal["best_of_n", "majority_vote", "weighted_merge"] | None): How to combine results if n_samples > 1.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -375,7 +502,16 @@ class SolverConfig(CoReasonBaseModel):
 
 
 class GenerativeNode(RecipeNode):
-    """A node that acts as an interface definition for dynamic solvers."""
+    """
+    A node that acts as an interface definition for dynamic solvers.
+
+    Attributes:
+        type (Literal["generative"]): Discriminator. (Default: "generative").
+        goal (str): The high-level objective.
+        solver (SolverConfig): Configuration for the autonomous planning capabilities.
+        allowed_tools (list[str]): Whitelist of Tool IDs the solver is permitted to use.
+        output_schema (dict[str, Any]): The contract for the result.
+    """
 
     type: Literal["generative"] = "generative"
     goal: str = Field(..., description="The high-level objective.")
@@ -390,7 +526,15 @@ class GenerativeNode(RecipeNode):
 
 
 class HumanNode(RecipeNode):
-    """A node that pauses execution for human input/approval."""
+    """
+    A node that pauses execution for human input/approval.
+
+    Attributes:
+        type (Literal["human"]): Discriminator. (Default: "human").
+        prompt (str): Instruction for the human user.
+        timeout_seconds (int | None): SLA for approval.
+        required_role (str | None): Role required to approve (e.g., manager).
+    """
 
     type: Literal["human"] = "human"
     prompt: str = Field(..., description="Instruction for the human user.")
@@ -399,7 +543,15 @@ class HumanNode(RecipeNode):
 
 
 class RouterNode(RecipeNode):
-    """A node that routes execution based on a variable."""
+    """
+    A node that routes execution based on a variable.
+
+    Attributes:
+        type (Literal["router"]): Discriminator. (Default: "router").
+        input_key (str): The variable to evaluate (e.g., 'classification').
+        routes (dict[str, str]): Map of value -> target_node_id.
+        default_route (str): Fallback target_node_id.
+    """
 
     type: Literal["router"] = "router"
     input_key: str = Field(..., description="The variable to evaluate (e.g., 'classification').")
@@ -408,7 +560,20 @@ class RouterNode(RecipeNode):
 
 
 class EvaluatorNode(RecipeNode):
-    """A node that evaluates a target variable using an LLM judge."""
+    """
+    A node that evaluates a target variable using an LLM judge.
+
+    Attributes:
+        type (Literal["evaluator"]): Discriminator. (Default: "evaluator").
+        target_variable (str): The key in the shared state/blackboard containing the content to evaluate.
+        evaluator_agent_ref (str): Reference to the Agent Definition ID that will act as the judge.
+        evaluation_profile (EvaluationProfile | str): Inline criteria definition or a reference to a preset profile.
+        pass_threshold (float): The score, 0.0-1.0, required to proceed.
+        max_refinements (int): Maximum number of loops allowed before forcing a generic fail/fallback.
+        pass_route (str): Node ID to go to if score >= threshold.
+        fail_route (str): Node ID to go to if score < threshold.
+        feedback_variable (str): The key in the state where the critique/reasoning will be written.
+    """
 
     type: Literal["evaluator"] = "evaluator"
     target_variable: str = Field(
@@ -432,7 +597,14 @@ class EvaluatorNode(RecipeNode):
 
 
 class GraphEdge(CoReasonBaseModel):
-    """A directed edge between two nodes."""
+    """
+    A directed edge between two nodes.
+
+    Attributes:
+        source (str): Source Node ID.
+        target (str): Target Node ID.
+        condition (str | None): Label for visualization (e.g., 'approved').
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -442,7 +614,24 @@ class GraphEdge(CoReasonBaseModel):
 
 
 class GraphTopology(CoReasonBaseModel):
-    """The directed cyclic graph structure defining the control flow."""
+    """
+    The directed cyclic graph structure defining the control flow.
+
+    Attributes:
+        nodes (list[AgentNode | HumanNode | RouterNode | EvaluatorNode | GenerativeNode]): List of nodes in the graph.
+        edges (list[GraphEdge]): List of directed edges.
+        entry_point (str): ID of the start node.
+        status (Literal["draft", "valid"]): Validation status of the topology. (Default: "valid").
+
+    Validators:
+        validate_integrity (@model_validator):
+            Verifies graph integrity:
+            1. Checks for duplicate node IDs.
+            2. If status is 'valid', calls _validate_completeness() to ensure:
+                - Entry point exists in nodes.
+                - All edges connect existing nodes (no dangling edges).
+                - All fallback nodes (from RecoveryConfig) exist.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -507,7 +696,12 @@ class GraphTopology(CoReasonBaseModel):
 
 
 class TaskSequence(CoReasonBaseModel):
-    """A linear sequence of tasks that simplifies graph creation."""
+    """
+    A linear sequence of tasks that simplifies graph creation.
+
+    Attributes:
+        steps (list[AgentNode | ...]): Ordered list of steps to execute. (Constraint: Min length 1).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -524,7 +718,12 @@ class TaskSequence(CoReasonBaseModel):
 
 
 def coerce_topology(v: Any) -> Any:
-    """Coerce linear lists or TaskSequence dicts into GraphTopology."""
+    """
+    Coerce linear lists or TaskSequence dicts into GraphTopology.
+
+    This validator allows users to provide a simple list of steps, which will be
+    converted into a full graph topology automatically.
+    """
     # 1. If topology is a list (simplification), treat as steps
     if isinstance(v, list):
         return TaskSequence(steps=v).to_graph()
@@ -539,7 +738,16 @@ def coerce_topology(v: Any) -> Any:
 
 
 class Constraint(CoReasonBaseModel):
-    """Represents a feasibility constraint for a Recipe."""
+    """
+    Represents a feasibility constraint for a Recipe.
+
+    Attributes:
+        variable (str): The context variable path to check (e.g., 'data.row_count').
+        operator (Literal["eq", "neq", "gt", "gte", "lt", "lte", "in", "contains"]): Comparison operator.
+        value (Any): The threshold or reference value.
+        required (bool): If True, failure halts execution. If False, it's a warning. (Default: True).
+        error_message (str | None): Custom error message to display on failure.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -590,7 +798,36 @@ class Constraint(CoReasonBaseModel):
 
 
 class RecipeDefinition(CoReasonBaseModel):
-    """Definition of a Recipe (Graph-based Workflow)."""
+    """
+    Definition of a Recipe (Graph-based Workflow).
+
+    Attributes:
+        apiVersion (Literal["coreason.ai/v2"]): API Version. (Default: "coreason.ai/v2").
+        kind (Literal["Recipe"]): Kind of the object. (Default: "Recipe").
+        metadata (ManifestMetadata): Metadata including name and design info.
+        status (RecipeStatus): Lifecycle state. 'published' enforces strict validation. (Default: DRAFT).
+        interface (RecipeInterface): Input/Output contract.
+        environment (RuntimeEnvironment | None): The infrastructure requirements for the recipe.
+        default_model_policy (ModelSelectionPolicy | None): Default model selection rules for all agents in this recipe.
+        tests (list[SimulationScenario]): Self-contained test scenarios (harvested from Simulacrum) to validate this recipe.
+        requirements (list[Constraint]): List of feasibility constraints.
+        state (StateDefinition | None): Internal state schema.
+        policy (PolicyConfig | None): Execution limits and error handling.
+        compliance (ComplianceConfig | None): Directives for the Auditor worker (logging, retention, signing).
+        identity (IdentityRequirement | None): Access control and user context injection rules.
+        guardrails (GuardrailsConfig | None): Active defense rules (Circuit Breakers, Drift, Spot Checks).
+        topology (Annotated[GraphTopology, BeforeValidator(coerce_topology)]): The execution graph topology.
+            (Validation: Applies `coerce_topology` before parsing).
+
+    Validators:
+        validate_topology_integrity (@model_validator):
+            Ensures all `recovery.fallback_node_id` references point to existing Node IDs.
+        enforce_lifecycle_constraints (@model_validator):
+            If status is PUBLISHED:
+            - Rejects abstract nodes (SemanticRef).
+            - Rejects incomplete nodes (missing cognitive_profile or agent_ref).
+            - Enforces strict graph integrity (no dangling edges).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/spec/v2/resources.py
+++ b/src/coreason_manifest/spec/v2/resources.py
@@ -33,7 +33,16 @@ class Currency(StrEnum):
 
 
 class RateCard(CoReasonBaseModel):
-    """Pricing details for a resource."""
+    """
+    Pricing details for a resource.
+
+    Attributes:
+        unit (PricingUnit): Unit of pricing. (Default: TOKEN_1M).
+        currency (Currency): Currency. (Default: USD).
+        input_cost (float): Cost per unit for input/prompt.
+        output_cost (float): Cost per unit for output/completion.
+        fixed_cost_per_request (float): Optional base fee. (Default: 0.0).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -45,7 +54,15 @@ class RateCard(CoReasonBaseModel):
 
 
 class ResourceConstraints(CoReasonBaseModel):
-    """Technical limitations and constraints."""
+    """
+    Technical limitations and constraints.
+
+    Attributes:
+        context_window_size (int): Total tokens supported. (Constraint: >= 0).
+        max_output_tokens (int | None): Limit on generation. (Constraint: >= 0).
+        rate_limit_rpm (int | None): Requests per minute. (Constraint: >= 0).
+        rate_limit_tpm (int | None): Tokens per minute. (Constraint: >= 0).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -56,7 +73,15 @@ class ResourceConstraints(CoReasonBaseModel):
 
 
 class ModelProfile(CoReasonBaseModel):
-    """Resource profile describing hardware, pricing, and operational constraints."""
+    """
+    Resource profile describing hardware, pricing, and operational constraints.
+
+    Attributes:
+        provider (str): Provider name (e.g. openai).
+        model_id (str): The technical ID (e.g. gpt-4).
+        pricing (RateCard | None): Financials.
+        constraints (ResourceConstraints | None): Technical limits.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -67,7 +92,15 @@ class ModelProfile(CoReasonBaseModel):
 
 
 class ToolParameter(CoReasonBaseModel):
-    """Parameter definition for a tool."""
+    """
+    Parameter definition for a tool.
+
+    Attributes:
+        name (str): Parameter name.
+        type (str): Data type of the parameter.
+        description (str): Parameter description.
+        required (bool): Whether the parameter is required. (Default: True).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -78,7 +111,16 @@ class ToolParameter(CoReasonBaseModel):
 
 
 class ToolDefinition(CoReasonBaseModel):
-    """Static definition of an MCP tool capability."""
+    """
+    Static definition of an MCP tool capability.
+
+    Attributes:
+        name (str): The tool name (e.g., 'brave_search').
+        description (str): What the tool does.
+        parameters (dict[str, Any]): JSON Schema of inputs.
+        is_consequential (bool): If True, coreason-mcp MUST require human approval before execution. (Default: False).
+        namespace (str | None): Expected MCP server namespace (e.g., 'github').
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -92,7 +134,14 @@ class ToolDefinition(CoReasonBaseModel):
 
 
 class McpServerRequirement(CoReasonBaseModel):
-    """Declares that this recipe needs a specific MCP server available."""
+    """
+    Declares that this recipe needs a specific MCP server available.
+
+    Attributes:
+        name (str): Server name.
+        required_tools (list[str]): List of required tools.
+        version_constraint (str | None): Version constraint.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -102,7 +151,13 @@ class McpServerRequirement(CoReasonBaseModel):
 
 
 class RuntimeEnvironment(CoReasonBaseModel):
-    """The infrastructure requirements for the recipe."""
+    """
+    The infrastructure requirements for the recipe.
+
+    Attributes:
+        mcp_servers (list[McpServerRequirement]): Required MCP servers.
+        python_version (str | None): Required Python version. (Default: "3.12").
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -130,7 +185,17 @@ class ComplianceTier(StrEnum):
 
 
 class ModelSelectionPolicy(CoReasonBaseModel):
-    """Configuration for dynamic model routing (Arbitrage)."""
+    """
+    Configuration for dynamic model routing (Arbitrage).
+
+    Attributes:
+        strategy (RoutingStrategy): Selection algorithm. (Default: PRIORITY).
+        min_context_window (int | None): Minimum required context size.
+        max_input_cost_per_m (float | None): Max allowed input cost ($/1M tokens).
+        compliance (list[ComplianceTier]): Required compliance certifications.
+        provider_whitelist (list[str]): Allowed providers (e.g. ['azure', 'anthropic']).
+        allow_fallback (bool): If primary selection fails, try others? (Default: True).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/spec/v2/skills.py
+++ b/src/coreason_manifest/spec/v2/skills.py
@@ -25,7 +25,14 @@ class LoadStrategy(StrEnum):
 
 
 class SkillDependency(CoReasonBaseModel):
-    """Dependency required by a skill."""
+    """
+    Dependency required by a skill.
+
+    Attributes:
+        ecosystem (Literal["python", "node", "system", "mcp"]): The ecosystem of the dependency.
+        package (str): The package name or command.
+        version_constraint (str | None): Optional version constraint.
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
@@ -35,7 +42,28 @@ class SkillDependency(CoReasonBaseModel):
 
 
 class SkillDefinition(CoReasonBaseModel):
-    """Definition of an Agent Skill (Procedural Knowledge)."""
+    """
+    Definition of an Agent Skill (Procedural Knowledge).
+
+    Attributes:
+        type (Literal["skill"]): Discriminator. (Default: "skill").
+        id (str): Unique ID for the skill.
+        name (str): Human-readable name of the skill.
+        version (str): Semantic version of the skill. (Default: "1.0.0").
+        description (str): Human-readable summary.
+        trigger_intent (str | None): Dense, semantic description used for vector routing. Critical for lazy loading.
+        instructions (str | None): Inline system prompt/instructions.
+        instructions_uri (str | None): Path to external SKILL.md file.
+        scripts (dict[str, str]): Map of script names to file paths.
+        dependencies (list[SkillDependency]): List of dependencies required by the skill.
+        load_strategy (LoadStrategy): Strategy for loading the skill instructions. (Default: LAZY).
+
+    Validators:
+        validate_consistency (@model_validator):
+            Ensures consistency between load strategy and trigger intent.
+            - LAZY loading requires a `trigger_intent`.
+            - Enforces XOR between `instructions` and `instructions_uri` (must have exactly one).
+    """
 
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 

--- a/src/coreason_manifest/utils/mcp_adapter.py
+++ b/src/coreason_manifest/utils/mcp_adapter.py
@@ -17,7 +17,21 @@ from coreason_manifest.spec.v2.definitions import AgentDefinition
 def create_mcp_tool_definition(agent: AgentDefinition) -> dict[str, Any]:
     """
     Converts a Coreason Agent Definition into an MCP Tool structure.
-    Returns a dictionary compatible with MCP's 'Tool' type.
+
+    This function adapts the agent's identity and interface to match the Model Context Protocol (MCP)
+    'Tool' specification.
+
+    WARNING: This conversion is lossy and opinionated:
+    1. Name Sanitization: The agent name is lowercased and non-alphanumeric characters are replaced
+       with underscores to meet MCP strict naming conventions.
+    2. Description Fallback: Uses `backstory` if available, otherwise `goal`, otherwise a generic string.
+    3. Schema: Directly uses `agent.interface.inputs` as `inputSchema`. Ensure this is a valid JSON Schema.
+
+    Args:
+        agent (AgentDefinition): The source agent definition.
+
+    Returns:
+        dict[str, Any]: A dictionary compatible with MCP's 'Tool' type.
     """
     # Sanitize name: lowercase, replace non-alphanumeric with _, collapse _, strip _
     name = re.sub(r"[^a-zA-Z0-9_-]", "_", agent.name).lower()

--- a/src/coreason_manifest/utils/openai_adapter.py
+++ b/src/coreason_manifest/utils/openai_adapter.py
@@ -20,11 +20,18 @@ def convert_to_openai_assistant(agent: AgentDefinition) -> dict[str, Any]:
     This function maps the agent's identity, instructions, and tools to the format
     expected by the OpenAI Assistants API.
 
+    WARNING: This conversion involves lossy transformations:
+    1. Instructions: Concatenates `role`, `goal`, and `backstory` into a single text block.
+    2. Tool Dropping: SILENTLY DROPS any `ToolRequirement` (remote tools) because their
+       schema is not available locally for registration with OpenAI.
+    3. Model Default: Invents "gpt-4-turbo-preview" as the default model if `agent.model`
+       is not specified.
+
     Args:
-        agent: The agent definition to convert.
+        agent (AgentDefinition): The agent definition to convert.
 
     Returns:
-        A dictionary representing the OpenAI Assistant configuration.
+        dict[str, Any]: A dictionary representing the OpenAI Assistant configuration.
     """
     instructions_parts = [
         f"Role: {agent.role}",


### PR DESCRIPTION
This PR updates the docstrings across the `coreason-manifest` library to meet "SOTA Documentation" standards. 

Key changes include:
1.  **Field Promotion**: All Pydantic models in `spec/v2` now have class-level docstrings detailing attributes, constraints, and default values, extracted from `Field()` definitions.
2.  **Validator Visibility**: `model_validator` logic (e.g., topology integrity checks, lifecycle constraints) is now explicitly documented in class docstrings.
3.  **Builder Pattern**: `AgentBuilder` and `ManifestBuilder` methods now explicitly return `Self` to document fluent interface capabilities.
4.  **Adapter Transparency**: `mcp_adapter.py` and `openai_adapter.py` now include warnings about data loss, sanitization, and default inventions during conversion.

These changes ensure that the documentation serves as a strict data contract for users of the library.

---
*PR created automatically by Jules for task [734166587984182899](https://jules.google.com/task/734166587984182899) started by @gowthamrao*