### PR TITLE
Refactor ManifestV2 validation and consolidate adapters/tests (#452)

### DIFF
--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -8,9 +8,9 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Self
 
-from pydantic import ConfigDict, Field, field_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from coreason_manifest.spec.common.capabilities import AgentCapabilities
 from coreason_manifest.spec.common.interoperability import AgentRuntimeConfig
@@ -402,6 +402,7 @@ class ManifestV2(CoReasonBaseModel):
     interface: InterfaceDefinition = Field(default_factory=InterfaceDefinition)
     state: StateDefinition = Field(default_factory=StateDefinition)
     policy: PolicyDefinition = Field(default_factory=PolicyDefinition)
+    status: Literal["draft", "published"] = Field("draft", description="Lifecycle status.")
     definitions: dict[
         str,
         Annotated[
@@ -411,3 +412,73 @@ class ManifestV2(CoReasonBaseModel):
         | GenericDefinition,
     ] = Field(default_factory=dict, description="Reusable definitions.")
     workflow: Workflow = Field(..., description="The main workflow topology.")
+
+    @model_validator(mode="after")
+    def validate_integrity(self) -> Self:
+        """Validate referential integrity of the manifest."""
+        if self.status != "published":
+            return self
+
+        steps = self.workflow.steps
+
+        # 1. Validate Start Step
+        if self.workflow.start not in steps:
+            raise ValueError(f"Start step '{self.workflow.start}' not found in steps.")
+
+        for step in steps.values():
+            # 2. Validate 'next' pointers (AgentStep, LogicStep, CouncilStep)
+            if hasattr(step, "next") and step.next and step.next not in steps:
+                raise ValueError(f"Step '{step.id}' references missing next step '{step.next}'.")
+
+            # 3. Validate SwitchStep targets
+            if isinstance(step, SwitchStep):
+                for target in step.cases.values():
+                    if target not in steps:
+                        raise ValueError(f"SwitchStep '{step.id}' references missing step '{target}' in cases.")
+                if step.default and step.default not in steps:
+                    raise ValueError(f"SwitchStep '{step.id}' references missing step '{step.default}' in default.")
+
+            # 4. Validate Definition References
+            if isinstance(step, AgentStep):
+                if step.agent not in self.definitions:
+                    raise ValueError(f"AgentStep '{step.id}' references missing agent '{step.agent}'.")
+
+                # Check type
+                agent_def = self.definitions[step.agent]
+                if not isinstance(agent_def, AgentDefinition):
+                    raise ValueError(
+                        f"AgentStep '{step.id}' references '{step.agent}' which is not an AgentDefinition "
+                        f"(got {type(agent_def).__name__})."
+                    )
+
+            if isinstance(step, CouncilStep):
+                for voter in step.voters:
+                    if voter not in self.definitions:
+                        raise ValueError(f"CouncilStep '{step.id}' references missing voter '{voter}'.")
+
+                    # Check type
+                    agent_def = self.definitions[voter]
+                    if not isinstance(agent_def, AgentDefinition):
+                        raise ValueError(
+                            f"CouncilStep '{step.id}' references voter '{voter}' which is not an AgentDefinition "
+                            f"(got {type(agent_def).__name__})."
+                        )
+
+        # 5. Validate Agent Tools
+        for definition in self.definitions.values():
+            if isinstance(definition, AgentDefinition):
+                for tool_ref in definition.tools:
+                    # Handle ToolRequirement (remote tools)
+                    if isinstance(tool_ref, ToolRequirement):
+                        if tool_ref.uri in self.definitions:
+                            tool_def = self.definitions[tool_ref.uri]
+                            if not isinstance(tool_def, ToolDefinition):
+                                raise ValueError(
+                                    f"Agent '{definition.id}' references '{tool_ref.uri}' "
+                                    f"which is not a ToolDefinition (got {type(tool_def).__name__})."
+                                )
+                        elif "://" not in tool_ref.uri:
+                            # If it's not a valid URI (no scheme) and not in definitions, assume broken ID reference
+                            raise ValueError(f"Agent '{definition.id}' references missing tool '{tool_ref.uri}'.")
+
+        return self

--- a/src/coreason_manifest/utils/base_adapter.py
+++ b/src/coreason_manifest/utils/base_adapter.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from collections.abc import Generator
+
+from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition
+
+
+class BaseManifestAdapter:
+    """Base class for adapting Coreason Agents to external frameworks."""
+
+    @staticmethod
+    def _build_system_prompt(agent: AgentDefinition, include_header: bool = False) -> str:
+        """
+        Constructs a standard system prompt from agent attributes.
+
+        Args:
+            agent: The agent definition.
+            include_header: If True, prepends "You are {agent.name}."
+        """
+        parts = []
+        if include_header:
+            parts.append(f"You are {agent.name}.")
+
+        parts.extend(
+            [
+                f"Role: {agent.role}",
+                f"Goal: {agent.goal}",
+            ]
+        )
+
+        if agent.backstory:
+            parts.append(f"Backstory: {agent.backstory}")
+
+        return "\n\n".join(parts)
+
+    @staticmethod
+    def _iter_inline_tools(agent: AgentDefinition) -> Generator[InlineToolDefinition, None, None]:
+        """Yields only InlineToolDefinitions, skipping ToolRequirements (remote tools)."""
+        for tool in agent.tools:
+            if isinstance(tool, InlineToolDefinition):
+                yield tool

--- a/src/coreason_manifest/utils/langchain_adapter.py
+++ b/src/coreason_manifest/utils/langchain_adapter.py
@@ -10,7 +10,8 @@
 
 from typing import Any
 
-from coreason_manifest.spec.v2.definitions import AgentDefinition, InlineToolDefinition, ToolRequirement
+from coreason_manifest.spec.v2.definitions import AgentDefinition
+from coreason_manifest.utils.base_adapter import BaseManifestAdapter
 
 
 def convert_to_langchain_kwargs(agent: AgentDefinition) -> dict[str, Any]:
@@ -31,33 +32,20 @@ def convert_to_langchain_kwargs(agent: AgentDefinition) -> dict[str, Any]:
         - `model_name`: The name of the LLM model to use.
     """
     # Construct the system message
-    instructions_parts = [
-        f"You are {agent.name}.",
-        f"Role: {agent.role}",
-        f"Goal: {agent.goal}",
-    ]
-    if agent.backstory:
-        instructions_parts.append(f"Backstory: {agent.backstory}")
-
-    system_message = "\n\n".join(instructions_parts)
+    system_message = BaseManifestAdapter._build_system_prompt(agent, include_header=True)
 
     # Convert tools to schemas compatible with LangChain's bind_tools (which accepts OpenAI format)
-    tool_schemas = []
-    for tool in agent.tools:
-        if isinstance(tool, InlineToolDefinition):
-            tool_schemas.append(
-                {
-                    "type": "function",
-                    "function": {
-                        "name": tool.name,
-                        "description": tool.description,
-                        "parameters": tool.parameters,
-                    },
-                }
-            )
-        elif isinstance(tool, ToolRequirement):
-            # Remote tools are skipped as their schema is not available locally.
-            continue
+    tool_schemas = [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.name,
+                "description": tool.description,
+                "parameters": tool.parameters,
+            },
+        }
+        for tool in BaseManifestAdapter._iter_inline_tools(agent)
+    ]
 
     return {
         "system_message": system_message,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,0 +1,114 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any
+
+from coreason_manifest.spec.common_base import ToolRiskLevel
+from coreason_manifest.spec.v2.definitions import (
+    AgentDefinition,
+    InlineToolDefinition,
+    ManifestV2,
+    ToolDefinition,
+    Workflow,
+)
+
+
+def create_agent_definition(
+    agent_id: str = "agent-1",
+    name: str = "Test Agent",
+    role: str = "Tester",
+    goal: str = "Test things",
+    **kwargs: Any,
+) -> AgentDefinition:
+    """Factory for AgentDefinition."""
+    defaults = {
+        "type": "agent",
+        "id": agent_id,
+        "name": name,
+        "role": role,
+        "goal": goal,
+    }
+    defaults.update(kwargs)
+    return AgentDefinition(**defaults)
+
+
+def create_tool_definition(
+    tool_id: str = "tool-1",
+    name: str = "Test Tool",
+    uri: str = "https://example.com/tool",
+    risk_level: ToolRiskLevel = ToolRiskLevel.SAFE,
+    **kwargs: Any,
+) -> ToolDefinition:
+    """Factory for ToolDefinition."""
+    defaults = {
+        "type": "tool",
+        "id": tool_id,
+        "name": name,
+        "uri": uri,
+        "risk_level": risk_level,
+    }
+    defaults.update(kwargs)
+    return ToolDefinition(**defaults)
+
+
+def create_inline_tool_definition(
+    name: str = "inline_tool",
+    description: str = "Does something",
+    parameters: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> InlineToolDefinition:
+    """Factory for InlineToolDefinition."""
+    if parameters is None:
+        parameters = {"type": "object", "properties": {}}
+
+    defaults = {
+        "type": "inline",
+        "name": name,
+        "description": description,
+        "parameters": parameters,
+    }
+    defaults.update(kwargs)
+    return InlineToolDefinition(**defaults)
+
+
+def create_workflow(start: str = "step-1", steps: dict[str, Any] | None = None) -> Workflow:
+    """Factory for Workflow."""
+    if steps is None:
+        steps = {
+            "step-1": {
+                "type": "logic",
+                "id": "step-1",
+                "code": "pass",
+            }
+        }
+    return Workflow(start=start, steps=steps)
+
+
+def create_manifest_v2(
+    name: str = "Test Manifest",
+    definitions: dict[str, Any] | None = None,
+    workflow: Workflow | None = None,
+    **kwargs: Any,
+) -> ManifestV2:
+    """Factory for ManifestV2."""
+    if definitions is None:
+        definitions = {}
+    if workflow is None:
+        workflow = create_workflow()
+
+    defaults = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": name},
+        "definitions": definitions,
+        "workflow": workflow,
+    }
+    defaults.update(kwargs)
+    return ManifestV2.model_validate(defaults)

--- a/tests/test_manifest_integrity.py
+++ b/tests/test_manifest_integrity.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestV2
+
+
+def test_integrity_start_step_missing() -> None:
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "Invalid Start"},
+        "status": "published",
+        "workflow": {
+            "start": "missing-step",
+            "steps": {"step-1": {"type": "logic", "id": "step-1", "code": "pass"}},
+        },
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        ManifestV2.model_validate(data)
+    assert "Start step 'missing-step' not found" in str(excinfo.value)
+
+
+def test_integrity_next_step_missing() -> None:
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "Invalid Next"},
+        "status": "published",
+        "workflow": {
+            "start": "step-1",
+            "steps": {
+                "step-1": {
+                    "type": "logic",
+                    "id": "step-1",
+                    "code": "pass",
+                    "next": "missing-next",
+                }
+            },
+        },
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        ManifestV2.model_validate(data)
+    assert "references missing next step 'missing-next'" in str(excinfo.value)
+
+
+def test_integrity_switch_case_missing() -> None:
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "Invalid Switch"},
+        "status": "published",
+        "workflow": {
+            "start": "step-1",
+            "steps": {
+                "step-1": {
+                    "type": "switch",
+                    "id": "step-1",
+                    "cases": {"cond": "missing-case"},
+                    "default": "missing-default",
+                }
+            },
+        },
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        ManifestV2.model_validate(data)
+    # The error could be about case or default, depends on order.
+    assert "references missing step" in str(excinfo.value)
+
+
+def test_integrity_agent_definition_missing() -> None:
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "Invalid Agent Ref"},
+        "status": "published",
+        "workflow": {
+            "start": "step-1",
+            "steps": {
+                "step-1": {
+                    "type": "agent",
+                    "id": "step-1",
+                    "agent": "missing-agent",
+                }
+            },
+        },
+        "definitions": {},
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        ManifestV2.model_validate(data)
+    assert "references missing agent 'missing-agent'" in str(excinfo.value)
+
+
+def test_integrity_agent_tool_reference_missing() -> None:
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "Invalid Tool Ref"},
+        "status": "published",
+        "workflow": {
+            "start": "step-1",
+            "steps": {"step-1": {"type": "logic", "id": "step-1", "code": "pass"}},
+        },
+        "definitions": {
+            "my-agent": {
+                "type": "agent",
+                "id": "my-agent",
+                "name": "Agent",
+                "role": "Worker",
+                "goal": "Work",
+                "tools": ["missing-tool-id"],
+            }
+        },
+    }
+    with pytest.raises(ValidationError) as excinfo:
+        ManifestV2.model_validate(data)
+    assert "references missing tool 'missing-tool-id'" in str(excinfo.value)
+
+
+def test_integrity_success_published() -> None:
+    """Ensure validation passes for a correct published manifest."""
+    data = {
+        "apiVersion": "coreason.ai/v2",
+        "kind": "Recipe",
+        "metadata": {"name": "Valid Published"},
+        "status": "published",
+        "workflow": {
+            "start": "step-1",
+            "steps": {"step-1": {"type": "logic", "id": "step-1", "code": "pass"}},
+        },
+    }
+    manifest = ManifestV2.model_validate(data)
+    assert manifest.status == "published"

--- a/tests/test_v2_agent_def.py
+++ b/tests/test_v2_agent_def.py
@@ -11,6 +11,20 @@
 import yaml
 
 from coreason_manifest.spec.v2.definitions import AgentDefinition, GenericDefinition, ManifestV2, ToolDefinition
+from tests.factories import create_agent_definition
+
+
+def test_factory_usage() -> None:
+    """Demonstrate using the factory to create an agent."""
+    agent = create_agent_definition(
+        id="factory-agent",
+        name="Factory Agent",
+        # defaults handle type, role, goal
+    )
+    assert agent.id == "factory-agent"
+    assert agent.name == "Factory Agent"
+    assert agent.role == "Tester"
+    assert agent.type == "agent"
 
 
 def test_polymorphic_parsing() -> None:

--- a/tests/test_v2_complex_scenarios.py
+++ b/tests/test_v2_complex_scenarios.py
@@ -22,17 +22,16 @@ from coreason_manifest.spec.v2.definitions import (
     SwitchStep,
     ToolDefinition,
 )
+from tests.factories import create_agent_definition, create_manifest_v2, create_workflow
 
 
 # Test 1: Complex Workflow with Cycles
 def test_complex_workflow_with_cycles() -> None:
-    data = {
-        "apiVersion": "coreason.ai/v2",
-        "kind": "Recipe",
-        "metadata": {"name": "Cyclic Workflow"},
-        "workflow": {
-            "start": "start-switch",
-            "steps": {
+    manifest = create_manifest_v2(
+        name="Cyclic Workflow",
+        workflow=create_workflow(
+            start="start-switch",
+            steps={
                 "start-switch": {
                     "type": "switch",
                     "id": "start-switch",
@@ -57,18 +56,17 @@ def test_complex_workflow_with_cycles() -> None:
                     "code": "print('Done')",
                 },
             },
+        ),
+        definitions={
+            "worker-1": create_agent_definition(
+                id="worker-1",
+                name="Worker",
+                role="worker",
+                goal="work",
+            )
         },
-        "definitions": {
-            "worker-1": {
-                "type": "agent",
-                "id": "worker-1",
-                "name": "Worker",
-                "role": "worker",
-                "goal": "work",
-            }
-        },
-    }
-    manifest = ManifestV2.model_validate(data)
+    )
+
     assert manifest.workflow.start == "start-switch"
     steps = manifest.workflow.steps
     assert isinstance(steps["start-switch"], SwitchStep)

--- a/tests/test_v2_coverage.py
+++ b/tests/test_v2_coverage.py
@@ -12,6 +12,7 @@
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from coreason_manifest.spec.common_base import ToolRiskLevel
 from coreason_manifest.spec.governance import GovernanceConfig
@@ -26,7 +27,7 @@ from coreason_manifest.spec.v2.definitions import (
     Workflow,
 )
 from coreason_manifest.utils.v2.governance import _risk_score, check_compliance_v2
-from coreason_manifest.utils.v2.validator import validate_integrity, validate_loose
+from coreason_manifest.utils.v2.validator import validate_loose
 
 # --- Governance Tests ---
 
@@ -215,40 +216,46 @@ def test_validator_strict_missing_start() -> None:
     """Test strict validation missing start step."""
     agent_def = AgentDefinition(id="a", name="A", type="agent", role="R", goal="G")
 
-    manifest = ManifestV2(
-        kind="Agent",
-        metadata=ManifestMetadata(name="Test"),
-        workflow=Workflow(start="missing_start", steps={"s1": AgentStep(id="s1", agent="a")}),
-        definitions={"a": agent_def},
-    )
+    # Construct as draft first to bypass initial validation
+    # Now manually call validate_integrity or rely on Pydantic to catch it if instantiated with status=published
+    # But wait, if I instantiate with status="published", it should raise ValidationError immediately!
+    # The previous test used validate_integrity explicitly.
+    # Now it's a model validator.
+    # So constructing it should fail.
 
-    with pytest.raises(ValueError, match="Start step 'missing_start' not found"):
-        validate_integrity(manifest)
+    with pytest.raises(ValidationError, match="Start step 'missing_start' not found"):
+        ManifestV2(
+            kind="Agent",
+            metadata=ManifestMetadata(name="Test"),
+            status="published",
+            workflow=Workflow(start="missing_start", steps={"s1": AgentStep(id="s1", agent="a")}),
+            definitions={"a": agent_def},
+        )
 
 
 def test_validator_strict_switch_broken_targets() -> None:
     """Test strict validation broken switch targets."""
-    manifest = ManifestV2(
-        kind="Agent",
-        metadata=ManifestMetadata(name="Test"),
-        workflow=Workflow(
-            start="s1",
-            steps={"s1": SwitchStep(id="s1", cases={"cond": "missing_case_target"}, default="missing_default_target")},
-        ),
-    )
-
-    with pytest.raises(ValueError, match="references missing step"):
-        validate_integrity(manifest)
+    with pytest.raises(ValidationError, match="references missing step"):
+        ManifestV2(
+            kind="Agent",
+            metadata=ManifestMetadata(name="Test"),
+            status="published",
+            workflow=Workflow(
+                start="s1",
+                steps={
+                    "s1": SwitchStep(id="s1", cases={"cond": "missing_case_target"}, default="missing_default_target")
+                },
+            ),
+        )
 
 
 def test_validator_strict_missing_agent_definition() -> None:
     """Test strict validation missing agent definition."""
-    manifest = ManifestV2(
-        kind="Agent",
-        metadata=ManifestMetadata(name="Test"),
-        workflow=Workflow(start="s1", steps={"s1": AgentStep(id="s1", agent="missing_agent")}),
-        definitions={},
-    )
-
-    with pytest.raises(ValueError, match="references missing agent"):
-        validate_integrity(manifest)
+    with pytest.raises(ValidationError, match="references missing agent"):
+        ManifestV2(
+            kind="Agent",
+            metadata=ManifestMetadata(name="Test"),
+            status="published",
+            workflow=Workflow(start="s1", steps={"s1": AgentStep(id="s1", agent="missing_agent")}),
+            definitions={},
+        )

--- a/tests/test_v2_spec.py
+++ b/tests/test_v2_spec.py
@@ -55,10 +55,12 @@ def test_integrity_failure_missing_tool(base_manifest_kwargs: dict[str, Any]) ->
     agent = AgentDefinition(id="agent1", name="Agent", role="Role", goal="Goal", tools=["missing-tool"])
     workflow = Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1")})
 
-    manifest = ManifestV2(workflow=workflow, definitions={"agent1": agent}, **base_manifest_kwargs)
+    # Add status='published' to kwargs
+    kwargs = base_manifest_kwargs.copy()
+    kwargs["status"] = "published"
 
-    with pytest.raises(ValueError, match="Agent 'agent1' references missing tool 'missing-tool'"):
-        validate_integrity(manifest)
+    with pytest.raises(ValidationError, match="Agent 'agent1' references missing tool 'missing-tool'"):
+        ManifestV2(workflow=workflow, definitions={"agent1": agent}, **kwargs)
 
 
 def test_integrity_failure_wrong_tool_type(base_manifest_kwargs: dict[str, Any]) -> None:
@@ -73,10 +75,12 @@ def test_integrity_failure_wrong_tool_type(base_manifest_kwargs: dict[str, Any])
     agent2 = AgentDefinition(id="agent2", name="Agent 2", role="Role", goal="Goal")
     workflow = Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1")})
 
-    manifest = ManifestV2(workflow=workflow, definitions={"agent1": agent1, "agent2": agent2}, **base_manifest_kwargs)
+    # Add status='published' to kwargs
+    kwargs = base_manifest_kwargs.copy()
+    kwargs["status"] = "published"
 
-    with pytest.raises(ValueError, match="Agent 'agent1' references 'agent2' which is not a ToolDefinition"):
-        validate_integrity(manifest)
+    with pytest.raises(ValidationError, match="Agent 'agent1' references 'agent2' which is not a ToolDefinition"):
+        ManifestV2(workflow=workflow, definitions={"agent1": agent1, "agent2": agent2}, **kwargs)
 
 
 def test_integrity_failure_missing_next_step(base_manifest_kwargs: dict[str, Any]) -> None:
@@ -84,10 +88,12 @@ def test_integrity_failure_missing_next_step(base_manifest_kwargs: dict[str, Any
     agent = AgentDefinition(id="agent1", name="Agent", role="Role", goal="Goal")
     workflow = Workflow(start="step1", steps={"step1": AgentStep(id="step1", agent="agent1", next="missing-step")})
 
-    manifest = ManifestV2(workflow=workflow, definitions={"agent1": agent}, **base_manifest_kwargs)
+    # Add status='published' to kwargs
+    kwargs = base_manifest_kwargs.copy()
+    kwargs["status"] = "published"
 
-    with pytest.raises(ValueError, match="Step 'step1' references missing next step 'missing-step'"):
-        validate_integrity(manifest)
+    with pytest.raises(ValidationError, match="Step 'step1' references missing next step 'missing-step'"):
+        ManifestV2(workflow=workflow, definitions={"agent1": agent}, **kwargs)
 
 
 def test_integrity_failure_missing_switch_target(base_manifest_kwargs: dict[str, Any]) -> None:
@@ -97,11 +103,13 @@ def test_integrity_failure_missing_switch_target(base_manifest_kwargs: dict[str,
         steps={"switch1": SwitchStep(id="switch1", cases={"cond": "missing-case"}, default="missing-default")},
     )
 
-    manifest = ManifestV2(workflow=workflow, definitions={}, **base_manifest_kwargs)
+    # Add status='published' to kwargs
+    kwargs = base_manifest_kwargs.copy()
+    kwargs["status"] = "published"
 
     # It might fail on the first missing one it finds
-    with pytest.raises(ValueError, match="SwitchStep 'switch1' references missing step"):
-        validate_integrity(manifest)
+    with pytest.raises(ValidationError, match="SwitchStep 'switch1' references missing step"):
+        ManifestV2(workflow=workflow, definitions={}, **kwargs)
 
 
 def test_strictness_unknown_field_step() -> None:

--- a/tests/test_validation_governance.py
+++ b/tests/test_validation_governance.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import pytest
+from pydantic import ValidationError
 
 from coreason_manifest import (
     AgentStep,
@@ -20,7 +21,6 @@ from coreason_manifest import (
     ToolRiskLevel,
     Workflow,
     check_compliance_v2,
-    validate_integrity,
     validate_loose,
 )
 
@@ -31,6 +31,7 @@ def test_draft_mode_loose() -> None:
     manifest = Manifest(
         kind="Agent",
         metadata={"name": "Broken Agent"},
+        status="draft",
         workflow=Workflow(
             start="step1",
             steps={},  # Missing step1
@@ -48,10 +49,13 @@ def test_draft_mode_loose() -> None:
 
 def test_compiler_mode_strict() -> None:
     """Test that strict validation raises ValueError."""
-    manifest = Manifest(kind="Agent", metadata={"name": "Broken Agent"}, workflow=Workflow(start="step1", steps={}))
-
-    with pytest.raises(ValueError, match="Start step 'step1' not found"):
-        validate_integrity(manifest)
+    with pytest.raises(ValidationError, match="Start step 'step1' not found"):
+        Manifest(
+            kind="Agent",
+            metadata={"name": "Broken Agent"},
+            status="published",
+            workflow=Workflow(start="step1", steps={}),
+        )
 
 
 def test_governance_risk() -> None:


### PR DESCRIPTION
* Refactor ManifestV2 validation and consolidate adapters/tests

- Created AUDIT_REPORT.md identifying 3 key DRY violations.
- Moved `validate_integrity` from `validator.py` to `ManifestV2` model validator.
- Created `BaseManifestAdapter` and refactored OpenAI/LangChain adapters to inherit from it.
- Created `tests/factories.py` and refactored `test_v2_complex_scenarios.py` and `test_v2_agent_def.py` to use factories.
- Added `tests/test_manifest_integrity.py` to verify validation logic.
- Added `tests/__init__.py` to make tests importable.