### PR TITLE
Refactor: Enforce Greenfield strictness in Manifest V2

### DIFF
--- a/docs/provenance_metadata.md
+++ b/docs/provenance_metadata.md
@@ -33,7 +33,7 @@ metadata = ManifestMetadata(
 ## Validation
 
 *   **Confidence Score**: Must be between `0.0` and `1.0` inclusive.
-*   **Extra Fields**: The schema permits extra fields (`extra="allow"`) to support forward compatibility and custom metadata, but the fields above are strictly typed.
+*   **Extra Fields**: The schema strictly forbids extra fields (`extra="forbid"`) to prevent metadata drift. Standard fields like `version`, `description`, `created`, and `requires_auth` are explicitly defined.
 
 ## Provenance Data (New in 0.22.0)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -8,7 +8,7 @@ It is designed to be a pure data library, meaning it contains **no execution log
 
 ### 1. Agent & Recipe Definition
 The `Manifest` is the source of truth for an AI Agent or Recipe. It includes:
-- **Metadata**: Identity, versioning (Strict SemVer), and authorship.
+- **Metadata**: Identity, versioning (Strict SemVer), and authorship. Extra fields are strictly forbidden to prevent drift.
 - **Interface**: Strictly typed modes of interaction (`inputs`, `outputs` as JSON Schema).
 - **Topology**: A graph-based execution flow (`Workflow`) supporting cyclic loops (e.g., for reflection).
 - **Definitions**: Reusable components like Tools (`ToolDefinition`) and sub-agents.

--- a/src/coreason_manifest/spec/common_base.py
+++ b/src/coreason_manifest/spec/common_base.py
@@ -17,10 +17,9 @@ from pydantic import AnyUrl, BaseModel, ConfigDict, PlainSerializer
 
 
 class ManifestBaseModel(BaseModel):
-    """Base model for all CoReason Pydantic models with enhanced serialization.
+    """Base model for all CoReason Pydantic models.
 
-    This base class addresses JSON serialization challenges in Pydantic v2 (e.g., UUID, datetime)
-    by providing standardized methods (`dump`, `to_json`) with optimal configuration.
+    Configured for strict serialization of types like UUID and datetime using standard Pydantic mechanisms.
     """
 
     model_config = ConfigDict(

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -443,7 +443,7 @@ class ManifestV2(ManifestBaseModel):
             errors.append(f"Start step '{self.workflow.start}' missing from workflow.")
 
         for def_id, definition in self.definitions.items():
-            if definition.id != def_id:
+            if hasattr(definition, "id") and definition.id != def_id:
                 errors.append(f"Definition Key Mismatch: Key '{def_id}' does not match object ID '{definition.id}'.")
 
         for step_id, step in steps.items():

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -185,6 +185,7 @@ class AgentDefinition(ManifestBaseModel):
     type: Literal["agent"] = "agent"
     id: str = Field(..., description="Unique ID for the agent.")
     name: str = Field(..., description="Name of the agent.")
+    description: str | None = Field(None, description="Description of the agent.")
     role: str = Field(..., description="The persona/job title.")
     goal: str = Field(..., description="Primary objective.")
     backstory: str | None = Field(None, description="Backstory or directives.")
@@ -351,9 +352,13 @@ class ManifestMetadata(ManifestBaseModel):
         tested_models (list[str]): List of LLM identifiers this manifest has been tested on.
     """
 
-    model_config = ConfigDict(extra="allow", populate_by_name=True, frozen=True)
+    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     name: str = Field(..., description="Human-readable name of the workflow/agent.")
+    version: str = Field("0.1.0", description="Semantic version of the manifest.")
+    description: str | None = Field(None, description="Description of the agent/recipe.")
+    created: str | None = Field(None, description="Creation date.")
+    requires_auth: bool = Field(False, description="Whether authentication is required to use this agent.")
     generation_rationale: str | None = Field(
         None, description="Reasoning behind the creation or selection of this workflow."
     )
@@ -436,6 +441,10 @@ class ManifestV2(ManifestBaseModel):
 
         if self.workflow.start not in steps:
             errors.append(f"Start step '{self.workflow.start}' missing from workflow.")
+
+        for def_id, definition in self.definitions.items():
+            if definition.id != def_id:
+                errors.append(f"Definition Key Mismatch: Key '{def_id}' does not match object ID '{definition.id}'.")
 
         for step_id, step in steps.items():
             if isinstance(step, PlaceholderStep):

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -162,6 +162,7 @@ class AgentDefinition(ManifestBaseModel):
         type (Literal["agent"]): Discriminator. (Default: "agent").
         id (str): Unique ID for the agent.
         name (str): Name of the agent.
+        description (str | None): Description of the agent.
         role (str): The persona/job title.
         goal (str): Primary objective.
         backstory (str | None): Backstory or directives.
@@ -443,8 +444,11 @@ class ManifestV2(ManifestBaseModel):
             errors.append(f"Start step '{self.workflow.start}' missing from workflow.")
 
         for def_id, definition in self.definitions.items():
-            if hasattr(definition, "id") and definition.id != def_id:
-                errors.append(f"Definition Key Mismatch: Key '{def_id}' does not match object ID '{definition.id}'.")
+            # Check for 'id' attribute to handle types like MCPResourceDefinition or future types
+            if hasattr(definition, "id"):
+                def_id_val = getattr(definition, "id")
+                if def_id_val != def_id:
+                    errors.append(f"Definition Key Mismatch: Key '{def_id}' does not match object ID '{def_id_val}'.")
 
         for step_id, step in steps.items():
             if isinstance(step, PlaceholderStep):

--- a/src/coreason_manifest/spec/v2/definitions.py
+++ b/src/coreason_manifest/spec/v2/definitions.py
@@ -446,7 +446,7 @@ class ManifestV2(ManifestBaseModel):
         for def_id, definition in self.definitions.items():
             # Check for 'id' attribute to handle types like MCPResourceDefinition or future types
             if hasattr(definition, "id"):
-                def_id_val = getattr(definition, "id")
+                def_id_val = getattr(definition, "id")  # noqa: B009
                 if def_id_val != def_id:
                     errors.append(f"Definition Key Mismatch: Key '{def_id}' does not match object ID '{def_id_val}'.")
 

--- a/src/coreason_manifest/utils/docs.py
+++ b/src/coreason_manifest/utils/docs.py
@@ -48,10 +48,8 @@ def render_agent_card(agent: ManifestV2) -> str:
                 break
 
     # 2. Header Section
-    # Check for version in extra fields of metadata
+    # Check for version in metadata (now strict)
     version = getattr(metadata, "version", "0.0.0")
-    if not isinstance(version, str):
-        version = str(version)
 
     output = [f"# {metadata.name} (v{version})"]
 

--- a/src/coreason_manifest/utils/v2/governance.py
+++ b/src/coreason_manifest/utils/v2/governance.py
@@ -128,11 +128,7 @@ def check_compliance_v2(manifest: ManifestV2, config: GovernanceConfig) -> Compl
 
     if config.require_auth_for_critical_tools and has_critical_tools:
         # Check if auth is required in metadata.
-        # Pydantic V2 allows accessing extra fields via getattr if extra='allow'.
         requires_auth = getattr(manifest.metadata, "requires_auth", False)
-        # Fallback for Pydantic v2 model_extra if needed
-        if not requires_auth and manifest.metadata.model_extra:
-            requires_auth = manifest.metadata.model_extra.get("requires_auth", False)
 
         if not requires_auth:
             violations.append(

--- a/tests/test_builder_manifest.py
+++ b/tests/test_builder_manifest.py
@@ -115,7 +115,7 @@ def test_manifest_builder_interface_metadata_error() -> None:
     builder.set_interface(interface)
 
     # Test set_metadata
-    builder.set_metadata("extra_field", "extra_value")
+    # builder.set_metadata("extra_field", "extra_value")  # Removed: extra fields are now forbidden
 
     # Test ValueError for missing start step
     builder.add_step(LogicStep(id="s1", code="pass"))
@@ -130,7 +130,7 @@ def test_manifest_builder_interface_metadata_error() -> None:
 
     assert manifest.interface.inputs["type"] == "object"
     # Pydantic V2 allows accessing extra fields as attributes if not colliding
-    assert getattr(manifest.metadata, "extra_field", None) == "extra_value"
+    # assert getattr(manifest.metadata, "extra_field", None) == "extra_value"
 
 
 def test_manifest_builder_switch_and_council_steps() -> None:

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -74,7 +74,7 @@ def test_validate_manifest_v2_no_version(tmp_path: Path, capsys: pytest.CaptureF
         main()
 
     captured = capsys.readouterr()
-    assert "✅ Valid Agent: Manifest Agent NoVer (vUnknown)" in captured.out
+    assert "✅ Valid Agent: Manifest Agent NoVer (v0.1.0)" in captured.out
 
 
 def test_validate_yaml_success(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/test_docs_generator.py
+++ b/tests/test_docs_generator.py
@@ -134,7 +134,7 @@ def test_render_minimal_agent() -> None:
 
     card = render_agent_card(manifest)
 
-    assert "# Minimal (v0.0.0)" in card
+    assert "# Minimal (v0.1.0)" in card
     assert "**Role:** Minion" in card
     assert "## 💰 Resource & Cost Profile" not in card
     assert "## 🧪 Evaluation Standards" not in card
@@ -246,8 +246,8 @@ def test_render_metadata_variants() -> None:
 
     metadata = ManifestMetadata(
         name="Describer",
-        version=2.5,  # Float version to trigger str() conversion
-        created="2025-01-01",  # Extra field
+        version="2.5",  # Pydantic strictly validates type
+        created="2025-01-01",
     )
 
     manifest = Manifest(

--- a/tests/test_metadata_provenance.py
+++ b/tests/test_metadata_provenance.py
@@ -55,7 +55,7 @@ def test_manifest_metadata_confidence_score_validation() -> None:
 def test_manifest_metadata_extra_fields() -> None:
     """Test that extra fields are forbidden."""
     with pytest.raises(ValidationError) as excinfo:
-        ManifestMetadata(name="Test Extra", unknown_field="some value")
+        ManifestMetadata.model_validate({"name": "Test Extra", "unknown_field": "some value"})
     assert "Extra inputs are not permitted" in str(excinfo.value)
 
 

--- a/tests/test_metadata_provenance.py
+++ b/tests/test_metadata_provenance.py
@@ -54,6 +54,7 @@ def test_manifest_metadata_confidence_score_validation() -> None:
 
 def test_manifest_metadata_extra_fields() -> None:
     """Test that extra fields are forbidden."""
+    # We use model_validate to bypass static type checkers complaining about unknown args
     with pytest.raises(ValidationError) as excinfo:
         ManifestMetadata.model_validate({"name": "Test Extra", "unknown_field": "some value"})
     assert "Extra inputs are not permitted" in str(excinfo.value)

--- a/tests/test_v2_edge_cases.py
+++ b/tests/test_v2_edge_cases.py
@@ -109,7 +109,7 @@ def test_agent_step_referencing_tool() -> None:
         "kind": "Recipe",
         "metadata": {"name": "Test"},
         "definitions": {
-                "my-tool": {"type": "tool", "id": "my-tool", "name": "Tool", "uri": "mcp://tool", "risk_level": "safe"}
+            "my-tool": {"type": "tool", "id": "my-tool", "name": "Tool", "uri": "mcp://tool", "risk_level": "safe"}
         },
         "workflow": {
             "start": "step-1",
@@ -128,7 +128,7 @@ def test_council_step_referencing_tool() -> None:
         "kind": "Recipe",
         "metadata": {"name": "Test"},
         "definitions": {
-                "my-tool": {"type": "tool", "id": "my-tool", "name": "Tool", "uri": "mcp://tool", "risk_level": "safe"}
+            "my-tool": {"type": "tool", "id": "my-tool", "name": "Tool", "uri": "mcp://tool", "risk_level": "safe"}
         },
         "workflow": {
             "start": "step-1",

--- a/tests/test_v2_edge_cases.py
+++ b/tests/test_v2_edge_cases.py
@@ -109,7 +109,7 @@ def test_agent_step_referencing_tool() -> None:
         "kind": "Recipe",
         "metadata": {"name": "Test"},
         "definitions": {
-            "my-tool": {"type": "tool", "id": "tool-1", "name": "Tool", "uri": "mcp://tool", "risk_level": "safe"}
+                "my-tool": {"type": "tool", "id": "my-tool", "name": "Tool", "uri": "mcp://tool", "risk_level": "safe"}
         },
         "workflow": {
             "start": "step-1",
@@ -128,7 +128,7 @@ def test_council_step_referencing_tool() -> None:
         "kind": "Recipe",
         "metadata": {"name": "Test"},
         "definitions": {
-            "my-tool": {"type": "tool", "id": "tool-1", "name": "Tool", "uri": "mcp://tool", "risk_level": "safe"}
+                "my-tool": {"type": "tool", "id": "my-tool", "name": "Tool", "uri": "mcp://tool", "risk_level": "safe"}
         },
         "workflow": {
             "start": "step-1",

--- a/tests/test_v2_strictness.py
+++ b/tests/test_v2_strictness.py
@@ -47,10 +47,10 @@ def test_generic_definition_gone() -> None:
     Ensure GenericDefinition is completely removed.
     """
     with pytest.raises(ImportError):
-        from coreason_manifest.spec.v2.definitions import GenericDefinition  # type: ignore
+        from coreason_manifest.spec.v2.definitions import GenericDefinition
 
     with pytest.raises(ImportError):
-        from coreason_manifest.spec.v2 import GenericDefinition  # type: ignore
+        from coreason_manifest.spec.v2 import GenericDefinition
 
 
 def test_all_exports_clean() -> None:

--- a/tests/test_v2_strictness.py
+++ b/tests/test_v2_strictness.py
@@ -1,66 +1,59 @@
 import pytest
 from pydantic import ValidationError
-from coreason_manifest.spec.v2.definitions import ManifestMetadata, ManifestV2, AgentDefinition, Workflow
-from coreason_manifest.spec.common_base import ManifestBaseModel
 
-def test_manifest_metadata_strictness():
+from coreason_manifest.spec.common_base import ManifestBaseModel
+from coreason_manifest.spec.v2.definitions import AgentDefinition, ManifestMetadata, ManifestV2, Workflow
+
+
+def test_manifest_metadata_strictness() -> None:
     """
     Ensure ManifestMetadata forbids extra fields.
     """
-    try:
-        ManifestMetadata(
-            name="Test",
-            extra_field="should fail"
-        )
-    except ValidationError as e:
-        assert "Extra inputs are not permitted" in str(e)
-        return
+    with pytest.raises(ValidationError, match="Extra inputs are not permitted"):
+        ManifestMetadata.model_validate({"name": "Test", "extra_field": "should fail"})
 
-    pytest.fail("ManifestMetadata should forbid extra fields")
 
-def test_verify_id_mismatch():
+def test_verify_id_mismatch() -> None:
     """
     Ensure verify() catches dictionary key vs object ID mismatch.
     """
-    agent = AgentDefinition(
-        id="agent1",
-        name="Agent 1",
-        role="Role",
-        goal="Goal"
-    )
+    agent = AgentDefinition(id="agent1", name="Agent 1", role="Role", goal="Goal")
 
     manifest = ManifestV2(
         kind="Agent",
         metadata=ManifestMetadata(name="Test"),
         workflow=Workflow(start="s", steps={"s": {"type": "placeholder", "id": "s"}}),
-        definitions={
-            "wrong_key": agent
-        }
+        definitions={"wrong_key": agent},
     )
 
     errors = manifest.verify()
     if not any("Definition Key Mismatch" in e for e in errors):
         pytest.fail("verify() should detect ID mismatch")
 
-def test_manifest_base_model_docstring():
+
+def test_manifest_base_model_docstring() -> None:
     """
     Ensure ManifestBaseModel docstring is updated.
     """
     doc = ManifestBaseModel.__doc__
+    if not doc:
+        pytest.fail("Docstring is missing")
     if "dump" in doc or "to_json" in doc:
         pytest.fail("ManifestBaseModel docstring contains obsolete 'dump' or 'to_json'")
 
-def test_generic_definition_gone():
+
+def test_generic_definition_gone() -> None:
     """
     Ensure GenericDefinition is completely removed.
     """
     with pytest.raises(ImportError):
-        from coreason_manifest.spec.v2.definitions import GenericDefinition
+        from coreason_manifest.spec.v2.definitions import GenericDefinition  # type: ignore
 
     with pytest.raises(ImportError):
-        from coreason_manifest.spec.v2 import GenericDefinition
+        from coreason_manifest.spec.v2 import GenericDefinition  # type: ignore
 
-def test_all_exports_clean():
+
+def test_all_exports_clean() -> None:
     """
     Ensure GenericDefinition is not in __all__.
     """

--- a/tests/test_v2_strictness.py
+++ b/tests/test_v2_strictness.py
@@ -1,0 +1,71 @@
+import pytest
+from pydantic import ValidationError
+from coreason_manifest.spec.v2.definitions import ManifestMetadata, ManifestV2, AgentDefinition, Workflow
+from coreason_manifest.spec.common_base import ManifestBaseModel
+
+def test_manifest_metadata_strictness():
+    """
+    Ensure ManifestMetadata forbids extra fields.
+    """
+    try:
+        ManifestMetadata(
+            name="Test",
+            extra_field="should fail"
+        )
+    except ValidationError as e:
+        assert "Extra inputs are not permitted" in str(e)
+        return
+
+    pytest.fail("ManifestMetadata should forbid extra fields")
+
+def test_verify_id_mismatch():
+    """
+    Ensure verify() catches dictionary key vs object ID mismatch.
+    """
+    agent = AgentDefinition(
+        id="agent1",
+        name="Agent 1",
+        role="Role",
+        goal="Goal"
+    )
+
+    manifest = ManifestV2(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Test"),
+        workflow=Workflow(start="s", steps={"s": {"type": "placeholder", "id": "s"}}),
+        definitions={
+            "wrong_key": agent
+        }
+    )
+
+    errors = manifest.verify()
+    if not any("Definition Key Mismatch" in e for e in errors):
+        pytest.fail("verify() should detect ID mismatch")
+
+def test_manifest_base_model_docstring():
+    """
+    Ensure ManifestBaseModel docstring is updated.
+    """
+    doc = ManifestBaseModel.__doc__
+    if "dump" in doc or "to_json" in doc:
+        pytest.fail("ManifestBaseModel docstring contains obsolete 'dump' or 'to_json'")
+
+def test_generic_definition_gone():
+    """
+    Ensure GenericDefinition is completely removed.
+    """
+    with pytest.raises(ImportError):
+        from coreason_manifest.spec.v2.definitions import GenericDefinition
+
+    with pytest.raises(ImportError):
+        from coreason_manifest.spec.v2 import GenericDefinition
+
+def test_all_exports_clean():
+    """
+    Ensure GenericDefinition is not in __all__.
+    """
+    from coreason_manifest.spec.v2 import definitions
+    import coreason_manifest.spec.v2 as v2_pkg
+
+    assert "GenericDefinition" not in definitions.__all__
+    assert "GenericDefinition" not in v2_pkg.__all__

--- a/tests/test_v2_strictness.py
+++ b/tests/test_v2_strictness.py
@@ -3,6 +3,7 @@ from pydantic import ValidationError
 
 from coreason_manifest.spec.common_base import ManifestBaseModel
 from coreason_manifest.spec.v2.definitions import AgentDefinition, ManifestMetadata, ManifestV2, Workflow
+from coreason_manifest.spec.v2.packs import MCPResourceDefinition
 
 
 def test_manifest_metadata_strictness() -> None:
@@ -47,18 +48,95 @@ def test_generic_definition_gone() -> None:
     Ensure GenericDefinition is completely removed.
     """
     with pytest.raises(ImportError):
-        from coreason_manifest.spec.v2.definitions import GenericDefinition
+        from coreason_manifest.spec.v2.definitions import GenericDefinition  # type: ignore[attr-defined]
 
     with pytest.raises(ImportError):
-        from coreason_manifest.spec.v2 import GenericDefinition
+        from coreason_manifest.spec.v2 import GenericDefinition  # type: ignore[attr-defined] # noqa: F401
 
 
 def test_all_exports_clean() -> None:
     """
     Ensure GenericDefinition is not in __all__.
     """
-    from coreason_manifest.spec.v2 import definitions
     import coreason_manifest.spec.v2 as v2_pkg
+    from coreason_manifest.spec.v2 import definitions
 
     assert "GenericDefinition" not in definitions.__all__
     assert "GenericDefinition" not in v2_pkg.__all__
+
+
+def test_edge_case_invalid_version_type() -> None:
+    """Test invalid version type (int instead of str) causes validation error."""
+    with pytest.raises(ValidationError, match="Input should be a valid string"):
+        ManifestMetadata.model_validate({"name": "Test", "version": 123})
+
+
+def test_edge_case_empty_name() -> None:
+    """
+    Test ManifestMetadata with empty name.
+    (should technically pass string check, but checks strictness of required fields).
+    """
+    # Pydantic default min_length is not set, so empty string is valid unless constrained.
+    # But missing name should fail.
+    with pytest.raises(ValidationError, match="Field required"):
+        ManifestMetadata.model_validate({"version": "1.0.0"})
+
+
+def test_verify_skip_no_id_attribute() -> None:
+    """
+    Test that verify() safely skips definitions that do not have an 'id' attribute.
+    (like MCPResourceDefinition).
+    """
+    resource = MCPResourceDefinition(
+        uri="file:///tmp/test.txt",
+        name="Test Resource",
+    )
+
+    # This should NOT raise AttributeError: 'MCPResourceDefinition' object has no attribute 'id'
+    manifest = ManifestV2(
+        kind="Agent",
+        metadata=ManifestMetadata(name="Test"),
+        workflow=Workflow(start="s", steps={"s": {"type": "placeholder", "id": "s"}}),
+        definitions={"my_resource": resource},
+    )
+
+    errors = manifest.verify()
+    # verify() reports placeholder steps as errors, so we ignore that one to focus on the crash check
+    relevant_errors = [e for e in errors if "placeholder" not in e]
+    assert len(relevant_errors) == 0
+
+
+def test_complex_manifest_integrity() -> None:
+    """
+    Complex test case: Validating a large manifest with mixed valid and invalid definitions.
+    """
+    # 1. Valid Agent
+    valid_agent = AgentDefinition(id="agent1", name="Valid Agent", role="R", goal="G")
+
+    # 2. Invalid Agent (Key mismatch)
+    invalid_agent = AgentDefinition(id="agent2", name="Invalid Agent", role="R", goal="G")
+
+    # 3. Valid Resource (No ID, so skipped)
+    resource = MCPResourceDefinition(uri="file:///data", name="Data")
+
+    manifest = ManifestV2(
+        kind="Recipe",
+        metadata=ManifestMetadata(name="Complex Test", version="2.0.0"),
+        workflow=Workflow(start="s", steps={"s": {"type": "placeholder", "id": "s"}}),
+        definitions={
+            "agent1": valid_agent,      # Valid
+            "wrong_key_agent": invalid_agent, # Invalid: key != id
+            "my_resource": resource     # Valid: no ID check
+        }
+    )
+
+    errors = manifest.verify()
+
+    # Filter out placeholder step warnings
+    relevant_errors = [e for e in errors if "placeholder" not in e]
+
+    # Expect exactly 1 error for the key mismatch
+    assert len(relevant_errors) == 1
+    assert "Definition Key Mismatch" in relevant_errors[0]
+    assert "'wrong_key_agent'" in relevant_errors[0]
+    assert "'agent2'" in relevant_errors[0]

--- a/tests/test_validation_governance_edge_cases.py
+++ b/tests/test_validation_governance_edge_cases.py
@@ -128,7 +128,8 @@ def test_auth_mandate_coercion(base_workflow: Workflow) -> None:
         workflow=base_workflow,
     )
     report = check_compliance_v2(manifest_str_false, config)
-    assert report.passed is True  # "false" is truthy
+    # "false" string -> False boolean (strict typing parses it correctly now)
+    assert report.passed is False
 
     # "true" string -> Truthy -> Pass
     manifest_str_true = Manifest(
@@ -149,7 +150,7 @@ def test_auth_mandate_coercion(base_workflow: Workflow) -> None:
     )
     report_int = check_compliance_v2(manifest_int_0, config)
     assert report_int.passed is False
-    assert len(report.violations) == 0
+    assert len(report_int.violations) == 1
 
 
 def test_auth_mandate_dynamic_extra_field(base_workflow: Workflow) -> None:


### PR DESCRIPTION
This PR finalizes the "Greenfield" strictness refactor for `coreason-manifest`.

Key changes:
1.  **Strict Metadata**: `ManifestMetadata` now forbids extra fields (`extra="forbid"`). To support standard usage, fields `version`, `description`, `created`, and `requires_auth` were explicitly added to the schema.
2.  **Verify Consistency**: `ManifestV2.verify()` now checks that the key in the `definitions` dictionary matches the `id` of the definition object, preventing subtle reference errors.
3.  **Docstring Cleanup**: Removed stale references to `dump()` and `to_json()` in `ManifestBaseModel`.
4.  **Test Updates**: Updated numerous tests to comply with strict metadata validation (e.g., removing arbitrary extra fields, fixing type coercion expectations) and fixed pre-existing bugs in test data (ID mismatches).
5.  **Clean Exports**: Verified `GenericDefinition` is absent from public API exports.
6.  **Coverage**: Maintained 100% code coverage by removing dead code paths made obsolete by strict typing.

---
*PR created automatically by Jules for task [6646681161998033227](https://jules.google.com/task/6646681161998033227) started by @gowthamrao*