### PR TITLE
style: fix formatting in tests/test_v2_strictness.py

### DIFF
--- a/tests/test_v2_strictness.py
+++ b/tests/test_v2_strictness.py
@@ -124,10 +124,10 @@ def test_complex_manifest_integrity() -> None:
         metadata=ManifestMetadata(name="Complex Test", version="2.0.0"),
         workflow=Workflow(start="s", steps={"s": {"type": "placeholder", "id": "s"}}),
         definitions={
-            "agent1": valid_agent,      # Valid
-            "wrong_key_agent": invalid_agent, # Invalid: key != id
-            "my_resource": resource     # Valid: no ID check
-        }
+            "agent1": valid_agent,  # Valid
+            "wrong_key_agent": invalid_agent,  # Invalid: key != id
+            "my_resource": resource,  # Valid: no ID check
+        },
     )
 
     errors = manifest.verify()


### PR DESCRIPTION
Fixes lint formatting errors in `tests/test_v2_strictness.py` by applying `ruff format`.
- Standardized whitespace around comments.
- Added trailing commas to multi-line data structures.
Verified with `ruff format --check` and `ruff check`.
Ran tests in `tests/test_v2_strictness.py` to ensure no regressions.

---
*PR created automatically by Jules for task [6617837104931843658](https://jules.google.com/task/6617837104931843658) started by @gowthamrao*