### PR TITLE
Implement visualization for RecipeDefinition

### DIFF
--- a/src/coreason_manifest/cli.py
+++ b/src/coreason_manifest/cli.py
@@ -20,7 +20,6 @@ from coreason_manifest.spec.v2.definitions import (
     AgentDefinition,
     ManifestV2,
 )
-from coreason_manifest.spec.v2.recipe import RecipeDefinition
 from coreason_manifest.utils.loader import load_agent_from_ref
 from coreason_manifest.utils.viz import generate_mermaid_graph
 

--- a/src/coreason_manifest/cli.py
+++ b/src/coreason_manifest/cli.py
@@ -268,11 +268,6 @@ def main() -> None:
         print(agent.model_dump_json(indent=2, by_alias=True, exclude_none=True))
 
     elif args.command == "viz":
-        if isinstance(agent, RecipeDefinition):
-            # TODO: Implement visualization for RecipeDefinition
-            sys.stderr.write("Visualization not yet implemented for RecipeDefinition.\n")
-            sys.exit(1)
-
         mermaid = generate_mermaid_graph(agent)
         if args.json:
             print(json.dumps({"mermaid": mermaid}))

--- a/src/coreason_manifest/utils/viz.py
+++ b/src/coreason_manifest/utils/viz.py
@@ -17,6 +17,14 @@ from coreason_manifest.spec.v2.definitions import (
     ManifestV2,
     SwitchStep,
 )
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    EvaluatorNode,
+    GenerativeNode,
+    HumanNode,
+    RecipeDefinition,
+    RouterNode,
+)
 
 
 def _sanitize_id(text: str) -> str:
@@ -25,10 +33,120 @@ def _sanitize_id(text: str) -> str:
     return re.sub(r"[^a-zA-Z0-9_]", "_", text)
 
 
-def generate_mermaid_graph(agent: ManifestV2) -> str:
+def _generate_recipe_mermaid(recipe: RecipeDefinition) -> str:
     """
-    Generates a Mermaid.js flowchart string from a ManifestV2 (Agent Definition).
+    Generates a Mermaid.js flowchart string from a RecipeDefinition.
     """
+    lines = ["graph TD"]
+
+    # Styling Definitions
+    # Consistent color palette but adapted for Recipe nodes
+    lines.append("classDef default fill:#f9f9f9,stroke:#333,stroke-width:1px;")
+    lines.append("classDef input fill:#e1f5fe,stroke:#01579b,stroke-width:2px;")  # Light Blue
+    lines.append("classDef agent fill:#e3f2fd,stroke:#1565c0,stroke-width:2px;")  # Blue
+    lines.append("classDef human fill:#fff3e0,stroke:#e65100,stroke-width:2px;")  # Orange
+    lines.append("classDef router fill:#f3e5f5,stroke:#4a148c,stroke-width:2px;")  # Purple
+    lines.append("classDef evaluator fill:#e8f5e9,stroke:#1b5e20,stroke-width:2px;")  # Green
+    lines.append("classDef generative fill:#fce4ec,stroke:#880e4f,stroke-width:2px;")  # Pink
+    lines.append("classDef term fill:#eceff1,stroke:#37474f,stroke-width:2px,rx:10,ry:10;")  # Grey
+
+    # Start Node
+    lines.append("START((Start)):::term")
+
+    # Inputs Node
+    input_keys = list(recipe.interface.inputs.keys())
+    input_label = "Inputs"
+    if input_keys:
+        input_label += "<br/>" + "<br/>".join(f"- {k}" for k in input_keys)
+    lines.append(f'INPUTS["{input_label}"]:::input')
+
+    # Nodes
+    for node in recipe.topology.nodes:
+        sanitized_id = _sanitize_id(node.id)
+        label = node.id
+        style_class = "default"
+        shape_open = "["
+        shape_close = "]"
+
+        if isinstance(node, AgentNode):
+            # Agent Node: Box
+            style_class = "agent"
+            ref = getattr(node, "agent_ref", "Inline")
+            if hasattr(ref, "intent"):  # SemanticRef
+                ref_str = f"Draft: {ref.intent}"
+            else:
+                ref_str = str(ref)
+            label = f"{node.id}<br/>(Agent: {ref_str})"
+
+        elif isinstance(node, HumanNode):
+            # Human Node: Hexagon {{ }}
+            style_class = "human"
+            shape_open = "{{"
+            shape_close = "}}"
+            label = f"{node.id}<br/>(Human Input)"
+
+        elif isinstance(node, RouterNode):
+            # Router Node: Rhombus { }
+            style_class = "router"
+            shape_open = "{"
+            shape_close = "}"
+            label = f"{node.id}<br/>(Router: {node.input_key})"
+
+        elif isinstance(node, EvaluatorNode):
+            # Evaluator Node: Circle/Stadium ([ ])
+            style_class = "evaluator"
+            shape_open = "(["
+            shape_close = "])"
+            label = f"{node.id}<br/>(Evaluator)"
+
+        elif isinstance(node, GenerativeNode):
+            # Generative Node: Subroutine [[ ]]
+            style_class = "generative"
+            shape_open = "[["
+            shape_close = "]]"
+            label = f"{node.id}<br/>(Generative)"
+
+        lines.append(f'{sanitized_id}{shape_open}"{label}"{shape_close}:::{style_class}')
+
+    # End Node
+    lines.append("END((End)):::term")
+
+    # Edges: Start -> Inputs -> Entry Point
+    lines.append("START --> INPUTS")
+    entry_point = recipe.topology.entry_point
+    if entry_point:
+        lines.append(f"INPUTS --> {_sanitize_id(entry_point)}")
+    else:
+        lines.append("INPUTS --> END")
+
+    # Topology Edges
+    for edge in recipe.topology.edges:
+        src = _sanitize_id(edge.source)
+        tgt = _sanitize_id(edge.target)
+        if edge.condition:
+            # Labeled edge
+            safe_cond = edge.condition.replace('"', "'")
+            lines.append(f'{src} -- "{safe_cond}" --> {tgt}')
+        else:
+            # Unlabeled edge
+            lines.append(f"{src} --> {tgt}")
+
+    # Implicit edges (e.g. from leaf nodes to END)
+    # Finding leaf nodes is a bit complex in graph, so we skip for now unless requested.
+    # Users can manually add edges to END if needed, or rely on visual inspection.
+    # However, for clarity, we might want to verify if any node has no outgoing edges.
+    # But graph topology doesn't strictly enforce a sink node structure except via edges.
+
+    return "\n".join(lines)
+
+
+def generate_mermaid_graph(agent: ManifestV2 | RecipeDefinition) -> str:
+    """
+    Generates a Mermaid.js flowchart string from a ManifestV2 (Agent Definition) or RecipeDefinition.
+    """
+    if isinstance(agent, RecipeDefinition):
+        return _generate_recipe_mermaid(agent)
+
     lines = ["graph TD"]
 
     # Styling Definitions

--- a/src/coreason_manifest/utils/viz.py
+++ b/src/coreason_manifest/utils/viz.py
@@ -72,10 +72,7 @@ def _generate_recipe_mermaid(recipe: RecipeDefinition) -> str:
             # Agent Node: Box
             style_class = "agent"
             ref = getattr(node, "agent_ref", "Inline")
-            if hasattr(ref, "intent"):  # SemanticRef
-                ref_str = f"Draft: {ref.intent}"
-            else:
-                ref_str = str(ref)
+            ref_str = f"Draft: {ref.intent}" if hasattr(ref, "intent") else str(ref)
             label = f"{node.id}<br/>(Agent: {ref_str})"
 
         elif isinstance(node, HumanNode):
@@ -106,7 +103,9 @@ def _generate_recipe_mermaid(recipe: RecipeDefinition) -> str:
             shape_close = "]]"
             label = f"{node.id}<br/>(Generative)"
 
-        lines.append(f'{sanitized_id}{shape_open}"{label}"{shape_close}:::{style_class}')
+        # Escape quotes in label
+        safe_label = label.replace('"', "'")
+        lines.append(f'{sanitized_id}{shape_open}"{safe_label}"{shape_close}:::{style_class}')
 
     # End Node
     lines.append("END((End)):::term")

--- a/tests/test_cli_recipe.py
+++ b/tests/test_cli_recipe.py
@@ -34,17 +34,18 @@ def create_dummy_recipe() -> RecipeDefinition:
     )
 
 
-def test_viz_recipe_not_implemented(capsys: pytest.CaptureFixture[str]) -> None:
-    """Test that 'viz' command fails for RecipeDefinition."""
+def test_viz_recipe_success(capsys: pytest.CaptureFixture[str]) -> None:
+    """Test that 'viz' command succeeds for RecipeDefinition."""
     recipe = create_dummy_recipe()
 
     with (
         patch("coreason_manifest.cli.load_agent_from_ref", return_value=recipe),
         patch.object(sys, "argv", ["coreason", "viz", "dummy:recipe"]),
     ):
-        with pytest.raises(SystemExit) as exc:
-            main()
-        assert exc.value.code == 1
+        main()
 
     captured = capsys.readouterr()
-    assert "Visualization not yet implemented for RecipeDefinition" in captured.err
+    # Check for Mermaid graph start
+    assert "graph TD" in captured.out
+    # Check for the node
+    assert "start" in captured.out

--- a/tests/test_viz_recipe.py
+++ b/tests/test_viz_recipe.py
@@ -246,4 +246,4 @@ def test_recipe_mermaid_label_sanitization() -> None:
     chart = generate_mermaid_graph(recipe)
 
     # Quotes in label should be replaced by single quotes
-    assert 'step1["step1<br/>(Agent: Draft: Say \'Hello\')"]:::agent' in chart
+    assert "step1[\"step1<br/>(Agent: Draft: Say 'Hello')\"]:::agent" in chart

--- a/tests/test_viz_recipe.py
+++ b/tests/test_viz_recipe.py
@@ -1,0 +1,259 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    EvaluatorNode,
+    GenerativeNode,
+    GraphEdge,
+    GraphTopology,
+    HumanNode,
+    RecipeDefinition,
+    RecipeInterface,
+    RouterNode,
+    SemanticRef,
+    SolverConfig,
+)
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.utils.viz import generate_mermaid_graph
+
+
+def test_recipe_mermaid_agent_node() -> None:
+    nodes = [AgentNode(id="step1", agent_ref="agent1")]
+    edges = []
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="step1"
+        )
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    assert "graph TD" in chart
+    assert "classDef agent" in chart
+    assert 'step1["step1<br/>(Agent: agent1)"]:::agent' in chart
+    assert "START --> INPUTS" in chart
+    assert "INPUTS --> step1" in chart
+
+def test_recipe_mermaid_semantic_ref() -> None:
+    nodes = [AgentNode(id="step1", agent_ref=SemanticRef(intent="Do something"))]
+    edges = []
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="step1"
+        )
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    assert 'step1["step1<br/>(Agent: Draft: Do something)"]:::agent' in chart
+
+def test_recipe_mermaid_human_node() -> None:
+    nodes = [HumanNode(id="human1", prompt="Approve?")]
+    edges = []
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="human1"
+        )
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    assert "classDef human" in chart
+    assert 'human1{{"human1<br/>(Human Input)"}}:::human' in chart
+
+def test_recipe_mermaid_router_node() -> None:
+    nodes = [
+        RouterNode(
+            id="router1",
+            input_key="classification",
+            routes={"A": "stepA"},
+            default_route="stepA"
+        ),
+        AgentNode(id="stepA", agent_ref="agentA")
+    ]
+    edges = [
+        GraphEdge(source="router1", target="stepA", condition="A"),
+        GraphEdge(source="router1", target="stepA", condition="default")
+    ]
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="router1"
+        )
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    assert "classDef router" in chart
+    assert 'router1{"router1<br/>(Router: classification)"}:::router' in chart
+    assert 'router1 -- "A" --> stepA' in chart
+    # Unlabeled edge for default is usually handled by not having a condition in edge definition if we strictly follow GraphEdge.
+    # But here we added condition="default" manually to the edge.
+    assert 'router1 -- "default" --> stepA' in chart
+
+def test_recipe_mermaid_evaluator_node() -> None:
+    nodes = [
+        EvaluatorNode(
+            id="eval1",
+            target_variable="output",
+            evaluator_agent_ref="judge",
+            evaluation_profile="standard",
+            pass_threshold=0.8,
+            max_refinements=3,
+            pass_route="pass",
+            fail_route="fail",
+            feedback_variable="critique"
+        ),
+        AgentNode(id="pass", agent_ref="agentP"),
+        AgentNode(id="fail", agent_ref="agentF")
+    ]
+    edges = [
+        GraphEdge(source="eval1", target="pass"),
+        GraphEdge(source="eval1", target="fail")
+    ]
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="eval1"
+        )
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    assert "classDef evaluator" in chart
+    assert 'eval1(["eval1<br/>(Evaluator)"]):::evaluator' in chart
+    assert "eval1 --> pass" in chart
+    assert "eval1 --> fail" in chart
+
+def test_recipe_mermaid_generative_node() -> None:
+    nodes = [
+        GenerativeNode(
+            id="gen1",
+            goal="Solve world hunger",
+            output_schema={"type": "string"}
+        )
+    ]
+    edges = []
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="gen1"
+        )
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    assert "classDef generative" in chart
+    assert 'gen1[["gen1<br/>(Generative)"]]:::generative' in chart
+
+def test_recipe_mermaid_inputs() -> None:
+    nodes = [AgentNode(id="step1", agent_ref="agent1")]
+    edges = []
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(inputs={"q": {"type": "string"}, "n": {"type": "int"}}),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="step1"
+        )
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    assert 'INPUTS["Inputs<br/>- q<br/>- n"]:::input' in chart
+
+def test_recipe_mermaid_sanitization() -> None:
+    nodes = [AgentNode(id="step 1!", agent_ref="agent1")]
+    edges = []
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="step 1!"
+        )
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    assert 'step_1_["step 1!<br/>(Agent: agent1)"]:::agent' in chart
+    assert "INPUTS --> step_1_" in chart
+
+def test_recipe_mermaid_no_entry_point_fallback() -> None:
+    # Use model_construct to bypass validation and simulate a missing entry point
+    nodes = [AgentNode(id="A", agent_ref="a")]
+    topology = GraphTopology.model_construct(
+        nodes=nodes,
+        edges=[],
+        entry_point=""  # Simulate missing entry point
+    )
+    recipe = RecipeDefinition.model_construct(
+        apiVersion="coreason.ai/v2",
+        kind="Recipe",
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=topology
+    )
+
+    chart = generate_mermaid_graph(recipe)
+    assert "INPUTS --> END" in chart
+
+def test_recipe_mermaid_edges() -> None:
+    nodes = [AgentNode(id="A", agent_ref="a"), AgentNode(id="B", agent_ref="b")]
+    edges = [GraphEdge(source="A", target="B")]
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="A"
+        )
+    )
+    chart = generate_mermaid_graph(recipe)
+    assert "A --> B" in chart
+
+    # Ensure quotes are sanitized in condition
+    edges[0] = GraphEdge(source="A", target="B", condition='foo "bar"')
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(
+            nodes=nodes,
+            edges=edges,
+            entry_point="A"
+        )
+    )
+    chart = generate_mermaid_graph(recipe)
+    assert "A -- \"foo 'bar'\" --> B" in chart

--- a/tests/test_viz_recipe.py
+++ b/tests/test_viz_recipe.py
@@ -8,6 +8,9 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from typing import Any, cast
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
 from coreason_manifest.spec.v2.recipe import (
     AgentNode,
     EvaluatorNode,
@@ -19,23 +22,17 @@ from coreason_manifest.spec.v2.recipe import (
     RecipeInterface,
     RouterNode,
     SemanticRef,
-    SolverConfig,
 )
-from coreason_manifest.spec.v2.definitions import ManifestMetadata
 from coreason_manifest.utils.viz import generate_mermaid_graph
 
 
 def test_recipe_mermaid_agent_node() -> None:
     nodes = [AgentNode(id="step1", agent_ref="agent1")]
-    edges = []
+    edges: list[GraphEdge] = []
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="step1"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="step1"),
     )
 
     chart = generate_mermaid_graph(recipe)
@@ -46,34 +43,28 @@ def test_recipe_mermaid_agent_node() -> None:
     assert "START --> INPUTS" in chart
     assert "INPUTS --> step1" in chart
 
+
 def test_recipe_mermaid_semantic_ref() -> None:
     nodes = [AgentNode(id="step1", agent_ref=SemanticRef(intent="Do something"))]
-    edges = []
+    edges: list[GraphEdge] = []
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="step1"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="step1"),
     )
 
     chart = generate_mermaid_graph(recipe)
 
     assert 'step1["step1<br/>(Agent: Draft: Do something)"]:::agent' in chart
 
+
 def test_recipe_mermaid_human_node() -> None:
     nodes = [HumanNode(id="human1", prompt="Approve?")]
-    edges = []
+    edges: list[GraphEdge] = []
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="human1"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="human1"),
     )
 
     chart = generate_mermaid_graph(recipe)
@@ -81,28 +72,25 @@ def test_recipe_mermaid_human_node() -> None:
     assert "classDef human" in chart
     assert 'human1{{"human1<br/>(Human Input)"}}:::human' in chart
 
+
 def test_recipe_mermaid_router_node() -> None:
     nodes = [
         RouterNode(
             id="router1",
             input_key="classification",
             routes={"A": "stepA"},
-            default_route="stepA"
+            default_route="stepA",
         ),
-        AgentNode(id="stepA", agent_ref="agentA")
+        AgentNode(id="stepA", agent_ref="agentA"),
     ]
-    edges = [
+    edges: list[GraphEdge] = [
         GraphEdge(source="router1", target="stepA", condition="A"),
-        GraphEdge(source="router1", target="stepA", condition="default")
+        GraphEdge(source="router1", target="stepA", condition="default"),
     ]
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="router1"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="router1"),
     )
 
     chart = generate_mermaid_graph(recipe)
@@ -110,9 +98,11 @@ def test_recipe_mermaid_router_node() -> None:
     assert "classDef router" in chart
     assert 'router1{"router1<br/>(Router: classification)"}:::router' in chart
     assert 'router1 -- "A" --> stepA' in chart
-    # Unlabeled edge for default is usually handled by not having a condition in edge definition if we strictly follow GraphEdge.
+    # Unlabeled edge for default is usually handled by not having a condition
+    # in edge definition if we strictly follow GraphEdge.
     # But here we added condition="default" manually to the edge.
     assert 'router1 -- "default" --> stepA' in chart
+
 
 def test_recipe_mermaid_evaluator_node() -> None:
     nodes = [
@@ -125,23 +115,19 @@ def test_recipe_mermaid_evaluator_node() -> None:
             max_refinements=3,
             pass_route="pass",
             fail_route="fail",
-            feedback_variable="critique"
+            feedback_variable="critique",
         ),
         AgentNode(id="pass", agent_ref="agentP"),
-        AgentNode(id="fail", agent_ref="agentF")
+        AgentNode(id="fail", agent_ref="agentF"),
     ]
-    edges = [
+    edges: list[GraphEdge] = [
         GraphEdge(source="eval1", target="pass"),
-        GraphEdge(source="eval1", target="fail")
+        GraphEdge(source="eval1", target="fail"),
     ]
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="eval1"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="eval1"),
     )
 
     chart = generate_mermaid_graph(recipe)
@@ -151,23 +137,20 @@ def test_recipe_mermaid_evaluator_node() -> None:
     assert "eval1 --> pass" in chart
     assert "eval1 --> fail" in chart
 
+
 def test_recipe_mermaid_generative_node() -> None:
     nodes = [
         GenerativeNode(
             id="gen1",
             goal="Solve world hunger",
-            output_schema={"type": "string"}
+            output_schema={"type": "string"},
         )
     ]
-    edges = []
+    edges: list[GraphEdge] = []
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="gen1"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="gen1"),
     )
 
     chart = generate_mermaid_graph(recipe)
@@ -175,34 +158,28 @@ def test_recipe_mermaid_generative_node() -> None:
     assert "classDef generative" in chart
     assert 'gen1[["gen1<br/>(Generative)"]]:::generative' in chart
 
+
 def test_recipe_mermaid_inputs() -> None:
     nodes = [AgentNode(id="step1", agent_ref="agent1")]
-    edges = []
+    edges: list[GraphEdge] = []
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(inputs={"q": {"type": "string"}, "n": {"type": "int"}}),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="step1"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="step1"),
     )
 
     chart = generate_mermaid_graph(recipe)
 
     assert 'INPUTS["Inputs<br/>- q<br/>- n"]:::input' in chart
 
+
 def test_recipe_mermaid_sanitization() -> None:
     nodes = [AgentNode(id="step 1!", agent_ref="agent1")]
-    edges = []
+    edges: list[GraphEdge] = []
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="step 1!"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="step 1!"),
     )
 
     chart = generate_mermaid_graph(recipe)
@@ -210,36 +187,38 @@ def test_recipe_mermaid_sanitization() -> None:
     assert 'step_1_["step 1!<br/>(Agent: agent1)"]:::agent' in chart
     assert "INPUTS --> step_1_" in chart
 
+
 def test_recipe_mermaid_no_entry_point_fallback() -> None:
     # Use model_construct to bypass validation and simulate a missing entry point
     nodes = [AgentNode(id="A", agent_ref="a")]
+    # Cast nodes to list[Any] to bypass MyPy strict check for model_construct args if needed,
+    # or rely on typing being loose for construct.
+    # The error was: Argument "nodes" to "model_construct" of "GraphTopology" has incompatible type "list[AgentNode]"
+    # It expects the Union type.
     topology = GraphTopology.model_construct(
-        nodes=nodes,
+        nodes=cast("Any", nodes),
         edges=[],
-        entry_point=""  # Simulate missing entry point
+        entry_point="",  # Simulate missing entry point
     )
     recipe = RecipeDefinition.model_construct(
         apiVersion="coreason.ai/v2",
         kind="Recipe",
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=topology
+        topology=topology,
     )
 
     chart = generate_mermaid_graph(recipe)
     assert "INPUTS --> END" in chart
 
+
 def test_recipe_mermaid_edges() -> None:
     nodes = [AgentNode(id="A", agent_ref="a"), AgentNode(id="B", agent_ref="b")]
-    edges = [GraphEdge(source="A", target="B")]
+    edges: list[GraphEdge] = [GraphEdge(source="A", target="B")]
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="A"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="A"),
     )
     chart = generate_mermaid_graph(recipe)
     assert "A --> B" in chart
@@ -249,11 +228,22 @@ def test_recipe_mermaid_edges() -> None:
     recipe = RecipeDefinition(
         metadata=ManifestMetadata(name="TestRecipe"),
         interface=RecipeInterface(),
-        topology=GraphTopology(
-            nodes=nodes,
-            edges=edges,
-            entry_point="A"
-        )
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="A"),
     )
     chart = generate_mermaid_graph(recipe)
     assert "A -- \"foo 'bar'\" --> B" in chart
+
+
+def test_recipe_mermaid_label_sanitization() -> None:
+    nodes = [AgentNode(id="step1", agent_ref=SemanticRef(intent='Say "Hello"'))]
+    edges: list[GraphEdge] = []
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="TestRecipe"),
+        interface=RecipeInterface(),
+        topology=GraphTopology(nodes=nodes, edges=edges, entry_point="step1"),
+    )
+
+    chart = generate_mermaid_graph(recipe)
+
+    # Quotes in label should be replaced by single quotes
+    assert 'step1["step1<br/>(Agent: Draft: Say \'Hello\')"]:::agent' in chart


### PR DESCRIPTION
Implemented the missing visualization logic for `RecipeDefinition` objects in the CLI `viz` command. The command now generates Mermaid.js graphs for recipes, supporting all standard node types (Agent, Human, Router, Evaluator, Generative) with appropriate styling and labels. Added comprehensive tests to verify the output and ensure 100% code coverage.

---
*PR created automatically by Jules for task [17498418758101948719](https://jules.google.com/task/17498418758101948719) started by @gowthamrao*