### PR TITLE
chore: bump minor version to 0.24.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "coreason_manifest"
-version = "0.23.0"
+version = "0.24.0"
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -117,7 +117,7 @@ from .utils.v2.governance import check_compliance_v2
 from .utils.v2.io import dump_to_yaml, load_from_yaml
 from .utils.viz import generate_mermaid_graph
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"
 
 Manifest = ManifestV2
 Recipe = RecipeDefinition

--- a/uv.lock
+++ b/uv.lock
@@ -132,7 +132,7 @@ wheels = [
 
 [[package]]
 name = "coreason-manifest"
-version = "0.23.0"
+version = "0.24.0"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Bump minor version in pyproject.toml and src/coreason_manifest/__init__.py to 0.24.0. Updated uv.lock.

---
*PR created automatically by Jules for task [3746866983898167491](https://jules.google.com/task/3746866983898167491) started by @gowthamrao*