### PR TITLE
Add Architectural Visuals (Mermaid Diagrams)

### DIFF
--- a/docs/package_structure.md
+++ b/docs/package_structure.md
@@ -78,6 +78,9 @@ Governance Policies (`GovernanceConfig`) are data, but applying them (`check_com
 
 ```mermaid
 graph TD
+    %% SOTA Styling Init
+    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffecb3', 'edgeLabelBackground':'#ffffff', 'tertiaryColor': '#e1f5fe'}}}%%
+
     External_App[External App]
     spec[spec]
     utils[utils]
@@ -88,6 +91,16 @@ graph TD
 
     %% Forbidden dependency
     spec --x|Forbidden| utils
+
+    %% Styling Classes
+    classDef app fill:#e1f5fe,stroke:#4fc3f7,stroke-width:2px;
+    classDef kernel fill:#ffecb3,stroke:#ffb74d,stroke-width:2px;
+    classDef logic fill:#e0f2f1,stroke:#4db6ac,stroke-width:2px;
+
+    %% Apply Styles
+    class External_App app;
+    class spec kernel;
+    class utils logic;
 
     linkStyle 3 stroke:red,stroke-width:2px,color:red;
 ```

--- a/docs/package_structure.md
+++ b/docs/package_structure.md
@@ -73,3 +73,21 @@ The Manifest allows local file references (`$ref`). Security logic to ensure the
 
 ### 3. Governance Portability
 Governance Policies (`GovernanceConfig`) are data, but applying them (`check_compliance`) is logic. By keeping the enforcer in the kernel, we allow "Policy" to be portable. A policy defined in the Web UI can be enforced identically in the CLI because they share the exact same enforcement code.
+
+## Package Map
+
+```mermaid
+graph TD
+    External_App[External App]
+    spec[spec]
+    utils[utils]
+
+    External_App --> spec
+    External_App --> utils
+    utils --> spec
+
+    %% Forbidden dependency
+    spec --x|Forbidden| utils
+
+    linkStyle 3 stroke:red,stroke-width:2px,color:red;
+```

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -6,6 +6,9 @@ This diagram illustrates the composition of an `AgentDefinition`, highlighting i
 
 ```mermaid
 classDiagram
+    %% SOTA Styling Init
+    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffecb3', 'edgeLabelBackground':'#ffffff', 'tertiaryColor': '#e1f5fe'}}}%%
+
     class AgentDefinition {
         +str id
         +str name
@@ -50,4 +53,14 @@ classDiagram
     AgentDefinition *-- InlineToolDefinition : tools (embedded)
 
     %% Note: Knowledge is represented as a list of strings (IDs/Paths) within AgentDefinition
+
+    %% Styling Classes
+    classDef root fill:#ffecb3,stroke:#ffb74d,stroke-width:2px;
+    classDef config fill:#e1f5fe,stroke:#4fc3f7,stroke-width:1px;
+    classDef tool fill:#e0f2f1,stroke:#4db6ac,stroke-width:1px;
+
+    %% Apply Styles
+    class AgentDefinition root;
+    class ModelProfile,InterfaceDefinition config;
+    class ToolRequirement,InlineToolDefinition tool;
 ```

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1,0 +1,53 @@
+# Agent Definition
+
+## Architecture
+
+This diagram illustrates the composition of an `AgentDefinition`, highlighting its relationships with resources (Model), tools, and knowledge.
+
+```mermaid
+classDiagram
+    class AgentDefinition {
+        +str id
+        +str name
+        +str role
+        +str goal
+        +str backstory
+        +list~str~ knowledge
+        +list~str~ skills
+        +InterfaceDefinition interface
+        +AgentCapabilities capabilities
+        +AgentRuntimeConfig runtime
+        +EvaluationProfile evaluation
+        +ModelProfile resources
+    }
+    class ModelProfile {
+        +str provider
+        +str model_id
+        +RateCard pricing
+        +ResourceConstraints constraints
+    }
+    class ToolRequirement {
+        +str uri
+        +str hash
+    }
+    class InlineToolDefinition {
+        +str name
+        +str description
+        +dict parameters
+        +str code_hash
+    }
+    class InterfaceDefinition {
+        +dict inputs
+        +dict outputs
+    }
+
+    %% Composition
+    AgentDefinition *-- ModelProfile : resources
+    AgentDefinition *-- InterfaceDefinition : interface
+
+    %% Aggregation/Composition for tools (Polymorphic list)
+    AgentDefinition o-- ToolRequirement : tools (reference)
+    AgentDefinition *-- InlineToolDefinition : tools (embedded)
+
+    %% Note: Knowledge is represented as a list of strings (IDs/Paths) within AgentDefinition
+```

--- a/docs/reference/governance.md
+++ b/docs/reference/governance.md
@@ -6,6 +6,9 @@ This diagram visualizes the `GovernanceConfig` for static validation and `Compli
 
 ```mermaid
 classDiagram
+    %% SOTA Styling Init
+    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffecb3', 'edgeLabelBackground':'#ffffff', 'tertiaryColor': '#e1f5fe'}}}%%
+
     class GovernanceConfig {
         +list~str~ allowed_domains
         +ToolRiskLevel max_risk_level
@@ -49,4 +52,14 @@ classDiagram
     ComplianceConfig *-- IntegrityConfig : contains
 
     %% Note: GovernanceConfig validates the Manifest, while ComplianceConfig governs runtime auditing.
+
+    %% Styling Classes
+    classDef root fill:#ffecb3,stroke:#ffb74d,stroke-width:2px;
+    classDef config fill:#e1f5fe,stroke:#4fc3f7,stroke-width:1px;
+    classDef enum fill:#fbe9e7,stroke:#ffab91,stroke-width:1px,stroke-dasharray: 2 2;
+
+    %% Apply Styles
+    class GovernanceConfig,ComplianceConfig root;
+    class IntegrityConfig config;
+    class ToolRiskLevel,AuditLevel enum;
 ```

--- a/docs/reference/governance.md
+++ b/docs/reference/governance.md
@@ -1,0 +1,52 @@
+# Governance Model
+
+## Policy and Compliance
+
+This diagram visualizes the `GovernanceConfig` for static validation and `ComplianceConfig` for runtime auditing.
+
+```mermaid
+classDiagram
+    class GovernanceConfig {
+        +list~str~ allowed_domains
+        +ToolRiskLevel max_risk_level
+        +bool require_auth_for_critical_tools
+        +bool allow_inline_tools
+        +bool allow_custom_logic
+        +bool strict_url_validation
+    }
+    class ComplianceConfig {
+        +AuditLevel audit_level
+        +RetentionPolicy retention
+        +bool generate_aibom
+        +bool generate_pdf_report
+        +bool require_signature
+        +bool mask_pii
+        +IntegrityConfig integrity
+    }
+    class ToolRiskLevel {
+        <<Enum>>
+        SAFE
+        STANDARD
+        CRITICAL
+    }
+    class AuditLevel {
+        <<Enum>>
+        NONE
+        BASIC
+        FULL
+        GXP_COMPLIANT
+    }
+    class IntegrityConfig {
+        +AuditContentMode input_mode
+        +AuditContentMode output_mode
+        +IntegrityLevel integrity_level
+        +str hash_algorithm
+    }
+
+    %% Relationships (Conceptual Dependencies)
+    GovernanceConfig ..> ToolRiskLevel : uses
+    ComplianceConfig ..> AuditLevel : uses
+    ComplianceConfig *-- IntegrityConfig : contains
+
+    %% Note: GovernanceConfig validates the Manifest, while ComplianceConfig governs runtime auditing.
+```

--- a/docs/reference/orchestration.md
+++ b/docs/reference/orchestration.md
@@ -1,0 +1,98 @@
+# Orchestration Core
+
+## Architecture
+
+This diagram illustrates the structure of a `RecipeDefinition` and the inheritance hierarchy of `RecipeNode`.
+
+```mermaid
+classDiagram
+    class RecipeDefinition {
+        +ManifestMetadata metadata
+        +RecipeInterface interface
+        +PolicyConfig policy
+        +GraphTopology topology
+        +list~Constraint~ requirements
+        +StateDefinition state
+        +ComplianceConfig compliance
+        +IdentityRequirement identity
+        +GuardrailsConfig guardrails
+    }
+    class GraphTopology {
+        +str entry_point
+        +list~RecipeNode~ nodes
+        +list~GraphEdge~ edges
+    }
+    class RecipeNode {
+        <<Abstract>>
+        +str id
+        +dict metadata
+        +NodePresentation presentation
+        +InteractionConfig interaction
+        +RecoveryConfig recovery
+        +ReasoningConfig reasoning
+    }
+    class AgentNode {
+        +str agent_ref
+        +CognitiveProfile cognitive_profile
+        +ModelSelectionPolicy model_policy
+        +str system_prompt_override
+        +dict inputs_map
+    }
+    class RouterNode {
+        +str input_key
+        +dict routes
+        +str default_route
+    }
+    class HumanNode {
+        +str prompt
+        +int timeout_seconds
+        +str required_role
+    }
+    class EvaluatorNode {
+        +str target_variable
+        +str evaluator_agent_ref
+        +EvaluationProfile evaluation_profile
+        +float pass_threshold
+        +int max_refinements
+        +str pass_route
+        +str fail_route
+        +str feedback_variable
+    }
+    class GenerativeNode {
+        +str goal
+        +SolverConfig solver
+        +list~str~ allowed_tools
+        +dict output_schema
+    }
+    class RecipeInterface {
+        +dict inputs
+        +dict outputs
+    }
+    class PolicyConfig {
+        +int max_retries
+        +int timeout_seconds
+        +str execution_mode
+        +ExecutionPriority priority
+    }
+
+    RecipeDefinition *-- GraphTopology : contains
+    RecipeDefinition *-- RecipeInterface : contains
+    RecipeDefinition *-- PolicyConfig : contains
+    GraphTopology *-- RecipeNode : contains
+    RecipeNode <|-- AgentNode : inherits
+    RecipeNode <|-- RouterNode : inherits
+    RecipeNode <|-- HumanNode : inherits
+    RecipeNode <|-- EvaluatorNode : inherits
+    RecipeNode <|-- GenerativeNode : inherits
+
+    %% Aggregation
+    AgentNode o-- AgentDefinition : agent_ref (ID)
+
+    class AgentDefinition {
+        <<External>>
+    }
+
+    %% Styling
+    classDef abstract fill:#f9f9f9,stroke:#333,stroke-width:2px,stroke-dasharray: 5 5;
+    class RecipeNode abstract;
+```

--- a/docs/reference/orchestration.md
+++ b/docs/reference/orchestration.md
@@ -6,6 +6,9 @@ This diagram illustrates the structure of a `RecipeDefinition` and the inheritan
 
 ```mermaid
 classDiagram
+    %% SOTA Styling Init
+    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffecb3', 'edgeLabelBackground':'#ffffff', 'tertiaryColor': '#e1f5fe'}}}%%
+
     class RecipeDefinition {
         +ManifestMetadata metadata
         +RecipeInterface interface
@@ -92,7 +95,17 @@ classDiagram
         <<External>>
     }
 
-    %% Styling
-    classDef abstract fill:#f9f9f9,stroke:#333,stroke-width:2px,stroke-dasharray: 5 5;
+    %% Styling Classes
+    classDef root fill:#ffecb3,stroke:#ffb74d,stroke-width:2px;
+    classDef config fill:#e1f5fe,stroke:#4fc3f7,stroke-width:1px;
+    classDef node fill:#e0f2f1,stroke:#4db6ac,stroke-width:1px;
+    classDef abstract fill:#f5f5f5,stroke:#9e9e9e,stroke-width:1px,stroke-dasharray: 5 5;
+    classDef external fill:#fff3e0,stroke:#ffcc80,stroke-width:1px,stroke-dasharray: 2 2;
+
+    %% Apply Styles
+    class RecipeDefinition root;
+    class GraphTopology,RecipeInterface,PolicyConfig config;
+    class AgentNode,RouterNode,HumanNode,EvaluatorNode,GenerativeNode node;
     class RecipeNode abstract;
+    class AgentDefinition external;
 ```


### PR DESCRIPTION
This PR implements the Visual Architect Agent task.
It adds detailed Mermaid.js class diagrams to the documentation to visualize the system architecture.

### Changes:
1.  **Orchestration Core (`docs/reference/orchestration.md`)**:
    *   Visualizes `RecipeDefinition`, `GraphTopology`, and the `RecipeNode` inheritance hierarchy (`AgentNode`, `RouterNode`, etc.).
    *   Models relationships using Composition (`*--`) for internal structures and Aggregation (`o--`) for references.
    *   Includes `RecipeInterface` and `PolicyConfig`.
    *   Styles the `RecipeNode` abstract class.

2.  **Agent Definition (`docs/reference/agents.md`)**:
    *   Visualizes `AgentDefinition` composition, including `ModelProfile` (for ModelReference), `ToolRequirement` (for ToolReference), and `InterfaceDefinition`.

3.  **Governance Model (`docs/reference/governance.md`)**:
    *   Visualizes `GovernanceConfig` and `ComplianceConfig` along with their Enums (`ToolRiskLevel`, `AuditLevel`).

4.  **Package Map (`docs/package_structure.md`)**:
    *   Adds a flowchart showing the dependency boundaries between `External App`, `spec`, and `utils`.
    *   Highlights the forbidden dependency `spec --x utils` with a red link.

All diagrams strictly follow the source code structure ("No Hallucinations") while adhering to the requested UML semantics where possible.

---
*PR created automatically by Jules for task [5119776927987338092](https://jules.google.com/task/5119776927987338092) started by @gowthamrao*