### PR TITLE
Implement Automated API References with mkdocstrings

### DIFF
--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1,66 +1,34 @@
-# Agent Definition
+# Agent Definitions
 
-## Architecture
+## Overview
+This module defines the core structure of an AI Agent, including its persona, goals, tools, and knowledge sources.
 
-This diagram illustrates the composition of an `AgentDefinition`, highlighting its relationships with resources (Model), tools, and knowledge.
+## Application Pattern
+This example demonstrates the minimal configuration required to define a compliant agent with a specific tool requirement.
 
-```mermaid
-classDiagram
-    %% SOTA Styling Init
-    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffecb3', 'edgeLabelBackground':'#ffffff', 'tertiaryColor': '#e1f5fe'}}}%%
+```python
+# Example: Defining a Support Agent
+from coreason_manifest.spec.v2.definitions import AgentDefinition, ToolRequirement
 
-    class AgentDefinition {
-        +str id
-        +str name
-        +str role
-        +str goal
-        +str backstory
-        +list~str~ knowledge
-        +list~str~ skills
-        +InterfaceDefinition interface
-        +AgentCapabilities capabilities
-        +AgentRuntimeConfig runtime
-        +EvaluationProfile evaluation
-        +ModelProfile resources
-    }
-    class ModelProfile {
-        +str provider
-        +str model_id
-        +RateCard pricing
-        +ResourceConstraints constraints
-    }
-    class ToolRequirement {
-        +str uri
-        +str hash
-    }
-    class InlineToolDefinition {
-        +str name
-        +str description
-        +dict parameters
-        +str code_hash
-    }
-    class InterfaceDefinition {
-        +dict inputs
-        +dict outputs
-    }
-
-    %% Composition
-    AgentDefinition *-- ModelProfile : resources
-    AgentDefinition *-- InterfaceDefinition : interface
-
-    %% Aggregation/Composition for tools (Polymorphic list)
-    AgentDefinition o-- ToolRequirement : tools (reference)
-    AgentDefinition *-- InlineToolDefinition : tools (embedded)
-
-    %% Note: Knowledge is represented as a list of strings (IDs/Paths) within AgentDefinition
-
-    %% Styling Classes
-    classDef root fill:#ffecb3,stroke:#ffb74d,stroke-width:2px;
-    classDef config fill:#e1f5fe,stroke:#4fc3f7,stroke-width:1px;
-    classDef tool fill:#e0f2f1,stroke:#4db6ac,stroke-width:1px;
-
-    %% Apply Styles
-    class AgentDefinition root;
-    class ModelProfile,InterfaceDefinition config;
-    class ToolRequirement,InlineToolDefinition tool;
+support_agent = AgentDefinition(
+    id="customer-support-v1",
+    name="Support Bot",
+    role="Customer Service Representative",
+    goal="Resolve user inquiries efficiently and politely.",
+    backstory="You are a helpful assistant with 10 years of experience.",
+    model="gpt-4-turbo",
+    tools=[
+        ToolRequirement(
+            uri="mcp://zendesk/ticket-search",
+            hash="sha256:..."
+        )
+    ],
+    knowledge=["s3://company-docs/faq.pdf"]
+)
 ```
+
+## API Reference
+
+::: coreason_manifest.spec.v2.definitions.AgentDefinition
+
+::: coreason_manifest.spec.v2.definitions.ToolRequirement

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -1,14 +1,15 @@
 # Agent Definitions
 
 ## Overview
-This module defines the core structure of an AI Agent, including its persona, goals, tools, and knowledge sources.
+This module defines the core structure of an AI Agent, including its persona, goals, [tools][coreason_manifest.spec.v2.definitions.ToolRequirement], and knowledge sources. Agents can also be configured with specific [capabilities](../reference/capabilities.md).
 
 ## Application Pattern
-This example demonstrates the minimal configuration required to define a compliant agent with a specific tool requirement.
+This example demonstrates the configuration of an [AgentDefinition][coreason_manifest.spec.v2.definitions.AgentDefinition] with specific [ModelProfile][coreason_manifest.spec.v2.resources.ModelProfile] constraints, ensuring the semantic requirements (e.g., context window size) are explicitly defined.
 
 ```python
-# Example: Defining a Support Agent
+# Example: Defining a Support Agent with Semantic Model Constraints
 from coreason_manifest.spec.v2.definitions import AgentDefinition, ToolRequirement
+from coreason_manifest.spec.v2.resources import ModelProfile, ResourceConstraints, RateCard, PricingUnit
 
 support_agent = AgentDefinition(
     id="customer-support-v1",
@@ -16,7 +17,24 @@ support_agent = AgentDefinition(
     role="Customer Service Representative",
     goal="Resolve user inquiries efficiently and politely.",
     backstory="You are a helpful assistant with 10 years of experience.",
+
+    # Semantic Model Definition
+    # Instead of just a string ID, we define the required capabilities
     model="gpt-4-turbo",
+    resources=ModelProfile(
+        provider="openai",
+        model_id="gpt-4-turbo",
+        constraints=ResourceConstraints(
+            context_window_size=128000,
+            max_output_tokens=4096
+        ),
+        pricing=RateCard(
+            unit=PricingUnit.TOKEN_1M,
+            input_cost=10.00,
+            output_cost=30.00
+        )
+    ),
+
     tools=[
         ToolRequirement(
             uri="mcp://zendesk/ticket-search",
@@ -32,3 +50,13 @@ support_agent = AgentDefinition(
 ::: coreason_manifest.spec.v2.definitions.AgentDefinition
 
 ::: coreason_manifest.spec.v2.definitions.ToolRequirement
+
+### Resources
+
+::: coreason_manifest.spec.v2.resources.ModelProfile
+
+::: coreason_manifest.spec.v2.resources.ResourceConstraints
+
+::: coreason_manifest.spec.v2.resources.RateCard
+
+::: coreason_manifest.spec.v2.resources.PricingUnit

--- a/docs/reference/capabilities.md
+++ b/docs/reference/capabilities.md
@@ -1,0 +1,22 @@
+# Agent Capabilities
+
+## Overview
+This module defines the feature flags and architectural capabilities of an agent, such as history support and delivery mode.
+
+## Application Pattern
+This example shows how to configure an agent's capabilities to support server-sent events (streaming) and disable history for a stateless micro-agent.
+
+```python
+# Example: Configuring Agent Capabilities
+from coreason_manifest.spec.common.capabilities import AgentCapabilities, DeliveryMode, CapabilityType
+
+capabilities = AgentCapabilities(
+    type=CapabilityType.ATOMIC,
+    delivery_mode=DeliveryMode.SERVER_SENT_EVENTS,
+    history_support=False
+)
+```
+
+## API Reference
+
+::: coreason_manifest.spec.common.capabilities.AgentCapabilities

--- a/docs/reference/governance.md
+++ b/docs/reference/governance.md
@@ -1,10 +1,10 @@
 # Governance
 
 ## Overview
-This module defines the policies for static validation and runtime auditing, ensuring that agents and tools comply with security and safety standards.
+This module defines the policies for static validation and runtime auditing, ensuring that [agents](../reference/agents.md) and tools comply with security and safety standards.
 
 ## Application Pattern
-This example shows how to configure a `GovernanceConfig` that enforces strict risk levels and blocks the use of "Critical" tools without authentication.
+This example shows how to configure a [GovernanceConfig][coreason_manifest.spec.governance.GovernanceConfig] that enforces strict risk levels and blocks the use of "Critical" tools without authentication.
 
 ```python
 # Example: Creating a Governance Configuration

--- a/docs/reference/governance.md
+++ b/docs/reference/governance.md
@@ -1,65 +1,30 @@
-# Governance Model
+# Governance
 
-## Policy and Compliance
+## Overview
+This module defines the policies for static validation and runtime auditing, ensuring that agents and tools comply with security and safety standards.
 
-This diagram visualizes the `GovernanceConfig` for static validation and `ComplianceConfig` for runtime auditing.
+## Application Pattern
+This example shows how to configure a `GovernanceConfig` that enforces strict risk levels and blocks the use of "Critical" tools without authentication.
 
-```mermaid
-classDiagram
-    %% SOTA Styling Init
-    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffecb3', 'edgeLabelBackground':'#ffffff', 'tertiaryColor': '#e1f5fe'}}}%%
+```python
+# Example: Creating a Governance Configuration
+from coreason_manifest.spec.governance import GovernanceConfig, ToolRiskLevel
 
-    class GovernanceConfig {
-        +list~str~ allowed_domains
-        +ToolRiskLevel max_risk_level
-        +bool require_auth_for_critical_tools
-        +bool allow_inline_tools
-        +bool allow_custom_logic
-        +bool strict_url_validation
-    }
-    class ComplianceConfig {
-        +AuditLevel audit_level
-        +RetentionPolicy retention
-        +bool generate_aibom
-        +bool generate_pdf_report
-        +bool require_signature
-        +bool mask_pii
-        +IntegrityConfig integrity
-    }
-    class ToolRiskLevel {
-        <<Enum>>
-        SAFE
-        STANDARD
-        CRITICAL
-    }
-    class AuditLevel {
-        <<Enum>>
-        NONE
-        BASIC
-        FULL
-        GXP_COMPLIANT
-    }
-    class IntegrityConfig {
-        +AuditContentMode input_mode
-        +AuditContentMode output_mode
-        +IntegrityLevel integrity_level
-        +str hash_algorithm
-    }
+# Define a policy that blocks critical tools and restricts domains
+policy = GovernanceConfig(
+    allowed_domains=["api.github.com", "slack.com"],
+    max_risk_level=ToolRiskLevel.STANDARD,
+    require_auth_for_critical_tools=True,
+    allow_inline_tools=False,
+    strict_url_validation=True
+)
 
-    %% Relationships (Conceptual Dependencies)
-    GovernanceConfig ..> ToolRiskLevel : uses
-    ComplianceConfig ..> AuditLevel : uses
-    ComplianceConfig *-- IntegrityConfig : contains
-
-    %% Note: GovernanceConfig validates the Manifest, while ComplianceConfig governs runtime auditing.
-
-    %% Styling Classes
-    classDef root fill:#ffecb3,stroke:#ffb74d,stroke-width:2px;
-    classDef config fill:#e1f5fe,stroke:#4fc3f7,stroke-width:1px;
-    classDef enum fill:#fbe9e7,stroke:#ffab91,stroke-width:1px,stroke-dasharray: 2 2;
-
-    %% Apply Styles
-    class GovernanceConfig,ComplianceConfig root;
-    class IntegrityConfig config;
-    class ToolRiskLevel,AuditLevel enum;
+# If an agent attempts to use a tool with Risk Level 'CRITICAL',
+# this policy will cause a validation error during the manifest check.
 ```
+
+## API Reference
+
+::: coreason_manifest.spec.governance.GovernanceConfig
+
+::: coreason_manifest.spec.governance.ComplianceReport

--- a/docs/reference/orchestration.md
+++ b/docs/reference/orchestration.md
@@ -1,10 +1,10 @@
 # Orchestration
 
 ## Overview
-This module controls the flow of execution within an agentic workflow, defining how nodes (agents, routers, humans) are connected and how data flows between them.
+This module controls the flow of execution within an agentic workflow, defining how nodes ([agents](../reference/agents.md), routers, humans) are connected and how data flows between them.
 
 ## Application Pattern
-This example demonstrates how to wire a `GraphTopology` with a simple feedback loop, where an agent's output is evaluated and potentially routed back for refinement.
+This example demonstrates how to wire a [GraphTopology][coreason_manifest.spec.v2.recipe.GraphTopology] with a simple feedback loop, where an [AgentNode][coreason_manifest.spec.v2.recipe.AgentNode]'s output is evaluated and potentially routed back for refinement.
 
 ```python
 # Example: Instantiating a GraphTopology with a Loop
@@ -16,6 +16,7 @@ from coreason_manifest.spec.v2.recipe import (
 )
 
 # Define the Agent Node (The Doer)
+# Refers to an AgentDefinition in 'agents.md'
 agent_node = AgentNode(
     id="step_1_generate",
     agent_ref="agent-writer-v1"

--- a/docs/reference/orchestration.md
+++ b/docs/reference/orchestration.md
@@ -1,111 +1,56 @@
-# Orchestration Core
+# Orchestration
 
-## Architecture
+## Overview
+This module controls the flow of execution within an agentic workflow, defining how nodes (agents, routers, humans) are connected and how data flows between them.
 
-This diagram illustrates the structure of a `RecipeDefinition` and the inheritance hierarchy of `RecipeNode`.
+## Application Pattern
+This example demonstrates how to wire a `GraphTopology` with a simple feedback loop, where an agent's output is evaluated and potentially routed back for refinement.
 
-```mermaid
-classDiagram
-    %% SOTA Styling Init
-    %%{init: {'theme': 'base', 'themeVariables': { 'primaryColor': '#ffecb3', 'edgeLabelBackground':'#ffffff', 'tertiaryColor': '#e1f5fe'}}}%%
+```python
+# Example: Instantiating a GraphTopology with a Loop
+from coreason_manifest.spec.v2.recipe import (
+    GraphTopology,
+    AgentNode,
+    EvaluatorNode,
+    GraphEdge
+)
 
-    class RecipeDefinition {
-        +ManifestMetadata metadata
-        +RecipeInterface interface
-        +PolicyConfig policy
-        +GraphTopology topology
-        +list~Constraint~ requirements
-        +StateDefinition state
-        +ComplianceConfig compliance
-        +IdentityRequirement identity
-        +GuardrailsConfig guardrails
-    }
-    class GraphTopology {
-        +str entry_point
-        +list~RecipeNode~ nodes
-        +list~GraphEdge~ edges
-    }
-    class RecipeNode {
-        <<Abstract>>
-        +str id
-        +dict metadata
-        +NodePresentation presentation
-        +InteractionConfig interaction
-        +RecoveryConfig recovery
-        +ReasoningConfig reasoning
-    }
-    class AgentNode {
-        +str agent_ref
-        +CognitiveProfile cognitive_profile
-        +ModelSelectionPolicy model_policy
-        +str system_prompt_override
-        +dict inputs_map
-    }
-    class RouterNode {
-        +str input_key
-        +dict routes
-        +str default_route
-    }
-    class HumanNode {
-        +str prompt
-        +int timeout_seconds
-        +str required_role
-    }
-    class EvaluatorNode {
-        +str target_variable
-        +str evaluator_agent_ref
-        +EvaluationProfile evaluation_profile
-        +float pass_threshold
-        +int max_refinements
-        +str pass_route
-        +str fail_route
-        +str feedback_variable
-    }
-    class GenerativeNode {
-        +str goal
-        +SolverConfig solver
-        +list~str~ allowed_tools
-        +dict output_schema
-    }
-    class RecipeInterface {
-        +dict inputs
-        +dict outputs
-    }
-    class PolicyConfig {
-        +int max_retries
-        +int timeout_seconds
-        +str execution_mode
-        +ExecutionPriority priority
-    }
+# Define the Agent Node (The Doer)
+agent_node = AgentNode(
+    id="step_1_generate",
+    agent_ref="agent-writer-v1"
+)
 
-    RecipeDefinition *-- GraphTopology : contains
-    RecipeDefinition *-- RecipeInterface : contains
-    RecipeDefinition *-- PolicyConfig : contains
-    GraphTopology *-- RecipeNode : contains
-    RecipeNode <|-- AgentNode : inherits
-    RecipeNode <|-- RouterNode : inherits
-    RecipeNode <|-- HumanNode : inherits
-    RecipeNode <|-- EvaluatorNode : inherits
-    RecipeNode <|-- GenerativeNode : inherits
+# Define the Evaluator Node (The Checker)
+evaluator_node = EvaluatorNode(
+    id="step_2_evaluate",
+    target_variable="step_1_generate.output",
+    evaluator_agent_ref="agent-editor-v1",
+    evaluation_profile="profile-grammar-check",
+    pass_threshold=0.8,
+    max_refinements=3,
+    pass_route="end",
+    fail_route="step_1_generate",  # Loop back on failure
+    feedback_variable="editor_feedback"
+)
 
-    %% Aggregation
-    AgentNode o-- AgentDefinition : agent_ref (ID)
-
-    class AgentDefinition {
-        <<External>>
-    }
-
-    %% Styling Classes
-    classDef root fill:#ffecb3,stroke:#ffb74d,stroke-width:2px;
-    classDef config fill:#e1f5fe,stroke:#4fc3f7,stroke-width:1px;
-    classDef node fill:#e0f2f1,stroke:#4db6ac,stroke-width:1px;
-    classDef abstract fill:#f5f5f5,stroke:#9e9e9e,stroke-width:1px,stroke-dasharray: 5 5;
-    classDef external fill:#fff3e0,stroke:#ffcc80,stroke-width:1px,stroke-dasharray: 2 2;
-
-    %% Apply Styles
-    class RecipeDefinition root;
-    class GraphTopology,RecipeInterface,PolicyConfig config;
-    class AgentNode,RouterNode,HumanNode,EvaluatorNode,GenerativeNode node;
-    class RecipeNode abstract;
-    class AgentDefinition external;
+# Define the Topology
+topology = GraphTopology(
+    entry_point="step_1_generate",
+    nodes=[agent_node, evaluator_node],
+    edges=[
+        GraphEdge(source="step_1_generate", target="step_2_evaluate"),
+        # The loops are implicit in the EvaluatorNode's pass/fail routes,
+        # but can also be explicit edges for visualization tools.
+        GraphEdge(source="step_2_evaluate", target="step_1_generate", condition="needs_revision")
+    ]
+)
 ```
+
+## API Reference
+
+::: coreason_manifest.spec.v2.recipe.RecipeDefinition
+
+::: coreason_manifest.spec.v2.recipe.GraphTopology
+
+::: coreason_manifest.spec.v2.recipe.AgentNode

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: coreason_manifest
 theme:
   name: material
 plugins:
+  - search
   - mkdocstrings:
       handlers:
         python:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,18 @@
 site_name: coreason_manifest
 theme:
   name: material
+plugins:
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src]
+          options:
+            show_source: true
+            show_root_heading: true
+            heading_level: 2
+            show_category_heading: true
+            docstring_style: google
+            separate_signature: true
 markdown_extensions:
   - pymdownx.superfences:
       custom_fences:
@@ -23,6 +35,9 @@ nav:
       - "Runtime Principles": runtime/runtime_principles.md
       - "Flow Governance": flow_governance.md
   - Reference:
-      - "Glossary": GLOSSARY.md
+      - "Orchestration API": reference/orchestration.md
+      - "Governance API": reference/governance.md
+      - "Agent API": reference/agents.md
+      - "Capabilities API": reference/capabilities.md
       - "Package Structure": package_structure.md
       - "Full Index": index.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dev = [
     "pytest-cov>=7.0.0",
     "mkdocs>=1.6.1",
     "mkdocs-material>=9.7.1",
+    "mkdocstrings[python]>=0.24.0",
     "mypy>=1.19.1",
     "pytest-asyncio>=1.3.0",
     "types-pyyaml>=6.0.12.20250915",

--- a/src/coreason_manifest/spec/__init__.py
+++ b/src/coreason_manifest/spec/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest

--- a/src/coreason_manifest/spec/common/__init__.py
+++ b/src/coreason_manifest/spec/common/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest

--- a/uv.lock
+++ b/uv.lock
@@ -143,6 +143,7 @@ dependencies = [
 dev = [
     { name = "mkdocs" },
     { name = "mkdocs-material" },
+    { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
@@ -163,6 +164,7 @@ requires-dist = [
 dev = [
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.7.1" },
+    { name = "mkdocstrings", extras = ["python"], specifier = ">=0.24.0" },
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pytest", specifier = ">=9.0.2" },
@@ -275,6 +277,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "griffe"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffecli" },
+    { name = "griffelib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/94/ee21d41e7eb4f823b94603b9d40f86d3c7fde80eacc2c3c71845476dddaa/griffe-2.0.0-py3-none-any.whl", hash = "sha256:5418081135a391c3e6e757a7f3f156f1a1a746cc7b4023868ff7d5e2f9a980aa", size = 5214, upload-time = "2026-02-09T19:09:44.105Z" },
+]
+
+[[package]]
+name = "griffecli"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+    { name = "griffelib" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e6/ed/d93f7a447bbf7a935d8868e9617cbe1cadf9ee9ee6bd275d3040fbf93d60/griffecli-2.0.0-py3-none-any.whl", hash = "sha256:9f7cd9ee9b21d55e91689358978d2385ae65c22f307a63fb3269acf3f21e643d", size = 9345, upload-time = "2026-02-09T19:09:42.554Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/51/c936033e16d12b627ea334aaaaf42229c37620d0f15593456ab69ab48161/griffelib-2.0.0-py3-none-any.whl", hash = "sha256:01284878c966508b6d6f1dbff9b6fa607bc062d8261c5c7253cb285b06422a7f", size = 142004, upload-time = "2026-02-09T19:09:40.561Z" },
 ]
 
 [[package]]
@@ -474,6 +508,20 @@ wheels = [
 ]
 
 [[package]]
+name = "mkdocs-autorefs"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/51/fa/9124cd63d822e2bcbea1450ae68cdc3faf3655c69b455f3a7ed36ce6c628/mkdocs_autorefs-1.4.3.tar.gz", hash = "sha256:beee715b254455c4aa93b6ef3c67579c399ca092259cc41b7d9342573ff1fc75", size = 55425, upload-time = "2025-08-26T14:23:17.223Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9f/4d/7123b6fa2278000688ebd338e2a06d16870aaf9eceae6ba047ea05f92df1/mkdocs_autorefs-1.4.3-py3-none-any.whl", hash = "sha256:469d85eb3114801d08e9cc55d102b3ba65917a869b893403b8987b601cf55dc9", size = 25034, upload-time = "2025-08-26T14:23:15.906Z" },
+]
+
+[[package]]
 name = "mkdocs-get-deps"
 version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -516,6 +564,42 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/79/9b/9b4c96d6593b2a541e1cb8b34899a6d021d208bb357042823d4d2cabdbe7/mkdocs_material_extensions-1.3.1.tar.gz", hash = "sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443", size = 11847, upload-time = "2023-11-22T19:09:45.208Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5b/54/662a4743aa81d9582ee9339d4ffa3c8fd40a4965e033d77b9da9774d3960/mkdocs_material_extensions-1.3.1-py3-none-any.whl", hash = "sha256:adff8b62700b25cb77b53358dad940f3ef973dd6db797907c49e3c2ef3ab4e31", size = 8728, upload-time = "2023-11-22T19:09:43.465Z" },
+]
+
+[[package]]
+name = "mkdocstrings"
+version = "1.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "markdown" },
+    { name = "markupsafe" },
+    { name = "mkdocs" },
+    { name = "mkdocs-autorefs" },
+    { name = "pymdown-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/46/62/0dfc5719514115bf1781f44b1d7f2a0923fcc01e9c5d7990e48a05c9ae5d/mkdocstrings-1.0.3.tar.gz", hash = "sha256:ab670f55040722b49bb45865b2e93b824450fb4aef638b00d7acb493a9020434", size = 100946, upload-time = "2026-02-07T14:31:40.973Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/41/1cf02e3df279d2dd846a1bf235a928254eba9006dd22b4a14caa71aed0f7/mkdocstrings-1.0.3-py3-none-any.whl", hash = "sha256:0d66d18430c2201dc7fe85134277382baaa15e6b30979f3f3bdbabd6dbdb6046", size = 35523, upload-time = "2026-02-07T14:31:39.27Z" },
+]
+
+[package.optional-dependencies]
+python = [
+    { name = "mkdocstrings-python" },
+]
+
+[[package]]
+name = "mkdocstrings-python"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "griffe" },
+    { name = "mkdocs-autorefs" },
+    { name = "mkdocstrings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/84/78243847ad9d5c21d30a2842720425b17e880d99dfe824dee11d6b2149b4/mkdocstrings_python-2.0.2.tar.gz", hash = "sha256:4a32ccfc4b8d29639864698e81cfeb04137bce76bb9f3c251040f55d4b6e1ad8", size = 199124, upload-time = "2026-02-09T15:12:01.543Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/31/7ee938abbde2322e553a2cb5f604cdd1e4728e08bba39c7ee6fae9af840b/mkdocstrings_python-2.0.2-py3-none-any.whl", hash = "sha256:31241c0f43d85a69306d704d5725786015510ea3f3c4bdfdb5a5731d83cdc2b0", size = 104900, upload-time = "2026-02-09T15:12:00.166Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implemented Automated API References using `mkdocstrings` as requested.
This includes:
1.  Infrastructure: Added `mkdocstrings[python]` dependency and configured `mkdocs.yml`.
2.  Package Structure: Added `__init__.py` files to `src/coreason_manifest/spec` and `src/coreason_manifest/spec/common` to allow `mkdocstrings` (via `griffe`) to correctly traverse the package structure.
3.  Documentation: Created new modular markdown files in `docs/reference/` following the "Application-First" philosophy with usage examples and API references for:
    - Orchestration (`RecipeDefinition`, `GraphTopology`, `AgentNode`)
    - Governance (`GovernanceConfig`, `ComplianceReport`)
    - Agents (`AgentDefinition`, `ToolRequirement`)
    - Capabilities (`AgentCapabilities`)
4.  Navigation: Updated `mkdocs.yml` to include the new Reference section.

Verified that `mkdocs build` passes without warnings and `uv run pytest` passes with 100% coverage.

---
*PR created automatically by Jules for task [1999699062493836382](https://jules.google.com/task/1999699062493836382) started by @gowthamrao*