### PR TITLE
Refactor Presentation Layer for Magentic-UI Support

### DIFF
--- a/src/coreason_manifest/spec/common/presentation.py
+++ b/src/coreason_manifest/spec/common/presentation.py
@@ -168,3 +168,87 @@ class RuntimeStateSnapshot(ManifestBaseModel):
 
     node_states: dict[str, NodeStatus]
     active_path: list[str] = Field(default_factory=list)
+
+
+class ViewportMode(StrEnum):
+    """Layout mode for the presentation."""
+
+    STREAM = "stream"
+    ARTIFACT_SPLIT = "artifact_split"
+    PLANNER_CONSOLE = "planner_console"
+    CANVAS = "canvas"
+
+
+class ComponentType(StrEnum):
+    """Type of generative UI component."""
+
+    MARKDOWN = "markdown"
+    CODE_EDITOR = "code_editor"
+    DATA_GRID = "data_grid"
+    KANBAN_BOARD = "kanban_board"
+    FORM = "form"
+
+
+class DesignIntent(StrEnum):
+    """Visual design intent."""
+
+    PRIMARY = "primary"
+    SECONDARY = "secondary"
+    DANGER = "danger"
+    SUCCESS = "success"
+    NEUTRAL = "neutral"
+
+
+class ComponentSpec(ManifestBaseModel):
+    """Defines a generative UI element."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    type: ComponentType
+    title: str | None = None
+    data_source: str
+    is_mutable: bool = False
+    mutation_handler_ref: str | None = None
+
+
+class ArtifactDefinition(ManifestBaseModel):
+    """Defines a side-panel artifact."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    label: str
+    content_type: str
+    auto_open: bool = False
+
+
+class Perspective(ManifestBaseModel):
+    """Defines role-based filtering."""
+
+    model_config = ConfigDict(frozen=True)
+
+    role_id: str
+    visible_components: list[str]
+    allow_mutation: bool = False
+
+
+class PresentationHints(ManifestBaseModel):
+    """
+    Directives for the frontend on how to render the internal reasoning.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    initial_viewport: ViewportMode = Field(ViewportMode.STREAM, description="Layout mode")
+    components: list[ComponentSpec] = Field(default_factory=list)
+    supported_artifacts: list[ArtifactDefinition] = Field(default_factory=list)
+    perspectives: list[Perspective] = Field(default_factory=list)
+
+    display_title: str | None = Field(None, description="Human-friendly label override.")
+    icon: str | None = Field(None, description="Icon name/emoji, e.g., 'lucide:brain'.")
+    hidden_fields: list[str] = Field(
+        default_factory=list, description="Whitelist of internal variables to hide from the non-debug UI."
+    )
+    accent_intent: DesignIntent = DesignIntent.PRIMARY
+    progress_indicator: str | None = Field(None, description="Name of the context variable to watch for % completion.")

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -275,8 +275,6 @@ class InteractionConfig(ManifestBaseModel):
     guidance_hint: str | None = Field(None, description="Hint for the human operator.")
 
 
-
-
 class CollaborationMode(StrEnum):
     """The protocol for human engagement."""
 

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -15,7 +15,7 @@ from typing import Annotated, Any, Literal, Self
 
 from pydantic import ConfigDict, Field, model_validator
 
-from coreason_manifest.spec.common.presentation import NodePresentation
+from coreason_manifest.spec.common.presentation import NodePresentation, PresentationHints
 from coreason_manifest.spec.common_base import ManifestBaseModel
 from coreason_manifest.spec.simulation import SimulationScenario
 from coreason_manifest.spec.v2.agent import CognitiveProfile
@@ -275,36 +275,6 @@ class InteractionConfig(ManifestBaseModel):
     guidance_hint: str | None = Field(None, description="Hint for the human operator.")
 
 
-class VisualizationStyle(StrEnum):
-    """How the UI should render the node's running state."""
-
-    CHAT = "chat"
-    TREE = "tree"
-    KANBAN = "kanban"
-    DOCUMENT = "document"
-
-
-class PresentationHints(ManifestBaseModel):
-    """
-    Directives for the frontend on how to render the internal reasoning.
-
-    Attributes:
-        style (VisualizationStyle): Visualization style. (Default: CHAT).
-        display_title (str | None): Human-friendly label override.
-        icon (str | None): Icon name/emoji, e.g., 'lucide:brain'.
-        hidden_fields (list[str]): Whitelist of internal variables to hide from the non-debug UI.
-        progress_indicator (str | None): Name of the context variable to watch for % completion.
-    """
-
-    model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
-
-    style: VisualizationStyle = Field(VisualizationStyle.CHAT, description="Visualization style.")
-    display_title: str | None = Field(None, description="Human-friendly label override.")
-    icon: str | None = Field(None, description="Icon name/emoji, e.g., 'lucide:brain'.")
-    hidden_fields: list[str] = Field(
-        default_factory=list, description="Whitelist of internal variables to hide from the non-debug UI."
-    )
-    progress_indicator: str | None = Field(None, description="Name of the context variable to watch for % completion.")
 
 
 class CollaborationMode(StrEnum):

--- a/tests/test_magentic_presentation.py
+++ b/tests/test_magentic_presentation.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+from coreason_manifest.spec.common.presentation import (
+    ComponentSpec,
+    ComponentType,
+    PresentationHints,
+    ViewportMode,
+)
+from coreason_manifest.spec.v2.recipe import AgentNode
+
+
+def test_presentation_hints_viewport_initialization() -> None:
+    """Test initializing PresentationHints with ViewportMode.PLANNER_CONSOLE."""
+    hints = PresentationHints(initial_viewport=ViewportMode.PLANNER_CONSOLE)
+    assert hints.initial_viewport == ViewportMode.PLANNER_CONSOLE
+    assert hints.initial_viewport == "planner_console"
+
+
+def test_component_spec_serialization() -> None:
+    """Test defining a mutable ComponentSpec and verifying serialization."""
+    comp = ComponentSpec(
+        id="plan-editor-1",
+        type=ComponentType.CODE_EDITOR,
+        title="Plan Editor",
+        data_source="plan.markdown",
+        is_mutable=True,
+        mutation_handler_ref="handler-1",
+    )
+
+    dumped = comp.model_dump(mode="json")
+
+    assert dumped["id"] == "plan-editor-1"
+    assert dumped["type"] == "code_editor"
+    assert dumped["title"] == "Plan Editor"
+    assert dumped["data_source"] == "plan.markdown"
+    assert dumped["is_mutable"] is True
+    assert dumped["mutation_handler_ref"] == "handler-1"
+
+
+def test_agent_node_with_magentic_hints() -> None:
+    """Verify that AgentNode loads correctly with the new PresentationHints."""
+    hints = PresentationHints(
+        initial_viewport=ViewportMode.ARTIFACT_SPLIT,
+        components=[
+            ComponentSpec(
+                id="comp-1",
+                type=ComponentType.MARKDOWN,
+                data_source="output",
+            )
+        ],
+        display_title="Magentic Agent",
+    )
+
+    node = AgentNode(
+        id="agent-1",
+        agent_ref="agent-ref-1",
+        visualization=hints,
+    )
+
+    assert node.visualization is not None
+    assert node.visualization.initial_viewport == ViewportMode.ARTIFACT_SPLIT
+    assert len(node.visualization.components) == 1
+    assert node.visualization.components[0].id == "comp-1"
+    assert node.visualization.display_title == "Magentic Agent"
+
+    # Verify serialization
+    dumped = node.model_dump(mode="json")
+    assert dumped["visualization"]["initial_viewport"] == "artifact_split"
+    assert dumped["visualization"]["components"][0]["type"] == "markdown"

--- a/tests/test_magentic_presentation.py
+++ b/tests/test_magentic_presentation.py
@@ -13,7 +13,6 @@ def test_presentation_hints_viewport_initialization() -> None:
     """Test initializing PresentationHints with ViewportMode.PLANNER_CONSOLE."""
     hints = PresentationHints(initial_viewport=ViewportMode.PLANNER_CONSOLE)
     assert hints.initial_viewport == ViewportMode.PLANNER_CONSOLE
-    assert hints.initial_viewport == "planner_console"
 
 
 def test_component_spec_serialization() -> None:

--- a/tests/test_v2_visualization_collab.py
+++ b/tests/test_v2_visualization_collab.py
@@ -93,7 +93,7 @@ def test_edge_cases() -> None:
 
     # 2. Test invalid Viewport Mode
     with pytest.raises(ValidationError) as exc:
-        PresentationHints(initial_viewport="INVALID_STYLE")  # type: ignore
+        PresentationHints(initial_viewport="INVALID_STYLE")
     assert "Input should be 'stream', 'artifact_split', 'planner_console' or 'canvas'" in str(exc.value)
 
     # 3. Test invalid Collaboration Mode

--- a/tests/test_v2_visualization_collab.py
+++ b/tests/test_v2_visualization_collab.py
@@ -11,7 +11,7 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest.spec.common.presentation import NodePresentation
+from coreason_manifest.spec.common.presentation import NodePresentation, PresentationHints, ViewportMode
 from coreason_manifest.spec.v2.recipe import (
     AgentNode,
     CollaborationConfig,
@@ -19,9 +19,7 @@ from coreason_manifest.spec.v2.recipe import (
     GenerativeNode,
     InteractionConfig,
     InterventionTrigger,
-    PresentationHints,
     TransparencyLevel,
-    VisualizationStyle,
 )
 
 
@@ -31,7 +29,7 @@ def test_sota_tree_search_configuration() -> None:
         goal="Solve the problem",
         output_schema={"type": "string"},
         visualization=PresentationHints(
-            style=VisualizationStyle.TREE,
+            initial_viewport=ViewportMode.PLANNER_CONSOLE,
             display_title="Reasoning Tree",
         ),
         collaboration=CollaborationConfig(
@@ -41,7 +39,7 @@ def test_sota_tree_search_configuration() -> None:
     )
 
     data = node.model_dump(mode="json", by_alias=True, exclude_none=True)
-    assert data["visualization"]["style"] == "tree"
+    assert data["visualization"]["initial_viewport"] == "planner_console"
     assert data["visualization"]["display_title"] == "Reasoning Tree"
     assert data["collaboration"]["mode"] == "interactive"
     assert data["collaboration"]["supported_commands"] == ["/prune"]
@@ -51,12 +49,12 @@ def test_co_edit_agent() -> None:
     node = AgentNode(
         id="agent-1",
         agent_ref="agent-ref-1",
-        visualization=PresentationHints(style=VisualizationStyle.DOCUMENT),
+        visualization=PresentationHints(initial_viewport=ViewportMode.ARTIFACT_SPLIT),
         collaboration=CollaborationConfig(mode=CollaborationMode.CO_EDIT),
     )
 
     assert node.visualization is not None
-    assert node.visualization.style == VisualizationStyle.DOCUMENT
+    assert node.visualization.initial_viewport == ViewportMode.ARTIFACT_SPLIT
     assert node.collaboration is not None
     assert node.collaboration.mode == CollaborationMode.CO_EDIT
 
@@ -66,7 +64,7 @@ def test_conflict_avoidance() -> None:
         id="agent-1",
         agent_ref="agent-ref-1",
         presentation=NodePresentation(x=100, y=200, color="#0000FF"),
-        visualization=PresentationHints(style=VisualizationStyle.CHAT),
+        visualization=PresentationHints(initial_viewport=ViewportMode.STREAM),
     )
 
     data = node.model_dump(mode="json", by_alias=True, exclude_none=True)
@@ -74,7 +72,7 @@ def test_conflict_avoidance() -> None:
     # Check that both fields exist and are correct
     assert data["presentation"]["x"] == 100
     assert data["presentation"]["y"] == 200
-    assert data["visualization"]["style"] == "chat"
+    assert data["visualization"]["initial_viewport"] == "stream"
 
 
 def test_edge_cases() -> None:
@@ -83,20 +81,20 @@ def test_edge_cases() -> None:
     node = AgentNode(
         id="minimal",
         agent_ref="ref",
-        visualization=PresentationHints(),  # Should use default style=CHAT
+        visualization=PresentationHints(),  # Should use default initial_viewport=STREAM
         collaboration=CollaborationConfig(),  # Should use default mode=COMPLETION
     )
     assert node.visualization is not None
-    assert node.visualization.style == VisualizationStyle.CHAT
+    assert node.visualization.initial_viewport == ViewportMode.STREAM
     assert node.visualization.hidden_fields == []
     assert node.collaboration is not None
     assert node.collaboration.mode == CollaborationMode.COMPLETION
     assert node.collaboration.supported_commands == []
 
-    # 2. Test invalid Visualization Style
+    # 2. Test invalid Viewport Mode
     with pytest.raises(ValidationError) as exc:
-        PresentationHints(style="INVALID_STYLE")
-    assert "Input should be 'chat', 'tree', 'kanban' or 'document'" in str(exc.value)
+        PresentationHints(initial_viewport="INVALID_STYLE")  # type: ignore
+    assert "Input should be 'stream', 'artifact_split', 'planner_console' or 'canvas'" in str(exc.value)
 
     # 3. Test invalid Collaboration Mode
     with pytest.raises(ValidationError) as exc:
@@ -104,7 +102,9 @@ def test_edge_cases() -> None:
     assert "Input should be 'completion', 'interactive' or 'co_edit'" in str(exc.value)
 
     # 4. Test nullable fields
-    hints = PresentationHints(style=VisualizationStyle.KANBAN, display_title=None, icon=None, progress_indicator=None)
+    hints = PresentationHints(
+        initial_viewport=ViewportMode.CANVAS, display_title=None, icon=None, progress_indicator=None
+    )
     assert hints.display_title is None
 
     # 5. Test empty hidden fields
@@ -122,7 +122,7 @@ def test_complex_configuration() -> None:
         presentation=NodePresentation(x=50, y=50, color="#FF0000"),
         # 2. Visualization
         visualization=PresentationHints(
-            style=VisualizationStyle.TREE,
+            initial_viewport=ViewportMode.PLANNER_CONSOLE,
             display_title="Master Plan",
             icon="lucide:brain-circuit",
             hidden_fields=["internal_scratchpad"],
@@ -159,7 +159,7 @@ def test_serialization_roundtrip() -> None:
     original = AgentNode(
         id="roundtrip",
         agent_ref="ref",
-        visualization=PresentationHints(style=VisualizationStyle.KANBAN),
+        visualization=PresentationHints(initial_viewport=ViewportMode.CANVAS),
         collaboration=CollaborationConfig(mode=CollaborationMode.CO_EDIT),
     )
 
@@ -171,6 +171,6 @@ def test_serialization_roundtrip() -> None:
 
     assert reloaded.id == original.id
     assert reloaded.visualization is not None
-    assert reloaded.visualization.style == VisualizationStyle.KANBAN
+    assert reloaded.visualization.initial_viewport == ViewportMode.CANVAS
     assert reloaded.collaboration is not None
     assert reloaded.collaboration.mode == CollaborationMode.CO_EDIT


### PR DESCRIPTION
This PR refactors the Presentation Layer to support "Magentic-UI" (Generative UI & Co-Planning) by centralizing all visualization logic into `presentation.py` and upgrading the schema.

It moves `PresentationHints` from `recipe.py` to `presentation.py` and updates it to use `ViewportMode` instead of `VisualizationStyle`. It adds new models for `ComponentSpec`, `ArtifactDefinition`, and `Perspective` to support dynamic generative UI.

It also updates `AgentNode` and other nodes in `recipe.py` to use the new `PresentationHints` class. Existing tests are updated to work with the new schema, and new tests are added to verify the new capabilities.

---
*PR created automatically by Jules for task [13303256211644226918](https://jules.google.com/task/13303256211644226918) started by @gowthamrao*