### PR TITLE
Update Visualization Engine to support Magentic features

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -41,8 +41,16 @@ A pattern where a dedicated `EvaluatorNode` critiques the output of a Generator 
 
 ## G
 
+### Generative Component
+A specific UI widget (e.g., Data Grid, Kanban Board, Code Editor) instantiated dynamically by the agent's manifest (`ComponentSpec`) rather than being hardcoded in the frontend application.
+
 ### Governance Policy
 Static analysis rules (allowlists, risk levels) enforced at build time to ensure organizational standards and security compliance (e.g., "No tools from untrusted domains"). Distinct from runtime feasibility checks. See [Governance Policy Enforcement](governance_policy_enforcement.md).
+
+## M
+
+### Magentic UI
+An interface paradigm where the user and agent collaborate on shared, mutable state objects (co-planning). In a Magentic UI, the agent can "draft" a plan or document, which the user can then "edit" directly before execution resumes.
 
 ## P
 
@@ -78,6 +86,11 @@ Syntactic sugar in `RecipeDefinition` that allows defining a simple list of node
 
 ### Topology
 The structural layout of a Graph Recipe, defined as a Directed Cyclic Graph (DCG) of Nodes and Edges. It is distinct from the *execution* of the graph.
+
+## V
+
+### Viewport
+The high-level layout container (e.g., Chat, Split View, Planner Console, Canvas) requested by an agent via `ViewportMode`. It dictates the overall structure of the Magentic UI for a specific step.
 
 ## W
 

--- a/docs/presentation_schemas.md
+++ b/docs/presentation_schemas.md
@@ -81,3 +81,14 @@ class PresentationEvent(CoReasonBaseModel):
   }
 }
 ```
+
+## 3. User Experience (`PresentationHints`)
+
+While `NodePresentation` controls the *static layout* of the graph, `PresentationHints` controls the *dynamic user experience* when the agent is active. This field lives in `node.visualization` and is defined in `coreason_manifest.spec.common.presentation`.
+
+It dictates:
+*   **ViewportMode:** Whether to show a Chat, Split View, or Planner Console.
+*   **Components:** Which Generative UI widgets (Data Grid, Kanban) to render.
+*   **Mutability:** Whether the user can edit the agent's workspace.
+
+See [Magentic UI & Visualization Protocol](visualization.md) for details.

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -1,90 +1,112 @@
-# Glass Box Visualization Engine
+# Magentic UI & Visualization Protocol
 
-The `coreason-manifest` library includes a "Glass Box" visualization engine designed to render not just the static topology of an agent system, but its **runtime state** and **interactive capabilities**.
+The `coreason-manifest` library includes a visualization engine designed to render not just the static topology of an agent system, but its **runtime state** and **interactive capabilities**.
+
+The engine serves two distinct purposes:
+1.  **Static Rendering:** Generates Mermaid.js/JSON graphs for documentation and "Glass Box" transparency.
+2.  **Dynamic Experience:** Defines the "Viewport" and "Components" for the runtime UI, dictating how the frontend (e.g., Flutter, Streamlit) adapts to the agent's current cognitive state.
 
 ## The Passive Visualization Engine
 
-Adhering to the "Shared Kernel" philosophy, the visualization engine in `coreason_manifest.utils.viz` is strictly **passive**. It does not run a server, open sockets, or require heavy dependencies like `matplotlib` or `graphviz`.
+Adhering to the "Shared Kernel" philosophy, the visualization engine in `coreason_manifest.utils.viz` is strictly **passive**. It converts a `RecipeDefinition` into visual artifacts without running a server or requiring heavy dependencies.
 
-Instead, it converts a `RecipeDefinition` (or `ManifestV2`) into:
-1.  **Mermaid.js Strings:** For rapid documentation, prototyping, and markdown rendering.
-2.  **Structured JSON:** For consumption by production UIs (React Flow, Flutter, Streamlit).
+## Magentic Concepts
 
-This ensures that the manifest package remains a lightweight data library while enabling rich observability.
+The V2 engine introduces three key concepts that allow the backend to drive the frontend experience:
+
+### 1. Cognitive Viewports (`ViewportMode`)
+
+Agents often need more than a chat interface. The `initial_viewport` field tells the UI which high-level layout to display.
+
+| Viewport Mode | Description | Use Case |
+| :--- | :--- | :--- |
+| `STREAM` | Standard chat interface. | Simple Q&A, fast interactions. |
+| `ARTIFACT_SPLIT` | Chat on left, Document/Code on right. | Code generation, document drafting. |
+| `PLANNER_CONSOLE` | Dedicated task list and Gantt chart view. | Project management, multi-step planning. |
+| `CANVAS` | Infinite whiteboard. | Brainstorming, architectural diagrams. |
+
+### 2. Generative Components (`ComponentSpec`)
+
+Agents can request specific "Generative Components" to be rendered within the viewport. Instead of returning markdown text, the agent specifies a `type` (e.g., `DATA_GRID`, `KANBAN_BOARD`).
+
+### 3. Magentic Co-Planning (`is_mutable`)
+
+This is the core of the "Magentic" experience. When `is_mutable=True` is set on a component, it signals that the **User** is expected to edit the agent's draft before execution proceeds.
+
+**Workflow:**
+1.  **Agent Drafts:** The agent generates a plan and populates a mutable `KANBAN_BOARD` component.
+2.  **User Edits:** The user drags and drops tasks in the UI.
+3.  **Agent Executes:** The agent reads the *modified* state from the UI and executes the revised plan.
+
+## Defining Visualization Hints
+
+You define these behaviors using `PresentationHints` on the `RecipeNode`.
+
+```python
+from coreason_manifest.spec.common.presentation import (
+    PresentationHints,
+    ViewportMode,
+    ComponentSpec,
+    ComponentType
+)
+from coreason_manifest.spec.v2.recipe import AgentNode
+
+# Example: An Agent that presents an editable plan
+node = AgentNode(
+    id="planner_agent",
+    # ... other agent fields ...
+    visualization=PresentationHints(
+        initial_viewport=ViewportMode.PLANNER_CONSOLE,
+        display_title="Strategic Planner",
+        icon="lucide:map",
+        components=[
+            ComponentSpec(
+                id="plan_editor",
+                type=ComponentType.KANBAN_BOARD,
+                data_source="memory.strategic_plan",
+                is_mutable=True,  # User can drag/drop tasks
+                title="Proposed Strategy"
+            )
+        ]
+    )
+)
+```
+
+## Visual Semantics (Mermaid.js)
+
+When generating static documentation using `generate_mermaid_graph`, the engine applies specific visual cues to represent these capabilities.
+
+| Feature | Visual Representation | Meaning |
+| :--- | :--- | :--- |
+| **Standard Node** | Solid Border | A deterministic, non-interactive step. |
+| **Magentic Node** | **Dashed Purple Border** | The node contains mutable components (Drafting/Editing state). |
+| **Viewport Label** | `(View: PLANNER)` text | The step triggers a major UI layout shift. |
+| **Custom Icon** | Icon prepended to title | Visual aid defined in manifest (e.g., 🧠, 🗺️). |
+
+### Example Output
+
+```mermaid
+graph TD
+classDef magentic fill:#f3e5f5,stroke:#7b1fa2,stroke-width:2px,stroke-dasharray: 5 5;
+planner_node["🧠 Strategic Planner<br/>(View: planner_console)"]:::magentic
+```
 
 ## Glass Box Observability
 
-The engine supports "Time Travel" debug views by accepting a `RuntimeStateSnapshot`. This allows you to overlay execution status (e.g., "Running", "Failed") onto the static graph structure.
-
-### `generate_mermaid_graph`
-
-```python
-def generate_mermaid_graph(
-    agent: ManifestV2 | RecipeDefinition,
-    theme: GraphTheme | None = None,
-    state: RuntimeStateSnapshot | None = None,
-) -> str:
-    ...
-```
-
-### Example: Rendering a Failed State
-
-By passing a `RuntimeStateSnapshot` with node statuses, you can generate a graph that highlights exactly where a process failed.
+The engine also supports "Time Travel" debug views by accepting a `RuntimeStateSnapshot`. This overlays execution status (e.g., "Running", "Failed") onto the graph.
 
 ```python
 from coreason_manifest.utils.viz import generate_mermaid_graph
-from coreason_manifest.spec.common.presentation import (
-    RuntimeStateSnapshot,
-    NodeStatus,
-    GraphTheme
-)
+from coreason_manifest.spec.common.presentation import RuntimeStateSnapshot, NodeStatus
 
-# 1. Create a Snapshot of the execution state
-# (In a real app, this would come from the engine's event log)
+# Create a snapshot of execution
 snapshot = RuntimeStateSnapshot(
     node_states={
-        "research_step": NodeStatus.COMPLETED,
-        "critique_step": NodeStatus.FAILED,  # This will be red
-        "rewrite_step": NodeStatus.SKIPPED   # This will be dashed
-    },
-    active_path=["research_step", "critique_step"]
-)
-
-# 2. Generate the Mermaid graph with the snapshot
-mermaid_code = generate_mermaid_graph(my_recipe, state=snapshot)
-
-# 3. Render in Markdown (e.g., inside a Jupyter Notebook or Streamlit)
-# st.markdown(f"```mermaid\n{mermaid_code}\n```")
-```
-
-## Theming
-
-The visual appearance of the graph is fully customizable via the `GraphTheme` schema. This allows consuming applications to inject brand colors and style overrides without modifying the core library.
-
-```python
-theme = GraphTheme(
-    primary_color="#6200ea",  # Brand Primary
-    orientation="LR",         # Left-to-Right layout
-    node_styles={
-        "agent": "fill:#ede7f6,stroke:#6200ea,stroke-width:2px",
-        "failed": "fill:#ffebee,stroke:#c62828,stroke-width:3px"
+        "planner_agent": NodeStatus.COMPLETED,
+        "executor": NodeStatus.RUNNING
     }
 )
+
+# Generate graph with state overlay
+mermaid_code = generate_mermaid_graph(recipe, state=snapshot)
 ```
-
-## BPMN 2.0 Semantics
-
-The engine maps Coreason concepts to standard BPMN 2.0 shapes to ensure familiarity for business users and system architects.
-
-| Node Type | Shape | Visual Representation | Meaning |
-| :--- | :--- | :--- | :--- |
-| **`AgentNode`** | Rectangle | `[ Task ]` | A unit of work performed by an Agent. |
-| **`RouterNode`** | Rhombus | `{ Decision }` | A gateway that routes flow based on logic. |
-| **`HumanNode`** | Hexagon | `{{ Interaction }}` | A step requiring human input or approval. |
-| **`CouncilStep`** | Double-lined Rect | `[[ Sub-process ]]` | A complex governance or voting process. |
-
-### Legend
-*   **Rectangle (`[ ]`)**: Standard Task.
-*   **Rhombus (`{ }`)**: Exclusive Gateway (Decision).
-*   **Hexagon (`{{ }}`)**: User Task (Interaction).
-*   **Double-lined Rect (`[[ ]]`)**: Sub-process or Collapsed Activity.


### PR DESCRIPTION
Updates `src/coreason_manifest/utils/viz.py` to support new visualization features defined in `PresentationHints`. Specifically:
- Adds a `magentic` classDef for mutable nodes.
- Overrides node labels with `display_title` and `icon` if present.
- Appends viewport information to node labels.
- Detects mutable components and applies the `magentic` style.


---
*PR created automatically by Jules for task [2188578362446886098](https://jules.google.com/task/2188578362446886098) started by @gowthamrao*