### PR TITLE
feat(schema): Update HumanNode for Shared Agency and Server-Driven UI

### DIFF
--- a/src/coreason_manifest/utils/viz.py
+++ b/src/coreason_manifest/utils/viz.py
@@ -25,6 +25,7 @@ from coreason_manifest.spec.v2.definitions import (
 )
 from coreason_manifest.spec.v2.recipe import (
     AgentNode,
+    CollaborationMode,
     EvaluatorNode,
     GenerativeNode,
     HumanNode,
@@ -209,7 +210,22 @@ def _generate_recipe_mermaid(
                 label = f"{display_name}<br/>(Agent: {ref_str})"
 
         elif isinstance(node, HumanNode):
-            label = f"{display_name}<br/>(Human Input)"
+            # Icon Logic
+            icon = "👤"
+            if node.collaboration and node.collaboration.mode == CollaborationMode.CO_EDIT:
+                icon = "✍️"
+
+            # Render Strategy
+            strategy = ""
+            if node.collaboration:
+                strategy = f" [{node.collaboration.render_strategy}]"
+
+            label = f"{display_name}<br/>{icon} (Human Input){strategy}"
+
+            # Routing Edges
+            if node.routes:
+                for command, target in node.routes.items():
+                    lines.append(f'{sanitized_id} -- "{command}" --> {_sanitize_id(target)}')
 
         elif isinstance(node, RouterNode):
             label = f"{display_name}<br/>(Router: {node.input_key})"

--- a/tests/test_v2_visualization_collab.py
+++ b/tests/test_v2_visualization_collab.py
@@ -19,8 +19,8 @@ from coreason_manifest.spec.v2.recipe import (
     GenerativeNode,
     InteractionConfig,
     InterventionTrigger,
-    TransparencyLevel,
     SteeringCommand,
+    TransparencyLevel,
 )
 
 

--- a/tests/test_v2_visualization_collab.py
+++ b/tests/test_v2_visualization_collab.py
@@ -20,6 +20,7 @@ from coreason_manifest.spec.v2.recipe import (
     InteractionConfig,
     InterventionTrigger,
     TransparencyLevel,
+    SteeringCommand,
 )
 
 
@@ -34,7 +35,7 @@ def test_sota_tree_search_configuration() -> None:
         ),
         collaboration=CollaborationConfig(
             mode=CollaborationMode.INTERACTIVE,
-            supported_commands=["/prune"],
+            supported_commands=[SteeringCommand.MODIFY],
         ),
     )
 
@@ -42,7 +43,7 @@ def test_sota_tree_search_configuration() -> None:
     assert data["visualization"]["initial_viewport"] == "planner_console"
     assert data["visualization"]["display_title"] == "Reasoning Tree"
     assert data["collaboration"]["mode"] == "interactive"
-    assert data["collaboration"]["supported_commands"] == ["/prune"]
+    assert data["collaboration"]["supported_commands"] == ["modify"]
 
 
 def test_co_edit_agent() -> None:
@@ -132,7 +133,7 @@ def test_complex_configuration() -> None:
         collaboration=CollaborationConfig(
             mode=CollaborationMode.INTERACTIVE,
             feedback_schema={"type": "object", "properties": {"rating": {"type": "integer"}}},
-            supported_commands=["/retry", "/explain"],
+            supported_commands=[SteeringCommand.REWIND, SteeringCommand.REPLY],
         ),
         # 4. Interaction (Control)
         interaction=InteractionConfig(
@@ -150,7 +151,7 @@ def test_complex_configuration() -> None:
     assert data["visualization"]["icon"] == "lucide:brain-circuit"
     assert "internal_scratchpad" in data["visualization"]["hidden_fields"]
     assert data["collaboration"]["feedback_schema"]["properties"]["rating"]["type"] == "integer"
-    assert "/retry" in data["collaboration"]["supported_commands"]
+    assert "rewind" in data["collaboration"]["supported_commands"]
     assert data["interaction"]["transparency"] == "observable"
 
 

--- a/tests/test_viz_advanced.py
+++ b/tests/test_viz_advanced.py
@@ -275,7 +275,7 @@ def test_viz_recipe_full_coverage() -> None:
     # Check Labels
     assert 'agent1["Role: Researcher<br/>Mode: standard"]' in chart
     assert 'router1{"router1<br/>(Router: classification)"}' in chart
-    assert 'human1{{"human1<br/>(Human Input)"}}' in chart
+    assert 'human1{{"human1<br/>👤 (Human Input)"}}' in chart
     assert 'eval1(["eval1<br/>(Evaluator)"])' in chart
     assert 'gen1[["gen1<br/>(Generative)"]]' in chart
 
@@ -466,7 +466,7 @@ def test_viz_complex_dashboard_scenario() -> None:
 
     # Verify Nodes & Shapes
     assert 'router{"router<br/>(Router: type)"}:::router' in chart
-    assert 'approval{{"approval<br/>(Human Input)"}}:::human' in chart
+    assert 'approval{{"approval<br/>👤 (Human Input)"}}:::human' in chart
 
     # Verify State Overlays
     assert "class router completed;" in chart
@@ -556,7 +556,7 @@ def test_viz_custom_shape_override() -> None:
     # 1. Check Mermaid
     chart = generate_mermaid_graph(recipe, theme=theme)
     # Default is {{ }} (hexagon), rect is [ ]
-    assert 'human1["human1<br/>(Human Input)"]' in chart
+    assert 'human1["human1<br/>👤 (Human Input)"]' in chart
     assert "{{" not in chart
 
     # 2. Check JSON

--- a/tests/test_viz_recipe.py
+++ b/tests/test_viz_recipe.py
@@ -76,7 +76,7 @@ def test_recipe_mermaid_human_node() -> None:
     chart = generate_mermaid_graph(recipe)
 
     assert "classDef human" in chart
-    assert 'human1{{"human1<br/>(Human Input)"}}:::human' in chart
+    assert 'human1{{"human1<br/>👤 (Human Input)"}}:::human' in chart
 
 
 def test_recipe_mermaid_router_node() -> None:


### PR DESCRIPTION
This PR updates the `coreason-manifest` schema to support "Shared Agency" and Server-Driven UI (HOTL v2). It introduces strict typing with `SteeringCommand` and `RenderStrategy` Enums, updates `CollaborationConfig` and `HumanNode` with new fields, and enhances visualization logic to reflect these changes. This addresses the "Magic String" issues and prepares the schema for more advanced human-in-the-loop interactions.

---
*PR created automatically by Jules for task [13908826891611769912](https://jules.google.com/task/13908826891611769912) started by @gowthamrao*