### PR TITLE
Refactor HOTL Schema for Shared Agency

### DIFF
--- a/docs/graph_recipes.md
+++ b/docs/graph_recipes.md
@@ -287,10 +287,12 @@ All nodes inherit from `RecipeNode`, which includes `id`, `metadata`, and `prese
     - `system_prompt_override`: Context-specific instructions (optional).
     - `inputs_map`: Mapping parent outputs to agent inputs (dict[str, str]).
 
-2.  **`HumanNode`** (`type: human`): Suspends execution until a human provides input or approval.
+2.  **`HumanNode`** (`type: human`): Suspends execution until a human provides input or approval. Acts as a **Router** based on the user's decision.
     - `prompt`: Instruction for the human user.
     - `timeout_seconds`: SLA for approval (optional).
     - `required_role`: Role required to approve (e.g., manager) (optional).
+    - `routes`: A dictionary mapping `SteeringCommand` keys to Target Node IDs (e.g., `{ "approve": "next_step", "reject": "previous_step" }`).
+    - **Note:** `HumanNode` inherits `collaboration` from `RecipeNode`. It does *not* use a separate `config` field.
 
 3.  **`RouterNode`** (`type: router`): Evaluates a variable and branches execution to different target nodes.
     - `input_key`: The variable to evaluate (e.g., 'classification').
@@ -579,6 +581,7 @@ The `collaboration` field defines the protocol for human engagement (e.g., Co-Ed
 
 *   `mode`: `CollaborationMode` (`COMPLETION`, `INTERACTIVE`, `CO_EDIT`).
 *   `feedback_schema`: JSON Schema for structured feedback.
-*   `supported_commands`: Slash commands the agent understands (e.g., `/refine`).
+*   `supported_commands`: Typed list of `SteeringCommand` (e.g., `[SteeringCommand.MODIFY]`).
+*   `render_strategy`: UI protocol (`JSON_FORMS`, `ADAPTIVE_CARD`).
 
 See [UX & Collaboration: Human-on-the-Loop](ux_collaboration.md) for detailed configuration examples.

--- a/docs/ux_collaboration.md
+++ b/docs/ux_collaboration.md
@@ -65,13 +65,37 @@ The `collaboration` field defines the rules of engagement for "Human-on-the-Loop
 class CollaborationConfig(CoReasonBaseModel):
     mode: CollaborationMode = Field(CollaborationMode.COMPLETION, ...)
     feedback_schema: dict[str, Any] | None = Field(None, ...)
-    supported_commands: list[str] = Field(default=[], ...)
+    supported_commands: list[SteeringCommand] = Field(default=[], ...)
+
+    # Shared Agency Fields
+    render_strategy: RenderStrategy = Field(RenderStrategy.PLAIN_TEXT, ...)
+    trace_intervention: bool = Field(False, ...) # If True, intervention is crystallized into memory
 
     # Harvesting Fields (Human-Layer)
     channels: list[str] = Field(default=[], ...)
     timeout_seconds: int | None = Field(None, ...)
     fallback_behavior: Literal["fail", "proceed_with_default", "escalate"] = Field("fail", ...)
 ```
+
+### Steering Commands (`SteeringCommand`)
+
+Replaces "magic strings" with standardized primitives for human intervention.
+
+1.  **`APPROVE`**: Accept the current state/plan.
+2.  **`REJECT`**: Deny the current state/plan.
+3.  **`MODIFY`**: Edit the content or parameters directly.
+4.  **`ESCALATE`**: Route to a higher authority or specialized human pool.
+5.  **`REWIND`**: Go back to a previous state (Time Travel).
+6.  **`REPLY`**: Provide textual feedback or answer a question.
+
+### Render Strategies (`RenderStrategy`)
+
+Protocol for rendering the feedback interface.
+
+1.  **`PLAIN_TEXT`**: Simple text input.
+2.  **`JSON_FORMS`**: Native forms generated via JSON Schema.
+3.  **`ADAPTIVE_CARD`**: Microsoft Adaptive Cards format.
+4.  **`CUSTOM_IFRAME`**: Embedded Web View.
 
 ### Collaboration Modes (`CollaborationMode`)
 
@@ -92,11 +116,15 @@ class CollaborationConfig(CoReasonBaseModel):
 ### Example: Interactive Feedback
 
 ```python
+from coreason_manifest.spec.v2.recipe import SteeringCommand, RenderStrategy
+
 node = AgentNode(
     id="writer",
     agent_ref="copywriter",
     collaboration=CollaborationConfig(
         mode=CollaborationMode.INTERACTIVE,
+        render_strategy=RenderStrategy.JSON_FORMS,
+        trace_intervention=True,
         # Structured Feedback Form
         feedback_schema={
             "type": "object",
@@ -105,8 +133,8 @@ node = AgentNode(
                 "critique": {"type": "string"}
             }
         },
-        # Slash Commands
-        supported_commands=["/rewrite", "/expand", "/shorten"]
+        # Strictly Typed Commands
+        supported_commands=[SteeringCommand.MODIFY, SteeringCommand.REPLY]
     )
 )
 ```

--- a/src/coreason_manifest/spec/v2/recipe.py
+++ b/src/coreason_manifest/spec/v2/recipe.py
@@ -320,9 +320,7 @@ class CollaborationConfig(ManifestBaseModel):
     model_config = ConfigDict(extra="forbid", populate_by_name=True, frozen=True)
 
     mode: CollaborationMode = Field(CollaborationMode.COMPLETION, description="Engagement mode.")
-    feedback_schema: dict[str, Any] | None = Field(
-        None, description="JSON Schema for structured feedback."
-    )
+    feedback_schema: dict[str, Any] | None = Field(None, description="JSON Schema for structured feedback.")
     supported_commands: list[SteeringCommand] = Field(
         default_factory=list, description="Slash commands the agent understands."
     )
@@ -556,9 +554,7 @@ class HumanNode(RecipeNode):
     type: Literal["human"] = "human"
     prompt: str = Field(..., description="Instruction for the human user.")
     timeout_seconds: int | None = Field(None, description="SLA for approval.")
-    required_role: str | None = Field(
-        None, description="Role required to approve (e.g., manager)."
-    )
+    required_role: str | None = Field(None, description="Role required to approve (e.g., manager).")
     routes: dict[SteeringCommand, str] | None = Field(
         None, description="Map of SteeringCommands to Target Node IDs. If None, flow is linear."
     )

--- a/tests/test_v2_human_node.py
+++ b/tests/test_v2_human_node.py
@@ -1,0 +1,133 @@
+# Copyright (c) 2025 CoReason, Inc.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.v2.definitions import ManifestMetadata
+from coreason_manifest.spec.v2.recipe import (
+    AgentNode,
+    CollaborationConfig,
+    GraphTopology,
+    HumanNode,
+    RecipeDefinition,
+    RecipeInterface,
+    RenderStrategy,
+    SteeringCommand,
+)
+
+
+def test_collaboration_config_deserialization() -> None:
+    """Test that CollaborationConfig parses new fields correctly."""
+    data = {
+        "mode": "interactive",
+        "supported_commands": ["approve", "reject"],
+        "render_strategy": "adaptive_card",
+        "trace_intervention": True,
+    }
+    config = CollaborationConfig.model_validate(data)
+
+    assert config.supported_commands == [SteeringCommand.APPROVE, SteeringCommand.REJECT]
+    assert config.render_strategy == RenderStrategy.ADAPTIVE_CARD
+    assert config.trace_intervention is True
+
+
+def test_collaboration_config_strict_typing_fail() -> None:
+    """Test that invalid enum values raise ValidationError."""
+    data = {
+        "mode": "interactive",
+        "supported_commands": ["approve", "make_coffee"],  # Invalid command
+    }
+    with pytest.raises(ValidationError) as exc:
+        CollaborationConfig.model_validate(data)
+
+    assert "make_coffee" in str(exc.value)
+
+
+def test_human_node_with_routes() -> None:
+    """Test that HumanNode parses routes correctly."""
+    data = {
+        "type": "human",
+        "id": "human-1",
+        "prompt": "Review this.",
+        "routes": {
+            "approve": "next-step",
+            "reject": "end-step",
+        },
+    }
+    node = HumanNode.model_validate(data)
+
+    assert node.routes
+    assert node.routes[SteeringCommand.APPROVE] == "next-step"
+    assert node.routes[SteeringCommand.REJECT] == "end-step"
+
+
+def test_topology_validation_human_routes_success() -> None:
+    """Test that valid routes pass topology validation."""
+    nodes = [
+        HumanNode(
+            id="human-1",
+            prompt="Review",
+            routes={
+                SteeringCommand.APPROVE: "step-2",
+                SteeringCommand.REJECT: "step-3",
+            },
+        ),
+        AgentNode(id="step-2", agent_ref="agent-a"),
+        AgentNode(id="step-3", agent_ref="agent-b"),
+    ]
+    edges = []  # Implicit edges via routes don't need explicit graph edges for this test?
+                # Wait, usually edges are explicit. But here flow is directed by routes.
+                # However, GraphTopology requires valid edges if they exist.
+                # If routes are used, edges might not be needed in the `edges` list strictly for connectivity if the runner handles it,
+                # but topology validation checks for dangling edges in `edges` list.
+                # Here we are testing `validate_topology_integrity` which checks references.
+
+    # We need to wrap it in RecipeDefinition to trigger the validator
+    topology = GraphTopology(
+        nodes=nodes,
+        edges=[], # No explicit edges needed for this specific validator check
+        entry_point="human-1",
+    )
+
+    recipe = RecipeDefinition(
+        metadata=ManifestMetadata(name="Test"),
+        interface=RecipeInterface(),
+        topology=topology,
+    )
+
+    assert recipe.topology.nodes[0].routes[SteeringCommand.APPROVE] == "step-2"
+
+
+def test_topology_validation_human_routes_failure() -> None:
+    """Test that invalid routes fail topology validation."""
+    nodes = [
+        HumanNode(
+            id="human-1",
+            prompt="Review",
+            routes={
+                SteeringCommand.APPROVE: "step-2", # Exists
+                SteeringCommand.REJECT: "missing-step", # Missing
+            },
+        ),
+        AgentNode(id="step-2", agent_ref="agent-a"),
+    ]
+
+    # Use draft status for Topology, but RecipeDefinition validator runs regardless?
+    # Actually RecipeDefinition validator runs `validate_topology_integrity`
+
+    topology = GraphTopology(
+        nodes=nodes,
+        edges=[],
+        entry_point="human-1",
+        status="draft",
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        RecipeDefinition(
+            metadata=ManifestMetadata(name="Test"),
+            interface=RecipeInterface(),
+            topology=topology,
+        )
+
+    assert "Topology Integrity Error" in str(exc.value)
+    assert "missing-step" in str(exc.value)

--- a/tests/test_v2_visualization_collab.py
+++ b/tests/test_v2_visualization_collab.py
@@ -19,6 +19,7 @@ from coreason_manifest.spec.v2.recipe import (
     GenerativeNode,
     InteractionConfig,
     InterventionTrigger,
+    SteeringCommand,
     TransparencyLevel,
 )
 
@@ -34,7 +35,7 @@ def test_sota_tree_search_configuration() -> None:
         ),
         collaboration=CollaborationConfig(
             mode=CollaborationMode.INTERACTIVE,
-            supported_commands=["/prune"],
+            supported_commands=[SteeringCommand.REWIND],
         ),
     )
 
@@ -42,7 +43,7 @@ def test_sota_tree_search_configuration() -> None:
     assert data["visualization"]["initial_viewport"] == "planner_console"
     assert data["visualization"]["display_title"] == "Reasoning Tree"
     assert data["collaboration"]["mode"] == "interactive"
-    assert data["collaboration"]["supported_commands"] == ["/prune"]
+    assert data["collaboration"]["supported_commands"] == ["rewind"]
 
 
 def test_co_edit_agent() -> None:
@@ -132,7 +133,7 @@ def test_complex_configuration() -> None:
         collaboration=CollaborationConfig(
             mode=CollaborationMode.INTERACTIVE,
             feedback_schema={"type": "object", "properties": {"rating": {"type": "integer"}}},
-            supported_commands=["/retry", "/explain"],
+            supported_commands=[SteeringCommand.REWIND, SteeringCommand.REPLY],
         ),
         # 4. Interaction (Control)
         interaction=InteractionConfig(
@@ -150,7 +151,8 @@ def test_complex_configuration() -> None:
     assert data["visualization"]["icon"] == "lucide:brain-circuit"
     assert "internal_scratchpad" in data["visualization"]["hidden_fields"]
     assert data["collaboration"]["feedback_schema"]["properties"]["rating"]["type"] == "integer"
-    assert "/retry" in data["collaboration"]["supported_commands"]
+    assert "rewind" in data["collaboration"]["supported_commands"]
+    assert "reply" in data["collaboration"]["supported_commands"]
     assert data["interaction"]["transparency"] == "observable"
 
 


### PR DESCRIPTION
Refactored Human-on-the-Loop schema to support Shared Agency and Server-Driven UI:
- Defined `SteeringCommand` and `RenderStrategy` enums.
- Updated `CollaborationConfig` to use strict typing for commands and added UI directives.
- Updated `HumanNode` to support routing via `routes`.
- Added topology validation for `HumanNode.routes`.
- Added tests in `tests/test_v2_human_node.py`.

---
*PR created automatically by Jules for task [10694490616068182016](https://jules.google.com/task/10694490616068182016) started by @gowthamrao*