### PR TITLE
Implement Semantic Validator (Phase 3a)

### DIFF
--- a/src/coreason_manifest/utils/validator.py
+++ b/src/coreason_manifest/utils/validator.py
@@ -1,0 +1,82 @@
+from coreason_manifest.spec.core.flow import GraphFlow, LinearFlow
+from coreason_manifest.spec.core.nodes import AgentNode, SwitchNode
+
+
+def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
+    """
+    Validates the semantic correctness of a flow.
+
+    Args:
+        flow: The LinearFlow or GraphFlow to validate.
+
+    Returns:
+        A list of human-readable error strings. If empty, the flow is valid.
+    """
+    errors = []
+
+    # 1. Gather all node IDs and nodes
+    nodes = []
+    node_ids = set()
+
+    if isinstance(flow, GraphFlow):
+        nodes = list(flow.graph.nodes.values())
+        node_ids = set(flow.graph.nodes.keys())
+    elif isinstance(flow, LinearFlow):
+        nodes = flow.sequence
+        node_ids = {node.id for node in nodes}
+    else:
+        # Should not happen given type hint, but safe to handle?
+        return ["Unknown flow type"]
+
+    # 2. Gather all available tools
+    available_tools = set()
+    for tool_pack in flow.tool_packs:
+        available_tools.update(tool_pack.tools)
+
+    # 3. Graph Integrity (GraphFlow only)
+    if isinstance(flow, GraphFlow):
+        for edge in flow.graph.edges:
+            if edge.source not in node_ids:
+                errors.append(f"Edge source '{edge.source}' not found in graph nodes.")
+            if edge.target not in node_ids:
+                errors.append(f"Edge target '{edge.target}' not found in graph nodes.")
+
+    # 4. Linear Integrity (LinearFlow only)
+    if isinstance(flow, LinearFlow):
+        if not flow.sequence:
+            errors.append("LinearFlow sequence must not be empty.")
+
+    # 5. Node Logic Checks
+    for node in nodes:
+        # Switch Logic
+        if isinstance(node, SwitchNode):
+            for case_key, target_id in node.cases.items():
+                if target_id not in node_ids:
+                    errors.append(f"SwitchNode '{node.id}' case '{case_key}' target '{target_id}' not found.")
+            if node.default not in node_ids:
+                errors.append(f"SwitchNode '{node.id}' default target '{node.default}' not found.")
+
+        # Missing Tool Check
+        if isinstance(node, AgentNode):
+            for tool in node.tools:
+                if tool not in available_tools:
+                    errors.append(
+                        f"Agent '{node.id}' requires tool '{tool}' but it is not provided by any ToolPack."
+                    )
+
+    # 6. Governance Sanity Check
+    if flow.governance:
+        # rate_limit_rpm: int | None
+        if (
+            flow.governance.rate_limit_rpm is not None
+            and flow.governance.rate_limit_rpm < 0
+        ):
+            errors.append("Governance rate_limit_rpm must be non-negative.")
+        # cost_limit_usd: float | None
+        if (
+            flow.governance.cost_limit_usd is not None
+            and flow.governance.cost_limit_usd < 0
+        ):
+            errors.append("Governance cost_limit_usd must be non-negative.")
+
+    return errors

--- a/src/coreason_manifest/utils/validator.py
+++ b/src/coreason_manifest/utils/validator.py
@@ -66,16 +66,10 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
     # 6. Governance Sanity Check
     if flow.governance:
         # rate_limit_rpm: int | None
-        if (
-            flow.governance.rate_limit_rpm is not None
-            and flow.governance.rate_limit_rpm < 0
-        ):
+        if flow.governance.rate_limit_rpm is not None and flow.governance.rate_limit_rpm < 0:
             errors.append("Governance rate_limit_rpm must be non-negative.")
         # cost_limit_usd: float | None
-        if (
-            flow.governance.cost_limit_usd is not None
-            and flow.governance.cost_limit_usd < 0
-        ):
+        if flow.governance.cost_limit_usd is not None and flow.governance.cost_limit_usd < 0:
             errors.append("Governance cost_limit_usd must be non-negative.")
 
     return errors

--- a/src/coreason_manifest/utils/validator.py
+++ b/src/coreason_manifest/utils/validator.py
@@ -11,7 +11,7 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
     Semantically validate a Flow (Linear or Graph).
     Returns a list of error strings. Empty list implies validity.
     """
-    errors = []
+    errors: list[str] = []
 
     # 1. Common Checks
     if flow.governance:
@@ -53,7 +53,7 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
 
 
 def _validate_governance(gov: Governance) -> list[str]:
-    errors = []
+    errors: list[str] = []
     if gov.rate_limit_rpm is not None and gov.rate_limit_rpm < 0:
         errors.append("Governance Error: rate_limit_rpm cannot be negative.")
     if gov.cost_limit_usd is not None and gov.cost_limit_usd < 0:
@@ -62,7 +62,7 @@ def _validate_governance(gov: Governance) -> list[str]:
 
 
 def _validate_tools(nodes: list[AnyNode], packs: list[ToolPack]) -> list[str]:
-    errors = []
+    errors: list[str] = []
     available_tools = {t for pack in packs for t in pack.tools}
 
     for node in nodes:
@@ -84,7 +84,7 @@ def _validate_linear_integrity(flow: LinearFlow) -> list[str]:
 
 def _validate_unique_ids(nodes: list[AnyNode]) -> list[str]:
     seen = set()
-    errors = []
+    errors: list[str] = []
     for node in nodes:
         if node.id in seen:
             errors.append(f"ID Collision Error: Duplicate Node ID '{node.id}' found.")
@@ -93,7 +93,7 @@ def _validate_unique_ids(nodes: list[AnyNode]) -> list[str]:
 
 
 def _validate_graph_integrity(graph: Graph) -> list[str]:
-    errors = []
+    errors: list[str] = []
     valid_ids = set(graph.nodes.keys())
 
     # Check 1: Key/ID Integrity
@@ -112,21 +112,19 @@ def _validate_graph_integrity(graph: Graph) -> list[str]:
 
 
 def _validate_switch_logic(nodes: list[AnyNode], valid_ids: set[str]) -> list[str]:
-    errors = []
+    errors: list[str] = []
     for node in nodes:
         if isinstance(node, SwitchNode):
             # Check Cases
             for condition, target_id in node.cases.items():
                 if target_id not in valid_ids:
                     errors.append(
-                        f"Broken Switch Error: Node '{node.id}' case '{condition}' "
-                        f"points to missing ID '{target_id}'."
+                        f"Broken Switch Error: Node '{node.id}' case '{condition}' points to missing ID '{target_id}'."
                     )
             # Check Default
             if node.default not in valid_ids:
                 errors.append(
-                    f"Broken Switch Error: Node '{node.id}' default route "
-                    f"points to missing ID '{node.default}'."
+                    f"Broken Switch Error: Node '{node.id}' default route points to missing ID '{node.default}'."
                 )
     return errors
 

--- a/src/coreason_manifest/utils/validator.py
+++ b/src/coreason_manifest/utils/validator.py
@@ -42,9 +42,8 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
                 errors.append(f"Edge target '{edge.target}' not found in graph nodes.")
 
     # 4. Linear Integrity (LinearFlow only)
-    if isinstance(flow, LinearFlow):
-        if not flow.sequence:
-            errors.append("LinearFlow sequence must not be empty.")
+    if isinstance(flow, LinearFlow) and not flow.sequence:
+        errors.append("LinearFlow sequence must not be empty.")
 
     # 5. Node Logic Checks
     for node in nodes:
@@ -58,11 +57,11 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
 
         # Missing Tool Check
         if isinstance(node, AgentNode):
-            for tool in node.tools:
-                if tool not in available_tools:
-                    errors.append(
-                        f"Agent '{node.id}' requires tool '{tool}' but it is not provided by any ToolPack."
-                    )
+            errors.extend(
+                f"Agent '{node.id}' requires tool '{tool}' but it is not provided by any ToolPack."
+                for tool in node.tools
+                if tool not in available_tools
+            )
 
     # 6. Governance Sanity Check
     if flow.governance:

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -1,0 +1,160 @@
+import pytest
+from coreason_manifest.spec.core.flow import GraphFlow, LinearFlow, Graph, FlowMetadata, FlowInterface, Blackboard, Edge
+from coreason_manifest.spec.core.nodes import AgentNode, SwitchNode, Brain
+from coreason_manifest.spec.core.tools import ToolPack, Dependency
+from coreason_manifest.spec.core.governance import Governance
+from coreason_manifest.utils.validator import validate_flow
+
+# Helpers to create dummy objects
+def create_metadata():
+    return FlowMetadata(name="test", version="1.0", description="test", tags=[])
+
+def create_interface():
+    return FlowInterface(inputs={}, outputs={})
+
+def create_agent_node(id: str, tools: list[str]):
+    return AgentNode(
+        id=id,
+        metadata={},
+        supervision=None,
+        brain=Brain(role="assistant", persona="helpful", reasoning=None, reflex=None),
+        tools=tools
+    )
+
+def create_switch_node(id: str, variable: str, cases: dict[str, str], default: str):
+    return SwitchNode(
+        id=id,
+        metadata={},
+        supervision=None,
+        variable=variable,
+        cases=cases,
+        default=default
+    )
+
+def create_tool_pack(namespace: str, tools: list[str]):
+    return ToolPack(
+        kind="ToolPack",
+        namespace=namespace,
+        tools=tools,
+        dependencies=[],
+        env_vars=[]
+    )
+
+def test_validate_graph_flow_valid():
+    agent = create_agent_node("agent1", ["tool1"])
+    tp = create_tool_pack("ns", ["tool1"])
+    graph = Graph(nodes={"agent1": agent}, edges=[])
+    flow = GraphFlow(
+        kind="GraphFlow",
+        metadata=create_metadata(),
+        interface=create_interface(),
+        blackboard=None,
+        graph=graph,
+        tool_packs=[tp]
+    )
+    errors = validate_flow(flow)
+    assert errors == []
+
+def test_validate_graph_flow_invalid_edges():
+    agent = create_agent_node("agent1", [])
+    # Edge points to non-existent nodes
+    graph = Graph(
+        nodes={"agent1": agent},
+        edges=[Edge(source="agent1", target="missing"), Edge(source="missing", target="agent1")]
+    )
+    flow = GraphFlow(
+        kind="GraphFlow",
+        metadata=create_metadata(),
+        interface=create_interface(),
+        blackboard=None,
+        graph=graph
+    )
+    errors = validate_flow(flow)
+    assert len(errors) == 2
+    assert "Edge target 'missing' not found in graph nodes." in errors
+    assert "Edge source 'missing' not found in graph nodes." in errors
+
+def test_validate_switch_node_invalid_targets():
+    switch = create_switch_node("switch1", "var", {"case1": "missing1"}, "missing2")
+    graph = Graph(nodes={"switch1": switch}, edges=[])
+    flow = GraphFlow(
+        kind="GraphFlow",
+        metadata=create_metadata(),
+        interface=create_interface(),
+        blackboard=None,
+        graph=graph
+    )
+    errors = validate_flow(flow)
+    assert len(errors) == 2
+    assert "SwitchNode 'switch1' case 'case1' target 'missing1' not found." in errors
+    assert "SwitchNode 'switch1' default target 'missing2' not found." in errors
+
+def test_validate_missing_tool():
+    agent = create_agent_node("agent1", ["tool1"])
+    # Tool pack has no tools
+    tp = create_tool_pack("ns", [])
+    graph = Graph(nodes={"agent1": agent}, edges=[])
+    flow = GraphFlow(
+        kind="GraphFlow",
+        metadata=create_metadata(),
+        interface=create_interface(),
+        blackboard=None,
+        graph=graph,
+        tool_packs=[tp]
+    )
+    errors = validate_flow(flow)
+    assert len(errors) == 1
+    assert "Agent 'agent1' requires tool 'tool1' but it is not provided by any ToolPack." in errors
+
+def test_validate_governance_sanity():
+    agent = create_agent_node("agent1", [])
+    graph = Graph(nodes={"agent1": agent}, edges=[])
+    gov = Governance(rate_limit_rpm=-1, cost_limit_usd=-5.0)
+    flow = GraphFlow(
+        kind="GraphFlow",
+        metadata=create_metadata(),
+        interface=create_interface(),
+        blackboard=None,
+        graph=graph,
+        governance=gov
+    )
+    errors = validate_flow(flow)
+    assert len(errors) == 2
+    assert "Governance rate_limit_rpm must be non-negative." in errors
+    assert "Governance cost_limit_usd must be non-negative." in errors
+
+def test_validate_linear_flow_valid():
+    agent = create_agent_node("agent1", ["tool1"])
+    tp = create_tool_pack("ns", ["tool1"])
+    flow = LinearFlow(
+        kind="LinearFlow",
+        metadata=create_metadata(),
+        sequence=[agent],
+        tool_packs=[tp]
+    )
+    errors = validate_flow(flow)
+    assert errors == []
+
+def test_validate_linear_flow_empty():
+    flow = LinearFlow(
+        kind="LinearFlow",
+        metadata=create_metadata(),
+        sequence=[],
+    )
+    errors = validate_flow(flow)
+    assert len(errors) == 1
+    assert "LinearFlow sequence must not be empty." in errors
+
+def test_validate_linear_flow_switch_missing_targets():
+    # Switch node in linear flow referring to missing nodes (since they are not in sequence)
+    switch = create_switch_node("switch1", "var", {"case1": "missing1"}, "missing2")
+    flow = LinearFlow(
+        kind="LinearFlow",
+        metadata=create_metadata(),
+        sequence=[switch], # switch is the only node
+    )
+    errors = validate_flow(flow)
+    # Target IDs must be present in the sequence
+    assert len(errors) == 2
+    assert "SwitchNode 'switch1' case 'case1' target 'missing1' not found." in errors
+    assert "SwitchNode 'switch1' default target 'missing2' not found." in errors

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -189,6 +189,7 @@ def test_validate_linear_flow_switch_missing_targets() -> None:
 
 def test_validate_flow_invalid_type() -> None:
     """Test that validate_flow handles unknown flow types gracefully."""
+
     class DummyFlow:
         governance = None
         tool_packs: ClassVar[list[Any]] = []
@@ -201,7 +202,7 @@ def test_validate_flow_invalid_type() -> None:
 def test_validate_duplicate_node_ids() -> None:
     """Test validation for duplicate node IDs."""
     agent1 = create_agent_node("agent1", [])
-    agent2 = create_agent_node("agent1", []) # Duplicate ID
+    agent2 = create_agent_node("agent1", [])  # Duplicate ID
     flow = LinearFlow(
         kind="LinearFlow",
         metadata=create_metadata(),
@@ -250,10 +251,7 @@ def test_validate_orphan_nodes() -> None:
     node2 = create_agent_node("node2", [])
     node3 = create_agent_node("node3", [])
 
-    graph = Graph(
-        nodes={"node1": node1, "node2": node2, "node3": node3},
-        edges=[Edge(source="node1", target="node2")]
-    )
+    graph = Graph(nodes={"node1": node1, "node2": node2, "node3": node3}, edges=[Edge(source="node1", target="node2")])
     flow = GraphFlow(
         kind="GraphFlow",
         metadata=create_metadata(),

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -1,3 +1,5 @@
+from typing import cast
+
 from coreason_manifest.spec.core.flow import (
     Edge,
     FlowInterface,
@@ -180,3 +182,10 @@ def test_validate_linear_flow_switch_missing_targets() -> None:
     assert len(errors) == 2
     assert "SwitchNode 'switch1' case 'case1' target 'missing1' not found." in errors
     assert "SwitchNode 'switch1' default target 'missing2' not found." in errors
+
+
+def test_validate_flow_invalid_type() -> None:
+    """Test that validate_flow returns error for unknown type."""
+    # Cast to LinearFlow to satisfy type checker but pass None
+    errors = validate_flow(cast(LinearFlow, None))
+    assert errors == ["Unknown flow type"]

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -31,9 +31,7 @@ def create_agent_node(node_id: str, tools: list[str]) -> AgentNode:
     )
 
 
-def create_switch_node(
-    node_id: str, variable: str, cases: dict[str, str], default: str
-) -> SwitchNode:
+def create_switch_node(node_id: str, variable: str, cases: dict[str, str], default: str) -> SwitchNode:
     return SwitchNode(
         id=node_id,
         metadata={},
@@ -124,10 +122,7 @@ def test_validate_missing_tool() -> None:
     )
     errors = validate_flow(flow)
     assert len(errors) == 1
-    assert (
-        "Agent 'agent1' requires tool 'tool1' but it is not provided by any ToolPack."
-        in errors
-    )
+    assert "Agent 'agent1' requires tool 'tool1' but it is not provided by any ToolPack." in errors
 
 
 def test_validate_governance_sanity() -> None:

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -187,5 +187,5 @@ def test_validate_linear_flow_switch_missing_targets() -> None:
 def test_validate_flow_invalid_type() -> None:
     """Test that validate_flow returns error for unknown type."""
     # Cast to LinearFlow to satisfy type checker but pass None
-    errors = validate_flow(cast(LinearFlow, None))
+    errors = validate_flow(cast("LinearFlow", None))
     assert errors == ["Unknown flow type"]


### PR DESCRIPTION
This PR implements the Semantic Validator logic (`src/coreason_manifest/utils/validator.py`) as part of Phase 3a of the `coreason-manifest` refactor.

It includes:
1. `validate_flow` function that checks:
   - Graph integrity (for GraphFlow): edges point to valid nodes.
   - Switch logic: SwitchNode targets exist in the flow.
   - Missing tools: AgentNode requested tools are in ToolPacks.
   - Governance sanity: rate_limit_rpm and cost_limit_usd are non-negative.
   - Linear integrity (for LinearFlow): sequence is not empty.
2. Unit tests in `tests/test_validator_phase3a.py` covering valid and invalid scenarios for both LinearFlow and GraphFlow.

The implementation adheres to the Pydantic models defined in the codebase and follows the provided specifications.


---
*PR created automatically by Jules for task [8198785991727245428](https://jules.google.com/task/8198785991727245428) started by @gowthamrao*