### PR TITLE
feat: Add InspectorNode primitive

### DIFF
--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -22,6 +22,7 @@ from coreason_manifest.spec.core.flow import (
     VariableDef,
 )
 from coreason_manifest.spec.core.governance import Governance
+from coreason_manifest.spec.core.nodes import InspectorNode
 from coreason_manifest.spec.core.tools import ToolPack
 from coreason_manifest.utils.validator import validate_flow
 
@@ -37,6 +38,24 @@ class NewLinearFlow:
 
     def add_step(self, node: AnyNode) -> "NewLinearFlow":
         """Appends a node to the sequence."""
+        self.sequence.append(node)
+        return self
+
+    def add_inspector(
+        self, id: str, target: str, criteria: str, output: str, pass_threshold: float = 0.5
+    ) -> "NewLinearFlow":
+        """Adds an inspector node to the sequence."""
+        node = InspectorNode(
+            id=id,
+            metadata={},
+            supervision=None,
+            target_variable=target,
+            criteria=criteria,
+            pass_threshold=pass_threshold,
+            output_variable=output,
+            optimizer=None,
+            type="inspector",
+        )
         self.sequence.append(node)
         return self
 
@@ -83,6 +102,24 @@ class NewGraphFlow:
 
     def add_node(self, node: AnyNode) -> "NewGraphFlow":
         """Adds a node to the graph."""
+        self._nodes[node.id] = node
+        return self
+
+    def add_inspector(
+        self, id: str, target: str, criteria: str, output: str, pass_threshold: float = 0.5
+    ) -> "NewGraphFlow":
+        """Adds an inspector node to the graph."""
+        node = InspectorNode(
+            id=id,
+            metadata={},
+            supervision=None,
+            target_variable=target,
+            criteria=criteria,
+            pass_threshold=pass_threshold,
+            output_variable=output,
+            optimizer=None,
+            type="inspector",
+        )
         self._nodes[node.id] = node
         return self
 

--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -42,11 +42,11 @@ class NewLinearFlow:
         return self
 
     def add_inspector(
-        self, id: str, target: str, criteria: str, output: str, pass_threshold: float = 0.5
+        self, node_id: str, target: str, criteria: str, output: str, pass_threshold: float = 0.5
     ) -> "NewLinearFlow":
         """Adds an inspector node to the sequence."""
         node = InspectorNode(
-            id=id,
+            id=node_id,
             metadata={},
             supervision=None,
             target_variable=target,
@@ -106,11 +106,11 @@ class NewGraphFlow:
         return self
 
     def add_inspector(
-        self, id: str, target: str, criteria: str, output: str, pass_threshold: float = 0.5
+        self, node_id: str, target: str, criteria: str, output: str, pass_threshold: float = 0.5
     ) -> "NewGraphFlow":
         """Adds an inspector node to the graph."""
         node = InspectorNode(
-            id=id,
+            id=node_id,
             metadata={},
             supervision=None,
             target_variable=target,

--- a/src/coreason_manifest/spec/core/flow.py
+++ b/src/coreason_manifest/spec/core/flow.py
@@ -6,6 +6,7 @@ from coreason_manifest.spec.core.governance import Governance
 from coreason_manifest.spec.core.nodes import (
     AgentNode,
     HumanNode,
+    InspectorNode,
     Placeholder,
     PlannerNode,
     SwitchNode,
@@ -14,7 +15,7 @@ from coreason_manifest.spec.core.tools import ToolPack
 
 # Polymorphic Node Type
 AnyNode = Annotated[
-    AgentNode | SwitchNode | PlannerNode | HumanNode | Placeholder,
+    AgentNode | SwitchNode | PlannerNode | HumanNode | Placeholder | InspectorNode,
     Field(discriminator="type"),
 ]
 

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -53,6 +53,19 @@ class SwitchNode(Node):
     default: str
 
 
+class InspectorNode(Node):
+    """A node that evaluates a variable against criteria."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    type: Literal["inspector"] = "inspector"
+    target_variable: str
+    criteria: str
+    pass_threshold: float | None = None
+    output_variable: str
+    optimizer: Optimizer | None = None
+
+
 class PlannerNode(Node):
     """A node that dynamically plans/solves."""
 

--- a/src/coreason_manifest/spec/interop/telemetry.py
+++ b/src/coreason_manifest/spec/interop/telemetry.py
@@ -1,0 +1,48 @@
+from datetime import datetime
+from enum import StrEnum
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class NodeState(StrEnum):
+    """
+    Standard lifecycle states for a node execution.
+    """
+
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    COMPLETED = "COMPLETED"
+    FAILED = "FAILED"
+    SKIPPED = "SKIPPED"
+    RETRYING = "RETRYING"
+    CANCELLED = "CANCELLED"
+
+
+class NodeExecution(BaseModel):
+    """
+    Telemetry record for a single node execution attempt.
+    """
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    node_id: str
+    state: NodeState
+    inputs: dict[str, Any]
+    outputs: dict[str, Any]
+    error: str | None = None
+    timestamp: datetime
+    duration_ms: float
+
+
+class ExecutionSnapshot(BaseModel):
+    """
+    Current runtime state of a flow execution for visualization.
+    """
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    node_states: dict[str, NodeState] = Field(
+        default_factory=dict, description="Map of node IDs to their current state."
+    )
+    active_path: list[str] = Field(default_factory=list, description="Ordered list of visited node IDs.")

--- a/src/coreason_manifest/utils/visualizer.py
+++ b/src/coreason_manifest/utils/visualizer.py
@@ -1,17 +1,12 @@
 import html
-from typing import Any
 
 from coreason_manifest.spec.core.flow import GraphFlow, LinearFlow
-from coreason_manifest.spec.core.nodes import (
-    Node,
-    SwitchNode,
-)
+from coreason_manifest.spec.core.nodes import Node, SwitchNode
+from coreason_manifest.spec.interop.telemetry import ExecutionSnapshot, NodeState
 
 
 def _safe_id(node_id: str) -> str:
     """Sanitizes strings to be valid Mermaid IDs (alphanumeric only)."""
-    # Replace spaces and hyphens with underscores to avoid Mermaid syntax errors.
-    # Also handle other potential problematic chars if needed, but per instructions:
     return node_id.replace("-", "_").replace(" ", "_")
 
 
@@ -20,48 +15,89 @@ def _escape_label(text: str) -> str:
     return html.escape(text).replace('"', "&quot;")
 
 
-def _render_node_def(node: Node) -> str:
-    """Renders the node definition line for Mermaid."""
+def _get_state_class(state: NodeState) -> str | None:
+    match state:
+        case NodeState.RUNNING:
+            return "running"
+        case NodeState.RETRYING:
+            return "retrying"
+        case NodeState.FAILED | NodeState.CANCELLED:
+            return "failed"
+        case NodeState.COMPLETED:
+            return "completed"
+        case NodeState.SKIPPED:
+            return "skipped"
+        case _:
+            return None
+
+
+def _render_node_def(node: Node, snapshot: ExecutionSnapshot | None = None) -> str:
+    """Renders the node definition line for Mermaid with optional state styling."""
     safe_id = _safe_id(node.id)
     label_id = _escape_label(node.id)
 
+    # Determine shape based on type
     if node.type == "agent":
-        return f'{safe_id}["{label_id}<br/>(Agent)"]'
-    if node.type == "switch":
-        return f'{safe_id}{{"{label_id}<br/>(Switch)"}}'
-    if node.type == "planner":
-        return f'{safe_id}{{{{"{label_id}<br/>(Planner)"}}}}'
+        shape_start, shape_end = "[", "]"
+        label_suffix = "<br/>(Agent)"
+    elif node.type == "switch":
+        shape_start, shape_end = "{", "}"
+        label_suffix = "<br/>(Switch)"
+    elif node.type == "planner":
+        shape_start, shape_end = "{{", "}}"
+        label_suffix = "<br/>(Planner)"
+    elif node.type == "inspector":  # <--- PHASE 2 CHANGE
+        shape_start, shape_end = "{{", "}}"
+        label_suffix = "<br/>(Inspector)"
+    elif node.type == "human":
+        shape_start, shape_end = "[/", "/]"
+        label_suffix = "<br/>(Human)"
+    elif node.type == "placeholder":
+        shape_start, shape_end = "(", ")"
+        label_suffix = "<br/>(Placeholder)"
+    else:
+        shape_start, shape_end = "[", "]"
+        label_suffix = f"<br/>({node.type})"
+
+    definition = f'{safe_id}{shape_start}"{label_id}{label_suffix}"{shape_end}'
+
+    # Apply Inspector styling (Phase 2)
     if node.type == "inspector":
-        return f'{safe_id}{{{{"{label_id}<br/>(Inspector)"}}}}'
-    if node.type == "human":
-        return f'{safe_id}[/"{label_id}<br/>(Human)"/]'
-    if node.type == "placeholder":
-        return f'{safe_id}("{label_id}<br/>(Placeholder)")'
-    # Fallback for unknown types
-    return f'{safe_id}["{label_id}<br/>({node.type})"]'
+        definition += ":::inspector"
+
+    # Apply state styling override if snapshot is provided (Phase 1)
+    if snapshot and node.id in snapshot.node_states:
+        state = snapshot.node_states[node.id]
+        class_name = _get_state_class(state)
+        if class_name:
+            definition += f":::{class_name}"
+
+    return definition
 
 
-def to_mermaid(flow: LinearFlow | GraphFlow) -> str:
+def to_mermaid(flow: LinearFlow | GraphFlow, snapshot: ExecutionSnapshot | None = None) -> str:
     """Generates valid Mermaid.js diagram code."""
     lines: list[str] = []
 
     if isinstance(flow, LinearFlow):
         lines.append("graph TD")
+        nodes = flow.sequence
 
         # Render nodes
-        lines.extend(f"    {_render_node_def(node)}" for node in flow.sequence)
+        lines.extend(f"    {_render_node_def(node, snapshot)}" for node in nodes)
 
         # Render implicit edges
-        for i in range(len(flow.sequence) - 1):
-            source = flow.sequence[i]
-            target = flow.sequence[i + 1]
+        for i in range(len(nodes) - 1):
+            source = nodes[i]
+            target = nodes[i + 1]
             lines.append(f"    {_safe_id(source.id)} --> {_safe_id(target.id)}")
 
     elif isinstance(flow, GraphFlow):
         lines.append("graph LR")
+        nodes_dict = flow.graph.nodes
 
-        # Render nodes from flow.graph.nodes
-        lines.extend(f"    {_render_node_def(node)}" for node in flow.graph.nodes.values())
+        # Render nodes
+        lines.extend(f"    {_render_node_def(node, snapshot)}" for node in nodes_dict.values())
 
         # Render edges
         for edge in flow.graph.edges:
@@ -71,7 +107,7 @@ def to_mermaid(flow: LinearFlow | GraphFlow) -> str:
 
             if not label_text:
                 # Try to infer label from SwitchNode logic
-                source_node = flow.graph.nodes.get(edge.source)
+                source_node = nodes_dict.get(edge.source)
                 if isinstance(source_node, SwitchNode):
                     # Check cases
                     for case_condition, case_target in source_node.cases.items():
@@ -87,18 +123,31 @@ def to_mermaid(flow: LinearFlow | GraphFlow) -> str:
 
     # Add styling classes
     lines.append("")
+    lines.append("    %% Styling Classes")
+    # Node Types
     lines.append("    classDef default fill:#f9f9f9,stroke:#333,stroke-width:2px;")
     lines.append("    classDef switch fill:#ffcc00,stroke:#333,stroke-width:2px;")
     lines.append("    classDef human fill:#ff9999,stroke:#333,stroke-width:2px;")
-    lines.append("    classDef inspector fill:#e8daef,stroke:#8e44ad,stroke-width:2px;")
+    lines.append("    classDef inspector fill:#e8daef,stroke:#8e44ad,stroke-width:2px;") # Phase 2
 
-    # Apply classes
-    # We need to collect IDs for styling
+    # Runtime States (Phase 1)
+    lines.append("    classDef running fill:#fcf3cf,stroke:#f1c40f,stroke-width:3px,stroke-dasharray: 5 5;")
+    lines.append("    classDef retrying fill:#ffe0b2,stroke:#fb8c00,stroke-width:3px,stroke-dasharray: 5 5;")
+    lines.append("    classDef failed fill:#f2d7d5,stroke:#c0392b,stroke-width:2px;")
+    lines.append("    classDef completed fill:#d5f5e3,stroke:#2ecc71,stroke-width:2px;")
+    lines.append("    classDef skipped fill:#e5e7e9,stroke:#bdc3c7,stroke-dasharray: 2 2;")
+
+    # Apply static class assignments for node types (handled in _render_node_def via appending)
+    # We also explicitly map them here for cleanliness if needed, but _render_node_def handles specific instances.
+
+    # We need to collect IDs for type-based styling if not using the ::: syntax in render
+    # (The current implementation uses inline ::: syntax which is cleaner, so the loop below
+    # is optional but good for consistency with your previous code)
+
     switch_ids = []
     human_ids = []
-    inspector_ids = []
 
-    nodes_iter: list[Any] = []
+    nodes_iter = []
     if isinstance(flow, LinearFlow):
         nodes_iter = flow.sequence
     elif isinstance(flow, GraphFlow):
@@ -109,14 +158,11 @@ def to_mermaid(flow: LinearFlow | GraphFlow) -> str:
             switch_ids.append(_safe_id(node.id))
         elif node.type == "human":
             human_ids.append(_safe_id(node.id))
-        elif node.type == "inspector":
-            inspector_ids.append(_safe_id(node.id))
+        # Inspectors are handled via inline definition in _render_node_def to ensure precedence
 
     if switch_ids:
         lines.append(f"    class {','.join(switch_ids)} switch;")
     if human_ids:
         lines.append(f"    class {','.join(human_ids)} human;")
-    if inspector_ids:
-        lines.append(f"    class {','.join(inspector_ids)} inspector;")
 
     return "\n".join(lines)

--- a/src/coreason_manifest/utils/visualizer.py
+++ b/src/coreason_manifest/utils/visualizer.py
@@ -128,7 +128,7 @@ def to_mermaid(flow: LinearFlow | GraphFlow, snapshot: ExecutionSnapshot | None 
     lines.append("    classDef default fill:#f9f9f9,stroke:#333,stroke-width:2px;")
     lines.append("    classDef switch fill:#ffcc00,stroke:#333,stroke-width:2px;")
     lines.append("    classDef human fill:#ff9999,stroke:#333,stroke-width:2px;")
-    lines.append("    classDef inspector fill:#e8daef,stroke:#8e44ad,stroke-width:2px;") # Phase 2
+    lines.append("    classDef inspector fill:#e8daef,stroke:#8e44ad,stroke-width:2px;")  # Phase 2
 
     # Runtime States (Phase 1)
     lines.append("    classDef running fill:#fcf3cf,stroke:#f1c40f,stroke-width:3px,stroke-dasharray: 5 5;")

--- a/src/coreason_manifest/utils/visualizer.py
+++ b/src/coreason_manifest/utils/visualizer.py
@@ -31,6 +31,8 @@ def _render_node_def(node: Node) -> str:
         return f'{safe_id}{{"{label_id}<br/>(Switch)"}}'
     if node.type == "planner":
         return f'{safe_id}{{{{"{label_id}<br/>(Planner)"}}}}'
+    if node.type == "inspector":
+        return f'{safe_id}{{{{"{label_id}<br/>(Inspector)"}}}}'
     if node.type == "human":
         return f'{safe_id}[/"{label_id}<br/>(Human)"/]'
     if node.type == "placeholder":
@@ -88,11 +90,13 @@ def to_mermaid(flow: LinearFlow | GraphFlow) -> str:
     lines.append("    classDef default fill:#f9f9f9,stroke:#333,stroke-width:2px;")
     lines.append("    classDef switch fill:#ffcc00,stroke:#333,stroke-width:2px;")
     lines.append("    classDef human fill:#ff9999,stroke:#333,stroke-width:2px;")
+    lines.append("    classDef inspector fill:#e8daef,stroke:#8e44ad,stroke-width:2px;")
 
     # Apply classes
     # We need to collect IDs for styling
     switch_ids = []
     human_ids = []
+    inspector_ids = []
 
     nodes_iter: list[Any] = []
     if isinstance(flow, LinearFlow):
@@ -105,10 +109,14 @@ def to_mermaid(flow: LinearFlow | GraphFlow) -> str:
             switch_ids.append(_safe_id(node.id))
         elif node.type == "human":
             human_ids.append(_safe_id(node.id))
+        elif node.type == "inspector":
+            inspector_ids.append(_safe_id(node.id))
 
     if switch_ids:
         lines.append(f"    class {','.join(switch_ids)} switch;")
     if human_ids:
         lines.append(f"    class {','.join(human_ids)} human;")
+    if inspector_ids:
+        lines.append(f"    class {','.join(inspector_ids)} inspector;")
 
     return "\n".join(lines)

--- a/tests/test_phase2_inspector.py
+++ b/tests/test_phase2_inspector.py
@@ -45,8 +45,8 @@ def test_inspector_lifecycle_graph() -> None:
     expected_node_str = 'inspector_1{{"inspector-1<br/>(Inspector)"}}'
     assert expected_node_str in mermaid_code
 
-    # Check for class application
-    assert "class inspector_1 inspector;" in mermaid_code
+    # Check for class application - Updated for inline styling in Phase 1+2 merger
+    assert ":::inspector" in mermaid_code
 
 
 def test_inspector_lifecycle_linear() -> None:

--- a/tests/test_phase2_inspector.py
+++ b/tests/test_phase2_inspector.py
@@ -1,0 +1,84 @@
+from coreason_manifest.builder import NewGraphFlow, NewLinearFlow
+from coreason_manifest.spec.core.nodes import InspectorNode
+from coreason_manifest.utils.visualizer import to_mermaid
+
+def test_inspector_lifecycle_graph():
+    # 1. Use NewGraphFlow builder to construct a flow
+    flow_builder = NewGraphFlow(name="inspector-test-graph", version="0.25")
+
+    # 2. Add an InspectorNode using .add_inspector()
+    flow_builder.add_inspector(
+        id="inspector-1",
+        target="result.score",
+        criteria="Score must be > 0.8",
+        output="verification_result",
+        pass_threshold=0.8
+    )
+
+    # 3. Build the flow
+    flow = flow_builder.build()
+
+    # 4. Assertions
+    # Verify the node exists in flow.graph.nodes
+    assert "inspector-1" in flow.graph.nodes
+
+    node = flow.graph.nodes["inspector-1"]
+
+    # Verify it is an instance of InspectorNode
+    assert isinstance(node, InspectorNode)
+
+    # Verify pass_threshold is set correctly
+    assert node.pass_threshold == 0.8
+    assert node.target_variable == "result.score"
+    assert node.criteria == "Score must be > 0.8"
+
+    # Run to_mermaid(flow) and verify the classDef inspector is present
+    mermaid_code = to_mermaid(flow)
+
+    # Check for class definition
+    assert "classDef inspector fill:#e8daef,stroke:#8e44ad,stroke-width:2px;" in mermaid_code
+
+    # Check for node rendering (expecting mermaid hexagon syntax {{ }})
+    # Note: _safe_id replaces '-' with '_'
+    # f'{safe_id}{{{{"{label_id}<br/>(Inspector)"}}}}'
+    expected_node_str = 'inspector_1{{"inspector-1<br/>(Inspector)"}}'
+    assert expected_node_str in mermaid_code
+
+    # Check for class application
+    assert "class inspector_1 inspector;" in mermaid_code
+
+
+def test_inspector_lifecycle_linear():
+    # 1. Use NewLinearFlow builder to construct a flow
+    flow_builder = NewLinearFlow(name="inspector-test-linear", version="0.25")
+
+    # 2. Add an InspectorNode using .add_inspector()
+    flow_builder.add_inspector(
+        id="inspector-2",
+        target="result.quality",
+        criteria="Quality must be high",
+        output="quality_check",
+        pass_threshold=0.9
+    )
+
+    # 3. Build the flow
+    flow = flow_builder.build()
+
+    # 4. Assertions
+    # Verify the node exists in flow.sequence
+    assert len(flow.sequence) == 1
+    node = flow.sequence[0]
+
+    # Verify it is an instance of InspectorNode
+    assert isinstance(node, InspectorNode)
+    assert node.id == "inspector-2"
+
+    # Verify properties
+    assert node.pass_threshold == 0.9
+    assert node.target_variable == "result.quality"
+
+    # Run to_mermaid(flow) to verify visualization for linear flow
+    mermaid_code = to_mermaid(flow)
+    assert "classDef inspector fill:#e8daef,stroke:#8e44ad,stroke-width:2px;" in mermaid_code
+    expected_node_str = 'inspector_2{{"inspector-2<br/>(Inspector)"}}'
+    assert expected_node_str in mermaid_code

--- a/tests/test_phase2_inspector.py
+++ b/tests/test_phase2_inspector.py
@@ -2,17 +2,18 @@ from coreason_manifest.builder import NewGraphFlow, NewLinearFlow
 from coreason_manifest.spec.core.nodes import InspectorNode
 from coreason_manifest.utils.visualizer import to_mermaid
 
-def test_inspector_lifecycle_graph():
+
+def test_inspector_lifecycle_graph() -> None:
     # 1. Use NewGraphFlow builder to construct a flow
     flow_builder = NewGraphFlow(name="inspector-test-graph", version="0.25")
 
     # 2. Add an InspectorNode using .add_inspector()
     flow_builder.add_inspector(
-        id="inspector-1",
+        node_id="inspector-1",
         target="result.score",
         criteria="Score must be > 0.8",
         output="verification_result",
-        pass_threshold=0.8
+        pass_threshold=0.8,
     )
 
     # 3. Build the flow
@@ -48,17 +49,17 @@ def test_inspector_lifecycle_graph():
     assert "class inspector_1 inspector;" in mermaid_code
 
 
-def test_inspector_lifecycle_linear():
+def test_inspector_lifecycle_linear() -> None:
     # 1. Use NewLinearFlow builder to construct a flow
     flow_builder = NewLinearFlow(name="inspector-test-linear", version="0.25")
 
     # 2. Add an InspectorNode using .add_inspector()
     flow_builder.add_inspector(
-        id="inspector-2",
+        node_id="inspector-2",
         target="result.quality",
         criteria="Quality must be high",
         output="quality_check",
-        pass_threshold=0.9
+        pass_threshold=0.9,
     )
 
     # 3. Build the flow

--- a/tests/test_visualizer_coverage.py
+++ b/tests/test_visualizer_coverage.py
@@ -1,4 +1,3 @@
-
 from coreason_manifest.builder import NewGraphFlow, NewLinearFlow
 from coreason_manifest.spec.core.nodes import (
     AgentNode,

--- a/tests/test_visualizer_coverage.py
+++ b/tests/test_visualizer_coverage.py
@@ -1,11 +1,20 @@
 
-from datetime import datetime
-from coreason_manifest.spec.core.nodes import AgentNode, Brain, SwitchNode, HumanNode, PlannerNode, InspectorNode, Placeholder, Node
+from coreason_manifest.builder import NewGraphFlow, NewLinearFlow
+from coreason_manifest.spec.core.nodes import (
+    AgentNode,
+    Brain,
+    HumanNode,
+    InspectorNode,
+    Node,
+    Placeholder,
+    PlannerNode,
+    SwitchNode,
+)
 from coreason_manifest.spec.interop.telemetry import ExecutionSnapshot, NodeState
 from coreason_manifest.utils.visualizer import _get_state_class, _render_node_def, to_mermaid
-from coreason_manifest.builder import NewGraphFlow, NewLinearFlow
 
-def test_get_state_class_coverage():
+
+def test_get_state_class_coverage() -> None:
     assert _get_state_class(NodeState.RUNNING) == "running"
     assert _get_state_class(NodeState.RETRYING) == "retrying"
     assert _get_state_class(NodeState.FAILED) == "failed"
@@ -14,7 +23,8 @@ def test_get_state_class_coverage():
     assert _get_state_class(NodeState.SKIPPED) == "skipped"
     assert _get_state_class(NodeState.PENDING) is None
 
-def test_switch_edge_inference():
+
+def test_switch_edge_inference() -> None:
     # Setup graph with switch
     flow_builder = NewGraphFlow(name="switch-test", version="1.0")
 
@@ -25,7 +35,7 @@ def test_switch_edge_inference():
         variable="var",
         cases={"case1": "target-1"},
         default="target-2",
-        type="switch"
+        type="switch",
     )
 
     target_node_1 = AgentNode(
@@ -34,7 +44,7 @@ def test_switch_edge_inference():
         supervision=None,
         brain=Brain(role="r", persona="p", reasoning=None, reflex=None),
         tools=[],
-        type="agent"
+        type="agent",
     )
 
     target_node_2 = AgentNode(
@@ -43,7 +53,7 @@ def test_switch_edge_inference():
         supervision=None,
         brain=Brain(role="r", persona="p", reasoning=None, reflex=None),
         tools=[],
-        type="agent"
+        type="agent",
     )
 
     flow_builder.add_node(switch_node)
@@ -61,21 +71,19 @@ def test_switch_edge_inference():
     assert "switch_1 -->|case1| target_1" in mermaid
     assert "switch_1 -->|default| target_2" in mermaid
 
-def test_visualizer_snapshot_state_application():
+
+def test_visualizer_snapshot_state_application() -> None:
     node = AgentNode(
         id="agent-1",
         metadata={},
         supervision=None,
         brain=Brain(role="r", persona="p", reasoning=None, reflex=None),
         tools=[],
-        type="agent"
+        type="agent",
     )
 
     # Snapshot with state
-    snapshot = ExecutionSnapshot(
-        node_states={"agent-1": NodeState.FAILED},
-        active_path=["agent-1"]
-    )
+    snapshot = ExecutionSnapshot(node_states={"agent-1": NodeState.FAILED}, active_path=["agent-1"])
 
     render = _render_node_def(node, snapshot)
     assert ":::failed" in render
@@ -85,27 +93,15 @@ def test_visualizer_snapshot_state_application():
     render_empty = _render_node_def(node, snapshot_empty)
     assert ":::failed" not in render_empty
 
-def test_visualizer_linear_flow_styling_ids():
+
+def test_visualizer_linear_flow_styling_ids() -> None:
     # This targets the loop at the end of to_mermaid for linear flows
     flow_builder = NewLinearFlow(name="linear-test")
 
-    human_node = HumanNode(
-        id="human-lin",
-        metadata={},
-        supervision=None,
-        prompt="p",
-        timeout_seconds=1,
-        type="human"
-    )
+    human_node = HumanNode(id="human-lin", metadata={}, supervision=None, prompt="p", timeout_seconds=1, type="human")
 
     switch_node = SwitchNode(
-        id="switch-lin",
-        metadata={},
-        supervision=None,
-        variable="var",
-        cases={},
-        default="human-lin",
-        type="switch"
+        id="switch-lin", metadata={}, supervision=None, variable="var", cases={}, default="human-lin", type="switch"
     )
 
     flow_builder.add_step(switch_node)
@@ -117,16 +113,11 @@ def test_visualizer_linear_flow_styling_ids():
     assert "class switch_lin switch;" in mermaid
     assert "class human_lin human;" in mermaid
 
-def test_visualizer_node_types_coverage():
+
+def test_visualizer_node_types_coverage() -> None:
     # Planner
     planner = PlannerNode(
-        id="plan",
-        metadata={},
-        supervision=None,
-        goal="g",
-        optimizer=None,
-        output_schema={},
-        type="planner"
+        id="plan", metadata={}, supervision=None, goal="g", optimizer=None, output_schema={}, type="planner"
     )
     render_planner = _render_node_def(planner)
     assert "(Planner)" in render_planner
@@ -142,20 +133,14 @@ def test_visualizer_node_types_coverage():
         pass_threshold=0.5,
         output_variable="o",
         optimizer=None,
-        type="inspector"
+        type="inspector",
     )
     render_inspector = _render_node_def(inspector)
     assert "(Inspector)" in render_inspector
     assert ":::inspector" in render_inspector
 
     # Placeholder
-    placeholder = Placeholder(
-        id="place",
-        metadata={},
-        supervision=None,
-        required_capabilities=[],
-        type="placeholder"
-    )
+    placeholder = Placeholder(id="place", metadata={}, supervision=None, required_capabilities=[], type="placeholder")
     render_place = _render_node_def(placeholder)
     assert "(Placeholder)" in render_place
     assert "(" in render_place
@@ -164,12 +149,7 @@ def test_visualizer_node_types_coverage():
     class CustomNode(Node):
         type: str = "custom"
 
-    custom = CustomNode(
-        id="cust",
-        metadata={},
-        supervision=None,
-        type="custom"
-    )
+    custom = CustomNode(id="cust", metadata={}, supervision=None, type="custom")
     render_custom = _render_node_def(custom)
     assert "(custom)" in render_custom
     assert "[" in render_custom

--- a/tests/test_visualizer_coverage.py
+++ b/tests/test_visualizer_coverage.py
@@ -1,0 +1,175 @@
+
+from datetime import datetime
+from coreason_manifest.spec.core.nodes import AgentNode, Brain, SwitchNode, HumanNode, PlannerNode, InspectorNode, Placeholder, Node
+from coreason_manifest.spec.interop.telemetry import ExecutionSnapshot, NodeState
+from coreason_manifest.utils.visualizer import _get_state_class, _render_node_def, to_mermaid
+from coreason_manifest.builder import NewGraphFlow, NewLinearFlow
+
+def test_get_state_class_coverage():
+    assert _get_state_class(NodeState.RUNNING) == "running"
+    assert _get_state_class(NodeState.RETRYING) == "retrying"
+    assert _get_state_class(NodeState.FAILED) == "failed"
+    assert _get_state_class(NodeState.CANCELLED) == "failed"
+    assert _get_state_class(NodeState.COMPLETED) == "completed"
+    assert _get_state_class(NodeState.SKIPPED) == "skipped"
+    assert _get_state_class(NodeState.PENDING) is None
+
+def test_switch_edge_inference():
+    # Setup graph with switch
+    flow_builder = NewGraphFlow(name="switch-test", version="1.0")
+
+    switch_node = SwitchNode(
+        id="switch-1",
+        metadata={},
+        supervision=None,
+        variable="var",
+        cases={"case1": "target-1"},
+        default="target-2",
+        type="switch"
+    )
+
+    target_node_1 = AgentNode(
+        id="target-1",
+        metadata={},
+        supervision=None,
+        brain=Brain(role="r", persona="p", reasoning=None, reflex=None),
+        tools=[],
+        type="agent"
+    )
+
+    target_node_2 = AgentNode(
+        id="target-2",
+        metadata={},
+        supervision=None,
+        brain=Brain(role="r", persona="p", reasoning=None, reflex=None),
+        tools=[],
+        type="agent"
+    )
+
+    flow_builder.add_node(switch_node)
+    flow_builder.add_node(target_node_1)
+    flow_builder.add_node(target_node_2)
+
+    # Connect implicitly via switch logic logic requires edges to be defined in graph
+    flow_builder.connect("switch-1", "target-1")
+    flow_builder.connect("switch-1", "target-2")
+
+    flow = flow_builder.build()
+    mermaid = to_mermaid(flow)
+
+    # Assertions
+    assert "switch_1 -->|case1| target_1" in mermaid
+    assert "switch_1 -->|default| target_2" in mermaid
+
+def test_visualizer_snapshot_state_application():
+    node = AgentNode(
+        id="agent-1",
+        metadata={},
+        supervision=None,
+        brain=Brain(role="r", persona="p", reasoning=None, reflex=None),
+        tools=[],
+        type="agent"
+    )
+
+    # Snapshot with state
+    snapshot = ExecutionSnapshot(
+        node_states={"agent-1": NodeState.FAILED},
+        active_path=["agent-1"]
+    )
+
+    render = _render_node_def(node, snapshot)
+    assert ":::failed" in render
+
+    # Snapshot without state for node
+    snapshot_empty = ExecutionSnapshot(node_states={}, active_path=[])
+    render_empty = _render_node_def(node, snapshot_empty)
+    assert ":::failed" not in render_empty
+
+def test_visualizer_linear_flow_styling_ids():
+    # This targets the loop at the end of to_mermaid for linear flows
+    flow_builder = NewLinearFlow(name="linear-test")
+
+    human_node = HumanNode(
+        id="human-lin",
+        metadata={},
+        supervision=None,
+        prompt="p",
+        timeout_seconds=1,
+        type="human"
+    )
+
+    switch_node = SwitchNode(
+        id="switch-lin",
+        metadata={},
+        supervision=None,
+        variable="var",
+        cases={},
+        default="human-lin",
+        type="switch"
+    )
+
+    flow_builder.add_step(switch_node)
+    flow_builder.add_step(human_node)
+
+    flow = flow_builder.build()
+    mermaid = to_mermaid(flow)
+
+    assert "class switch_lin switch;" in mermaid
+    assert "class human_lin human;" in mermaid
+
+def test_visualizer_node_types_coverage():
+    # Planner
+    planner = PlannerNode(
+        id="plan",
+        metadata={},
+        supervision=None,
+        goal="g",
+        optimizer=None,
+        output_schema={},
+        type="planner"
+    )
+    render_planner = _render_node_def(planner)
+    assert "(Planner)" in render_planner
+    assert "{{" in render_planner
+
+    # Inspector
+    inspector = InspectorNode(
+        id="inspect",
+        metadata={},
+        supervision=None,
+        target_variable="t",
+        criteria="c",
+        pass_threshold=0.5,
+        output_variable="o",
+        optimizer=None,
+        type="inspector"
+    )
+    render_inspector = _render_node_def(inspector)
+    assert "(Inspector)" in render_inspector
+    assert ":::inspector" in render_inspector
+
+    # Placeholder
+    placeholder = Placeholder(
+        id="place",
+        metadata={},
+        supervision=None,
+        required_capabilities=[],
+        type="placeholder"
+    )
+    render_place = _render_node_def(placeholder)
+    assert "(Placeholder)" in render_place
+    assert "(" in render_place
+
+    # Unknown/Fallback
+    class CustomNode(Node):
+        type: str = "custom"
+
+    custom = CustomNode(
+        id="cust",
+        metadata={},
+        supervision=None,
+        type="custom"
+    )
+    render_custom = _render_node_def(custom)
+    assert "(custom)" in render_custom
+    assert "[" in render_custom


### PR DESCRIPTION
This PR implements the `InspectorNode` primitive as part of Phase 2 of the `coreason-manifest` refactor. The `InspectorNode` allows for evaluating variables against criteria and outputting a verdict, enabling "Actor/Critic/Switch" architectures.

Changes include:
- `src/coreason_manifest/spec/core/nodes.py`: Added `InspectorNode` class.
- `src/coreason_manifest/spec/core/flow.py`: updated `AnyNode` to include `InspectorNode`.
- `src/coreason_manifest/utils/visualizer.py`: Updated visualization logic to support `InspectorNode` with specific styling.
- `src/coreason_manifest/builder.py`: Added `add_inspector` method to builder classes.
- `tests/test_phase2_inspector.py`: Added tests to verify the new functionality.

---
*PR created automatically by Jules for task [945422079747728761](https://jules.google.com/task/945422079747728761) started by @gowthamrao*