### PR TITLE
Resilience: Supervision and Governance Phase 3

### DIFF
--- a/src/coreason_manifest/spec/core/__init__.py
+++ b/src/coreason_manifest/spec/core/__init__.py
@@ -1,1 +1,15 @@
 # Core specification package
+
+from coreason_manifest.spec.core.governance import (
+    Audit,
+    CircuitBreaker,
+    Governance,
+    Safety,
+)
+
+__all__ = [
+    "Audit",
+    "CircuitBreaker",
+    "Governance",
+    "Safety",
+]

--- a/src/coreason_manifest/spec/core/engines.py
+++ b/src/coreason_manifest/spec/core/engines.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict
 
@@ -28,9 +28,12 @@ class Supervision(BaseModel):
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    strategy: Literal["resume", "restart", "escalate"]
+    strategy: Literal["resume", "restart", "escalate", "degrade"]
     max_retries: int
     fallback: str | None
+    retry_delay_seconds: float = 1.0
+    backoff_factor: float = 2.0
+    default_payload: dict[str, Any] | None = None
 
 
 class Optimizer(BaseModel):

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Safety(BaseModel):
@@ -22,6 +22,14 @@ class Audit(BaseModel):
     log_payloads: bool
 
 
+class CircuitBreaker(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    error_threshold_count: int = Field(..., description="Number of errors before opening the circuit.")
+    reset_timeout_seconds: int = Field(..., description="Seconds to wait before attempting half-open state.")
+    fallback_node_id: str | None = Field(None, description="Optional node to jump to when circuit opens.")
+
+
 class Governance(BaseModel):
     """Governance constraints and policies."""
 
@@ -32,3 +40,4 @@ class Governance(BaseModel):
     cost_limit_usd: float | None = None
     safety: Safety | None = None
     audit: Audit | None = None
+    circuit_breaker: CircuitBreaker | None = None

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -88,7 +88,9 @@ class HumanNode(Node):
     type: Literal["human"] = "human"
     prompt: str
     timeout_seconds: int
-    input_schema: dict[str, Any] | None = Field(None, description="JSON Schema for data entry (forms).")
+    input_schema: dict[str, Any] | None = Field(
+        None, description="JSON Schema for data entry (forms)."
+    )
     options: list[str] | None = Field(
         None, description="List of explicit decision buttons (e.g. ['Approve', 'Reject'])."
     )

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -88,6 +88,8 @@ class HumanNode(Node):
     type: Literal["human"] = "human"
     prompt: str
     timeout_seconds: int
+    input_schema: dict[str, Any] | None = Field(None, description="JSON Schema for data entry.")
+    options: list[str] | None = Field(None, description="List of decision buttons (e.g. ['Approve', 'Reject']).")
 
 
 class Placeholder(Node):

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -88,9 +88,7 @@ class HumanNode(Node):
     type: Literal["human"] = "human"
     prompt: str
     timeout_seconds: int
-    input_schema: dict[str, Any] | None = Field(
-        None, description="JSON Schema for data entry (forms)."
-    )
+    input_schema: dict[str, Any] | None = Field(None, description="JSON Schema for data entry (forms).")
     options: list[str] | None = Field(
         None, description="List of explicit decision buttons (e.g. ['Approve', 'Reject'])."
     )

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -88,8 +88,10 @@ class HumanNode(Node):
     type: Literal["human"] = "human"
     prompt: str
     timeout_seconds: int
-    input_schema: dict[str, Any] | None = Field(None, description="JSON Schema for data entry.")
-    options: list[str] | None = Field(None, description="List of decision buttons (e.g. ['Approve', 'Reject']).")
+    input_schema: dict[str, Any] | None = Field(None, description="JSON Schema for data entry (forms).")
+    options: list[str] | None = Field(
+        None, description="List of explicit decision buttons (e.g. ['Approve', 'Reject'])."
+    )
 
 
 class Placeholder(Node):

--- a/src/coreason_manifest/utils/validator.py
+++ b/src/coreason_manifest/utils/validator.py
@@ -13,10 +13,6 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
     """
     errors: list[str] = []
 
-    # 1. Common Checks
-    if flow.governance:
-        errors.extend(_validate_governance(flow.governance))
-
     # Flatten nodes based on flow type
     nodes: list[AnyNode] = []
     if isinstance(flow, GraphFlow):
@@ -24,11 +20,17 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
     elif isinstance(flow, LinearFlow):
         nodes = flow.sequence
 
+    valid_ids = {n.id for n in nodes}
+
+    # 1. Common Checks
+    if flow.governance:
+        errors.extend(_validate_governance(flow.governance, valid_ids))
+
     if flow.tool_packs:
         errors.extend(_validate_tools(nodes, flow.tool_packs))
 
     for node in nodes:
-        errors.extend(_validate_supervision(node))
+        errors.extend(_validate_supervision(node, valid_ids))
 
     # 2. LinearFlow Specific Checks
     if isinstance(flow, LinearFlow):
@@ -55,12 +57,20 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[str]:
     return errors
 
 
-def _validate_governance(gov: Governance) -> list[str]:
+def _validate_governance(gov: Governance, valid_ids: set[str]) -> list[str]:
     errors: list[str] = []
     if gov.rate_limit_rpm is not None and gov.rate_limit_rpm < 0:
         errors.append("Governance Error: rate_limit_rpm cannot be negative.")
     if gov.cost_limit_usd is not None and gov.cost_limit_usd < 0:
         errors.append("Governance Error: cost_limit_usd cannot be negative.")
+    if (
+        gov.circuit_breaker
+        and gov.circuit_breaker.fallback_node_id
+        and gov.circuit_breaker.fallback_node_id not in valid_ids
+    ):
+        errors.append(
+            f"Circuit Breaker Error: 'fallback_node_id' points to missing ID '{gov.circuit_breaker.fallback_node_id}'."
+        )
     return errors
 
 
@@ -153,7 +163,7 @@ def _validate_orphan_nodes(graph: Graph) -> list[str]:
     return [f"Orphan Node Warning: Node '{oid}' has no incoming edges." for oid in orphans]
 
 
-def _validate_supervision(node: AnyNode) -> list[str]:
+def _validate_supervision(node: AnyNode, valid_ids: set[str]) -> list[str]:
     errors: list[str] = []
     if node.supervision:
         if node.supervision.strategy == "degrade" and node.supervision.default_payload is None:
@@ -161,5 +171,10 @@ def _validate_supervision(node: AnyNode) -> list[str]:
 
         if node.supervision.backoff_factor < 1.0:
             errors.append(f"Supervision Error: Node '{node.id}' backoff_factor must be >= 1.0.")
+
+        if node.supervision.fallback and node.supervision.fallback not in valid_ids:
+            errors.append(
+                f"Supervision Error: Node '{node.id}' fallback points to missing ID '{node.supervision.fallback}'."
+            )
 
     return errors

--- a/src/coreason_manifest/utils/visualizer.py
+++ b/src/coreason_manifest/utils/visualizer.py
@@ -51,10 +51,10 @@ def _render_node_def(node: Node, snapshot: ExecutionSnapshot | None = None) -> s
         label_suffix = "<br/>(Inspector)"
     elif node.type == "human":
         shape_start, shape_end = "[/", "/]"
-        # Show options if present
+        # --- UPDATE: Render Options ---
         if hasattr(node, "options") and node.options:
-            opts_str = ", ".join(node.options)
-            label_suffix = f"<br/>(Human)<br/>[{opts_str}]"
+            opts = ", ".join(node.options)
+            label_suffix = f"<br/>(Human)<br/>[{opts}]"
         else:
             label_suffix = "<br/>(Human)"
     elif node.type == "placeholder":

--- a/src/coreason_manifest/utils/visualizer.py
+++ b/src/coreason_manifest/utils/visualizer.py
@@ -51,7 +51,12 @@ def _render_node_def(node: Node, snapshot: ExecutionSnapshot | None = None) -> s
         label_suffix = "<br/>(Inspector)"
     elif node.type == "human":
         shape_start, shape_end = "[/", "/]"
-        label_suffix = "<br/>(Human)"
+        # Show options if present
+        if hasattr(node, "options") and node.options:
+            opts_str = ", ".join(node.options)
+            label_suffix = f"<br/>(Human)<br/>[{opts_str}]"
+        else:
+            label_suffix = "<br/>(Human)"
     elif node.type == "placeholder":
         shape_start, shape_end = "(", ")"
         label_suffix = "<br/>(Placeholder)"

--- a/tests/test_phase3_resilience.py
+++ b/tests/test_phase3_resilience.py
@@ -203,3 +203,38 @@ def test_validator_catch_invalid_fallback_ids() -> None:
         ValueError, match="Supervision Error: Node 'node2' fallback points to missing ID 'missing_sup_node'"
     ):
         lf2.build()
+
+def test_human_node_options_and_visualizer() -> None:
+    from coreason_manifest.spec.core.nodes import HumanNode
+    from coreason_manifest.utils.visualizer import to_mermaid
+
+    # Test HumanNode instantiation with options
+    human = HumanNode(
+        id="human_decision",
+        metadata={},
+        supervision=None,
+        prompt="Approve or Reject?",
+        timeout_seconds=600,
+        options=["Approve", "Reject"],
+        input_schema={"type": "object", "properties": {"reason": {"type": "string"}}}
+    )
+
+    assert human.options == ["Approve", "Reject"]
+    assert human.input_schema is not None
+
+    # Test Visualizer rendering
+    lf = NewLinearFlow(name="Human Flow")
+    lf.add_step(human)
+    flow = lf.build()
+
+    mermaid_code = to_mermaid(flow)
+
+    # Check if options are present in the mermaid code
+    assert "[Approve, Reject]" in mermaid_code
+    assert "(Human)" in mermaid_code
+    assert "human_decision" in mermaid_code
+
+def test_circuit_breaker_export() -> None:
+    # Test that CircuitBreaker is exported from spec.core
+    from coreason_manifest.spec.core import CircuitBreaker
+    assert CircuitBreaker is not None

--- a/tests/test_phase3_resilience.py
+++ b/tests/test_phase3_resilience.py
@@ -204,6 +204,7 @@ def test_validator_catch_invalid_fallback_ids() -> None:
     ):
         lf2.build()
 
+
 def test_human_node_options_and_visualizer() -> None:
     from coreason_manifest.spec.core.nodes import HumanNode
     from coreason_manifest.utils.visualizer import to_mermaid
@@ -216,7 +217,7 @@ def test_human_node_options_and_visualizer() -> None:
         prompt="Approve or Reject?",
         timeout_seconds=600,
         options=["Approve", "Reject"],
-        input_schema={"type": "object", "properties": {"reason": {"type": "string"}}}
+        input_schema={"type": "object", "properties": {"reason": {"type": "string"}}},
     )
 
     assert human.options == ["Approve", "Reject"]
@@ -234,7 +235,9 @@ def test_human_node_options_and_visualizer() -> None:
     assert "(Human)" in mermaid_code
     assert "human_decision" in mermaid_code
 
+
 def test_circuit_breaker_export() -> None:
     # Test that CircuitBreaker is exported from spec.core
     from coreason_manifest.spec.core import CircuitBreaker
+
     assert CircuitBreaker is not None

--- a/tests/test_phase3_resilience.py
+++ b/tests/test_phase3_resilience.py
@@ -1,10 +1,11 @@
 import pytest
-from coreason_manifest.builder import NewLinearFlow, NewGraphFlow, create_supervision
-from coreason_manifest.spec.core.engines import Supervision, ReasoningEngine, Reflex
-from coreason_manifest.spec.core.nodes import AgentNode, Brain
-from coreason_manifest.utils.validator import validate_flow
 
-def test_builder_integration_circuit_breaker():
+from coreason_manifest.builder import NewGraphFlow, NewLinearFlow, create_supervision
+from coreason_manifest.spec.core.engines import Supervision
+from coreason_manifest.spec.core.nodes import AgentNode, Brain
+
+
+def test_builder_integration_circuit_breaker() -> None:
     # Linear Flow
     lf = NewLinearFlow(name="Test Linear")
     lf.set_circuit_breaker(error_threshold=5, reset_timeout=30)
@@ -14,13 +15,8 @@ def test_builder_integration_circuit_breaker():
         id="dummy_linear",
         metadata={},
         supervision=None,
-        brain=Brain(
-            role="dummy",
-            persona="dummy",
-            reasoning=None,
-            reflex=None
-        ),
-        tools=[]
+        brain=Brain(role="dummy", persona="dummy", reasoning=None, reflex=None),
+        tools=[],
     )
     lf.add_step(node)
 
@@ -40,13 +36,8 @@ def test_builder_integration_circuit_breaker():
         id="dummy",
         metadata={},
         supervision=None,
-        brain=Brain(
-            role="dummy",
-            persona="dummy",
-            reasoning=None,
-            reflex=None
-        ),
-        tools=[]
+        brain=Brain(role="dummy", persona="dummy", reasoning=None, reflex=None),
+        tools=[],
     )
     gf.add_node(node_g)
 
@@ -58,7 +49,7 @@ def test_builder_integration_circuit_breaker():
     assert flow_g.governance.circuit_breaker.fallback_node_id == "fallback"
 
 
-def test_supervision_logic():
+def test_supervision_logic() -> None:
     # Manual creation
     sup = Supervision(
         strategy="degrade",
@@ -66,7 +57,7 @@ def test_supervision_logic():
         fallback=None,
         retry_delay_seconds=1.5,
         backoff_factor=2.5,
-        default_payload={"status": "mock"}
+        default_payload={"status": "mock"},
     )
 
     assert sup.strategy == "degrade"
@@ -76,13 +67,7 @@ def test_supervision_logic():
     assert sup.default_payload == {"status": "mock"}
 
     # Helper creation
-    sup2 = create_supervision(
-        retries=2,
-        strategy="escalate",
-        backoff=3.0,
-        delay=0.5,
-        default=None
-    )
+    sup2 = create_supervision(retries=2, strategy="escalate", backoff=3.0, delay=0.5, default=None)
     assert sup2.strategy == "escalate"
     assert sup2.max_retries == 2
     assert sup2.backoff_factor == 3.0
@@ -90,67 +75,54 @@ def test_supervision_logic():
     assert sup2.default_payload is None
 
 
-def test_validator_catch_degrade_missing_payload():
+def test_validator_catch_degrade_missing_payload() -> None:
     sup = Supervision(
         strategy="degrade",
         max_retries=3,
         fallback=None,
-        default_payload=None # Invalid for degrade
+        default_payload=None,  # Invalid for degrade
     )
 
     node = AgentNode(
         id="node1",
         metadata={},
         supervision=sup,
-        brain=Brain(
-            role="tester",
-            persona="tester",
-            reasoning=None,
-            reflex=None
-        ),
-        tools=[]
+        brain=Brain(role="tester", persona="tester", reasoning=None, reflex=None),
+        tools=[],
     )
 
     lf = NewLinearFlow(name="Invalid Flow")
     lf.add_step(node)
 
     # Validation is called in build()
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match=r"Node 'node1' is set to 'degrade' but missing 'default_payload'\."):
         lf.build()
 
-    assert "Node 'node1' is set to 'degrade' but missing 'default_payload'." in str(excinfo.value)
 
-
-def test_validator_catch_invalid_backoff():
+def test_validator_catch_invalid_backoff() -> None:
     sup = Supervision(
         strategy="restart",
         max_retries=3,
         fallback=None,
-        backoff_factor=0.5 # Invalid < 1.0
+        backoff_factor=0.5,  # Invalid < 1.0
     )
 
     node = AgentNode(
         id="node2",
         metadata={},
         supervision=sup,
-        brain=Brain(
-            role="tester",
-            persona="tester",
-            reasoning=None,
-            reflex=None
-        ),
-        tools=[]
+        brain=Brain(role="tester", persona="tester", reasoning=None, reflex=None),
+        tools=[],
     )
 
     lf = NewLinearFlow(name="Invalid Flow Backoff")
     lf.add_step(node)
 
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match=r"backoff_factor must be >= 1\.0"):
         lf.build()
 
-    assert "backoff_factor must be >= 1.0" in str(excinfo.value)
 
-def test_builder_integration_governance_update():
+def test_builder_integration_governance_update() -> None:
     # Test setting circuit breaker when governance already exists
     from coreason_manifest.spec.core.governance import Governance
 
@@ -164,7 +136,7 @@ def test_builder_integration_governance_update():
         metadata={},
         supervision=None,
         brain=Brain(role="dummy", persona="dummy", reasoning=None, reflex=None),
-        tools=[]
+        tools=[],
     )
     lf.add_step(node)
 
@@ -180,7 +152,7 @@ def test_builder_integration_governance_update():
     gf.set_governance(Governance(timeout_seconds=60))
     gf.set_circuit_breaker(error_threshold=2, reset_timeout=10)
 
-    gf.add_node(node) # Use same dummy node
+    gf.add_node(node)  # Use same dummy node
 
     flow_g = gf.build()
     assert flow_g.governance is not None


### PR DESCRIPTION
Implements Phase 3 of the coreason-manifest refactor: Resilience.
1. Updated engines.py: Added 'degrade' strategy, retry_delay_seconds, backoff_factor, default_payload to Supervision.
2. Updated governance.py: Added CircuitBreaker class and updated Governance.
3. Updated builder.py: Added create_supervision helper and set_circuit_breaker method to Flow builders.
4. Updated validator.py: Added validation for supervision (degrade strategy and backoff factor).
5. Added tests/test_phase3_resilience.py for verification.

---
*PR created automatically by Jules for task [14139985838121507970](https://jules.google.com/task/14139985838121507970) started by @gowthamrao*