### PR TITLE
Replace ReasoningEngine with polymorphic SOTA Cognitive Architectures

### DIFF
--- a/docs/architecture/ADR-002-flow-topology.md
+++ b/docs/architecture/ADR-002-flow-topology.md
@@ -20,7 +20,7 @@ We are adopting standard terminology from Multi-Agent Systems, Actor Model, and 
 | `ManifestV2` | `LinearFlow` | A deterministic script must be a "Sequence". |
 | `RecipeDefinition` | `GraphFlow` | Explicitly describes the Cyclic Graph structure. |
 | `StateDefinition` | `Blackboard` | "Blackboard Pattern" implies shared multi-agent memory. |
-| `Episteme` | `ReasoningEngine` | System 2 slow-thinking logic. |
+| `Episteme` | `ReasoningConfig` | System 2 slow-thinking logic. |
 | `Cortex` | `Reflex` | System 1 fast-response logic. |
 | `Maco` | `Supervision` | "Supervisor Pattern" (Erlang) > "Error Handling". |
 | `Foundry` | `Optimizer` | DSPy-style self-improvement/compilation. |

--- a/docs/reference/agents.md
+++ b/docs/reference/agents.md
@@ -9,13 +9,13 @@ This example demonstrates the configuration of an `AgentNode` with specific capa
 ```python
 # Example: Defining a Support Agent with Semantic Model Constraints
 from coreason_manifest.spec.core.nodes import AgentNode, Brain
-from coreason_manifest.spec.core.engines import ReasoningEngine, Reflex, Supervision
+from coreason_manifest.spec.core.engines import StandardReasoning, Reflex, Supervision
 
 # Define the Cognitive Engine
 brain = Brain(
     role="Customer Service Representative",
     persona="You are a helpful assistant with 10 years of experience.",
-    reasoning=ReasoningEngine(
+    reasoning=StandardReasoning(
         model="gpt-4-turbo",
         thoughts_max=3,
         min_confidence=0.8
@@ -50,7 +50,13 @@ support_agent = AgentNode(
 
 ### Engines
 
-::: coreason_manifest.spec.core.engines.ReasoningEngine
+::: coreason_manifest.spec.core.engines.StandardReasoning
+
+::: coreason_manifest.spec.core.engines.TreeSearchReasoning
+
+::: coreason_manifest.spec.core.engines.AtomReasoning
+
+::: coreason_manifest.spec.core.engines.CouncilReasoning
 
 ::: coreason_manifest.spec.core.engines.Reflex
 

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -13,10 +13,15 @@ from coreason_manifest.builder import (
     NewLinearFlow,
 )
 from coreason_manifest.spec.core.engines import (
+    AtomReasoning,
+    BaseReasoning,
+    CouncilReasoning,
     Optimizer,
-    ReasoningEngine,
+    ReasoningConfig,
     Reflex,
+    StandardReasoning,
     Supervision,
+    TreeSearchReasoning,
 )
 from coreason_manifest.spec.core.flow import (
     AnyNode,
@@ -51,9 +56,12 @@ from coreason_manifest.spec.core.tools import (
 __all__ = [
     "AgentNode",
     "AnyNode",
+    "AtomReasoning",
     "Audit",
+    "BaseReasoning",
     "Blackboard",
     "Brain",
+    "CouncilReasoning",
     "Dependency",
     "Edge",
     "FlowInterface",
@@ -69,11 +77,13 @@ __all__ = [
     "Optimizer",
     "Placeholder",
     "PlannerNode",
-    "ReasoningEngine",
+    "ReasoningConfig",
     "Reflex",
     "Safety",
+    "StandardReasoning",
     "Supervision",
     "SwitchNode",
     "ToolPack",
+    "TreeSearchReasoning",
     "VariableDef",
 ]

--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -10,7 +10,12 @@
 
 from typing import Any
 
-from coreason_manifest.spec.core.engines import ReasoningEngine, Reflex, Supervision
+from coreason_manifest.spec.core.engines import (
+    ReasoningConfig,
+    Reflex,
+    StandardReasoning,
+    Supervision,
+)
 from coreason_manifest.spec.core.flow import (
     AnyNode,
     Blackboard,
@@ -54,7 +59,7 @@ class AgentBuilder:
         self.agent_id = agent_id
         self.role: str | None = None
         self.persona: str | None = None
-        self.reasoning: ReasoningEngine | None = None
+        self.reasoning: ReasoningConfig | None = None
         self.reflex: Reflex | None = None
         self.tools: list[str] = []
         self.supervision: Supervision | None = None
@@ -66,8 +71,8 @@ class AgentBuilder:
         return self
 
     def with_reasoning(self, model: str, thoughts_max: int = 5, min_confidence: float = 0.7) -> "AgentBuilder":
-        """Configures Brain.reasoning."""
-        self.reasoning = ReasoningEngine(model=model, thoughts_max=thoughts_max, min_confidence=min_confidence)
+        """Configures Brain.reasoning (Standard CoT)."""
+        self.reasoning = StandardReasoning(model=model, thoughts_max=thoughts_max, min_confidence=min_confidence)
         return self
 
     def with_reflex(self, model: str, timeout_ms: int = 1000, caching: bool = True) -> "AgentBuilder":

--- a/src/coreason_manifest/spec/core/engines.py
+++ b/src/coreason_manifest/spec/core/engines.py
@@ -1,43 +1,110 @@
-from typing import Any, Literal
+from typing import Annotated, Any, Literal, Union
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class ReasoningEngine(BaseModel):
-    """Configuration for deep thought."""
+class BaseReasoning(BaseModel):
+    """Base configuration for System 2 cognitive processes."""
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    model: str
-    thoughts_max: int
-    min_confidence: float
+    model: str = Field(..., description="The model ID responsible for this reasoning loop.")
+    temperature: float = Field(0.0, description="Sampling temperature (0.0 for deterministic).")
+    max_tokens: int | None = Field(None, description="Hard limit on reasoning tokens.")
+
+
+class StandardReasoning(BaseReasoning):
+    """Linear Chain-of-Thought (CoT) execution."""
+
+    type: Literal["standard"] = "standard"
+    thoughts_max: int = Field(..., description="Maximum number of sequential reasoning steps.")
+    min_confidence: float = Field(0.7, description="Minimum confidence score to proceed.")
+
+
+class TreeSearchReasoning(BaseReasoning):
+    """
+    Language Agent Tree Search (LATS) implementation.
+    Uses Monte Carlo Tree Search (MCTS) to simulate outcomes before acting.
+    """
+
+    type: Literal["tree_search"] = "tree_search"
+
+    depth: int = Field(3, description="Maximum depth of the search tree.")
+    branching_factor: int = Field(3, description="Number of candidate actions to generate per node.")
+    simulations: int = Field(5, description="Number of MCTS simulations to run.")
+    exploration_weight: float = Field(1.41, description="UCT exploration term (default 1.41).")
+    evaluator_model: str | None = Field(None, description="Model used to value/score leaf nodes.")
+
+
+class AtomReasoning(BaseReasoning):
+    """
+    Atom of Thoughts (AoT) strategy.
+    Decomposes problems into a DAG and iteratively 'contracts' context
+    to maintain efficiency akin to a Markov process.
+    """
+
+    type: Literal["atom"] = "atom"
+
+    decomposition_breadth: int = Field(..., description="Max parallel sub-thoughts to spawn.")
+    contract_every_steps: int = Field(2, description="Frequency of condensing the active context.")
+    global_context_window: int = Field(4096, description="Rolling window size for the active atom path.")
+
+
+class CouncilReasoning(BaseReasoning):
+    """
+    Multi-Persona Consensus (SPIO) strategy.
+    Orchestrates a debate or voting protocol among diverse personas.
+    """
+
+    type: Literal["council"] = "council"
+
+    personas: list[str] = Field(..., description="List of system prompts/personas to comprise the council.")
+    proposal_count: int = Field(1, description="Number of independent proposals each persona generates.")
+    voting_mode: Literal["unanimous", "majority", "weighted"] = Field(
+        "majority", description="Protocol for selecting the winning trajectory."
+    )
+    rounds: int = Field(1, description="Max debate rounds before forced voting.")
+
+
+# -------------------------------------------------------------------------
+# POLYMORPHIC UNION
+# -------------------------------------------------------------------------
+ReasoningConfig = Annotated[
+    Union[StandardReasoning, TreeSearchReasoning, AtomReasoning, CouncilReasoning],
+    Field(discriminator="type"),
+]
 
 
 class Reflex(BaseModel):
-    """Configuration for fast action."""
+    """Configuration for System 1 (Fast) reactions."""
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
     model: str
     timeout_ms: int
-    caching: bool
+    caching: bool = True
 
 
 class Supervision(BaseModel):
-    """The fault-tolerance config."""
+    """Oversight and Fault Tolerance."""
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    strategy: Literal["resume", "restart", "escalate", "degrade"]
+    strategy: Literal["resume", "restart", "escalate", "degrade", "adversarial"]
     max_retries: int
     fallback: str | None
+
+    # Adversarial / Critic Configuration
+    critic_model: str | None = Field(None, description="Model used for adversarial review if strategy='adversarial'.")
+    critic_prompt: str | None = None
+
     retry_delay_seconds: float = 1.0
     backoff_factor: float = 2.0
     default_payload: dict[str, Any] | None = None
 
 
 class Optimizer(BaseModel):
-    """Self-improvement config."""
+    """Self-Improvement / DSPy-style optimization."""
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 

--- a/src/coreason_manifest/spec/core/engines.py
+++ b/src/coreason_manifest/spec/core/engines.py
@@ -1,4 +1,4 @@
-from typing import Annotated, Any, Literal, Union
+from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -70,7 +70,7 @@ class CouncilReasoning(BaseReasoning):
 # POLYMORPHIC UNION
 # -------------------------------------------------------------------------
 ReasoningConfig = Annotated[
-    Union[StandardReasoning, TreeSearchReasoning, AtomReasoning, CouncilReasoning],
+    StandardReasoning | TreeSearchReasoning | AtomReasoning | CouncilReasoning,
     Field(discriminator="type"),
 ]
 

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel, ConfigDict, Field
 
 from coreason_manifest.spec.core.engines import (
     Optimizer,
-    ReasoningEngine,
+    ReasoningConfig,
     Reflex,
     Supervision,
 )
@@ -28,7 +28,7 @@ class Brain(BaseModel):
 
     role: str
     persona: str
-    reasoning: ReasoningEngine | None
+    reasoning: ReasoningConfig | None
     reflex: Reflex | None
 
 

--- a/tests/test_adapters_phase4.py
+++ b/tests/test_adapters_phase4.py
@@ -1,6 +1,6 @@
 import pytest
 
-from coreason_manifest.spec.core.engines import ReasoningEngine
+from coreason_manifest.spec.core.engines import StandardReasoning
 from coreason_manifest.spec.core.flow import Edge, FlowInterface, FlowMetadata, Graph, GraphFlow, LinearFlow
 from coreason_manifest.spec.core.nodes import AgentNode, Brain
 from coreason_manifest.spec.core.tools import ToolPack
@@ -24,7 +24,7 @@ def test_openai_adapter() -> None:
     brain = Brain(
         role="assistant",
         persona="helpful",
-        reasoning=ReasoningEngine(model="gpt-4o", thoughts_max=10, min_confidence=0.5),
+        reasoning=StandardReasoning(model="gpt-4o", thoughts_max=10, min_confidence=0.5),
         reflex=None,
     )
     node = AgentNode(id="agent1", metadata={}, supervision=None, type="agent", brain=brain, tools=["calculator"])
@@ -54,7 +54,7 @@ def test_langchain_adapter() -> None:
     brain = Brain(
         role="assistant",
         persona="helpful",
-        reasoning=ReasoningEngine(model="gpt-4o", thoughts_max=10, min_confidence=0.5),
+        reasoning=StandardReasoning(model="gpt-4o", thoughts_max=10, min_confidence=0.5),
         reflex=None,
     )
     node1 = AgentNode(id="agent1", metadata={}, supervision=None, type="agent", brain=brain, tools=["calculator"])

--- a/tests/test_core_kernel.py
+++ b/tests/test_core_kernel.py
@@ -123,21 +123,10 @@ def test_core_kernel_instantiation() -> None:
 def test_polymorphic_reasoning() -> None:
     # Test TreeSearchReasoning
     lats_reasoning = TreeSearchReasoning(
-        model="gpt-4",
-        depth=5,
-        branching_factor=4,
-        simulations=10,
-        exploration_weight=1.5
+        model="gpt-4", depth=5, branching_factor=4, simulations=10, exploration_weight=1.5
     )
     brain = Brain(role="solver", persona="math", reasoning=lats_reasoning, reflex=None)
-    agent = AgentNode(
-        id="agent-lats",
-        metadata={},
-        supervision=None,
-        type="agent",
-        brain=brain,
-        tools=[]
-    )
+    agent = AgentNode(id="agent-lats", metadata={}, supervision=None, type="agent", brain=brain, tools=[])
 
     # Validate JSON serialization/deserialization for LATS
     agent_json = agent.model_dump_json()

--- a/tests/test_phase5_builder.py
+++ b/tests/test_phase5_builder.py
@@ -1,6 +1,7 @@
 import pytest
 
 from coreason_manifest.builder import AgentBuilder, NewGraphFlow
+from coreason_manifest.spec.core.engines import StandardReasoning
 
 
 def test_fluent_agent_construction() -> None:
@@ -25,6 +26,7 @@ def test_fluent_agent_construction() -> None:
 
     # Verify Reasoning
     assert agent.brain.reasoning is not None
+    assert isinstance(agent.brain.reasoning, StandardReasoning)
     assert agent.brain.reasoning.model == "gpt-4o"
     assert agent.brain.reasoning.thoughts_max == 5  # default
 


### PR DESCRIPTION
This PR replaces the generic `ReasoningEngine` with a State-of-the-Art (SOTA) Cognitive Architecture. It introduces a polymorphic `ReasoningConfig` that supports:
- **StandardReasoning:** Basic Chain-of-Thought (CoT).
- **TreeSearchReasoning:** Language Agent Tree Search (LATS) using MCTS.
- **AtomReasoning:** Atom of Thoughts (AoT) strategy with DAG decomposition.
- **CouncilReasoning:** Multi-Persona Consensus (SPIO) strategy.

The changes include updates to `engines.py`, `nodes.py`, `builder.py`, and relevant tests. `Supervision` was also updated to include an `adversarial` strategy.

---
*PR created automatically by Jules for task [12493528018633353188](https://jules.google.com/task/12493528018633353188) started by @gowthamrao*