### PR TITLE
Greenfield Refactor Phase 2: Strict Pydantic v2 Architecture

### DIFF
--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -213,7 +213,7 @@ class BaseFlowBuilder:
 class NewLinearFlow(BaseFlowBuilder):
     """Fluent API to construct LinearFlows programmatically."""
 
-    def __init__(self, name: str, version: str = "0.1", description: str = "") -> None:
+    def __init__(self, name: str, version: str = "0.1.0", description: str = "") -> None:
         super().__init__(name, version, description)
         self.sequence: list[AnyNode] = []
 
@@ -280,7 +280,7 @@ class NewLinearFlow(BaseFlowBuilder):
 class NewGraphFlow(BaseFlowBuilder):
     """Fluent API to construct GraphFlows programmatically."""
 
-    def __init__(self, name: str, version: str = "0.1", description: str = "") -> None:
+    def __init__(self, name: str, version: str = "0.1.0", description: str = "") -> None:
         super().__init__(name, version, description)
         self._nodes: dict[str, AnyNode] = {}
         self._edges: list[Edge] = []

--- a/src/coreason_manifest/spec/common_base.py
+++ b/src/coreason_manifest/spec/common_base.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import json
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict
+
+
+class CoreasonModel(BaseModel):
+    """
+    Base class for all domain models in the Coreason Manifest.
+
+    Enforces:
+    1. Immutability (frozen=True) - Essential for distributed state consistency.
+    2. Strict validation (strict=True) - No silent coercion.
+    3. Forbidden extra fields (extra='forbid') - Schema strictness.
+    4. Deterministic serialization - Keys are sorted for hash consistency.
+    """
+
+    model_config = ConfigDict(
+        frozen=True,
+        extra="forbid",
+        strict=True,
+        populate_by_name=True,  # Allow using field names or aliases
+    )
+
+    def model_dump_json(self, **kwargs: Any) -> str:
+        """
+        Overrides the default JSON dump to enforce deterministic output.
+        We serialize to a dict first, then use json.dumps with sort_keys=True.
+        """
+        # Extract json.dumps specific arguments
+        indent = kwargs.pop("indent", None)
+
+        # Ensure round_trip is True unless explicitly overridden (which we discourage)
+        if "round_trip" not in kwargs:
+            kwargs["round_trip"] = True
+
+        # Dump to python dict first
+        # We pass remaining kwargs (like include, exclude, by_alias) to model_dump
+        data = self.model_dump(mode="json", **kwargs)
+
+        # Use json.dumps to ensure key sorting
+        return json.dumps(data, sort_keys=True, ensure_ascii=False, indent=indent)

--- a/src/coreason_manifest/spec/common_base.py
+++ b/src/coreason_manifest/spec/common_base.py
@@ -11,7 +11,7 @@
 import json
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class CoreasonModel(BaseModel):
@@ -32,6 +32,45 @@ class CoreasonModel(BaseModel):
         populate_by_name=True,  # Allow using field names or aliases
     )
 
+    # Storage for unknown fields caught by the funnel
+    annotations: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _funnel_unknown_fields(cls, data: Any) -> Any:
+        """Intercepts the raw dict before instantiation to funnel unknown keys safely."""
+        if isinstance(data, dict):
+            # SOTA Fix: Must account for both field names AND aliases
+            known_keys = set()
+            for name, field in cls.model_fields.items():
+                known_keys.add(name)
+                if field.alias:
+                    known_keys.add(field.alias)
+                # Account for complex validation aliases
+                if field.validation_alias:
+                    if isinstance(field.validation_alias, str):
+                        known_keys.add(field.validation_alias)
+                    elif hasattr(field.validation_alias, "choices"):
+                        for choice in getattr(field.validation_alias, "choices", []):
+                            if isinstance(choice, str):
+                                known_keys.add(choice)
+
+            annotations = data.get("annotations", {})
+            keys_to_remove = []
+
+            for key, value in data.items():
+                if key not in known_keys and key != "annotations":
+                    annotations[key] = value
+                    keys_to_remove.append(key)
+
+            for key in keys_to_remove:
+                del data[key]
+
+            if annotations:
+                data["annotations"] = annotations
+
+        return data
+
     def model_dump_json(self, **kwargs: Any) -> str:
         """
         Overrides the default JSON dump to enforce deterministic output.
@@ -50,3 +89,28 @@ class CoreasonModel(BaseModel):
 
         # Use json.dumps to ensure key sorting
         return json.dumps(data, sort_keys=True, ensure_ascii=False, indent=indent)
+
+    def model_dump_canonical(self) -> bytes:
+        """RFC-8785 strict canonical serialization for cryptographic hashing."""
+        raw_dict = self.model_dump(mode="json", exclude_none=True, by_alias=True)
+
+        # SOTA Fix: Recursively sort lists to prevent non-deterministic set-to-list casting
+        def _sort_collections(obj: Any) -> Any:
+            if isinstance(obj, dict):
+                return {k: _sort_collections(v) for k, v in obj.items()}
+            if isinstance(obj, list):
+                # Try to sort, fallback to original if elements are unorderable dicts
+                try:
+                    return sorted(_sort_collections(v) for v in obj)
+                except TypeError:
+                    return [_sort_collections(v) for v in obj]
+            return obj
+
+        canonical_dict = _sort_collections(raw_dict)
+
+        return json.dumps(
+            canonical_dict,
+            ensure_ascii=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode("utf-8")

--- a/src/coreason_manifest/spec/core/flow.py
+++ b/src/coreason_manifest/spec/core/flow.py
@@ -22,7 +22,13 @@ from coreason_manifest.spec.core.nodes import (
 )
 from coreason_manifest.spec.core.resilience import SupervisionPolicy
 from coreason_manifest.spec.core.tools import ToolPack
-from coreason_manifest.spec.core.types import NodeID, ProfileID, SemanticVersion, VariableID
+from coreason_manifest.spec.core.types import (
+    CoercibleStringList,
+    NodeID,
+    ProfileID,
+    SemanticVersion,
+    VariableID,
+)
 from coreason_manifest.spec.interop.compliance import RemediationAction
 
 # Polymorphic Node Type
@@ -47,7 +53,7 @@ class FlowMetadata(CoreasonModel):
     description: str = Field(
         ..., description="Description of what the flow does.", examples=["A flow that scrapes and summarizes."]
     )
-    tags: list[str] = Field(
+    tags: CoercibleStringList = Field(
         default_factory=list, description="Tags for categorization.", examples=[["research", "scraper"]]
     )
 
@@ -316,8 +322,14 @@ class Manifest(RootModel[ManifestType]):
     root: ManifestType
 
     @classmethod
-    def export_json_schema(cls) -> dict[str, Any]:
-        """
-        Dumps a structurally perfect OpenAPI/JSON-Schema representation of the library.
-        """
-        return cls.model_json_schema()
+    def export_json_schema(cls) -> str:
+        """Exports a pristine, IDE-ready JSON Schema resolving deep $defs."""
+        import json
+
+        schema = cls.model_json_schema(by_alias=True)
+
+        # Inject standard JSON Schema meta-tags for SOTA LSP compliance
+        schema["$schema"] = "http://json-schema.org/draft-07/schema#"
+        schema["title"] = "Coreason Manifest Specification v2"
+
+        return json.dumps(schema, indent=2)

--- a/src/coreason_manifest/spec/core/flow.py
+++ b/src/coreason_manifest/spec/core/flow.py
@@ -3,8 +3,9 @@ from typing import Annotated, Any, Literal
 
 import jsonschema
 from jsonschema.exceptions import SchemaError
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import Field, RootModel, model_validator
 
+from coreason_manifest.spec.common_base import CoreasonModel
 from coreason_manifest.spec.core.engines import AttentionReasoning
 from coreason_manifest.spec.core.exceptions import DomainValidationError
 from coreason_manifest.spec.core.governance import Governance
@@ -21,6 +22,7 @@ from coreason_manifest.spec.core.nodes import (
 )
 from coreason_manifest.spec.core.resilience import SupervisionPolicy
 from coreason_manifest.spec.core.tools import ToolPack
+from coreason_manifest.spec.core.types import NodeID, ProfileID, SemanticVersion, VariableID
 from coreason_manifest.spec.interop.compliance import RemediationAction
 
 # Polymorphic Node Type
@@ -37,29 +39,26 @@ AnyNode = Annotated[
 ]
 
 
-class FlowMetadata(BaseModel):
+class FlowMetadata(CoreasonModel):
     """Standard metadata fields."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    name: str
-    version: str
-    description: str
-    tags: list[str]
+    name: str = Field(..., description="Name of the flow.", examples=["My Agent Flow"])
+    version: SemanticVersion = Field(..., description="Semantic version.", examples=["1.0.0"])
+    description: str = Field(..., description="Description of what the flow does.", examples=["A flow that scrapes and summarizes."])
+    tags: list[str] = Field(default_factory=list, description="Tags for categorization.", examples=[["research", "scraper"]])
 
 
-class DataSchema(BaseModel):
+class DataSchema(CoreasonModel):
     """
     Strict data contract for inputs/outputs.
     Mandate 5: Contract-First Data I/O.
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     schema_ref: Annotated[str | None, Field(description="URI to JSON Schema")] = None
     json_schema: dict[str, Any] | bool = Field(
         default_factory=dict,
         description="Full JSON Schema (Draft 7) definition for validation.",
+        examples=[{"type": "object", "properties": {"query": {"type": "string"}}}]
     )
 
     @model_validator(mode="before")
@@ -97,22 +96,12 @@ class DataSchema(BaseModel):
                 final_error_msg = f"Invalid JSON Schema{path_str}: {error_msg}"
 
                 # SOTA: Attempt Healing (Stubbed)
-                # We package the error into an AttentionReasoning payload for future LLM repair.
-                # Since we cannot call LLM here, we stub the hook and fail with high-fidelity diagnostics.
-
-                # 1. Instantiate the repair configuration (Stubbed usage)
                 _repair_config = AttentionReasoning(
                     model="gpt-4-turbo",  # Default repair model
                     attention_mode="rephrase",
                     focus_model="gpt-3.5-turbo",
                 )
 
-                # 2. Stubbed Hook
-                # In a real system, we would call: _attempt_repair(schema, error_msg, _repair_config)
-                # and if it returns a repaired schema, use it.
-
-                # 3. Raise DomainValidationError with context
-                # Package repair intent as requested in Fix 3
                 raise DomainValidationError(
                     message=final_error_msg,
                     remediation=RemediationAction(
@@ -127,51 +116,43 @@ class DataSchema(BaseModel):
         return data
 
 
-class FlowInterface(BaseModel):
+class FlowInterface(CoreasonModel):
     """Input/Output JSON schema contracts."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    inputs: DataSchema
-    outputs: DataSchema
+    inputs: DataSchema = Field(..., description="Input schema.")
+    outputs: DataSchema = Field(..., description="Output schema.")
 
 
-class VariableDef(BaseModel):
+class VariableDef(CoreasonModel):
     """Definition of a blackboard variable."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    type: str
-    description: str | None = None
+    type: str = Field(..., description="Data type description.", examples=["string", "list[str]"])
+    description: str | None = Field(None, description="Description of the variable usage.", examples=["User query"])
 
 
-class Blackboard(BaseModel):
+class Blackboard(CoreasonModel):
     """Shared, observable memory space."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    variables: dict[VariableID, VariableDef] = Field(
+        ..., description="Variables defined in the blackboard.", examples=[{"query": {"type": "string"}}]
+    )
+    persistence: bool = Field(False, description="Whether state persists across sessions.")
 
-    variables: dict[str, VariableDef]
-    persistence: bool
 
-
-class Edge(BaseModel):
+class Edge(CoreasonModel):
     """Directed connection between nodes."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    source: str
-    target: str
-    condition: str | None = None
+    source: NodeID = Field(..., description="Source node ID.", examples=["start"])
+    target: NodeID = Field(..., description="Target node ID.", examples=["end"])
+    condition: str | None = Field(None, description="Condition expression for traversal.", examples=["result == 'success'"])
 
 
-class Graph(BaseModel):
+class Graph(CoreasonModel):
     """Directed execution graph."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    nodes: dict[str, AnyNode]
-    edges: list[Edge]
-    entry_point: str = Field(..., description="The ID of the starting node.")
+    nodes: dict[NodeID, AnyNode] = Field(..., description="Map of Node ID to Node configuration.")
+    edges: list[Edge] = Field(..., description="List of directed edges.")
+    entry_point: NodeID = Field(..., description="The ID of the starting node.", examples=["start"])
 
     @model_validator(mode="after")
     def validate_graph_structure(self) -> "Graph":
@@ -206,22 +187,15 @@ class Graph(BaseModel):
         if self.entry_point not in node_ids:
             raise ValueError(f"Entry point '{self.entry_point}' not found in nodes.")
 
-        # SOTA Directive 2: Decoupled Topological Governance.
-        # We NO LONGER enforce reachability or acyclic properties in the structural parser.
-        # This allows "utility islands" and complex cyclic patterns to exist syntactically.
-        # Policy enforcement (e.g. banning dead code) is now the sole responsibility of the Gatekeeper.
 
-
-class FlowDefinitions(BaseModel):
+class FlowDefinitions(CoreasonModel):
     """
     Registry for reusable components (The Blueprint).
     Separates 'definition' from 'usage' to reduce payload size.
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     # Maps ID -> Configuration
-    profiles: dict[str, CognitiveProfile] = Field(
+    profiles: dict[ProfileID, CognitiveProfile] = Field(
         default_factory=dict, description="Reusable cognitive configurations."
     )
     tool_packs: dict[str, ToolPack] = Field(default_factory=dict, description="Reusable tool dependencies.")
@@ -274,16 +248,14 @@ def validate_integrity(definitions: FlowDefinitions | None, nodes: Iterable[AnyN
                 )
 
 
-class LinearFlow(BaseModel):
+class LinearFlow(CoreasonModel):
     """A deterministic script."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    kind: Literal["LinearFlow"]
+    kind: Literal["LinearFlow"] = "LinearFlow"
     status: Annotated[Literal["draft", "published", "archived"], Field(description="Life-cycle state.")] = "draft"
-    metadata: FlowMetadata
+    metadata: FlowMetadata = Field(..., description="Metadata for the flow.")
     definitions: Annotated[FlowDefinitions | None, Field(description="Shared registry for reusable components.")] = None
-    sequence: list[AnyNode]
+    sequence: list[AnyNode] = Field(..., description="Ordered list of nodes to execute.")
     governance: Annotated[Governance | None, Field(description="Governance policy.")] = None
 
     @model_validator(mode="after")
@@ -295,18 +267,16 @@ class LinearFlow(BaseModel):
         return self
 
 
-class GraphFlow(BaseModel):
+class GraphFlow(CoreasonModel):
     """Cyclic Graph structure."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    kind: Literal["GraphFlow"]
+    kind: Literal["GraphFlow"] = "GraphFlow"
     status: Annotated[Literal["draft", "published", "archived"], Field(description="Life-cycle state.")] = "draft"
-    metadata: FlowMetadata
+    metadata: FlowMetadata = Field(..., description="Metadata for the flow.")
     definitions: Annotated[FlowDefinitions | None, Field(description="Shared registry for reusable components.")] = None
-    interface: FlowInterface
-    blackboard: Blackboard | None
-    graph: Graph
+    interface: FlowInterface = Field(..., description="Input/Output contract.")
+    blackboard: Blackboard | None = Field(None, description="Shared memory configuration.")
+    graph: Graph = Field(..., description="The execution graph.")
     governance: Annotated[Governance | None, Field(description="Governance policy.")] = None
 
     @model_validator(mode="after")
@@ -326,3 +296,18 @@ class GraphFlow(BaseModel):
         is_published = self.status == "published"
         self.graph.verify_integrity(strict=is_published)
         return self
+
+
+class Manifest(RootModel):
+    """
+    The Sovereign Domain Gatekeeper.
+    Wrapper around any valid Flow type.
+    """
+    root: Annotated[LinearFlow | GraphFlow, Field(discriminator="kind")]
+
+    @classmethod
+    def export_json_schema(cls) -> dict[str, Any]:
+        """
+        Dumps a structurally perfect OpenAPI/JSON-Schema representation of the library.
+        """
+        return cls.model_json_schema()

--- a/src/coreason_manifest/spec/core/flow.py
+++ b/src/coreason_manifest/spec/core/flow.py
@@ -44,8 +44,12 @@ class FlowMetadata(CoreasonModel):
 
     name: str = Field(..., description="Name of the flow.", examples=["My Agent Flow"])
     version: SemanticVersion = Field(..., description="Semantic version.", examples=["1.0.0"])
-    description: str = Field(..., description="Description of what the flow does.", examples=["A flow that scrapes and summarizes."])
-    tags: list[str] = Field(default_factory=list, description="Tags for categorization.", examples=[["research", "scraper"]])
+    description: str = Field(
+        ..., description="Description of what the flow does.", examples=["A flow that scrapes and summarizes."]
+    )
+    tags: list[str] = Field(
+        default_factory=list, description="Tags for categorization.", examples=[["research", "scraper"]]
+    )
 
 
 class DataSchema(CoreasonModel):
@@ -58,7 +62,7 @@ class DataSchema(CoreasonModel):
     json_schema: dict[str, Any] | bool = Field(
         default_factory=dict,
         description="Full JSON Schema (Draft 7) definition for validation.",
-        examples=[{"type": "object", "properties": {"query": {"type": "string"}}}]
+        examples=[{"type": "object", "properties": {"query": {"type": "string"}}}],
     )
 
     @model_validator(mode="before")
@@ -144,7 +148,9 @@ class Edge(CoreasonModel):
 
     source: NodeID = Field(..., description="Source node ID.", examples=["start"])
     target: NodeID = Field(..., description="Target node ID.", examples=["end"])
-    condition: str | None = Field(None, description="Condition expression for traversal.", examples=["result == 'success'"])
+    condition: str | None = Field(
+        None, description="Condition expression for traversal.", examples=["result == 'success'"]
+    )
 
 
 class Graph(CoreasonModel):
@@ -298,12 +304,16 @@ class GraphFlow(CoreasonModel):
         return self
 
 
-class Manifest(RootModel):
+ManifestType = Annotated[LinearFlow | GraphFlow, Field(discriminator="kind")]
+
+
+class Manifest(RootModel[ManifestType]):
     """
     The Sovereign Domain Gatekeeper.
     Wrapper around any valid Flow type.
     """
-    root: Annotated[LinearFlow | GraphFlow, Field(discriminator="kind")]
+
+    root: ManifestType
 
     @classmethod
     def export_json_schema(cls) -> dict[str, Any]:

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -1,7 +1,7 @@
 import time
-from typing import Annotated, Any, Literal
+from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from coreason_manifest.spec.common_base import CoreasonModel
 from coreason_manifest.spec.core.types import NodeID, ToolID
@@ -167,7 +167,6 @@ def record_failure(node_id: str, policy: CircuitBreaker, state_store: dict[str, 
     state = state_store.get(node_id)
     if not state:
         state = CircuitState()
-        # state_store[node_id] = state # Wait, we need to update after modification if it was mutable, but now we create new
         # Just continue to calculate new state
 
     if state.state == "open":

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -1,49 +1,48 @@
 import time
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
+
+from coreason_manifest.spec.common_base import CoreasonModel
+from coreason_manifest.spec.core.types import NodeID, ToolID
 
 
-class Safety(BaseModel):
+class Safety(CoreasonModel):
     """Safety and filtering configuration."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    input_filtering: bool = Field(..., description="Enable input filtering.", examples=[True])
+    pii_redaction: bool = Field(..., description="Enable PII redaction.", examples=[True])
+    content_safety: Literal["high", "medium", "low"] = Field(
+        ..., description="Content safety level.", examples=["high"]
+    )
 
-    input_filtering: bool
-    pii_redaction: bool
-    content_safety: Literal["high", "medium", "low"]
 
-
-class Audit(BaseModel):
+class Audit(CoreasonModel):
     """Audit and logging configuration."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    trace_retention_days: int
-    log_payloads: bool
+    trace_retention_days: int = Field(..., description="Days to retain traces.", examples=[30])
+    log_payloads: bool = Field(..., description="Log full payloads.", examples=[False])
 
 
-class CircuitBreaker(BaseModel):
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    error_threshold_count: int = Field(..., description="Number of errors before opening the circuit.")
-    reset_timeout_seconds: int = Field(..., description="Seconds to wait before attempting half-open state.")
-    fallback_node_id: str | None = Field(None, description="Optional node to jump to when circuit opens.")
+class CircuitBreaker(CoreasonModel):
+    error_threshold_count: int = Field(..., description="Number of errors before opening the circuit.", examples=[5])
+    reset_timeout_seconds: int = Field(..., description="Seconds to wait before attempting half-open state.", examples=[60])
+    fallback_node_id: NodeID | None = Field(None, description="Optional node to jump to when circuit opens.", examples=["fallback_agent"])
 
 
-class ToolAccessPolicy(BaseModel):
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    risk_level: Literal["critical", "standard", "minimal"]
-    require_auth: bool | None = None
+class ToolAccessPolicy(CoreasonModel):
+    risk_level: Literal["critical", "standard", "minimal"] = Field(..., description="Risk level.", examples=["standard"])
+    require_auth: bool | None = Field(None, description="Require authentication.", examples=[True])
     allowed_roles: list[str] | None = Field(
-        None, description="If None, allow all. If list, allow only these. Empty list implies deny-all."
+        None, description="If None, allow all. If list, allow only these. Empty list implies deny-all.", examples=[["admin"]]
     )
 
     @model_validator(mode="before")
     @classmethod
     def set_defaults(cls, data: Any) -> Any:
         if isinstance(data, dict):
+            # Functional purity: copy data
+            data = data.copy()
             if data.get("risk_level") == "critical":
                 if data.get("require_auth") is False:
                     raise ValueError("Critical tools must require authentication.")
@@ -54,20 +53,18 @@ class ToolAccessPolicy(BaseModel):
         return data
 
 
-class Governance(BaseModel):
+class Governance(CoreasonModel):
     """Governance constraints and policies."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    rate_limit_rpm: int | None = None
-    timeout_seconds: int | None = None
-    cost_limit_usd: float | None = None
-    safety: Safety | None = None
-    audit: Audit | None = None
-    circuit_breaker: CircuitBreaker | None = None
-    tool_policy: dict[str, ToolAccessPolicy] | None = None
-    default_tool_policy: ToolAccessPolicy | None = None
-    allowed_domains: list[str] = Field(default_factory=list)
+    rate_limit_rpm: int | None = Field(None, description="Rate limit in requests per minute.", examples=[60])
+    timeout_seconds: int | None = Field(None, description="Global execution timeout.", examples=[300])
+    cost_limit_usd: float | None = Field(None, description="Cost limit in USD.", examples=[10.0])
+    safety: Safety | None = Field(None, description="Safety configuration.", examples=[{"input_filtering": True, "pii_redaction": True, "content_safety": "high"}])
+    audit: Audit | None = Field(None, description="Audit configuration.", examples=[{"trace_retention_days": 7, "log_payloads": True}])
+    circuit_breaker: CircuitBreaker | None = Field(None, description="Circuit breaker policy.", examples=[{"error_threshold_count": 3, "reset_timeout_seconds": 30}])
+    tool_policy: dict[ToolID, ToolAccessPolicy] | None = Field(None, description="Per-tool access policies.", examples=[{"web_search": {"risk_level": "standard", "require_auth": False}}])
+    default_tool_policy: ToolAccessPolicy | None = Field(None, description="Default tool policy.", examples=[{"risk_level": "minimal", "require_auth": False}])
+    allowed_domains: list[str] = Field(default_factory=list, description="Allowed external domains.", examples=[["example.com"]])
 
     @field_validator("allowed_domains")
     @classmethod
@@ -96,12 +93,12 @@ class Governance(BaseModel):
         return cleaned
 
 
-class CircuitState(BaseModel):
+class CircuitState(CoreasonModel):
     """Runtime state of a circuit breaker for a specific node."""
 
-    state: Literal["open", "closed", "half-open"] = "closed"
-    failure_count: int = 0
-    last_failure_time: float | None = None
+    state: Literal["open", "closed", "half-open"] = Field("closed", description="Current state.")
+    failure_count: int = Field(0, description="Consecutive failure count.")
+    last_failure_time: float | None = Field(None, description="Timestamp of last failure.")
 
 
 class CircuitOpenError(Exception):
@@ -129,7 +126,9 @@ def check_circuit(node_id: str, policy: CircuitBreaker, state_store: dict[str, C
     if state.state == "open":
         if state.last_failure_time and (time.time() - state.last_failure_time > policy.reset_timeout_seconds):
             # Timeout expired, try half-open
-            state.state = "half-open"
+            # Immutability: Create new state and update store
+            new_state = state.model_copy(update={"state": "half-open"})
+            state_store[node_id] = new_state
             # We don't reset failure_count here; usually we wait for a success to close and reset.
         else:
             raise CircuitOpenError(f"Circuit is OPEN for node {node_id}")
@@ -142,16 +141,25 @@ def record_failure(node_id: str, policy: CircuitBreaker, state_store: dict[str, 
     state = state_store.get(node_id)
     if not state:
         state = CircuitState()
-        state_store[node_id] = state
+        # state_store[node_id] = state # Wait, we need to update after modification if it was mutable, but now we create new
+        # Just continue to calculate new state
 
     if state.state == "open":
         return
 
-    state.failure_count += 1
-    state.last_failure_time = time.time()
+    new_failure_count = state.failure_count + 1
+    new_last_failure_time = time.time()
+    new_status = state.state
 
-    if state.failure_count >= policy.error_threshold_count:
-        state.state = "open"
+    if new_failure_count >= policy.error_threshold_count:
+        new_status = "open"
+
+    new_state = state.model_copy(update={
+        "failure_count": new_failure_count,
+        "last_failure_time": new_last_failure_time,
+        "state": new_status
+    })
+    state_store[node_id] = new_state
 
 
 def record_success(node_id: str, state_store: dict[str, CircuitState]) -> None:
@@ -160,6 +168,9 @@ def record_success(node_id: str, state_store: dict[str, CircuitState]) -> None:
     """
     state = state_store.get(node_id)
     if state:
-        state.state = "closed"
-        state.failure_count = 0
-        state.last_failure_time = None
+        new_state = state.model_copy(update={
+            "state": "closed",
+            "failure_count": 0,
+            "last_failure_time": None
+        })
+        state_store[node_id] = new_state

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -26,15 +26,23 @@ class Audit(CoreasonModel):
 
 class CircuitBreaker(CoreasonModel):
     error_threshold_count: int = Field(..., description="Number of errors before opening the circuit.", examples=[5])
-    reset_timeout_seconds: int = Field(..., description="Seconds to wait before attempting half-open state.", examples=[60])
-    fallback_node_id: NodeID | None = Field(None, description="Optional node to jump to when circuit opens.", examples=["fallback_agent"])
+    reset_timeout_seconds: int = Field(
+        ..., description="Seconds to wait before attempting half-open state.", examples=[60]
+    )
+    fallback_node_id: NodeID | None = Field(
+        None, description="Optional node to jump to when circuit opens.", examples=["fallback_agent"]
+    )
 
 
 class ToolAccessPolicy(CoreasonModel):
-    risk_level: Literal["critical", "standard", "minimal"] = Field(..., description="Risk level.", examples=["standard"])
+    risk_level: Literal["critical", "standard", "minimal"] = Field(
+        ..., description="Risk level.", examples=["standard"]
+    )
     require_auth: bool | None = Field(None, description="Require authentication.", examples=[True])
     allowed_roles: list[str] | None = Field(
-        None, description="If None, allow all. If list, allow only these. Empty list implies deny-all.", examples=[["admin"]]
+        None,
+        description="If None, allow all. If list, allow only these. Empty list implies deny-all.",
+        examples=[["admin"]],
     )
 
     @model_validator(mode="before")
@@ -59,12 +67,30 @@ class Governance(CoreasonModel):
     rate_limit_rpm: int | None = Field(None, description="Rate limit in requests per minute.", examples=[60])
     timeout_seconds: int | None = Field(None, description="Global execution timeout.", examples=[300])
     cost_limit_usd: float | None = Field(None, description="Cost limit in USD.", examples=[10.0])
-    safety: Safety | None = Field(None, description="Safety configuration.", examples=[{"input_filtering": True, "pii_redaction": True, "content_safety": "high"}])
-    audit: Audit | None = Field(None, description="Audit configuration.", examples=[{"trace_retention_days": 7, "log_payloads": True}])
-    circuit_breaker: CircuitBreaker | None = Field(None, description="Circuit breaker policy.", examples=[{"error_threshold_count": 3, "reset_timeout_seconds": 30}])
-    tool_policy: dict[ToolID, ToolAccessPolicy] | None = Field(None, description="Per-tool access policies.", examples=[{"web_search": {"risk_level": "standard", "require_auth": False}}])
-    default_tool_policy: ToolAccessPolicy | None = Field(None, description="Default tool policy.", examples=[{"risk_level": "minimal", "require_auth": False}])
-    allowed_domains: list[str] = Field(default_factory=list, description="Allowed external domains.", examples=[["example.com"]])
+    safety: Safety | None = Field(
+        None,
+        description="Safety configuration.",
+        examples=[{"input_filtering": True, "pii_redaction": True, "content_safety": "high"}],
+    )
+    audit: Audit | None = Field(
+        None, description="Audit configuration.", examples=[{"trace_retention_days": 7, "log_payloads": True}]
+    )
+    circuit_breaker: CircuitBreaker | None = Field(
+        None,
+        description="Circuit breaker policy.",
+        examples=[{"error_threshold_count": 3, "reset_timeout_seconds": 30}],
+    )
+    tool_policy: dict[ToolID, ToolAccessPolicy] | None = Field(
+        None,
+        description="Per-tool access policies.",
+        examples=[{"web_search": {"risk_level": "standard", "require_auth": False}}],
+    )
+    default_tool_policy: ToolAccessPolicy | None = Field(
+        None, description="Default tool policy.", examples=[{"risk_level": "minimal", "require_auth": False}]
+    )
+    allowed_domains: list[str] = Field(
+        default_factory=list, description="Allowed external domains.", examples=[["example.com"]]
+    )
 
     @field_validator("allowed_domains")
     @classmethod
@@ -149,16 +175,14 @@ def record_failure(node_id: str, policy: CircuitBreaker, state_store: dict[str, 
 
     new_failure_count = state.failure_count + 1
     new_last_failure_time = time.time()
-    new_status = state.state
+    new_status: Literal["open", "closed", "half-open"] = state.state
 
     if new_failure_count >= policy.error_threshold_count:
         new_status = "open"
 
-    new_state = state.model_copy(update={
-        "failure_count": new_failure_count,
-        "last_failure_time": new_last_failure_time,
-        "state": new_status
-    })
+    new_state = state.model_copy(
+        update={"failure_count": new_failure_count, "last_failure_time": new_last_failure_time, "state": new_status}
+    )
     state_store[node_id] = new_state
 
 
@@ -168,9 +192,5 @@ def record_success(node_id: str, state_store: dict[str, CircuitState]) -> None:
     """
     state = state_store.get(node_id)
     if state:
-        new_state = state.model_copy(update={
-            "state": "closed",
-            "failure_count": 0,
-            "last_failure_time": None
-        })
+        new_state = state.model_copy(update={"state": "closed", "failure_count": 0, "last_failure_time": None})
         state_store[node_id] = new_state

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -66,17 +66,19 @@ class AgentNode(Node):
         examples=["profile_1", {"role": "Assistant", "persona": "..."}],
     )
     tools: list[str] = Field(
-        default_factory=list, description="List of tool names available to this agent.", examples=[["calculator", "web_search"]]
+        default_factory=list,
+        description="List of tool names available to this agent.",
+        examples=[["calculator", "web_search"]],
     )
 
 
 class SwitchNode(Node):
     type: Literal["switch"] = "switch"
-    variable: VariableID = Field(
-        ..., description="The blackboard variable to evaluate.", examples=["user_sentiment"]
-    )
+    variable: VariableID = Field(..., description="The blackboard variable to evaluate.", examples=["user_sentiment"])
     cases: dict[str, NodeID] = Field(
-        ..., description="Map of variable values to next node IDs.", examples=[{"positive": "thank_user", "negative": "apologize"}]
+        ...,
+        description="Map of variable values to next node IDs.",
+        examples=[{"positive": "thank_user", "negative": "apologize"}],
     )
     default: NodeID = Field(..., description="Default next node ID if no case matches.", examples=["default_handler"])
 
@@ -84,13 +86,9 @@ class SwitchNode(Node):
 class InspectorNodeBase(Node):
     """Shared logic for all inspection/judgement nodes."""
 
-    target_variable: VariableID = Field(
-        ..., description="The variable to inspect.", examples=["generated_content"]
-    )
+    target_variable: VariableID = Field(..., description="The variable to inspect.", examples=["generated_content"])
     criteria: str = Field(..., description="The criteria to evaluate against.", examples=["Is the content safe?"])
-    output_variable: VariableID = Field(
-        ..., description="The variable to store the result.", examples=["is_safe"]
-    )
+    output_variable: VariableID = Field(..., description="The variable to store the result.", examples=["is_safe"])
     judge_model: Annotated[
         ModelRef | None,
         Field(description="Model/Policy to use for semantic evaluation.", examples=["gpt-4"]),
@@ -110,9 +108,7 @@ class InspectorNode(InspectorNodeBase):
         "programmatic", description="Evaluation mode.", examples=["semantic"]
     )
 
-    pass_threshold: float | None = Field(
-        None, description="Threshold for passing the check (0.0-1.0).", examples=[0.8]
-    )
+    pass_threshold: float | None = Field(None, description="Threshold for passing the check (0.0-1.0).", examples=[0.8])
 
 
 class EmergenceInspectorNode(InspectorNodeBase):
@@ -137,7 +133,9 @@ class PlannerNode(Node):
     goal: str = Field(..., description="The high-level goal to plan for.", examples=["Build a website"])
     optimizer: Optimizer | None = Field(None, description="Optimization configuration.")
     output_schema: dict[str, Any] = Field(
-        ..., description="JSON Schema for the plan output.", examples=[{"type": "object", "properties": {"steps": {"type": "array"}}}]
+        ...,
+        description="JSON Schema for the plan output.",
+        examples=[{"type": "object", "properties": {"steps": {"type": "array"}}}],
     )
 
 
@@ -152,7 +150,10 @@ class HumanNode(Node):
     prompt: str = Field(..., description="Prompt to display to the human.", examples=["Approve this plan?"])
     timeout_seconds: Annotated[
         int | Literal["infinite"] | None,
-        Field(description="Max wait time for blocking/steering. Use 'infinite' for no timeout.", examples=[300, "infinite"]),
+        Field(
+            description="Max wait time for blocking/steering. Use 'infinite' for no timeout.",
+            examples=[300, "infinite"],
+        ),
     ]
     input_schema: dict[str, Any] | None = Field(
         None, description="JSON Schema for expected human input.", examples=[{"type": "object"}]
@@ -304,7 +305,10 @@ class SwarmNode(Node):
     )
     aggregator_model: Annotated[
         ModelRef | None,
-        Field(description="If set, uses this model to summarize the worker outputs into a single string.", examples=["gpt-4"]),
+        Field(
+            description="If set, uses this model to summarize the worker outputs into a single string.",
+            examples=["gpt-4"],
+        ),
     ] = None
     output_variable: VariableID = Field(
         ..., description="Variable to store the aggregated result.", examples=["final_report"]

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -1,11 +1,10 @@
 import warnings
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import Field, model_validator
 
 from coreason_manifest.spec.common.presentation import PresentationHints
-
-# IMPORT ModelRef to link the new routing capability
+from coreason_manifest.spec.common_base import CoreasonModel
 from coreason_manifest.spec.core.engines import (
     FastPath,
     ModelRef,
@@ -14,30 +13,41 @@ from coreason_manifest.spec.core.engines import (
 )
 from coreason_manifest.spec.core.exceptions import DomainValidationError
 from coreason_manifest.spec.core.resilience import ResilienceConfig
+from coreason_manifest.spec.core.types import NodeID, ProfileID, VariableID
 from coreason_manifest.spec.interop.compliance import RemediationAction
 
 
-class Node(BaseModel):
+class Node(CoreasonModel):
     """Base class for vertices of the execution graph."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    id: NodeID = Field(..., description="Unique identifier for the node.", examples=["start_node", "agent_1"])
+    metadata: dict[str, Any] = Field(
+        default_factory=dict, description="Arbitrary metadata for the node.", examples=[{"created_by": "user123"}]
+    )
+    resilience: Annotated[
+        ResilienceConfig | str | None,
+        Field(description="Error handling policy or reference ID.", examples=["retry_policy_1"]),
+    ] = None
+    presentation: Annotated[
+        PresentationHints | None,
+        Field(description="UI rendering hints.", examples=[{"x": 100, "y": 200}]),
+    ] = None
+    type: str = Field(..., description="The type of the node.")
 
-    id: str
-    metadata: dict[str, Any]
-    resilience: Annotated[ResilienceConfig | str | None, Field(description="Error handling policy.")] = None
-    presentation: Annotated[PresentationHints | None, Field(description="UI rendering hints.")] = None
-    type: str
 
-
-class CognitiveProfile(BaseModel):
+class CognitiveProfile(CoreasonModel):
     """The active processing unit of an agent."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    role: str
-    persona: str
-    reasoning: ReasoningConfig | None
-    fast_path: FastPath | None
+    role: str = Field(..., description="The role of the agent.", examples=["Assistant", "Researcher"])
+    persona: str = Field(
+        ..., description="The system prompt/persona description.", examples=["You are a helpful assistant."]
+    )
+    reasoning: ReasoningConfig | None = Field(
+        None, description="The reasoning engine configuration.", examples=[{"type": "standard", "model": "gpt-4"}]
+    )
+    fast_path: FastPath | None = Field(
+        None, description="Fast path configuration for low-latency responses.", examples=[{"model": "gpt-3.5-turbo"}]
+    )
 
 
 class AgentNode(Node):
@@ -49,32 +59,43 @@ class AgentNode(Node):
     - Pass a string ID to reference 'definitions.profiles' (Production mode).
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     type: Literal["agent"] = "agent"
-    profile: CognitiveProfile | str
-    tools: list[str]
+    profile: CognitiveProfile | ProfileID = Field(
+        ...,
+        description="The cognitive profile configuration or a reference ID.",
+        examples=["profile_1", {"role": "Assistant", "persona": "..."}],
+    )
+    tools: list[str] = Field(
+        default_factory=list, description="List of tool names available to this agent.", examples=[["calculator", "web_search"]]
+    )
 
 
 class SwitchNode(Node):
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     type: Literal["switch"] = "switch"
-    variable: str = Field(..., description="The blackboard variable to evaluate.")
-    cases: dict[str, str]
-    default: str
+    variable: VariableID = Field(
+        ..., description="The blackboard variable to evaluate.", examples=["user_sentiment"]
+    )
+    cases: dict[str, NodeID] = Field(
+        ..., description="Map of variable values to next node IDs.", examples=[{"positive": "thank_user", "negative": "apologize"}]
+    )
+    default: NodeID = Field(..., description="Default next node ID if no case matches.", examples=["default_handler"])
 
 
 class InspectorNodeBase(Node):
     """Shared logic for all inspection/judgement nodes."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    target_variable: str
-    criteria: str
-    output_variable: str
-    judge_model: Annotated[ModelRef | None, Field(description="Model/Policy to use for semantic evaluation.")] = None
-    optimizer: Optimizer | None = None
+    target_variable: VariableID = Field(
+        ..., description="The variable to inspect.", examples=["generated_content"]
+    )
+    criteria: str = Field(..., description="The criteria to evaluate against.", examples=["Is the content safe?"])
+    output_variable: VariableID = Field(
+        ..., description="The variable to store the result.", examples=["is_safe"]
+    )
+    judge_model: Annotated[
+        ModelRef | None,
+        Field(description="Model/Policy to use for semantic evaluation.", examples=["gpt-4"]),
+    ] = None
+    optimizer: Optimizer | None = Field(None, description="Optimization configuration.")
 
 
 class InspectorNode(InspectorNodeBase):
@@ -83,13 +104,15 @@ class InspectorNode(InspectorNodeBase):
     Can operate in deterministic mode (regex/numeric) or semantic mode (LLM Judge).
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     type: Literal["inspector"] = "inspector"
 
-    mode: Literal["programmatic", "semantic"] = "programmatic"
+    mode: Literal["programmatic", "semantic"] = Field(
+        "programmatic", description="Evaluation mode.", examples=["semantic"]
+    )
 
-    pass_threshold: float | None = None
+    pass_threshold: float | None = Field(
+        None, description="Threshold for passing the check (0.0-1.0).", examples=[0.8]
+    )
 
 
 class EmergenceInspectorNode(InspectorNodeBase):
@@ -97,14 +120,12 @@ class EmergenceInspectorNode(InspectorNodeBase):
     Specialized inspector for detecting novel/emergent behaviors.
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     type: Literal["emergence_inspector"] = "emergence_inspector"
 
     # Pre-defined behavioral markers to scan for
-    detect_sycophancy: bool = True
-    detect_power_seeking: bool = True
-    detect_deception: bool = True
+    detect_sycophancy: bool = Field(True, description="Detect if the agent is being sycophantic.")
+    detect_power_seeking: bool = Field(True, description="Detect power-seeking behavior.")
+    detect_deception: bool = Field(True, description="Detect deceptive behavior.")
 
     # Override defaults - Forced semantic mode
     mode: Literal["semantic"] = "semantic"
@@ -112,12 +133,12 @@ class EmergenceInspectorNode(InspectorNodeBase):
 
 
 class PlannerNode(Node):
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     type: Literal["planner"] = "planner"
-    goal: str
-    optimizer: Optimizer | None
-    output_schema: dict[str, Any]
+    goal: str = Field(..., description="The high-level goal to plan for.", examples=["Build a website"])
+    optimizer: Optimizer | None = Field(None, description="Optimization configuration.")
+    output_schema: dict[str, Any] = Field(
+        ..., description="JSON Schema for the plan output.", examples=[{"type": "object", "properties": {"steps": {"type": "array"}}}]
+    )
 
 
 class HumanNode(Node):
@@ -127,24 +148,27 @@ class HumanNode(Node):
     and proceeds if no signal is received, while 'steering' allows mid-flight plan alteration.
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     type: Literal["human"] = "human"
-    prompt: str
+    prompt: str = Field(..., description="Prompt to display to the human.", examples=["Approve this plan?"])
     timeout_seconds: Annotated[
         int | Literal["infinite"] | None,
-        Field(description="Max wait time for blocking/steering. Use 'infinite' for no timeout."),
+        Field(description="Max wait time for blocking/steering. Use 'infinite' for no timeout.", examples=[300, "infinite"]),
     ]
-    input_schema: dict[str, Any] | None = None
-    options: list[str] | None = None
+    input_schema: dict[str, Any] | None = Field(
+        None, description="JSON Schema for expected human input.", examples=[{"type": "object"}]
+    )
+    options: list[str] | None = Field(
+        None, description="List of valid options for the human.", examples=[["approve", "reject"]]
+    )
 
     # *** UPGRADE: SHADOW MODE ***
     interaction_mode: Annotated[
-        Literal["blocking", "shadow", "steering"], Field(description="Wait for input vs shadow execution.")
+        Literal["blocking", "shadow", "steering"],
+        Field(description="Wait for input vs shadow execution.", examples=["blocking"]),
     ] = "blocking"
     shadow_timeout_seconds: Annotated[
         int | Literal["infinite"] | None,
-        Field(description="Time window for intervention in shadow mode. Use 'infinite' for no timeout."),
+        Field(description="Time window for intervention in shadow mode. Use 'infinite' for no timeout.", examples=[60]),
     ] = None
 
     @model_validator(mode="before")
@@ -240,21 +264,23 @@ class SwarmNode(Node):
     Spins up N ephemeral worker agents to process a dataset/workload in parallel.
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     type: Literal["swarm"] = "swarm"
 
     # Worker Config
-    worker_profile: str = Field(..., min_length=1, description="Reference to a CognitiveProfile ID.")
-    workload_variable: str = Field(..., min_length=1, description="The Blackboard list/dataset to process.")
+    worker_profile: ProfileID = Field(
+        ..., description="Reference to a CognitiveProfile ID.", examples=["researcher_profile"]
+    )
+    workload_variable: VariableID = Field(
+        ..., description="The Blackboard list/dataset to process.", examples=["urls_to_scrape"]
+    )
 
     # Topology
     distribution_strategy: Literal["sharded", "replicated"] = Field(
-        ..., description="Sharded=split data; Replicated=same data, many attempts."
+        ..., description="Sharded=split data; Replicated=same data, many attempts.", examples=["sharded"]
     )
     max_concurrency: Annotated[
         int | Literal["infinite"] | None,
-        Field(description="Limit parallel workers. Use 'infinite' for no limit."),
+        Field(description="Limit parallel workers. Use 'infinite' for no limit.", examples=[10]),
     ]
 
     # SOTA: Reliability (Partial Failure)
@@ -268,16 +294,21 @@ class SwarmNode(Node):
                 "Executed AFTER the Node's 'resilience' strategy. "
                 "E.g., if retries exhaust, this tolerance allows the Swarm to still succeed partially."
             ),
+            examples=[0.1],
         ),
     ] = 0.0
 
     # Aggregation
-    reducer_function: Literal["concat", "vote", "summarize"] = Field(..., description="How to combine results.")
+    reducer_function: Literal["concat", "vote", "summarize"] = Field(
+        ..., description="How to combine results.", examples=["concat"]
+    )
     aggregator_model: Annotated[
         ModelRef | None,
-        Field(description="If set, uses this model to summarize the worker outputs into a single string."),
+        Field(description="If set, uses this model to summarize the worker outputs into a single string.", examples=["gpt-4"]),
     ] = None
-    output_variable: str = Field(..., description="Variable to store the aggregated result.")
+    output_variable: VariableID = Field(
+        ..., description="Variable to store the aggregated result.", examples=["final_report"]
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -317,10 +348,10 @@ class SwarmNode(Node):
 
 
 class PlaceholderNode(Node):
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
     type: Literal["placeholder"] = "placeholder"
-    required_capabilities: list[str]
+    required_capabilities: list[str] = Field(
+        ..., description="List of required capabilities.", examples=[["image_generation"]]
+    )
 
 
 __all__ = [

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -13,7 +13,12 @@ from coreason_manifest.spec.core.engines import (
 )
 from coreason_manifest.spec.core.exceptions import DomainValidationError
 from coreason_manifest.spec.core.resilience import ResilienceConfig
-from coreason_manifest.spec.core.types import NodeID, ProfileID, VariableID
+from coreason_manifest.spec.core.types import (
+    CoercibleStringList,
+    NodeID,
+    ProfileID,
+    VariableID,
+)
 from coreason_manifest.spec.interop.compliance import RemediationAction
 
 
@@ -65,7 +70,7 @@ class AgentNode(Node):
         description="The cognitive profile configuration or a reference ID.",
         examples=["profile_1", {"role": "Assistant", "persona": "..."}],
     )
-    tools: list[str] = Field(
+    tools: CoercibleStringList = Field(
         default_factory=list,
         description="List of tool names available to this agent.",
         examples=[["calculator", "web_search"]],
@@ -353,7 +358,7 @@ class SwarmNode(Node):
 
 class PlaceholderNode(Node):
     type: Literal["placeholder"] = "placeholder"
-    required_capabilities: list[str] = Field(
+    required_capabilities: CoercibleStringList = Field(
         ..., description="List of required capabilities.", examples=[["image_generation"]]
     )
 

--- a/src/coreason_manifest/spec/core/tools.py
+++ b/src/coreason_manifest/spec/core/tools.py
@@ -1,32 +1,44 @@
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, ConfigDict, HttpUrl, model_validator
+from pydantic import Field, HttpUrl, model_validator
+
+from coreason_manifest.spec.common_base import CoreasonModel
+from coreason_manifest.spec.core.types import ToolID
 
 
-class Dependency(BaseModel):
+class Dependency(CoreasonModel):
     """Dependency definition for a tool."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    name: str = Field(..., description="Name of the package.", examples=["requests", "pandas"])
+    version: str | None = Field(
+        None, description="Version constraint string.", examples=["^2.0.0", ">=1.0"]
+    )
+    manager: Literal["pip", "npm", "apt", "mcp"] = Field(
+        ..., description="Package manager to use.", examples=["pip"]
+    )
 
-    name: str
-    version: str | None = None
-    manager: Literal["pip", "npm", "apt", "mcp"]
 
-
-class ToolCapability(BaseModel):
+class ToolCapability(CoreasonModel):
     """
     Definition of a tool's capabilities and risk profile.
     Mandate 3: Semantic Tool Governance.
     """
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    name: str
-    risk_level: Literal["safe", "standard", "critical"] = "standard"
-    description: str | None = None
-    requires_approval: bool = False
+    type: Literal["capability"] = Field("capability", description="Discriminator for polymorphic tools.")
+    name: ToolID = Field(..., description="Unique identifier for the tool.", examples=["calculator"])
+    risk_level: Literal["safe", "standard", "critical"] = Field(
+        "standard", description="Risk classification for governance.", examples=["safe"]
+    )
+    description: str | None = Field(
+        None, description="Human-readable description of what the tool does.", examples=["Performs basic arithmetic."]
+    )
+    requires_approval: bool = Field(
+        False, description="If True, human approval is required before execution."
+    )
     # SOTA Fix: Strict URL validation
-    url: HttpUrl | None = None
+    url: HttpUrl | None = Field(
+        None, description="Documentation or endpoint URL.", examples=["https://example.com/docs"]
+    )
 
     @model_validator(mode="after")
     def validate_critical_description(self) -> "ToolCapability":
@@ -37,13 +49,21 @@ class ToolCapability(BaseModel):
         return self
 
 
-class ToolPack(BaseModel):
+# Polymorphic Tool Type (Extensible for future)
+AnyTool = Annotated[ToolCapability, Field(discriminator="type")]
+
+
+class ToolPack(CoreasonModel):
     """A bundle of tools."""
 
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    kind: Literal["ToolPack"]
-    namespace: str
-    tools: list[ToolCapability]
-    dependencies: list[Dependency]
-    env_vars: list[str]
+    kind: Literal["ToolPack"] = "ToolPack"
+    namespace: str = Field(..., description="Namespace prefix for tools in this pack.", examples=["std_utils"])
+    tools: list[AnyTool] = Field(
+        ..., description="List of tool capabilities provided by this pack.", examples=[[{"name": "calc", "type": "capability"}]]
+    )
+    dependencies: list[Dependency] = Field(
+        default_factory=list, description="External package dependencies.", examples=[[{"name": "numpy", "manager": "pip"}]]
+    )
+    env_vars: list[str] = Field(
+        default_factory=list, description="Required environment variables.", examples=[["API_KEY"]]
+    )

--- a/src/coreason_manifest/spec/core/tools.py
+++ b/src/coreason_manifest/spec/core/tools.py
@@ -10,12 +10,8 @@ class Dependency(CoreasonModel):
     """Dependency definition for a tool."""
 
     name: str = Field(..., description="Name of the package.", examples=["requests", "pandas"])
-    version: str | None = Field(
-        None, description="Version constraint string.", examples=["^2.0.0", ">=1.0"]
-    )
-    manager: Literal["pip", "npm", "apt", "mcp"] = Field(
-        ..., description="Package manager to use.", examples=["pip"]
-    )
+    version: str | None = Field(None, description="Version constraint string.", examples=["^2.0.0", ">=1.0"])
+    manager: Literal["pip", "npm", "apt", "mcp"] = Field(..., description="Package manager to use.", examples=["pip"])
 
 
 class ToolCapability(CoreasonModel):
@@ -32,9 +28,7 @@ class ToolCapability(CoreasonModel):
     description: str | None = Field(
         None, description="Human-readable description of what the tool does.", examples=["Performs basic arithmetic."]
     )
-    requires_approval: bool = Field(
-        False, description="If True, human approval is required before execution."
-    )
+    requires_approval: bool = Field(False, description="If True, human approval is required before execution.")
     # SOTA Fix: Strict URL validation
     url: HttpUrl | None = Field(
         None, description="Documentation or endpoint URL.", examples=["https://example.com/docs"]
@@ -59,10 +53,14 @@ class ToolPack(CoreasonModel):
     kind: Literal["ToolPack"] = "ToolPack"
     namespace: str = Field(..., description="Namespace prefix for tools in this pack.", examples=["std_utils"])
     tools: list[AnyTool] = Field(
-        ..., description="List of tool capabilities provided by this pack.", examples=[[{"name": "calc", "type": "capability"}]]
+        ...,
+        description="List of tool capabilities provided by this pack.",
+        examples=[[{"name": "calc", "type": "capability"}]],
     )
     dependencies: list[Dependency] = Field(
-        default_factory=list, description="External package dependencies.", examples=[[{"name": "numpy", "manager": "pip"}]]
+        default_factory=list,
+        description="External package dependencies.",
+        examples=[[{"name": "numpy", "manager": "pip"}]],
     )
     env_vars: list[str] = Field(
         default_factory=list, description="Required environment variables.", examples=[["API_KEY"]]

--- a/src/coreason_manifest/spec/core/tools.py
+++ b/src/coreason_manifest/spec/core/tools.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 from pydantic import Field, HttpUrl, model_validator
 
 from coreason_manifest.spec.common_base import CoreasonModel
-from coreason_manifest.spec.core.types import ToolID
+from coreason_manifest.spec.core.types import CoercibleStringList, ToolID
 
 
 class Dependency(CoreasonModel):
@@ -62,6 +62,6 @@ class ToolPack(CoreasonModel):
         description="External package dependencies.",
         examples=[[{"name": "numpy", "manager": "pip"}]],
     )
-    env_vars: list[str] = Field(
+    env_vars: CoercibleStringList = Field(
         default_factory=list, description="Required environment variables.", examples=[["API_KEY"]]
     )

--- a/src/coreason_manifest/spec/core/types.py
+++ b/src/coreason_manifest/spec/core/types.py
@@ -8,9 +8,9 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Annotated
+from typing import Annotated, Any
 
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 
 # =========================================================================
 #  DOMAIN VOCABULARY (Living Standard)
@@ -80,4 +80,19 @@ ProfileID = Annotated[
         description="Identifier for a cognitive profile.",
         examples=["default_assistant", "code_expert"],
     ),
+]
+
+
+def _coerce_comma_strings(v: Any) -> Any:
+    """Coerces 'a, b' into ['a', 'b'] before strict validation."""
+    if isinstance(v, str):
+        return [item.strip() for item in v.split(",") if item.strip()]
+    return v
+
+
+# Apply this to all fields expecting lists of strings (like tags, tools, capabilities)
+CoercibleStringList = Annotated[
+    list[str],
+    BeforeValidator(_coerce_comma_strings),
+    Field(default_factory=list),
 ]

--- a/src/coreason_manifest/spec/core/types.py
+++ b/src/coreason_manifest/spec/core/types.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Annotated
+
+from pydantic import Field
+
+# =========================================================================
+#  DOMAIN VOCABULARY (Living Standard)
+# =========================================================================
+
+# Strict Semantic Versioning (X.Y.Z)
+SemanticVersion = Annotated[
+    str,
+    Field(
+        pattern=r"^\d+\.\d+\.\d+$",
+        description="A semantic version string (e.g., '1.0.0').",
+        examples=["1.0.0", "0.1.0", "2.12.5"],
+    ),
+]
+
+# Git SHA-1 Hash
+GitSHA = Annotated[
+    str,
+    Field(
+        pattern=r"^[a-f0-9]{40}$",
+        description="A full 40-character Git SHA-1 hash.",
+        examples=["a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0"],
+        min_length=40,
+        max_length=40,
+    ),
+]
+
+# Node Identifiers (Must be URL-safe, no spaces)
+NodeID = Annotated[
+    str,
+    Field(
+        pattern=r"^[a-zA-Z0-9_-]+$",
+        min_length=1,
+        max_length=128,
+        description="Unique identifier for a node in the graph. Alphanumeric, underscores, hyphens only.",
+        examples=["agent_1", "start-node", "MyNode"],
+    ),
+]
+
+# Variable Identifiers (Must be valid Python identifiers or close to it)
+VariableID = Annotated[
+    str,
+    Field(
+        pattern=r"^[a-zA-Z_][a-zA-Z0-9_]*$",
+        min_length=1,
+        max_length=64,
+        description="Identifier for a variable in the blackboard. Must be a valid identifier format.",
+        examples=["user_input", "result_data", "_internal_state"],
+    ),
+]
+
+# Tool Identifiers
+ToolID = Annotated[
+    str,
+    Field(
+        min_length=1,
+        description="Identifier for a tool or capability.",
+        examples=["calculator", "web_search"],
+    ),
+]
+
+# Profile Identifiers
+ProfileID = Annotated[
+    str,
+    Field(
+        min_length=1,
+        description="Identifier for a cognitive profile.",
+        examples=["default_assistant", "code_expert"],
+    ),
+]

--- a/tests/test_adapters_phase4.py
+++ b/tests/test_adapters_phase4.py
@@ -70,7 +70,7 @@ def test_openai_adapter() -> None:
 
 
 def test_langchain_adapter() -> None:
-    meta = FlowMetadata(name="test", version="1.0", description="desc", tags=[])
+    meta = FlowMetadata(name="test", version="1.0.0", description="desc", tags=[])
     pack = ToolPack(
         kind="ToolPack",
         namespace="utils",

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -8,7 +8,7 @@ from coreason_manifest.spec.core.tools import ToolCapability, ToolPack
 
 
 def test_linear_builder() -> None:
-    builder = NewLinearFlow("MyLinear", version="1.0", description="Desc")
+    builder = NewLinearFlow("MyLinear", version="1.0.0", description="Desc")
     builder.add_step(PlaceholderNode(id="step1", type="placeholder", metadata={}, required_capabilities=[]))
     builder.add_step(PlaceholderNode(id="step2", type="placeholder", metadata={}, required_capabilities=[]))
 
@@ -43,7 +43,7 @@ def test_linear_builder() -> None:
 
 
 def test_graph_builder() -> None:
-    builder = NewGraphFlow("MyGraph", version="1.0", description="Desc")
+    builder = NewGraphFlow("MyGraph", version="1.0.0", description="Desc")
     builder.add_node(PlaceholderNode(id="n1", type="placeholder", metadata={}, required_capabilities=[]))
     builder.add_node(PlaceholderNode(id="n2", type="placeholder", metadata={}, required_capabilities=[]))
     builder.connect("n1", "n2", condition="ok")
@@ -117,7 +117,7 @@ def test_graph_builder_invalid() -> None:
 
 def test_builder_coverage_set_circuit_breaker_with_existing_governance() -> None:
     """Test setting circuit breaker when governance is already set."""
-    builder = NewLinearFlow("Test", "1.0", "Desc")
+    builder = NewLinearFlow("Test", "1.0.0", "Desc")
     gov = Governance(rate_limit_rpm=10)
     builder.set_governance(gov)
 
@@ -132,7 +132,7 @@ def test_builder_coverage_set_circuit_breaker_with_existing_governance() -> None
 
 def test_builder_coverage_set_circuit_breaker_without_governance() -> None:
     """Test setting circuit breaker when governance is NOT set."""
-    builder = NewLinearFlow("Test", "1.0", "Desc")
+    builder = NewLinearFlow("Test", "1.0.0", "Desc")
     # No governance set
 
     # This should trigger the `else:` branch in set_circuit_breaker
@@ -145,7 +145,7 @@ def test_builder_coverage_set_circuit_breaker_without_governance() -> None:
 
 def test_builder_coverage_add_inspector_linear() -> None:
     """Test add_inspector method in NewLinearFlow."""
-    builder = NewLinearFlow("Test", "1.0", "Desc")
+    builder = NewLinearFlow("Test", "1.0.0", "Desc")
     builder.add_inspector(node_id="inspector1", target="var1", criteria="criteria1", output="out1")
     assert len(builder.sequence) == 1
     node = builder.sequence[0]
@@ -155,7 +155,7 @@ def test_builder_coverage_add_inspector_linear() -> None:
 
 def test_builder_coverage_add_inspector_graph() -> None:
     """Test add_inspector method in NewGraphFlow."""
-    builder = NewGraphFlow("Test", "1.0", "Desc")
+    builder = NewGraphFlow("Test", "1.0.0", "Desc")
     builder.add_inspector(node_id="inspector1", target="var1", criteria="criteria1", output="out1")
     assert "inspector1" in builder._nodes
     node = builder._nodes["inspector1"]
@@ -165,7 +165,7 @@ def test_builder_coverage_add_inspector_graph() -> None:
 def test_builder_coverage_add_agent_ref_defaults() -> None:
     """Test add_agent_ref with default tools=None."""
     # Linear
-    builder_l = NewLinearFlow("Test", "1.0", "Desc")
+    builder_l = NewLinearFlow("Test", "1.0.0", "Desc")
     builder_l.define_profile("brain1", "role", "persona")
     builder_l.add_agent_ref("agent1", "brain1")  # Default tools=None -> []
     assert len(builder_l.sequence) == 1
@@ -174,7 +174,7 @@ def test_builder_coverage_add_agent_ref_defaults() -> None:
     assert node_l.tools == []
 
     # Graph
-    builder_g = NewGraphFlow("Test", "1.0", "Desc")
+    builder_g = NewGraphFlow("Test", "1.0.0", "Desc")
     builder_g.define_profile("brain1", "role", "persona")
     builder_g.add_agent_ref("agent1", "brain1")  # Default tools=None -> []
     assert "agent1" in builder_g._nodes
@@ -189,12 +189,12 @@ def test_builder_coverage_explicit_add_agent() -> None:
     agent = AgentNode(id="agent1", type="agent", profile=brain, tools=[], metadata={}, resilience=None)
 
     # Linear
-    builder_l = NewLinearFlow("Test", "1.0", "Desc")
+    builder_l = NewLinearFlow("Test", "1.0.0", "Desc")
     builder_l.add_agent(agent)
     assert len(builder_l.sequence) == 1
 
     # Graph
-    builder_g = NewGraphFlow("Test", "1.0", "Desc")
+    builder_g = NewGraphFlow("Test", "1.0.0", "Desc")
     builder_g.add_agent(agent)
     assert "agent1" in builder_g._nodes
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,7 +14,7 @@ from coreason_manifest.cli import main
 def create_valid_flow(path: str) -> None:
     data = {
         "kind": "LinearFlow",
-        "metadata": {"name": "ValidFlow", "version": "1.0", "description": "Test", "tags": []},
+        "metadata": {"name": "ValidFlow", "version": "1.0.0", "description": "Test", "tags": []},
         "sequence": [{"id": "step1", "type": "placeholder", "metadata": {}, "required_capabilities": []}],
     }
     with open(path, "w") as f:
@@ -24,7 +24,7 @@ def create_valid_flow(path: str) -> None:
 def create_invalid_flow(path: str) -> None:
     data = {
         "kind": "LinearFlow",
-        "metadata": {"name": "InvalidFlow", "version": "1.0", "description": "Test", "tags": []},
+        "metadata": {"name": "InvalidFlow", "version": "1.0.0", "description": "Test", "tags": []},
         "sequence": [],  # Empty sequence is invalid
     }
     with open(path, "w") as f:
@@ -166,7 +166,7 @@ def test_visualize_unexpected_error(capsys: CaptureFixture[str]) -> None:
 def test_version(capsys: CaptureFixture[str]) -> None:
     """Test that the version command works."""
     test_args = ["coreason", "--version"]
-    with patch.object(sys, "argv", test_args):
+    with patch.object(sys, "argv", test_args), patch("coreason_manifest.cli.version", return_value="0.25.0"):
         with pytest.raises(SystemExit) as exc:
             main()
         assert exc.value.code == 0

--- a/tests/test_core_kernel.py
+++ b/tests/test_core_kernel.py
@@ -80,7 +80,7 @@ def test_core_kernel_instantiation() -> None:
     )
 
     # Test Flow
-    metadata = FlowMetadata(name="test-flow", version="1.0", description="test", tags=["test"])
+    metadata = FlowMetadata(name="test-flow", version="1.0.0", description="test", tags=["test"])
     interface = FlowInterface(
         inputs=DataSchema(json_schema={"type": "object", "properties": {"q": {"type": "string"}}, "required": ["q"]}),
         outputs=DataSchema(json_schema={"type": "object", "properties": {"a": {"type": "string"}}, "required": ["a"]}),

--- a/tests/test_coverage_completion.py
+++ b/tests/test_coverage_completion.py
@@ -27,7 +27,7 @@ def test_loader_root_dir_mismatch(tmp_path: Path) -> None:
 kind: LinearFlow
 metadata:
   name: test
-  version: "1.0"
+  version: "1.0.0"
   description: test
   tags: []
 sequence: []
@@ -51,7 +51,7 @@ def test_loader_graph_flow(tmp_path: Path) -> None:
 kind: GraphFlow
 metadata:
   name: graph
-  version: "1.0"
+  version: "1.0.0"
   description: graph
   tags: []
 interface:
@@ -363,9 +363,10 @@ def test_governance_circuit_breaker_branches() -> None:
         check_circuit(node_id, cb, store)
 
     # 2. Open State, Expired
-    state.last_failure_time = time.time() - 200
+    new_state = state.model_copy(update={"last_failure_time": time.time() - 200})
+    store[node_id] = new_state
     check_circuit(node_id, cb, store)
-    assert state.state == "half-open"
+    assert store[node_id].state == "half-open"
 
     # 3. Open State, No Failure Time (Should raise)
     state = CircuitState(state="open", last_failure_time=None)

--- a/tests/test_coverage_gap.py
+++ b/tests/test_coverage_gap.py
@@ -215,7 +215,7 @@ def test_topology_self_loop_island() -> None:
     flow = GraphFlow.model_construct(
         kind="GraphFlow",
         status="draft",
-        metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+        metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph,
@@ -343,7 +343,7 @@ def test_gatekeeper_blocked_domain() -> None:
 
     flow = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
         sequence=[AgentNode(id="a", type="agent", metadata={}, profile="p", tools=["BadUrl"])],
         governance=gov,
         definitions=FlowDefinitions(
@@ -374,7 +374,7 @@ def test_visualizer_pure_cycle() -> None:
     flow = GraphFlow.model_construct(
         kind="GraphFlow",
         status="draft",
-        metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph,
@@ -408,7 +408,7 @@ def test_visualizer_disconnected_cycle() -> None:
     flow = GraphFlow.model_construct(
         kind="GraphFlow",
         status="draft",  # Allow disconnected
-        metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph,
@@ -500,7 +500,7 @@ def test_validator_edge_cases() -> None:
     flow_empty = GraphFlow.model_construct(
         kind="GraphFlow",
         status="draft",
-        metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph_empty,
@@ -519,7 +519,7 @@ def test_validator_edge_cases() -> None:
     flow_dangling = GraphFlow.model_construct(
         kind="GraphFlow",
         status="draft",
-        metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph_dangling,
@@ -536,7 +536,7 @@ def test_validator_edge_cases() -> None:
     flow_mismatch = GraphFlow.model_construct(
         kind="GraphFlow",
         status="draft",
-        metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph_mismatch_2,
@@ -633,7 +633,7 @@ def test_flow_edge_source_missing() -> None:
         GraphFlow(
             kind="GraphFlow",
             status="published",
-            metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+            metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
             interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
             blackboard=None,
             graph=graph,
@@ -650,7 +650,7 @@ def test_flow_edge_target_missing() -> None:
         GraphFlow(
             kind="GraphFlow",
             status="published",
-            metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+            metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
             interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
             blackboard=None,
             graph=graph,
@@ -666,7 +666,7 @@ def test_flow_entry_point_missing() -> None:
         GraphFlow(
             kind="GraphFlow",
             status="published",
-            metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+            metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
             interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
             blackboard=None,
             graph=graph,
@@ -701,7 +701,7 @@ def test_flow_cycle_detection_unreachable() -> None:
     flow = GraphFlow(
         kind="GraphFlow",
         status="published",
-        metadata=FlowMetadata(name="test", version="1", description="d", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="d", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph,

--- a/tests/test_cross_field_validation.py
+++ b/tests/test_cross_field_validation.py
@@ -5,7 +5,7 @@ from coreason_manifest.spec.core.nodes import HumanNode, SwarmNode
 from coreason_manifest.spec.core.tools import ToolCapability
 
 
-def test_human_node_shadow_mode_requirements():
+def test_human_node_shadow_mode_requirements() -> None:
     """
     If interaction_mode is 'shadow', shadow_timeout_seconds is required.
     """
@@ -15,26 +15,28 @@ def test_human_node_shadow_mode_requirements():
             type="human",
             prompt="Shadow?",
             interaction_mode="shadow",
-            timeout_seconds=None
+            timeout_seconds=None,
             # Missing shadow_timeout_seconds
         )
     # Check that one of the errors contains our message
     errors = excinfo.value.errors()
     assert any("HumanNode in 'shadow' mode requires 'shadow_timeout_seconds'" in e["msg"] for e in errors)
 
-def test_human_node_shadow_mode_valid():
+
+def test_human_node_shadow_mode_valid() -> None:
     h = HumanNode(
         id="h1",
         type="human",
         prompt="Shadow?",
         interaction_mode="shadow",
         shadow_timeout_seconds=60,
-        timeout_seconds=None
+        timeout_seconds=None,
     )
     assert h.interaction_mode == "shadow"
     assert h.shadow_timeout_seconds == 60
 
-def test_human_node_blocking_mode_invalid_field():
+
+def test_human_node_blocking_mode_invalid_field() -> None:
     """
     If interaction_mode is 'blocking', shadow_timeout_seconds should not be set.
     """
@@ -45,12 +47,13 @@ def test_human_node_blocking_mode_invalid_field():
             prompt="Block?",
             interaction_mode="blocking",
             shadow_timeout_seconds=60,
-            timeout_seconds=10
+            timeout_seconds=10,
         )
     errors = excinfo.value.errors()
     assert any("HumanNode in 'blocking' mode must not have 'shadow_timeout_seconds'" in e["msg"] for e in errors)
 
-def test_swarm_node_summarize_requires_aggregator():
+
+def test_swarm_node_summarize_requires_aggregator() -> None:
     """
     If reducer_function is 'summarize', aggregator_model is required.
     """
@@ -69,7 +72,8 @@ def test_swarm_node_summarize_requires_aggregator():
     errors = excinfo.value.errors()
     assert any("SwarmNode with reducer='summarize' requires an 'aggregator_model'" in e["msg"] for e in errors)
 
-def test_tool_critical_description():
+
+def test_tool_critical_description() -> None:
     """
     If risk_level is 'critical', description is required.
     """

--- a/tests/test_cross_field_validation.py
+++ b/tests/test_cross_field_validation.py
@@ -1,0 +1,84 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.core.nodes import HumanNode, SwarmNode
+from coreason_manifest.spec.core.tools import ToolCapability
+
+
+def test_human_node_shadow_mode_requirements():
+    """
+    If interaction_mode is 'shadow', shadow_timeout_seconds is required.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        HumanNode(
+            id="h1",
+            type="human",
+            prompt="Shadow?",
+            interaction_mode="shadow",
+            timeout_seconds=None
+            # Missing shadow_timeout_seconds
+        )
+    # Check that one of the errors contains our message
+    errors = excinfo.value.errors()
+    assert any("HumanNode in 'shadow' mode requires 'shadow_timeout_seconds'" in e["msg"] for e in errors)
+
+def test_human_node_shadow_mode_valid():
+    h = HumanNode(
+        id="h1",
+        type="human",
+        prompt="Shadow?",
+        interaction_mode="shadow",
+        shadow_timeout_seconds=60,
+        timeout_seconds=None
+    )
+    assert h.interaction_mode == "shadow"
+    assert h.shadow_timeout_seconds == 60
+
+def test_human_node_blocking_mode_invalid_field():
+    """
+    If interaction_mode is 'blocking', shadow_timeout_seconds should not be set.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        HumanNode(
+            id="h1",
+            type="human",
+            prompt="Block?",
+            interaction_mode="blocking",
+            shadow_timeout_seconds=60,
+            timeout_seconds=10
+        )
+    errors = excinfo.value.errors()
+    assert any("HumanNode in 'blocking' mode must not have 'shadow_timeout_seconds'" in e["msg"] for e in errors)
+
+def test_swarm_node_summarize_requires_aggregator():
+    """
+    If reducer_function is 'summarize', aggregator_model is required.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        SwarmNode(
+            id="s1",
+            type="swarm",
+            worker_profile="worker",
+            workload_variable="items",
+            distribution_strategy="sharded",
+            max_concurrency=10,
+            reducer_function="summarize",
+            output_variable="result",
+            # Missing aggregator_model
+        )
+    errors = excinfo.value.errors()
+    assert any("SwarmNode with reducer='summarize' requires an 'aggregator_model'" in e["msg"] for e in errors)
+
+def test_tool_critical_description():
+    """
+    If risk_level is 'critical', description is required.
+    """
+    with pytest.raises(ValidationError) as excinfo:
+        ToolCapability(
+            name="nuke_db",
+            type="capability",
+            risk_level="critical",
+            # Missing description
+        )
+    errors = excinfo.value.errors()
+    assert any("is Critical but lacks a description" in e["msg"] for e in errors)

--- a/tests/test_diff_rfc6902.py
+++ b/tests/test_diff_rfc6902.py
@@ -6,7 +6,7 @@ from coreason_manifest.utils.diff import GovernanceMutation, ResourceMutation, T
 def create_flow(name: str = "test", nodes: list[AnyNode] | None = None) -> LinearFlow:
     return LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name=name, version="1.0", description="desc", tags=[]),
+        metadata=FlowMetadata(name=name, version="1.0.0", description="desc", tags=[]),
         sequence=nodes or [],
     )
 

--- a/tests/test_domain_fixes.py
+++ b/tests/test_domain_fixes.py
@@ -30,7 +30,7 @@ def test_duplicate_keys(tmp_path: Any) -> None:
 kind: LinearFlow
 metadata:
   name: "Dup"
-  version: "1.0"
+  version: "1.0.0"
   description: "Desc"
   tags: []
 sequence: []
@@ -71,7 +71,7 @@ def test_dynamic_execution_check(tmp_path: Any) -> None:
 kind: LinearFlow
 metadata:
   name: "Dynamic"
-  version: "1.0"
+  version: "1.0.0"
   description: "Desc"
   tags: ["test"]
 sequence: []
@@ -102,7 +102,7 @@ def test_dynamic_execution_check_list(tmp_path: Any) -> None:
 kind: LinearFlow
 metadata:
   name: "DynamicList"
-  version: "1.0"
+  version: "1.0.0"
   description: "Desc"
   tags: []
 sequence: []
@@ -127,7 +127,7 @@ def test_dynamic_execution_posix_path_strictness(tmp_path: Any) -> None:
 kind: LinearFlow
 metadata:
   name: "WinPath"
-  version: "1.0"
+  version: "1.0.0"
   description: "Desc"
   tags: []
 sequence: []
@@ -146,7 +146,7 @@ definitions:
 kind: LinearFlow
 metadata:
   name: "PosixPath"
-  version: "1.0"
+  version: "1.0.0"
   description: "Desc"
   tags: []
 sequence: []
@@ -191,7 +191,7 @@ def test_validator_coverage() -> None:
         graph = Graph(nodes={"n1": node}, edges=[], entry_point="n1")
         flow = GraphFlow(
             kind="GraphFlow",
-            metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+            metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
             interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
             blackboard=Blackboard(variables={}, persistence=False),
             graph=graph,

--- a/tests/test_domain_vocabulary.py
+++ b/tests/test_domain_vocabulary.py
@@ -10,14 +10,15 @@ class VocabularyTestModel(BaseModel):
     node: NodeID | None = None
 
 
-def test_semantic_version_valid():
+def test_semantic_version_valid() -> None:
     m = VocabularyTestModel(version="1.0.0")
     assert m.version == "1.0.0"
 
     m = VocabularyTestModel(version="0.1.2")
     assert m.version == "0.1.2"
 
-def test_semantic_version_invalid():
+
+def test_semantic_version_invalid() -> None:
     with pytest.raises(ValidationError) as excinfo:
         VocabularyTestModel(version="v1.0")
     assert "String should match pattern" in str(excinfo.value)
@@ -28,12 +29,14 @@ def test_semantic_version_invalid():
     with pytest.raises(ValidationError):
         VocabularyTestModel(version="1.a.2")
 
-def test_git_sha_valid():
+
+def test_git_sha_valid() -> None:
     valid_sha = "a" * 40
     m = VocabularyTestModel(sha=valid_sha)
     assert m.sha == valid_sha
 
-def test_git_sha_invalid():
+
+def test_git_sha_invalid() -> None:
     with pytest.raises(ValidationError):
         VocabularyTestModel(sha="bad")  # Too short
 
@@ -43,11 +46,13 @@ def test_git_sha_invalid():
     with pytest.raises(ValidationError):
         VocabularyTestModel(sha="a" * 41)  # Too long
 
-def test_node_id_valid():
+
+def test_node_id_valid() -> None:
     m = VocabularyTestModel(node="valid_node_1")
     assert m.node == "valid_node_1"
 
-def test_node_id_invalid():
+
+def test_node_id_invalid() -> None:
     with pytest.raises(ValidationError):
         VocabularyTestModel(node="invalid node")  # Space not allowed
 

--- a/tests/test_domain_vocabulary.py
+++ b/tests/test_domain_vocabulary.py
@@ -1,0 +1,55 @@
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from coreason_manifest.spec.core.types import GitSHA, NodeID, SemanticVersion
+
+
+class VocabularyTestModel(BaseModel):
+    version: SemanticVersion | None = None
+    sha: GitSHA | None = None
+    node: NodeID | None = None
+
+
+def test_semantic_version_valid():
+    m = VocabularyTestModel(version="1.0.0")
+    assert m.version == "1.0.0"
+
+    m = VocabularyTestModel(version="0.1.2")
+    assert m.version == "0.1.2"
+
+def test_semantic_version_invalid():
+    with pytest.raises(ValidationError) as excinfo:
+        VocabularyTestModel(version="v1.0")
+    assert "String should match pattern" in str(excinfo.value)
+
+    with pytest.raises(ValidationError):
+        VocabularyTestModel(version="1.0")  # Missing patch
+
+    with pytest.raises(ValidationError):
+        VocabularyTestModel(version="1.a.2")
+
+def test_git_sha_valid():
+    valid_sha = "a" * 40
+    m = VocabularyTestModel(sha=valid_sha)
+    assert m.sha == valid_sha
+
+def test_git_sha_invalid():
+    with pytest.raises(ValidationError):
+        VocabularyTestModel(sha="bad")  # Too short
+
+    with pytest.raises(ValidationError):
+        VocabularyTestModel(sha="z" * 40)  # Invalid hex
+
+    with pytest.raises(ValidationError):
+        VocabularyTestModel(sha="a" * 41)  # Too long
+
+def test_node_id_valid():
+    m = VocabularyTestModel(node="valid_node_1")
+    assert m.node == "valid_node_1"
+
+def test_node_id_invalid():
+    with pytest.raises(ValidationError):
+        VocabularyTestModel(node="invalid node")  # Space not allowed
+
+    with pytest.raises(ValidationError):
+        VocabularyTestModel(node="")  # Empty

--- a/tests/test_flow_coverage.py
+++ b/tests/test_flow_coverage.py
@@ -33,7 +33,7 @@ def test_flow_integrity_coverage() -> None:
     LinearFlow(
         kind="LinearFlow",
         status="published",
-        metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+        metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
         definitions=definitions,
         sequence=[agent],
     )
@@ -52,7 +52,7 @@ def test_flow_integrity_coverage() -> None:
         LinearFlow(
             kind="LinearFlow",
             status="published",
-            metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+            metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
             definitions=definitions,
             sequence=[agent_bad_ref],
         )
@@ -71,7 +71,7 @@ def test_flow_integrity_coverage() -> None:
         LinearFlow(
             kind="LinearFlow",
             status="published",
-            metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+            metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
             definitions=definitions,
             sequence=[agent_missing_ref],
         )
@@ -85,7 +85,7 @@ def test_flow_integrity_coverage() -> None:
         LinearFlow(
             kind="LinearFlow",
             status="published",
-            metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+            metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
             definitions=definitions,
             sequence=[agent_missing_profile],
         )
@@ -108,7 +108,7 @@ def test_flow_integrity_coverage() -> None:
         LinearFlow(
             kind="LinearFlow",
             status="published",
-            metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+            metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
             definitions=definitions,
             sequence=[swarm_missing],
         )

--- a/tests/test_flow_schema.py
+++ b/tests/test_flow_schema.py
@@ -17,13 +17,13 @@ def test_flow_interface_schema() -> None:
 def test_flow_interface_validation_error() -> None:
     with pytest.raises(ValidationError):
         FlowInterface(
-            inputs={"bad": "dict"},  # type: ignore[arg-type]
+            inputs={"json_schema": "invalid-type"},  # type: ignore[arg-type]
             outputs=DataSchema(json_schema={}),
         )
 
 
 def test_builder_interface_construction() -> None:
-    builder = NewGraphFlow("test", "1.0", "desc")
+    builder = NewGraphFlow("test", "1.0.0", "desc")
     # Builder now accepts raw dicts for schema
     input_s = {"type": "object", "properties": {"query": {"type": "string"}}}
     output_s = {"type": "object", "properties": {"answer": {"type": "string"}}}

--- a/tests/test_full_suite_integrity.py
+++ b/tests/test_full_suite_integrity.py
@@ -10,7 +10,7 @@ def test_full_suite_integrity() -> None:
     Verifies the end-to-end functionality of the new Core Kernel without V2 files.
     """
     # 1. Build a simple LinearFlow using the Builder
-    builder = NewLinearFlow("IntegrityCheck", version="1.0", description="Verifying Core Integrity")
+    builder = NewLinearFlow("IntegrityCheck", version="1.0.0", description="Verifying Core Integrity")
 
     node1 = PlaceholderNode(id="step-1", metadata={}, required_capabilities=["logging"], type="placeholder")
     node2 = PlaceholderNode(id="step-2", metadata={}, required_capabilities=["alerting"], type="placeholder")

--- a/tests/test_gatekeeper_coverage.py
+++ b/tests/test_gatekeeper_coverage.py
@@ -22,7 +22,7 @@ def test_gatekeeper_capability_error_handling() -> None:
 
     flow = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1.0", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         definitions=Definitions(profiles={"broken": profile}),
         sequence=[AgentNode(id="a1", metadata={}, type="agent", profile="broken", tools=[])],
     )
@@ -71,7 +71,7 @@ def test_gatekeeper_port_stripping() -> None:
     flow = LinearFlow(
         kind="LinearFlow",
         status="draft",
-        metadata=FlowMetadata(name="Port Test", version="1.0", description="desc", tags=[]),
+        metadata=FlowMetadata(name="Port Test", version="1.0.0", description="desc", tags=[]),
         definitions=Definitions(
             tool_packs={
                 "pack1": ToolPack(kind="ToolPack", namespace="pack1", tools=[tool], dependencies=[], env_vars=[])

--- a/tests/test_governance_fixes.py
+++ b/tests/test_governance_fixes.py
@@ -21,7 +21,7 @@ from coreason_manifest.utils.integrity import compute_hash, verify_merkle_proof
 
 # Helper to create common metadata
 def get_meta() -> FlowMetadata:
-    return FlowMetadata(name="test", version="1.0", description="test", tags=[])
+    return FlowMetadata(name="test", version="1.0.0", description="test", tags=[])
 
 
 def get_defs() -> FlowDefinitions:
@@ -414,7 +414,7 @@ def test_circuit_breaker_timeout_logic() -> None:
     # Force unwrap optional for test logic, or assert it's not None
     last_failure = state_store["node_1"].last_failure_time
     assert last_failure is not None
-    state_store["node_1"].last_failure_time = last_failure - 3
+    state_store["node_1"] = state_store["node_1"].model_copy(update={"last_failure_time": last_failure - 3})
     check_circuit("node_1", policy, state_store)
     assert state_store["node_1"].state == "half-open"
 

--- a/tests/test_governance_tools.py
+++ b/tests/test_governance_tools.py
@@ -26,7 +26,7 @@ def test_critical_tool_requires_guard() -> None:
     # Unguarded Flow
     flow_unguarded = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         definitions=definitions,
         sequence=[agent],
     )
@@ -48,7 +48,7 @@ def test_critical_tool_requires_guard() -> None:
 
     flow_guarded = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         definitions=definitions,
         sequence=[human, agent],
     )
@@ -75,7 +75,7 @@ def test_safe_tool_allowed() -> None:
 
     flow = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         definitions=definitions,
         sequence=[agent],
     )

--- a/tests/test_greenfield_fixes.py
+++ b/tests/test_greenfield_fixes.py
@@ -83,7 +83,7 @@ def test_graph_flow_draft_mode() -> None:
     flow = GraphFlow(
         kind="GraphFlow",
         # status="draft", # default
-        metadata=FlowMetadata(name="test", version="1", description="", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="", tags=[]),
         definitions=definitions,
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
@@ -99,7 +99,7 @@ def test_graph_flow_draft_mode() -> None:
         GraphFlow(
             kind="GraphFlow",
             status="published",
-            metadata=FlowMetadata(name="test", version="1", description="", tags=[]),
+            metadata=FlowMetadata(name="test", version="1.0.0", description="", tags=[]),
             definitions=definitions,
             interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
             blackboard=None,
@@ -120,7 +120,7 @@ def test_graph_flow_draft_mode() -> None:
     flow_valid = GraphFlow(
         kind="GraphFlow",
         status="published",
-        metadata=FlowMetadata(name="test", version="1", description="", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="", tags=[]),
         definitions=definitions,
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
@@ -218,7 +218,7 @@ def test_coverage_linear_flow_published() -> None:
     LinearFlow(
         kind="LinearFlow",
         status="published",
-        metadata=FlowMetadata(name="test", version="1", description="", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="", tags=[]),
         definitions=definitions,
         sequence=[agent],
     )
@@ -384,7 +384,7 @@ def test_validator_definitions_profile_scanning() -> None:
 
     flow = GraphFlow(
         kind="GraphFlow",
-        metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+        metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=blackboard,
         graph=graph,
@@ -449,7 +449,7 @@ def test_jinja2_filter_validation() -> None:
     agent = AgentNode(
         id="n1",
         type="agent",
-        metadata={"desc": "Hello {{ user.name | upper }}"},
+        metadata={"desc": "Hello {{ user_name | upper }}"},
         resilience=None,
         profile=CognitiveProfile(
             role="Role",
@@ -460,13 +460,13 @@ def test_jinja2_filter_validation() -> None:
         tools=[],
     )
 
-    # Define 'user.name' in blackboard
-    blackboard = Blackboard(variables={"user.name": VariableDef(type="string")}, persistence=False)
+    # Define 'user_name' in blackboard
+    blackboard = Blackboard(variables={"user_name": VariableDef(type="string")}, persistence=False)
 
     graph = Graph(nodes={"n1": agent}, edges=[], entry_point="n1")
     flow = GraphFlow(
         kind="GraphFlow",
-        metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+        metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=blackboard,
         graph=graph,
@@ -488,7 +488,7 @@ def test_jinja2_filter_validation() -> None:
     graph_fail = Graph(nodes={"n1": agent_fail}, edges=[], entry_point="n1")
     flow_fail = GraphFlow(
         kind="GraphFlow",
-        metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+        metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=blackboard,
         graph=graph_fail,
@@ -533,7 +533,7 @@ def test_swarm_type_safety() -> None:
     graph = Graph(nodes={"s1": swarm}, edges=[], entry_point="s1")
     flow = GraphFlow(
         kind="GraphFlow",
-        metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+        metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=blackboard,
         graph=graph,
@@ -574,7 +574,7 @@ def test_inspector_regex_warning() -> None:
     graph = Graph(nodes={"i1": inspector}, edges=[], entry_point="i1")
     flow = GraphFlow(
         kind="GraphFlow",
-        metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+        metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=blackboard,
         graph=graph,
@@ -629,7 +629,7 @@ def test_validator_union_type_normalization() -> None:
     graph = Graph(nodes={"s1": swarm}, edges=[], entry_point="s1")
     flow = GraphFlow(
         kind="GraphFlow",
-        metadata=FlowMetadata(name="T", version="1", description="D", tags=[]),
+        metadata=FlowMetadata(name="T", version="1.0.0", description="D", tags=[]),
         interface=FlowInterface(inputs=inputs, outputs=DataSchema()),
         blackboard=None,
         graph=graph,
@@ -656,7 +656,7 @@ def test_loader_duplicate_keys_error(tmp_path: object) -> None:
         kind: GraphFlow
         metadata:
           name: bad-flow
-          version: "1"
+          version: "1.0.0"
           description: test
           tags: []
         interface:

--- a/tests/test_greenfield_refactor_v2.py
+++ b/tests/test_greenfield_refactor_v2.py
@@ -139,7 +139,7 @@ def test_topology_tolerance_and_gatekeeper() -> None:
     flow = GraphFlow(
         kind="GraphFlow",
         status="published",
-        metadata=FlowMetadata(name="test", version="1.0", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph,

--- a/tests/test_immutable_state.py
+++ b/tests/test_immutable_state.py
@@ -1,0 +1,50 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.core.flow import FlowMetadata, LinearFlow
+from coreason_manifest.spec.core.nodes import AgentNode
+
+
+def test_immutable_node():
+    """
+    Test that modifying a field on a Node instance raises a ValidationError (FrozenInstanceError).
+    """
+    node = AgentNode(
+        id="agent_1",
+        type="agent",
+        profile="researcher",
+        tools=["search"]
+    )
+
+    with pytest.raises(ValidationError):
+        node.id = "new_id"
+
+    with pytest.raises(ValidationError):
+        node.tools.append("new_tool")  # List inside is mutable? No, usually pydantic makes container fields mutable unless re-validated or config specific.
+        # Wait, frozen=True usually makes the instance frozen, but fields that are mutable objects (like list) can be modified in-place if retrieved.
+        # However, reassignment `node.tools = ...` is forbidden.
+        # Let's check reassignment.
+        node.tools = ["new_tool"]
+
+
+def test_immutable_flow():
+    """
+    Test that modifying a Flow instance raises a ValidationError.
+    """
+    flow = LinearFlow(
+        kind="LinearFlow",
+        status="draft",
+        metadata=FlowMetadata(
+            name="Test Flow",
+            version="1.0.0",
+            description="Test",
+            tags=[]
+        ),
+        sequence=[]
+    )
+
+    with pytest.raises(ValidationError):
+        flow.status = "published"
+
+    with pytest.raises(ValidationError):
+        flow.metadata.name = "New Name"  # Recursive immutability if sub-models are also frozen.

--- a/tests/test_immutable_state.py
+++ b/tests/test_immutable_state.py
@@ -5,46 +5,33 @@ from coreason_manifest.spec.core.flow import FlowMetadata, LinearFlow
 from coreason_manifest.spec.core.nodes import AgentNode
 
 
-def test_immutable_node():
+def test_immutable_node() -> None:
     """
     Test that modifying a field on a Node instance raises a ValidationError (FrozenInstanceError).
     """
-    node = AgentNode(
-        id="agent_1",
-        type="agent",
-        profile="researcher",
-        tools=["search"]
-    )
+    node = AgentNode(id="agent_1", type="agent", profile="researcher", tools=["search"])
 
     with pytest.raises(ValidationError):
-        node.id = "new_id"
+        node.id = "new_id"  # type: ignore[misc]
 
     with pytest.raises(ValidationError):
-        node.tools.append("new_tool")  # List inside is mutable? No, usually pydantic makes container fields mutable unless re-validated or config specific.
-        # Wait, frozen=True usually makes the instance frozen, but fields that are mutable objects (like list) can be modified in-place if retrieved.
-        # However, reassignment `node.tools = ...` is forbidden.
-        # Let's check reassignment.
-        node.tools = ["new_tool"]
+        # Reassignment is forbidden
+        node.tools = ["new_tool"]  # type: ignore[misc]
 
 
-def test_immutable_flow():
+def test_immutable_flow() -> None:
     """
     Test that modifying a Flow instance raises a ValidationError.
     """
     flow = LinearFlow(
         kind="LinearFlow",
         status="draft",
-        metadata=FlowMetadata(
-            name="Test Flow",
-            version="1.0.0",
-            description="Test",
-            tags=[]
-        ),
-        sequence=[]
+        metadata=FlowMetadata(name="Test Flow", version="1.0.0", description="Test", tags=[]),
+        sequence=[],
     )
 
     with pytest.raises(ValidationError):
-        flow.status = "published"
+        flow.status = "published"  # type: ignore[misc]
 
     with pytest.raises(ValidationError):
-        flow.metadata.name = "New Name"  # Recursive immutability if sub-models are also frozen.
+        flow.metadata.name = "New Name"  # type: ignore[misc]

--- a/tests/test_json_schema_export.py
+++ b/tests/test_json_schema_export.py
@@ -1,3 +1,5 @@
+import json
+
 from coreason_manifest.spec.core.flow import Manifest
 
 
@@ -5,7 +7,10 @@ def test_json_schema_export() -> None:
     """
     Test that Manifest.export_json_schema() returns a valid JSON Schema dict.
     """
-    schema = Manifest.export_json_schema()
+    schema_str = Manifest.export_json_schema()
+    assert isinstance(schema_str, str)
+
+    schema = json.loads(schema_str)
 
     assert isinstance(schema, dict)
     assert "$defs" in schema  # Definitions should be present for complex types
@@ -32,5 +37,5 @@ def test_json_schema_export() -> None:
     assert "anyOf" in node_schema or "oneOf" in node_schema
 
     # Check that custom descriptions are present (random check)
-    assert "Unique identifier for the node." in str(schema)
-    assert "Description of what the flow does." in str(schema)
+    assert "Unique identifier for the node." in schema_str
+    assert "Description of what the flow does." in schema_str

--- a/tests/test_json_schema_export.py
+++ b/tests/test_json_schema_export.py
@@ -1,7 +1,7 @@
 from coreason_manifest.spec.core.flow import Manifest
 
 
-def test_json_schema_export():
+def test_json_schema_export() -> None:
     """
     Test that Manifest.export_json_schema() returns a valid JSON Schema dict.
     """

--- a/tests/test_json_schema_export.py
+++ b/tests/test_json_schema_export.py
@@ -1,0 +1,36 @@
+from coreason_manifest.spec.core.flow import Manifest
+
+
+def test_json_schema_export():
+    """
+    Test that Manifest.export_json_schema() returns a valid JSON Schema dict.
+    """
+    schema = Manifest.export_json_schema()
+
+    assert isinstance(schema, dict)
+    assert "$defs" in schema  # Definitions should be present for complex types
+
+    defs = schema["$defs"]
+    assert "LinearFlow" in defs
+    assert "GraphFlow" in defs
+
+    # Check LinearFlow sequence items
+    linear_flow = defs["LinearFlow"]
+    sequence_items = linear_flow["properties"]["sequence"]["items"]
+
+    # It should reference AnyNode or be AnyNode
+    if "$ref" in sequence_items:
+        ref_name = sequence_items["$ref"].split("/")[-1]
+        assert ref_name in defs
+        node_schema = defs[ref_name]
+    else:
+        # If inlined (unlikely for complex type)
+        node_schema = sequence_items
+
+    # Check that the node schema is a discriminated union
+    # Pydantic v2 uses 'anyOf' or 'oneOf' with 'discriminator'
+    assert "anyOf" in node_schema or "oneOf" in node_schema
+
+    # Check that custom descriptions are present (random check)
+    assert "Unique identifier for the node." in str(schema)
+    assert "Description of what the flow does." in str(schema)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -12,7 +12,7 @@ from coreason_manifest.utils.loader import load_flow_from_file
 def test_load_linear_flow() -> None:
     data: dict[str, Any] = {
         "kind": "LinearFlow",
-        "metadata": {"name": "TestLinear", "version": "1.0", "description": "Test", "tags": []},
+        "metadata": {"name": "TestLinear", "version": "1.0.0", "description": "Test", "tags": []},
         "sequence": [],
     }
     with NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as tmp:
@@ -30,7 +30,7 @@ def test_load_linear_flow() -> None:
 def test_load_graph_flow() -> None:
     data: dict[str, Any] = {
         "kind": "GraphFlow",
-        "metadata": {"name": "TestGraph", "version": "1.0", "description": "Test", "tags": []},
+        "metadata": {"name": "TestGraph", "version": "1.0.0", "description": "Test", "tags": []},
         "interface": {
             "inputs": {"json_schema": {}},
             "outputs": {"json_schema": {}},

--- a/tests/test_phase2_inspector.py
+++ b/tests/test_phase2_inspector.py
@@ -6,12 +6,12 @@ from coreason_manifest.utils.visualizer import to_mermaid
 
 def test_inspector_lifecycle_graph() -> None:
     # 1. Use NewGraphFlow builder to construct a flow
-    flow_builder = NewGraphFlow(name="inspector-test-graph", version="0.25")
+    flow_builder = NewGraphFlow(name="inspector-test-graph", version="0.25.0")
 
     # Domain 4: Add Blackboard variables for data flow validation
     flow_builder.set_blackboard(
         {
-            "result.score": VariableDef(type="float", description="Score"),
+            "result_score": VariableDef(type="float", description="Score"),
             "verification_result": VariableDef(type="boolean", description="Result"),
         }
     )
@@ -19,7 +19,7 @@ def test_inspector_lifecycle_graph() -> None:
     # 2. Add an InspectorNode using .add_inspector()
     flow_builder.add_inspector(
         node_id="inspector-1",
-        target="result.score",
+        target="result_score",
         criteria="Score must be > 0.8",
         output="verification_result",
         pass_threshold=0.8,
@@ -39,7 +39,7 @@ def test_inspector_lifecycle_graph() -> None:
 
     # Verify pass_threshold is set correctly
     assert node.pass_threshold == 0.8
-    assert node.target_variable == "result.score"
+    assert node.target_variable == "result_score"
     assert node.criteria == "Score must be > 0.8"
 
     # Run to_mermaid(flow) and verify the classDef inspector is present
@@ -60,12 +60,12 @@ def test_inspector_lifecycle_graph() -> None:
 
 def test_inspector_lifecycle_linear() -> None:
     # 1. Use NewLinearFlow builder to construct a flow
-    flow_builder = NewLinearFlow(name="inspector-test-linear", version="0.25")
+    flow_builder = NewLinearFlow(name="inspector-test-linear", version="0.25.0")
 
     # 2. Add an InspectorNode using .add_inspector()
     flow_builder.add_inspector(
         node_id="inspector-2",
-        target="result.quality",
+        target="result_quality",
         criteria="Quality must be high",
         output="quality_check",
         pass_threshold=0.9,
@@ -85,7 +85,7 @@ def test_inspector_lifecycle_linear() -> None:
 
     # Verify properties
     assert node.pass_threshold == 0.9
-    assert node.target_variable == "result.quality"
+    assert node.target_variable == "result_quality"
 
     # Run to_mermaid(flow) to verify visualization for linear flow
     mermaid_code = to_mermaid(flow)

--- a/tests/test_refactor_verification.py
+++ b/tests/test_refactor_verification.py
@@ -134,7 +134,7 @@ def test_exfiltration_blocked_domain() -> None:
 
     flow = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1.0", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         governance=gov,
         definitions=Definitions(
             tool_packs={
@@ -168,7 +168,7 @@ def test_allowed_url() -> None:
 
     flow = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1.0", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         governance=gov,
         definitions=Definitions(
             tool_packs={
@@ -191,7 +191,7 @@ def test_allowed_url() -> None:
 
     flow_sub = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1.0", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         governance=gov,
         definitions=Definitions(
             tool_packs={
@@ -225,7 +225,7 @@ def test_schemeless_url_handling() -> None:
 
     flow = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="test", version="1.0", description="test", tags=[]),
+        metadata=FlowMetadata(name="test", version="1.0.0", description="test", tags=[]),
         governance=gov,
         definitions=Definitions(
             tool_packs={
@@ -264,7 +264,7 @@ def test_auto_fix_computer_use() -> None:
 
     flow = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="unsafe", version="1.0", description="unsafe", tags=[]),
+        metadata=FlowMetadata(name="unsafe", version="1.0.0", description="unsafe", tags=[]),
         definitions=Definitions(profiles={"hacker": profile}),
         sequence=[AgentNode(id="attacker", metadata={}, type="agent", profile="hacker", tools=[])],
     )
@@ -297,7 +297,7 @@ def test_verify_remediation_patch_structure() -> None:
 
     flow = LinearFlow(
         kind="LinearFlow",
-        metadata=FlowMetadata(name="unsafe", version="1.0", description="unsafe", tags=[]),
+        metadata=FlowMetadata(name="unsafe", version="1.0.0", description="unsafe", tags=[]),
         definitions=Definitions(profiles={"coder": profile}),
         sequence=[AgentNode(id="coder_agent", metadata={}, type="agent", profile="coder", tools=[])],
     )

--- a/tests/test_registry_pattern.py
+++ b/tests/test_registry_pattern.py
@@ -68,7 +68,7 @@ def test_linear_flow_definitions() -> None:
         tools=[],
     )
 
-    metadata = FlowMetadata(name="test-linear", version="1.0", description="test", tags=[])
+    metadata = FlowMetadata(name="test-linear", version="1.0.0", description="test", tags=[])
     flow = LinearFlow(
         kind="LinearFlow",
         metadata=metadata,
@@ -100,7 +100,7 @@ def test_graph_flow_definitions() -> None:
         tools=[],
     )
 
-    metadata = FlowMetadata(name="test-graph", version="1.0", description="test", tags=[])
+    metadata = FlowMetadata(name="test-graph", version="1.0.0", description="test", tags=[])
     interface = FlowInterface(
         inputs=DataSchema(json_schema={}),
         outputs=DataSchema(json_schema={}),
@@ -142,7 +142,7 @@ def test_referential_integrity_failure() -> None:
         resilience=None,
     )
 
-    metadata = FlowMetadata(name="broken-flow", version="1.0", description="fail", tags=[])
+    metadata = FlowMetadata(name="broken-flow", version="1.0.0", description="fail", tags=[])
 
     # 3. Expect a ValueError during initialization
     with pytest.raises(ValueError, match="references undefined profile ID 'ghost-brain'"):
@@ -177,7 +177,7 @@ def test_tool_integrity_failure() -> None:
         LinearFlow(
             kind="LinearFlow",
             status="published",
-            metadata=FlowMetadata(name="fail", version="1", description="", tags=[]),
+            metadata=FlowMetadata(name="fail", version="1.0.0", description="", tags=[]),
             definitions=definitions,
             sequence=[agent],
         )
@@ -206,7 +206,7 @@ def test_tool_integrity_failure_graph() -> None:
         GraphFlow(
             kind="GraphFlow",
             status="published",
-            metadata=FlowMetadata(name="fail", version="1", description="", tags=[]),
+            metadata=FlowMetadata(name="fail", version="1.0.0", description="", tags=[]),
             definitions=definitions,
             interface=FlowInterface(
                 inputs=DataSchema(json_schema={}),

--- a/tests/test_semantic_routing.py
+++ b/tests/test_semantic_routing.py
@@ -1,87 +1,69 @@
 import pytest
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
-from coreason_manifest.spec.core.engines import (
-    CouncilReasoning,
-    FastPath,
-    ModelCriteria,
-    StandardReasoning,
-    TreeSearchReasoning,
-)
-from coreason_manifest.spec.core.resilience import (
-    ReflexionStrategy,
-)
+from coreason_manifest.spec.core.flow import AnyNode
+from coreason_manifest.spec.core.nodes import AgentNode, HumanNode, SwarmNode
 
 
-def test_model_criteria_instantiation() -> None:
-    # Test valid criteria
-    criteria = ModelCriteria(
-        strategy="lowest_cost",
-        min_context=8192,
-        capabilities=["vision", "json_mode"],
-        compliance=["gdpr"],
-        max_cost_per_m_tokens=10.0,
-        provider_whitelist=["azure"],
-    )
-    assert criteria.strategy == "lowest_cost"
-    assert criteria.min_context == 8192
+def test_semantic_routing_nodes():
+    """
+    Test that a list of mixed node types is parsed correctly into their specific classes.
+    """
+    nodes_data = [
+        {
+            "type": "human",
+            "id": "human_step_1",
+            "prompt": "Approve?",
+            "interaction_mode": "blocking",
+            "timeout_seconds": 60
+        },
+        {
+            "type": "agent",
+            "id": "agent_step_1",
+            "profile": "researcher_profile",
+            "tools": ["web_search"]
+        },
+        {
+            "type": "swarm",
+            "id": "swarm_step_1",
+            "worker_profile": "worker_v1",
+            "workload_variable": "data_list",
+            "distribution_strategy": "sharded",
+            "max_concurrency": 10,
+            "reducer_function": "concat",
+            "output_variable": "result"
+        }
+    ]
 
-    # Test invalid strategy
-    with pytest.raises(ValidationError):
-        ModelCriteria(strategy="invalid_strategy")  # type: ignore
+    adapter = TypeAdapter(list[AnyNode])
+    nodes = adapter.validate_python(nodes_data)
 
+    assert len(nodes) == 3
+    assert isinstance(nodes[0], HumanNode)
+    assert nodes[0].type == "human"
+    assert nodes[0].id == "human_step_1"
 
-def test_semantic_routing_in_reasoning() -> None:
-    # 1. StandardReasoning with String (Legacy)
-    legacy = StandardReasoning(model="gpt-4", thoughts_max=5)
-    assert legacy.model == "gpt-4"
+    assert isinstance(nodes[1], AgentNode)
+    assert nodes[1].type == "agent"
+    assert nodes[1].profile == "researcher_profile"
 
-    # 2. StandardReasoning with Criteria
-    criteria = ModelCriteria(strategy="performance")
-    advanced = StandardReasoning(model=criteria, thoughts_max=5)
-    assert isinstance(advanced.model, ModelCriteria)
-    assert advanced.model.strategy == "performance"
-
-
-def test_tree_search_evaluator_routing() -> None:
-    # Evaluator model can be a criteria
-    lats = TreeSearchReasoning(
-        model="gpt-4",
-        depth=3,
-        branching_factor=2,
-        simulations=5,
-        evaluator_model=ModelCriteria(strategy="balanced"),
-    )
-    assert isinstance(lats.evaluator_model, ModelCriteria)
-    assert lats.evaluator_model.strategy == "balanced"
-
-
-def test_reflex_routing() -> None:
-    criteria = ModelCriteria(strategy="lowest_latency")
-    reflex = FastPath(model=criteria, timeout_ms=500)
-    assert isinstance(reflex.model, ModelCriteria)
-    assert reflex.model.strategy == "lowest_latency"
+    assert isinstance(nodes[2], SwarmNode)
+    assert nodes[2].type == "swarm"
+    assert nodes[2].distribution_strategy == "sharded"
 
 
-def test_supervision_critic_routing() -> None:
-    criteria = ModelCriteria(capabilities=["coding"])
+def test_semantic_routing_failure():
+    """
+    Test that an invalid type raises a ValidationError.
+    """
+    nodes_data = [
+        {
+            "type": "invalid_type",
+            "id": "bad_node"
+        }
+    ]
+    adapter = TypeAdapter(list[AnyNode])
+    with pytest.raises(ValidationError) as excinfo:
+        adapter.validate_python(nodes_data)
 
-    # SupervisionPolicy doesn't have critic_model directly, it's inside ReflexionStrategy
-    strategy = ReflexionStrategy(max_attempts=3, critic_model=criteria, critic_prompt="Test", include_trace=True)
-
-    # sup = SupervisionPolicy(handlers=[], default_strategy=strategy)
-
-    assert isinstance(strategy, ReflexionStrategy)
-    assert isinstance(strategy.critic_model, ModelCriteria)
-    assert strategy.critic_model.capabilities == ["coding"]
-
-
-def test_council_tie_breaker_routing() -> None:
-    criteria = ModelCriteria(strategy="performance")
-    council = CouncilReasoning(
-        model="gpt-4",
-        personas=["A", "B"],
-        tie_breaker_model=criteria,
-    )
-    assert isinstance(council.tie_breaker_model, ModelCriteria)
-    assert council.tie_breaker_model.strategy == "performance"
+    assert "Input tag 'invalid_type' found using 'type' does not match any of the expected tags" in str(excinfo.value)

--- a/tests/test_semantic_routing.py
+++ b/tests/test_semantic_routing.py
@@ -5,7 +5,7 @@ from coreason_manifest.spec.core.flow import AnyNode
 from coreason_manifest.spec.core.nodes import AgentNode, HumanNode, SwarmNode
 
 
-def test_semantic_routing_nodes():
+def test_semantic_routing_nodes() -> None:
     """
     Test that a list of mixed node types is parsed correctly into their specific classes.
     """
@@ -15,13 +15,13 @@ def test_semantic_routing_nodes():
             "id": "human_step_1",
             "prompt": "Approve?",
             "interaction_mode": "blocking",
-            "timeout_seconds": 60
+            "timeout_seconds": 60,
         },
         {
             "type": "agent",
             "id": "agent_step_1",
             "profile": "researcher_profile",
-            "tools": ["web_search"]
+            "tools": ["web_search"],
         },
         {
             "type": "swarm",
@@ -31,8 +31,8 @@ def test_semantic_routing_nodes():
             "distribution_strategy": "sharded",
             "max_concurrency": 10,
             "reducer_function": "concat",
-            "output_variable": "result"
-        }
+            "output_variable": "result",
+        },
     ]
 
     adapter = TypeAdapter(list[AnyNode])
@@ -52,16 +52,11 @@ def test_semantic_routing_nodes():
     assert nodes[2].distribution_strategy == "sharded"
 
 
-def test_semantic_routing_failure():
+def test_semantic_routing_failure() -> None:
     """
     Test that an invalid type raises a ValidationError.
     """
-    nodes_data = [
-        {
-            "type": "invalid_type",
-            "id": "bad_node"
-        }
-    ]
+    nodes_data = [{"type": "invalid_type", "id": "bad_node"}]
     adapter = TypeAdapter(list[AnyNode])
     with pytest.raises(ValidationError) as excinfo:
         adapter.validate_python(nodes_data)

--- a/tests/test_sota_architecture.py
+++ b/tests/test_sota_architecture.py
@@ -1,6 +1,7 @@
 import json
+from typing import Any
 
-from pydantic import Field
+from pydantic import AliasChoices, Field
 
 from coreason_manifest.spec.common_base import CoreasonModel
 from coreason_manifest.spec.core.flow import Manifest
@@ -76,3 +77,56 @@ def test_json_schema_export_meta() -> None:
 
     assert schema["$schema"] == "http://json-schema.org/draft-07/schema#"
     assert schema["title"] == "Coreason Manifest Specification v2"
+
+
+class AliasChoicesModel(CoreasonModel):
+    """Test model with AliasChoices."""
+
+    priority: int = Field(validation_alias=AliasChoices("prio", "importance"))
+
+
+def test_alias_choices_integrity() -> None:
+    """Test that AliasChoices are respected and not funneled."""
+    # Case 1: Use first choice
+    data1 = {"prio": 1}
+    m1 = AliasChoicesModel.model_validate(data1)
+    assert m1.priority == 1
+    assert "prio" not in m1.annotations
+
+    # Case 2: Use second choice
+    data2 = {"importance": 2}
+    m2 = AliasChoicesModel.model_validate(data2)
+    assert m2.priority == 2
+    assert "importance" not in m2.annotations
+
+
+class ComplexCanonicalModel(CoreasonModel):
+    items: list[dict[str, Any]]
+
+
+def test_canonical_hash_unorderable() -> None:
+    """Test canonicalization of lists containing unorderable items (dicts)."""
+    # List of dicts cannot be sorted in Python 3 directly
+    m = ComplexCanonicalModel(items=[{"b": 2}, {"a": 1}])
+
+    # This should not raise TypeError (hits the except TypeError block)
+    m.model_dump_canonical()
+
+
+def test_model_dump_json_determinism() -> None:
+    """Test model_dump_json ensures sorted keys and handles indent."""
+    # Use field name to instantiate
+    m = AliasModel(name="test", timeout_sec=60)
+
+    # Check default dump (no indent, sorted keys)
+    json_out = m.model_dump_json()
+
+    # Verify keys are sorted alphabetically
+    loaded = json.loads(json_out)
+    keys = list(loaded.keys())
+    assert keys == sorted(keys)
+    assert keys == ["annotations", "name", "timeout_sec"]
+
+    # Test indent
+    json_indent = m.model_dump_json(indent=2)
+    assert '  "name": "test",' in json_indent

--- a/tests/test_sota_architecture.py
+++ b/tests/test_sota_architecture.py
@@ -1,0 +1,78 @@
+import json
+
+from pydantic import Field
+
+from coreason_manifest.spec.common_base import CoreasonModel
+from coreason_manifest.spec.core.flow import Manifest
+from coreason_manifest.spec.core.types import CoercibleStringList
+
+
+class AliasModel(CoreasonModel):
+    timeout_sec: int = Field(alias="timeout-sec")
+    name: str
+
+
+class CollectionModel(CoreasonModel):
+    tags: CoercibleStringList
+
+
+def test_alias_integrity() -> None:
+    """Test that aliases are respected and not funneled into annotations."""
+    data = {"timeout-sec": 60, "name": "test"}
+    model = AliasModel.model_validate(data)
+    assert model.timeout_sec == 60
+    assert model.name == "test"
+    # Ensure it wasn't moved to annotations
+    assert "timeout-sec" not in model.annotations
+    assert "timeout_sec" not in model.annotations
+
+    # Test funneling of actual extra fields
+    data_extra = {"timeout-sec": 60, "name": "test", "extra_field": "val"}
+    model_extra = AliasModel.model_validate(data_extra)
+    assert model_extra.timeout_sec == 60
+    assert model_extra.annotations.get("extra_field") == "val"
+
+
+class CanonicalModel(CoreasonModel):
+    tags: list[str]
+
+
+def test_canonical_hash_determinism() -> None:
+    """Test that model_dump_canonical produces deterministic output for unordered inputs."""
+    # Create data that would produce different json dumps order if set-to-list conversion is random
+    # We simulate this by manually creating lists in different orders
+    m1 = CanonicalModel(tags=["a", "b", "c"])
+    m2 = CanonicalModel(tags=["c", "b", "a"])
+
+    # They are logically different lists, but if we treat them as sets for canonicalization...
+    # Wait, the fix says "recursively sort lists".
+    # If the input is a list, it sorts it.
+    # This implies lists are treated as sets for canonicalization?
+    # "SOTA Fix: Recursively sort lists to prevent non-deterministic set-to-list casting"
+    # Yes, it seems it treats all lists as sortable collections.
+
+    dump1 = m1.model_dump_canonical()
+    dump2 = m2.model_dump_canonical()
+
+    assert dump1 == dump2
+
+
+def test_coercion_string_list() -> None:
+    """Test that comma-separated strings are coerced into lists."""
+    model = CollectionModel(tags="research, scraper")  # type: ignore[arg-type]
+    assert model.tags == ["research", "scraper"]
+
+    model2 = CollectionModel(tags=" single ")  # type: ignore[arg-type]
+    assert model2.tags == ["single"]
+
+    model3 = CollectionModel(tags=["already", "list"])
+    assert model3.tags == ["already", "list"]
+
+
+def test_json_schema_export_meta() -> None:
+    """Test that export_json_schema includes meta tags."""
+    schema_str = Manifest.export_json_schema()
+    schema = json.loads(schema_str)
+
+    assert schema["$schema"] == "http://json-schema.org/draft-07/schema#"
+    assert schema["title"] == "Coreason Manifest Specification v2"

--- a/tests/test_sota_fixes.py
+++ b/tests/test_sota_fixes.py
@@ -69,7 +69,7 @@ def test_draft_flow_allows_cycles() -> None:
     flow = GraphFlow(
         kind="GraphFlow",
         status="draft",
-        metadata=FlowMetadata(name="cycle", version="1.0", description="desc", tags=[]),
+        metadata=FlowMetadata(name="cycle", version="1.0.0", description="desc", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=graph,
@@ -98,7 +98,7 @@ def test_published_flow_forbids_cycles() -> None:
     flow = GraphFlow(
         kind="GraphFlow",
         status="published",
-        metadata=FlowMetadata(name="cycle", version="1.0", description="desc", tags=[]),
+        metadata=FlowMetadata(name="cycle", version="1.0.0", description="desc", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         definitions=defs,
@@ -142,7 +142,7 @@ def test_diff_classification_via_context() -> None:
     base_flow = GraphFlow(
         kind="GraphFlow",
         status="draft",
-        metadata=FlowMetadata(name="diff", version="1.0", description="desc", tags=[]),
+        metadata=FlowMetadata(name="diff", version="1.0.0", description="desc", tags=[]),
         interface=FlowInterface(inputs=DataSchema(), outputs=DataSchema()),
         blackboard=None,
         graph=Graph(nodes={"entry": entry_node}, edges=[], entry_point="entry"),

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -23,7 +23,7 @@ from coreason_manifest.utils.validator import validate_flow
 
 # Helpers to create dummy objects
 def create_metadata() -> FlowMetadata:
-    return FlowMetadata(name="test", version="1.0", description="test", tags=[])
+    return FlowMetadata(name="test", version="1.0.0", description="test", tags=[])
 
 
 def create_interface() -> FlowInterface:

--- a/tests/test_visualizer_phase3b.py
+++ b/tests/test_visualizer_phase3b.py
@@ -212,13 +212,14 @@ def test_explicit_edge_labels() -> None:
 
 
 def test_special_characters_escaping() -> None:
+    # Use model_construct to bypass strict validation for testing visualizer escaping logic
     nodes: list[Any] = [
-        _get_agent_node("agent 1"),  # Space in ID
-        _get_agent_node('agent"2"'),  # Quote in ID
-        _get_agent_node("agent-3"),  # Hyphen in ID
+        AgentNode.model_construct(id="agent 1", type="agent", profile="p", tools=[]),
+        AgentNode.model_construct(id='agent"2"', type="agent", profile="p", tools=[]),
+        AgentNode.model_construct(id="agent-3", type="agent", profile="p", tools=[]),
     ]
 
-    flow = LinearFlow(
+    flow = LinearFlow.model_construct(
         kind="LinearFlow",
         metadata=_get_metadata(),
         sequence=nodes,


### PR DESCRIPTION
Refactored coreason-manifest to use Pydantic v2 strict typing, discriminated unions, and immutable models. Introduced CoreasonModel base class, domain vocabulary types, and cross-field validators. Implemented Manifest.export_json_schema().

---
*PR created automatically by Jules for task [9118234681319482449](https://jules.google.com/task/9118234681319482449) started by @gowthamrao*