### PR TITLE
Greenfield Refactor: SOTA Compliance (v0.25.0)

### DIFF
--- a/src/coreason_manifest/spec/interop/request.py
+++ b/src/coreason_manifest/spec/interop/request.py
@@ -26,11 +26,19 @@ class AgentRequest(BaseModel):
 
     # Payload
     agent_id: str
+    session_id: str
     inputs: dict[str, Any]
     metadata: dict[str, Any] = Field(default_factory=dict)
 
     # Versioning
     hash_version: Literal["v1"] = Field(default="v1", description="Versioning for integrity strategies.")
+
+    def create_child(self, metadata: dict[str, Any]) -> "AgentRequest":
+        return self.model_copy(update={
+            "request_id": str(uuid4()),
+            "parent_request_id": self.request_id,
+            "metadata": metadata,
+        })
 
     @model_validator(mode="before")
     @classmethod
@@ -73,7 +81,7 @@ class AgentRequest(BaseModel):
         """
         # Rule: Orphaned trace check
         if self.parent_request_id and not self.root_request_id:
-            raise ValueError("Orphaned trace detected: parent_request_id is set but root_request_id is missing.")
+            raise ValueError("Broken Lineage: parent_request_id is set but root_request_id is missing.")
 
         # W3C consistency (Optional but good):
         # If traceparent is present, it should ideally align with IDs,

--- a/src/coreason_manifest/spec/interop/request.py
+++ b/src/coreason_manifest/spec/interop/request.py
@@ -34,11 +34,13 @@ class AgentRequest(BaseModel):
     hash_version: Literal["v1"] = Field(default="v1", description="Versioning for integrity strategies.")
 
     def create_child(self, metadata: dict[str, Any]) -> "AgentRequest":
-        return self.model_copy(update={
-            "request_id": str(uuid4()),
-            "parent_request_id": self.request_id,
-            "metadata": metadata,
-        })
+        return self.model_copy(
+            update={
+                "request_id": str(uuid4()),
+                "parent_request_id": self.request_id,
+                "metadata": metadata,
+            }
+        )
 
     @model_validator(mode="before")
     @classmethod

--- a/src/coreason_manifest/spec/interop/request.py
+++ b/src/coreason_manifest/spec/interop/request.py
@@ -1,4 +1,4 @@
-from typing import Any, Literal
+from typing import Any, Literal, Self
 from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -33,7 +33,7 @@ class AgentRequest(BaseModel):
     # Versioning
     hash_version: Literal["v1"] = Field(default="v1", description="Versioning for integrity strategies.")
 
-    def create_child(self, metadata: dict[str, Any]) -> "AgentRequest":
+    def create_child(self, metadata: dict[str, Any]) -> Self:
         return self.model_copy(
             update={
                 "request_id": str(uuid4()),

--- a/src/coreason_manifest/spec/interop/stream.py
+++ b/src/coreason_manifest/spec/interop/stream.py
@@ -1,6 +1,6 @@
-from typing import Annotated, Any, Literal
+from typing import Annotated, Literal
 
-from pydantic import BaseModel, BeforeValidator, ConfigDict, ValidationError
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class StreamError(BaseModel):
@@ -15,29 +15,28 @@ class StreamError(BaseModel):
     severity: Literal["low", "medium", "high", "critical"]
 
 
-def _duck_type_stream_error(v: Any) -> Any:
-    """
-    SOTA Ingress: Duck-type inference to upgrade raw dicts to rigid objects.
-    """
-    if isinstance(v, dict):
-        # Check signature
-        required_keys = {"code", "message", "severity"}
-        if required_keys <= v.keys():
-            try:
-                # Attempt to cast to StreamError.
-                # Use model_validate to allow Pydantic to handle strict validation.
-                return StreamError.model_validate(v)
-            except ValidationError:
-                # If validation fails (e.g. types wrong), we return unmodified
-                # and let the Union fallback to dict[str, Any]
-                pass
-    return v
+class StreamErrorEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    op: Literal["error"]
+    p: StreamError
 
 
-# Union type for stream with intrinsic self-healing
+class StreamDeltaEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    op: Literal["delta"]
+    p: str
+
+
+class StreamCloseEnvelope(BaseModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    op: Literal["close"]
+    p: None = None
+
+
+# SOTA Python 3.12 Union syntax mapped to a Pydantic Discriminator
 StreamPacket = Annotated[
-    StreamError | dict[str, Any] | str,
-    BeforeValidator(_duck_type_stream_error),
+    StreamErrorEnvelope | StreamDeltaEnvelope | StreamCloseEnvelope,
+    Field(discriminator="op"),
 ]
 
 

--- a/src/coreason_manifest/utils/integrity.py
+++ b/src/coreason_manifest/utils/integrity.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import math
+import uuid
 from abc import ABC, abstractmethod
 from datetime import UTC, datetime
 from typing import Any, Literal, TypedDict
@@ -99,6 +100,8 @@ class CanonicalV2Strategy(HashingStrategy):
         if isinstance(obj, (set, frozenset)):
             # Sets should be sorted lists
             return sorted([self._recursive_sort_and_sanitize(x) for x in obj])
+        if isinstance(obj, uuid.UUID):
+            return str(obj)
         if isinstance(obj, datetime):
             return to_canonical_timestamp(obj)
         if isinstance(obj, BaseModel):

--- a/src/coreason_manifest/utils/loader.py
+++ b/src/coreason_manifest/utils/loader.py
@@ -103,7 +103,7 @@ class SandboxedPathFinder(importlib.abc.MetaPathFinder):
 
         # Security: Prevent directory traversal via package names
         if ".." in fullname:
-            return None
+            raise SecurityViolationError(f"Security Error: Reference {fullname} escapes the root directory.")
 
         # Determine path relative to jail
         # Logic: If '_path' is None, it's a top-level import.

--- a/src/coreason_manifest/utils/loader.py
+++ b/src/coreason_manifest/utils/loader.py
@@ -180,6 +180,38 @@ def _scan_for_dynamic_references(data: Any) -> bool:
     return False
 
 
+def _resolve_refs(data: Any, root_dir: Path, loader: ManifestIO, seen: set[str] | None = None) -> Any:
+    """Recursively resolves JSON/YAML $refs while guarding against circular dependencies and jail escapes."""
+    if seen is None:
+        seen = set()
+
+    if isinstance(data, dict):
+        if "$ref" in data:
+            ref_path = data["$ref"]
+            if ref_path in seen:
+                raise RecursionError(f"Circular dependency detected: {ref_path}")
+
+            target_path = (root_dir / ref_path).resolve()
+            if not target_path.is_relative_to(root_dir.resolve()):
+                raise SecurityViolationError(f"Security Error: Reference {ref_path} escapes the root directory.")
+
+            seen.add(ref_path)
+            try:
+                ref_content_str = loader.read_text(str(target_path.relative_to(root_dir)))
+                ref_data = yaml.load(ref_content_str, Loader=UniqueKeyLoader)
+            except Exception as e:
+                raise ValueError(f"Failed to load reference {ref_path}: {e}") from e
+
+            return _resolve_refs(ref_data, root_dir, loader, seen)
+
+        return {k: _resolve_refs(v, root_dir, loader, seen.copy()) for k, v in data.items()}
+
+    if isinstance(data, list):
+        return [_resolve_refs(item, root_dir, loader, seen.copy()) for item in data]
+
+    return data
+
+
 def load_flow_from_file(
     path: str, root_dir: Path | None = None, allow_dynamic_execution: bool = False
 ) -> LinearFlow | GraphFlow:
@@ -204,6 +236,9 @@ def load_flow_from_file(
         data = yaml.load(content_str, Loader=UniqueKeyLoader)
     except yaml.YAMLError as e:
         raise ValueError(f"Failed to parse manifest file: {e}") from e
+
+    # Resolve pointers before schema validation
+    data = _resolve_refs(data, jail_root, loader)
 
     if not isinstance(data, dict):
         raise ValueError("Manifest content must be a dictionary.")
@@ -239,6 +274,10 @@ def load_agent_from_ref(reference: str, root_dir: Path) -> type:
     file_ref, class_name = reference.rsplit(":", 1)
 
     file_path = (root_dir / file_ref).resolve()
+
+    if not file_path.is_relative_to(root_dir.resolve()):
+        raise SecurityViolationError(f"Security Error: Reference {file_ref} escapes the root directory.")
+
     if not file_path.is_file():
         raise ValueError(f"Agent file not found: {file_path}")
 

--- a/tests/test_coverage_gap.py
+++ b/tests/test_coverage_gap.py
@@ -708,3 +708,112 @@ def test_flow_cycle_detection_unreachable() -> None:
         graph=graph,
     )
     assert flow.status == "published"
+
+
+def test_loader_resolve_refs_complex() -> None:
+    """Test recursive $ref resolution in loader."""
+    from pathlib import Path
+    import tempfile
+    import yaml
+    from coreason_manifest.utils.loader import load_flow_from_file
+
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+
+        # main.yaml -> nested ref -> list ref -> leaf
+        main = {
+            "kind": "LinearFlow",
+            "metadata": {"name": "main", "version": "1.0.0", "description": "d", "tags": []},
+            "interface": {"inputs": {"json_schema": {"type": "object"}}, "outputs": {"json_schema": {"type": "object"}}},
+            "sequence": [
+                {"$ref": "step1.yaml"}
+            ],
+            "definitions": {
+                "shared": {"$ref": "shared.yaml"}
+            }
+        }
+
+        step1 = {
+            "id": "s1",
+            "type": "agent",
+            "metadata": {},
+            "profile": {"role": "tester", "persona": "p", "reasoning": {"type": "standard", "model": "gpt-4"}},
+            "tools": []
+        }
+
+        shared = {"key": "value"}
+
+        (p / "main.yaml").write_text(yaml.dump(main))
+        (p / "step1.yaml").write_text(yaml.dump(step1))
+        (p / "shared.yaml").write_text(yaml.dump(shared))
+
+        flow = load_flow_from_file(str(p / "main.yaml"))
+        # Verify resolution
+        assert flow.sequence[0].id == "s1"
+        # Since definitions is not part of LinearFlow model, it might be dropped if extra="ignore".
+        # But we validated that load_flow_from_file parsed it successfully.
+
+        # Test circular dependency
+        (p / "cycle1.yaml").write_text(yaml.dump({"$ref": "cycle2.yaml"}))
+        (p / "cycle2.yaml").write_text(yaml.dump({"$ref": "cycle1.yaml"}))
+
+        with pytest.raises(RecursionError, match="Circular dependency detected"):
+            # We call the internal resolver or mock load_flow to hit just this part?
+            # Or construct a flow that points to cycle1.
+            cycle_flow = main.copy()
+            cycle_flow["sequence"] = [{"$ref": "cycle1.yaml"}]
+            (p / "cycle_main.yaml").write_text(yaml.dump(cycle_flow))
+            load_flow_from_file(str(p / "cycle_main.yaml"))
+
+
+def test_loader_execution_exception_propagation() -> None:
+    """Verify that exceptions during module execution are propagated correctly as ValueErrors."""
+    import tempfile
+    from coreason_manifest.utils.loader import load_agent_from_ref
+
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        (p / "fail.py").write_text("raise RuntimeError('Boom')")
+
+        with pytest.raises(ValueError, match="Failed to execute agent code"):
+             load_agent_from_ref("fail.py:Agent", root_dir=p)
+
+
+def test_loader_dynamic_ref_recursion() -> None:
+    """Cover list recursion in _scan_for_dynamic_references."""
+    import yaml
+    import tempfile
+    from pathlib import Path
+    from coreason_manifest.utils.loader import load_flow_from_file, SecurityViolationError
+
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        # Manifest with dynamic ref inside a list
+        manifest = {
+            "kind": "LinearFlow",
+            "metadata": {"name": "test", "version": "1.0.0", "description": "d", "tags": []},
+            "interface": {"inputs": {}, "outputs": {}},
+            "sequence": [
+                "unsafe.py:Agent"
+            ],
+            "definitions": {}
+        }
+        (p / "list_unsafe.yaml").write_text(yaml.dump(manifest))
+
+        with pytest.raises(SecurityViolationError, match="Dynamic code execution"):
+            load_flow_from_file(str(p / "list_unsafe.yaml"), allow_dynamic_execution=False)
+
+        # Manifest with dynamic ref inside a nested dict
+        manifest_dict = {
+             "kind": "LinearFlow",
+            "metadata": {"name": "test", "version": "1.0.0", "description": "d", "tags": []},
+            "interface": {"inputs": {}, "outputs": {}},
+            "sequence": [],
+            "definitions": {
+                "agent": "unsafe.py:Agent"
+            }
+        }
+        (p / "dict_unsafe.yaml").write_text(yaml.dump(manifest_dict))
+
+        with pytest.raises(SecurityViolationError, match="Dynamic code execution"):
+            load_flow_from_file(str(p / "dict_unsafe.yaml"), allow_dynamic_execution=False)

--- a/tests/test_coverage_gap.py
+++ b/tests/test_coverage_gap.py
@@ -778,7 +778,7 @@ def test_loader_execution_exception_propagation() -> None:
         (p / "fail.py").write_text("raise RuntimeError('Boom')")
 
         with pytest.raises(ValueError, match="Failed to execute agent code"):
-             load_agent_from_ref("fail.py:Agent", root_dir=p)
+            load_agent_from_ref("fail.py:Agent", root_dir=p)
 
 
 def test_loader_dynamic_ref_recursion() -> None:
@@ -797,10 +797,8 @@ def test_loader_dynamic_ref_recursion() -> None:
             "kind": "LinearFlow",
             "metadata": {"name": "test", "version": "1.0.0", "description": "d", "tags": []},
             "interface": {"inputs": {}, "outputs": {}},
-            "sequence": [
-                "unsafe.py:Agent"
-            ],
-            "definitions": {}
+            "sequence": ["unsafe.py:Agent"],
+            "definitions": {},
         }
         (p / "list_unsafe.yaml").write_text(yaml.dump(manifest))
 
@@ -809,13 +807,11 @@ def test_loader_dynamic_ref_recursion() -> None:
 
         # Manifest with dynamic ref inside a nested dict
         manifest_dict = {
-             "kind": "LinearFlow",
+            "kind": "LinearFlow",
             "metadata": {"name": "test", "version": "1.0.0", "description": "d", "tags": []},
             "interface": {"inputs": {}, "outputs": {}},
             "sequence": [],
-            "definitions": {
-                "agent": "unsafe.py:Agent"
-            }
+            "definitions": {"agent": "unsafe.py:Agent"},
         }
         (p / "dict_unsafe.yaml").write_text(yaml.dump(manifest_dict))
 
@@ -826,9 +822,11 @@ def test_loader_dynamic_ref_recursion() -> None:
 def test_loader_security_escapes() -> None:
     """Test path traversal checks in loader."""
     import tempfile
-    import yaml
     from pathlib import Path
-    from coreason_manifest.utils.loader import load_flow_from_file, SecurityViolationError, load_agent_from_ref
+
+    import yaml
+
+    from coreason_manifest.utils.loader import SecurityViolationError, load_agent_from_ref, load_flow_from_file
 
     with tempfile.TemporaryDirectory() as d:
         p = Path(d)
@@ -853,8 +851,10 @@ def test_loader_security_escapes() -> None:
 def test_loader_ref_load_failure() -> None:
     """Test failure to load $ref."""
     import tempfile
-    import yaml
     from pathlib import Path
+
+    import yaml
+
     from coreason_manifest.utils.loader import load_flow_from_file
 
     with tempfile.TemporaryDirectory() as d:

--- a/tests/test_coverage_gap.py
+++ b/tests/test_coverage_gap.py
@@ -712,9 +712,11 @@ def test_flow_cycle_detection_unreachable() -> None:
 
 def test_loader_resolve_refs_complex() -> None:
     """Test recursive $ref resolution in loader."""
-    from pathlib import Path
     import tempfile
+    from pathlib import Path
+
     import yaml
+
     from coreason_manifest.utils.loader import load_flow_from_file
 
     with tempfile.TemporaryDirectory() as d:
@@ -724,13 +726,12 @@ def test_loader_resolve_refs_complex() -> None:
         main = {
             "kind": "LinearFlow",
             "metadata": {"name": "main", "version": "1.0.0", "description": "d", "tags": []},
-            "interface": {"inputs": {"json_schema": {"type": "object"}}, "outputs": {"json_schema": {"type": "object"}}},
-            "sequence": [
-                {"$ref": "step1.yaml"}
-            ],
-            "definitions": {
-                "shared": {"$ref": "shared.yaml"}
-            }
+            "interface": {
+                "inputs": {"json_schema": {"type": "object"}},
+                "outputs": {"json_schema": {"type": "object"}},
+            },
+            "sequence": [{"$ref": "step1.yaml"}],
+            "definitions": {"shared": {"$ref": "shared.yaml"}},
         }
 
         step1 = {
@@ -738,7 +739,7 @@ def test_loader_resolve_refs_complex() -> None:
             "type": "agent",
             "metadata": {},
             "profile": {"role": "tester", "persona": "p", "reasoning": {"type": "standard", "model": "gpt-4"}},
-            "tools": []
+            "tools": [],
         }
 
         shared = {"key": "value"}
@@ -749,26 +750,27 @@ def test_loader_resolve_refs_complex() -> None:
 
         flow = load_flow_from_file(str(p / "main.yaml"))
         # Verify resolution
+        from coreason_manifest.spec.core.flow import LinearFlow
+
+        assert isinstance(flow, LinearFlow)
         assert flow.sequence[0].id == "s1"
-        # Since definitions is not part of LinearFlow model, it might be dropped if extra="ignore".
-        # But we validated that load_flow_from_file parsed it successfully.
 
         # Test circular dependency
         (p / "cycle1.yaml").write_text(yaml.dump({"$ref": "cycle2.yaml"}))
         (p / "cycle2.yaml").write_text(yaml.dump({"$ref": "cycle1.yaml"}))
 
+        cycle_flow = main.copy()
+        cycle_flow["sequence"] = [{"$ref": "cycle1.yaml"}]
+        (p / "cycle_main.yaml").write_text(yaml.dump(cycle_flow))
+
         with pytest.raises(RecursionError, match="Circular dependency detected"):
-            # We call the internal resolver or mock load_flow to hit just this part?
-            # Or construct a flow that points to cycle1.
-            cycle_flow = main.copy()
-            cycle_flow["sequence"] = [{"$ref": "cycle1.yaml"}]
-            (p / "cycle_main.yaml").write_text(yaml.dump(cycle_flow))
             load_flow_from_file(str(p / "cycle_main.yaml"))
 
 
 def test_loader_execution_exception_propagation() -> None:
     """Verify that exceptions during module execution are propagated correctly as ValueErrors."""
     import tempfile
+
     from coreason_manifest.utils.loader import load_agent_from_ref
 
     with tempfile.TemporaryDirectory() as d:
@@ -781,10 +783,12 @@ def test_loader_execution_exception_propagation() -> None:
 
 def test_loader_dynamic_ref_recursion() -> None:
     """Cover list recursion in _scan_for_dynamic_references."""
-    import yaml
     import tempfile
     from pathlib import Path
-    from coreason_manifest.utils.loader import load_flow_from_file, SecurityViolationError
+
+    import yaml
+
+    from coreason_manifest.utils.loader import SecurityViolationError, load_flow_from_file
 
     with tempfile.TemporaryDirectory() as d:
         p = Path(d)
@@ -817,3 +821,46 @@ def test_loader_dynamic_ref_recursion() -> None:
 
         with pytest.raises(SecurityViolationError, match="Dynamic code execution"):
             load_flow_from_file(str(p / "dict_unsafe.yaml"), allow_dynamic_execution=False)
+
+
+def test_loader_security_escapes() -> None:
+    """Test path traversal checks in loader."""
+    import tempfile
+    import yaml
+    from pathlib import Path
+    from coreason_manifest.utils.loader import load_flow_from_file, SecurityViolationError, load_agent_from_ref
+
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        jail = p / "jail"
+        jail.mkdir()
+
+        # 1. $ref escape
+        manifest = {"$ref": "../outside.yaml"}
+        (jail / "bad_ref.yaml").write_text(yaml.dump(manifest))
+        (p / "outside.yaml").write_text("content: 1")
+
+        with pytest.raises(SecurityViolationError, match="escapes the root directory"):
+            load_flow_from_file(str(jail / "bad_ref.yaml"))
+
+        # 2. agent ref escape
+        (p / "outside.py").write_text("class Agent: pass")
+
+        with pytest.raises(SecurityViolationError, match="escapes the root directory"):
+            load_agent_from_ref("../outside.py:Agent", root_dir=jail)
+
+
+def test_loader_ref_load_failure() -> None:
+    """Test failure to load $ref."""
+    import tempfile
+    import yaml
+    from pathlib import Path
+    from coreason_manifest.utils.loader import load_flow_from_file
+
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d)
+        manifest = {"$ref": "missing.yaml"}
+        (p / "main.yaml").write_text(yaml.dump(manifest))
+
+        with pytest.raises(ValueError, match="Failed to load reference"):
+            load_flow_from_file(str(p / "main.yaml"))

--- a/tests/test_coverage_gap.py
+++ b/tests/test_coverage_gap.py
@@ -264,10 +264,10 @@ def test_loader_spec_none_coverage() -> None:
     assert finder.find_spec("foo") is None  # jail_root not set
 
     # ".." check
-    from coreason_manifest.utils.loader import sandbox_context, SecurityViolationError
+    from coreason_manifest.utils.loader import SecurityViolationError, sandbox_context
 
     with sandbox_context(Path(".")):
-        with pytest.raises(SecurityViolationError, match="Security Error: Reference ..foo escapes"):
+        with pytest.raises(SecurityViolationError, match=r"Security Error: Reference ..foo escapes"):
             finder.find_spec("..foo")
         # line 119: init_py is file -> create dummy init
         # line 126: module_py is file

--- a/tests/test_coverage_gap.py
+++ b/tests/test_coverage_gap.py
@@ -264,10 +264,11 @@ def test_loader_spec_none_coverage() -> None:
     assert finder.find_spec("foo") is None  # jail_root not set
 
     # ".." check
-    from coreason_manifest.utils.loader import sandbox_context
+    from coreason_manifest.utils.loader import sandbox_context, SecurityViolationError
 
     with sandbox_context(Path(".")):
-        assert finder.find_spec("..foo") is None
+        with pytest.raises(SecurityViolationError, match="Security Error: Reference ..foo escapes"):
+            finder.find_spec("..foo")
         # line 119: init_py is file -> create dummy init
         # line 126: module_py is file
 

--- a/tests/test_greenfield_refactor.py
+++ b/tests/test_greenfield_refactor.py
@@ -66,53 +66,37 @@ class TestAgent:
 # ------------------------------------------------------------------------
 
 
-def test_stream_error_duck_typing() -> None:
+def test_stream_packet_strict_envelope() -> None:
     """
-    Inject a raw, untyped dictionary into the stream packet parser.
-    Assert that it is successfully deserialized into a frozen StreamError object.
+    Verify strict envelope handling with discriminated unions.
+    Duck typing is removed; explicit 'op' is required.
     """
-    raw_payload = {"code": 500, "message": "Failure", "severity": "high"}
-
-    # Simulate receiving this payload in a StreamPacket container
-    # We need a model that uses StreamPacket
-    try:
-        # If StreamPacket is a Union, we might need a container to trigger validation
-        container = PacketContainer(packet=raw_payload)
-        packet = container.packet
-
-        assert isinstance(packet, StreamError)
-        assert packet.code == 500
-        assert packet.message == "Failure"
-        assert packet.severity == "high"
-
-        # Verify frozen
-        with pytest.raises(ValidationError):
-            packet.code = 200  # type: ignore[misc]
-
-    except ValidationError as e:
-        pytest.fail(f"Duck typing failed: {e}")
-
-
-def test_stream_error_duck_typing_fallback() -> None:
-    """
-    Inject a dictionary that matches signature but has wrong types.
-    Should fallback to dict.
-    """
-    # 'code' is string, but StreamError requires int. strict=True means no coercion?
-    # Actually Pydantic v2 strict=True might allow str->int if it looks like int?
-    # No, strict=True means strict types.
-    raw_payload = {"code": "500", "message": "Failure", "severity": "high"}
-
-    container = PacketContainer(packet=raw_payload)
+    # 1. Valid Error Envelope
+    payload = {
+        "op": "error",
+        "p": {"code": 500, "message": "Failure", "severity": "high"}
+    }
+    container = PacketContainer(packet=payload)
     packet = container.packet
+    # Packet is StreamErrorEnvelope
+    assert packet.op == "error"
+    assert packet.p.code == 500
+    assert packet.p.message == "Failure"
 
-    # Should remain a dict because StreamError validation failed (strict)
-    # OR if Pydantic casts it?
-    # If the validator code does StreamError.model_validate(raw_pkt), it raises ValidationError.
-    # The except block catches it and passes.
-    # So it remains a dict.
-    assert isinstance(packet, dict)
-    assert packet["code"] == "500"
+    # Verify frozen
+    with pytest.raises(ValidationError, match="frozen"):
+        packet.p.code = 200 # type: ignore
+
+    # 2. Invalid Payload (Old Duck Typing Format) -> Should Fail
+    raw_payload = {"code": 500, "message": "Failure", "severity": "high"}
+    with pytest.raises(ValidationError):
+        PacketContainer(packet=raw_payload)
+
+    # 3. Delta Envelope
+    delta_payload = {"op": "delta", "p": "some content"}
+    container_delta = PacketContainer(packet=delta_payload)
+    assert container_delta.packet.op == "delta"
+    assert container_delta.packet.p == "some content"
 
 
 def test_strict_internal_mutation() -> None:

--- a/tests/test_greenfield_refactor.py
+++ b/tests/test_greenfield_refactor.py
@@ -82,7 +82,7 @@ def test_stream_packet_strict_envelope() -> None:
 
     # Verify frozen
     with pytest.raises(ValidationError, match="frozen"):
-        packet.p.code = 200 # type: ignore
+        packet.p.code = 200  # type: ignore
 
     # 2. Invalid Payload (Old Duck Typing Format) -> Should Fail
     raw_payload = {"code": 500, "message": "Failure", "severity": "high"}

--- a/tests/test_greenfield_refactor.py
+++ b/tests/test_greenfield_refactor.py
@@ -72,11 +72,8 @@ def test_stream_packet_strict_envelope() -> None:
     Duck typing is removed; explicit 'op' is required.
     """
     # 1. Valid Error Envelope
-    payload = {
-        "op": "error",
-        "p": {"code": 500, "message": "Failure", "severity": "high"}
-    }
-    container = PacketContainer(packet=payload)
+    payload = {"op": "error", "p": {"code": 500, "message": "Failure", "severity": "high"}}
+    container = PacketContainer.model_validate({"packet": payload})
     packet = container.packet
     # Packet is StreamErrorEnvelope
     assert packet.op == "error"
@@ -90,11 +87,11 @@ def test_stream_packet_strict_envelope() -> None:
     # 2. Invalid Payload (Old Duck Typing Format) -> Should Fail
     raw_payload = {"code": 500, "message": "Failure", "severity": "high"}
     with pytest.raises(ValidationError):
-        PacketContainer(packet=raw_payload)
+        PacketContainer.model_validate({"packet": raw_payload})
 
     # 3. Delta Envelope
     delta_payload = {"op": "delta", "p": "some content"}
-    container_delta = PacketContainer(packet=delta_payload)
+    container_delta = PacketContainer.model_validate({"packet": delta_payload})
     assert container_delta.packet.op == "delta"
     assert container_delta.packet.p == "some content"
 

--- a/tests/test_sota_compliance.py
+++ b/tests/test_sota_compliance.py
@@ -126,7 +126,7 @@ def test_telemetry_request_auto_rooting() -> None:
     Test AgentRequest auto-rooting logic.
     """
     # Case A: No root, no parent -> Auto-promote
-    req = AgentRequest(agent_id="test", inputs={})
+    req = AgentRequest(agent_id="test", session_id="s1", inputs={})
     assert req.request_id is not None
     assert req.root_request_id == req.request_id
     assert req.parent_request_id is None
@@ -134,7 +134,7 @@ def test_telemetry_request_auto_rooting() -> None:
     # Case C: Parent and Root -> OK
     parent_id = str(uuid4())
     root_id = str(uuid4())
-    req2 = AgentRequest(agent_id="test", inputs={}, parent_request_id=parent_id, root_request_id=root_id)
+    req2 = AgentRequest(agent_id="test", session_id="s1", inputs={}, parent_request_id=parent_id, root_request_id=root_id)
     assert req2.parent_request_id == parent_id
     assert req2.root_request_id == root_id
 
@@ -144,9 +144,10 @@ def test_telemetry_request_orphaned_trace() -> None:
     Test AgentRequest orphaned trace detection.
     """
     # Case B: Parent but no root -> Error
-    with pytest.raises(ValueError, match="Orphaned trace detected"):
+    with pytest.raises(ValueError, match="Broken Lineage"):
         AgentRequest(
             agent_id="test",
+            session_id="s1",
             inputs={},
             parent_request_id="some-parent",
             # root_request_id missing

--- a/tests/test_sota_compliance.py
+++ b/tests/test_sota_compliance.py
@@ -141,6 +141,20 @@ def test_telemetry_request_auto_rooting() -> None:
     assert req2.root_request_id == root_id
 
 
+def test_telemetry_request_create_child() -> None:
+    """
+    Test create_child factory method.
+    """
+    req = AgentRequest(agent_id="root", session_id="s1", inputs={})
+    child = req.create_child(metadata={"step": 1})
+
+    assert child.request_id != req.request_id
+    assert child.parent_request_id == req.request_id
+    assert child.root_request_id == req.root_request_id
+    assert child.session_id == req.session_id
+    assert child.metadata["step"] == 1
+
+
 def test_telemetry_request_orphaned_trace() -> None:
     """
     Test AgentRequest orphaned trace detection.
@@ -220,6 +234,12 @@ def test_integrity_sanitization() -> None:
 
     # Check timestamp
     assert sanitized["nested"]["timestamp"] == "2023-01-01T12:00:00Z"
+
+    # Check UUID fast-path
+    uid = uuid4()
+    data_uuid = {"id": uid}
+    sanitized_uuid = strategy._recursive_sort_and_sanitize(data_uuid)
+    assert sanitized_uuid["id"] == str(uid)
 
     # Determinism check
     h1 = compute_hash(data)

--- a/tests/test_sota_compliance.py
+++ b/tests/test_sota_compliance.py
@@ -134,7 +134,9 @@ def test_telemetry_request_auto_rooting() -> None:
     # Case C: Parent and Root -> OK
     parent_id = str(uuid4())
     root_id = str(uuid4())
-    req2 = AgentRequest(agent_id="test", session_id="s1", inputs={}, parent_request_id=parent_id, root_request_id=root_id)
+    req2 = AgentRequest(
+        agent_id="test", session_id="s1", inputs={}, parent_request_id=parent_id, root_request_id=root_id
+    )
     assert req2.parent_request_id == parent_id
     assert req2.root_request_id == root_id
 


### PR DESCRIPTION
This PR implements the "Greenfield Refactor" for v0.25.0, addressing critical regressions and enforcing SOTA paradigms.

Changes include:
1.  **Distributed Tracing**: Added `session_id` and `create_child` to `AgentRequest` with strict immutability. Updated lineage validation error message.
2.  **Integrity**: Added fast-path UUID serialization to `CanonicalV2Strategy` to fix `TypeError`.
3.  **Security**: Updated `SandboxedPathFinder` to raise `SecurityViolationError` on path traversal attempts instead of silent failure.
4.  **Stream Protocol**: Replaced duck-typing with strict discriminated unions (`StreamPacket`) using `op` discriminator.

Tests were updated and verified to pass. A manual verification script was also executed to confirm specific requirements.

---
*PR created automatically by Jules for task [6327497451752289357](https://jules.google.com/task/6327497451752289357) started by @gowthamrao*