### PR TITLE
Fix TOCTOU Vulnerability in ManifestIO

### DIFF
--- a/src/coreason_manifest/utils/io.py
+++ b/src/coreason_manifest/utils/io.py
@@ -47,16 +47,15 @@ class ManifestIO:
 
         if not hasattr(os, "O_NOFOLLOW"):
             if self.strict_security:
-                raise EnvironmentError(
+                raise OSError(
                     "Host OS lacks O_NOFOLLOW support. Strict TOCTOU security cannot be guaranteed. "
                     "Set strict_security=False to bypass this check at your own risk."
                 )
-            else:
-                warnings.warn(
-                    "WARNING: TOCTOU protections disabled. Running on an OS without O_NOFOLLOW.",
-                    RuntimeSecurityWarning,
-                    stacklevel=2,
-                )
+            warnings.warn(
+                "WARNING: TOCTOU protections disabled. Running on an OS without O_NOFOLLOW.",
+                RuntimeSecurityWarning,
+                stacklevel=2,
+            )
 
     @property
     def _is_posix(self) -> bool:
@@ -132,7 +131,7 @@ class ManifestIO:
 
             # Post-Open Defense in Depth Check
             if stat_before.st_ino != st.st_ino or stat_before.st_dev != st.st_dev:
-                 raise SecurityViolationError("File swapped during open operation.")
+                raise SecurityViolationError("File swapped during open operation.")
 
             if self._is_posix and (st.st_mode & stat.S_IWOTH):
                 raise SecurityViolationError(f"Unsafe Permissions: {path} is world-writable.")

--- a/src/coreason_manifest/utils/io.py
+++ b/src/coreason_manifest/utils/io.py
@@ -2,6 +2,7 @@ import contextlib
 import errno
 import os
 import stat
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -21,22 +22,41 @@ class SecurityViolationError(Exception):
         return f"{prefix}{self.message}"
 
 
+class RuntimeSecurityWarning(RuntimeWarning):
+    """Warning for runtime security risks."""
+
+
 class ManifestIO:
     """
     A secure file loader that enforces path confinement and permission checks.
     Acts as a 'Jail' to prevent Path Traversal attacks.
     """
 
-    def __init__(self, root_dir: Path, allow_external_refs: bool = False):
+    def __init__(self, root_dir: Path, allow_external_refs: bool = False, strict_security: bool = True):
         """
         Initialize the secure loader.
 
         Args:
             root_dir: The root directory to confine file access to.
             allow_external_refs: Whether to allow loading files outside the root directory.
+            strict_security: Whether to strictly enforce security checks (e.g. O_NOFOLLOW).
         """
         self.jail = root_dir.resolve()
         self.allow_external = allow_external_refs
+        self.strict_security = strict_security
+
+        if not hasattr(os, "O_NOFOLLOW"):
+            if self.strict_security:
+                raise EnvironmentError(
+                    "Host OS lacks O_NOFOLLOW support. Strict TOCTOU security cannot be guaranteed. "
+                    "Set strict_security=False to bypass this check at your own risk."
+                )
+            else:
+                warnings.warn(
+                    "WARNING: TOCTOU protections disabled. Running on an OS without O_NOFOLLOW.",
+                    RuntimeSecurityWarning,
+                    stacklevel=2,
+                )
 
     @property
     def _is_posix(self) -> bool:
@@ -81,10 +101,20 @@ class ManifestIO:
         if not self.allow_external and not target_path.is_relative_to(self.jail):
             raise SecurityViolationError(f"Path Traversal Detected: {path}")
 
+        # Post-Open Defense in Depth
+        # Stat BEFORE open
+        try:
+            stat_before = os.lstat(target_path)
+        except OSError as e:
+            if e.errno == errno.ENOENT:
+                raise FileNotFoundError(f"File not found or inaccessible: {path}") from e
+            raise e
+
         # 2. LOW-LEVEL ATOMIC OPEN (TOCTOU Mitigation)
         try:
             # O_NOFOLLOW ensures we don't follow symlinks at the end of the path
             # O_RDONLY ensures read-only access
+            # Safe to use getattr here ONLY because we gated it in __init__
             flags = os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0)
             fd = os.open(str(target_path), flags)
         except OSError as e:
@@ -99,6 +129,10 @@ class ManifestIO:
             # 3. CHECK PERMISSIONS ON THE DESCRIPTOR (Not the path)
             # This guarantees we are checking the actual file we just opened.
             st = os.fstat(fd)
+
+            # Post-Open Defense in Depth Check
+            if stat_before.st_ino != st.st_ino or stat_before.st_dev != st.st_dev:
+                 raise SecurityViolationError("File swapped during open operation.")
 
             if self._is_posix and (st.st_mode & stat.S_IWOTH):
                 raise SecurityViolationError(f"Unsafe Permissions: {path} is world-writable.")

--- a/src/coreason_manifest/utils/loader.py
+++ b/src/coreason_manifest/utils/loader.py
@@ -19,13 +19,9 @@ from yaml.nodes import MappingNode
 
 from coreason_manifest.spec.core.flow import GraphFlow, LinearFlow
 from coreason_manifest.spec.interop.exceptions import SecurityJailViolationError
-from coreason_manifest.utils.io import ManifestIO, SecurityViolationError
+from coreason_manifest.utils.io import ManifestIO, RuntimeSecurityWarning, SecurityViolationError
 
 __all__ = ["RuntimeSecurityWarning", "SecurityViolationError", "load_agent_from_ref", "load_flow_from_file"]
-
-
-class RuntimeSecurityWarning(RuntimeWarning):
-    """Warning for runtime security risks."""
 
 
 class YamlLoaderProtocol(Protocol):

--- a/tests/test_domain_fixes.py
+++ b/tests/test_domain_fixes.py
@@ -292,11 +292,14 @@ def test_manifest_io_posix_permissions(tmp_path: Any) -> None:
     # Simulate world-writable permissions
     mock_stat = MagicMock()
     mock_stat.st_mode = stat.S_IWOTH
+    mock_stat.st_ino = 12345
+    mock_stat.st_dev = 1
 
     # Mock _is_posix property and os.fstat
     with (
         patch("coreason_manifest.utils.io.ManifestIO._is_posix", new_callable=PropertyMock) as mock_posix,
         patch("os.fstat", return_value=mock_stat),
+        patch("os.lstat", return_value=mock_stat),
     ):
         mock_posix.return_value = True
         with pytest.raises(SecurityViolationError, match="Unsafe Permissions"):

--- a/tests/test_loader_security.py
+++ b/tests/test_loader_security.py
@@ -56,29 +56,40 @@ def test_posix_permissions(jail_dir: Path) -> None:
 def test_manifest_io_eloop_enoent() -> None:
     """Cover lines 60-63 in io.py: ELOOP and ENOENT handling."""
     import errno
-    from unittest.mock import patch
+    from unittest.mock import patch, MagicMock
 
     loader = ManifestIO(root_dir=Path("/tmp"))
 
-    # Mock os.open to raise ELOOP
-    with patch("os.open") as mock_open:
-        mock_open.side_effect = OSError(errno.ELOOP, "Too many symlinks")
-        with pytest.raises(SecurityViolationError) as exc_sec:
-            loader.read_text("loop.txt")
-        assert "Symlink detected" in str(exc_sec.value)
+    # Mock os.lstat to succeed so we reach os.open
+    # We must configure mock_lstat to return a valid-looking stat object
+    # because Path.resolve calls it and expects integer st_mode.
+    mock_stat = MagicMock()
+    mock_stat.st_mode = 0o100644  # Regular file
+    mock_stat.st_ino = 12345
+    mock_stat.st_dev = 1
 
-    # Mock os.open to raise ENOENT
-    with patch("os.open") as mock_open:
-        mock_open.side_effect = OSError(errno.ENOENT, "No such file")
-        with pytest.raises(FileNotFoundError):
-            loader.read_text("missing.txt")
+    with patch("os.lstat", return_value=mock_stat) as mock_lstat:
+        # Mock os.open to raise ELOOP
+        with patch("os.open") as mock_open:
+            mock_open.side_effect = OSError(errno.ELOOP, "Too many symlinks")
+            with pytest.raises(SecurityViolationError) as exc_sec:
+                loader.read_text("loop.txt")
+            assert "Symlink detected" in str(exc_sec.value)
 
-    # Mock os.open to raise EACCES (other error)
-    with patch("os.open") as mock_open:
-        mock_open.side_effect = OSError(errno.EACCES, "Permission denied")
-        with pytest.raises(OSError, match="Permission denied") as exc_os:
-            loader.read_text("locked.txt")
-        assert exc_os.value.errno == errno.EACCES
+    # Mock os.lstat to succeed (race condition simulation where file vanishes)
+    with patch("os.lstat", return_value=mock_stat) as mock_lstat:
+        with patch("os.open") as mock_open:
+            mock_open.side_effect = OSError(errno.ENOENT, "No such file")
+            with pytest.raises(FileNotFoundError):
+                loader.read_text("missing.txt")
+
+    # Mock os.lstat to succeed
+    with patch("os.lstat", return_value=mock_stat) as mock_lstat:
+        with patch("os.open") as mock_open:
+            mock_open.side_effect = OSError(errno.EACCES, "Permission denied")
+            with pytest.raises(OSError, match="Permission denied") as exc_os:
+                loader.read_text("locked.txt")
+            assert exc_os.value.errno == errno.EACCES
 
 
 def test_loader_ast_import_from_banned(tmp_path: Path) -> None:
@@ -143,3 +154,68 @@ def test_loader_success(tmp_path: Path) -> None:
 
     cls = load_agent_from_ref(f"{file_path.name}:Agent", root_dir=tmp_path)
     assert cls.__name__ == "Agent"
+
+def test_init_strict_security_missing_nofollow(jail_dir: Path) -> None:
+    """Test that strict_security=True raises EnvironmentError when O_NOFOLLOW is missing."""
+    from unittest.mock import patch
+
+    # Patch the os module imported in coreason_manifest.utils.io
+    with patch("coreason_manifest.utils.io.os", autospec=True) as mock_os:
+        # Simulate O_NOFOLLOW missing
+        del mock_os.O_NOFOLLOW
+
+        with pytest.raises(EnvironmentError, match="Host OS lacks O_NOFOLLOW support"):
+            ManifestIO(root_dir=jail_dir, strict_security=True)
+
+
+def test_init_relaxed_security_missing_nofollow(jail_dir: Path) -> None:
+    """Test that strict_security=False warns when O_NOFOLLOW is missing."""
+    from unittest.mock import patch
+
+    with patch("coreason_manifest.utils.io.os", autospec=True) as mock_os:
+        del mock_os.O_NOFOLLOW
+
+        with pytest.warns(RuntimeWarning, match="TOCTOU protections disabled"):
+             ManifestIO(root_dir=jail_dir, strict_security=False)
+
+
+def test_read_text_uses_nofollow(jail_dir: Path) -> None:
+    """Test that read_text uses O_NOFOLLOW flag."""
+    if not hasattr(os, "O_NOFOLLOW"):
+        pytest.skip("Test requires O_NOFOLLOW support")
+
+    from unittest.mock import patch
+
+    loader = ManifestIO(root_dir=jail_dir)
+    target_file = jail_dir / "test.txt"
+    target_file.write_text("content")
+
+    # Patch os.open in coreason_manifest.utils.io
+    with patch("coreason_manifest.utils.io.os.open", side_effect=os.open) as mock_open:
+        loader.read_text("test.txt")
+
+        args, _ = mock_open.call_args
+        flags = args[1]
+        assert flags & os.O_NOFOLLOW, "O_NOFOLLOW flag missing in os.open call"
+
+
+def test_post_open_check_detects_swap(jail_dir: Path) -> None:
+    """Test that file swap between lstat and fstat is detected."""
+    from unittest.mock import patch, MagicMock
+
+    loader = ManifestIO(root_dir=jail_dir)
+    target_file = jail_dir / "test.txt"
+    target_file.write_text("content")
+
+    real_stat = target_file.stat()
+
+    bad_stat = MagicMock()
+    bad_stat.st_ino = real_stat.st_ino + 1
+    bad_stat.st_dev = real_stat.st_dev
+    bad_stat.st_mode = real_stat.st_mode
+
+    # We patch os.lstat and os.fstat in coreason_manifest.utils.io
+    with patch("coreason_manifest.utils.io.os.lstat", return_value=real_stat) as mock_lstat:
+        with patch("coreason_manifest.utils.io.os.fstat", return_value=bad_stat) as mock_fstat:
+             with pytest.raises(SecurityViolationError, match="File swapped during open operation"):
+                 loader.read_text("test.txt")

--- a/tests/test_loader_security.py
+++ b/tests/test_loader_security.py
@@ -68,28 +68,36 @@ def test_manifest_io_eloop_enoent() -> None:
     mock_stat.st_ino = 12345
     mock_stat.st_dev = 1
 
-    with patch("os.lstat", return_value=mock_stat) as mock_lstat:
-        # Mock os.open to raise ELOOP
-        with patch("os.open") as mock_open:
-            mock_open.side_effect = OSError(errno.ELOOP, "Too many symlinks")
-            with pytest.raises(SecurityViolationError) as exc_sec:
-                loader.read_text("loop.txt")
-            assert "Symlink detected" in str(exc_sec.value)
+    # Fix SIM117: Combine nested with statements
+    with (
+        patch("os.lstat", return_value=mock_stat),
+        patch("os.open") as mock_open,
+    ):
+        mock_open.side_effect = OSError(errno.ELOOP, "Too many symlinks")
+        with pytest.raises(SecurityViolationError) as exc_sec:
+            loader.read_text("loop.txt")
+        assert "Symlink detected" in str(exc_sec.value)
 
     # Mock os.lstat to succeed (race condition simulation where file vanishes)
-    with patch("os.lstat", return_value=mock_stat) as mock_lstat:
-        with patch("os.open") as mock_open:
-            mock_open.side_effect = OSError(errno.ENOENT, "No such file")
-            with pytest.raises(FileNotFoundError):
-                loader.read_text("missing.txt")
+    # Fix SIM117 and F841: Combine contexts, remove unused assignment
+    with (
+        patch("os.lstat", return_value=mock_stat),
+        patch("os.open") as mock_open,
+    ):
+        mock_open.side_effect = OSError(errno.ENOENT, "No such file")
+        with pytest.raises(FileNotFoundError):
+            loader.read_text("missing.txt")
 
     # Mock os.lstat to succeed
-    with patch("os.lstat", return_value=mock_stat) as mock_lstat:
-        with patch("os.open") as mock_open:
-            mock_open.side_effect = OSError(errno.EACCES, "Permission denied")
-            with pytest.raises(OSError, match="Permission denied") as exc_os:
-                loader.read_text("locked.txt")
-            assert exc_os.value.errno == errno.EACCES
+    # Fix SIM117 and F841
+    with (
+        patch("os.lstat", return_value=mock_stat),
+        patch("os.open") as mock_open,
+    ):
+        mock_open.side_effect = OSError(errno.EACCES, "Permission denied")
+        with pytest.raises(OSError, match="Permission denied") as exc_os:
+            loader.read_text("locked.txt")
+        assert exc_os.value.errno == errno.EACCES
 
 
 def test_loader_ast_import_from_banned(tmp_path: Path) -> None:
@@ -215,7 +223,10 @@ def test_post_open_check_detects_swap(jail_dir: Path) -> None:
     bad_stat.st_mode = real_stat.st_mode
 
     # We patch os.lstat and os.fstat in coreason_manifest.utils.io
-    with patch("coreason_manifest.utils.io.os.lstat", return_value=real_stat) as mock_lstat:
-        with patch("coreason_manifest.utils.io.os.fstat", return_value=bad_stat) as mock_fstat:
-             with pytest.raises(SecurityViolationError, match="File swapped during open operation"):
-                 loader.read_text("test.txt")
+    # Fix SIM117 and F841: Combine contexts, remove unused assignment
+    with (
+        patch("coreason_manifest.utils.io.os.lstat", return_value=real_stat),
+        patch("coreason_manifest.utils.io.os.fstat", return_value=bad_stat),
+    ):
+         with pytest.raises(SecurityViolationError, match="File swapped during open operation"):
+             loader.read_text("test.txt")


### PR DESCRIPTION
This PR addresses a critical TOCTOU vulnerability in `ManifestIO` where symlinks could be exploited. It introduces a `strict_security` mode that requires `O_NOFOLLOW` support from the OS. It also adds a defense-in-depth check comparing file stats before and after opening the file descriptor. Tests have been updated to cover these scenarios and ensure no regressions.

---
*PR created automatically by Jules for task [15417618173097035265](https://jules.google.com/task/15417618173097035265) started by @gowthamrao*