### PR TITLE
Refactor BlackBoxRecorder for Distributed Tracing

### DIFF
--- a/src/coreason_manifest/utils/recorder.py
+++ b/src/coreason_manifest/utils/recorder.py
@@ -28,7 +28,7 @@ class BlackBoxRecorder:
         timestamp: datetime | None = None,
         error: str | None = None,
         attributes: dict[str, Any] | None = None,
-        # Trace Context
+        *,  # Force Keyword-Only Args for Trace Context
         request_id: str | None = None,
         parent_request_id: str | None = None,
         root_request_id: str | None = None,
@@ -81,15 +81,10 @@ class BlackBoxRecorder:
             "hash_version": "v2",
             "request_id": resolved_request_id,
             "root_request_id": resolved_root_request_id,
+            "parent_request_id": parent_request_id,
+            "traceparent": traceparent,
+            "tracestate": tracestate,
         }
-
-        # Veritas Integrity Payload Construction: Add Context
-        if parent_request_id:
-            payload["parent_request_id"] = parent_request_id
-        if traceparent:
-            payload["traceparent"] = traceparent
-        if tracestate:
-            payload["tracestate"] = tracestate
 
         # 3. Compute Hash
         execution_hash = compute_hash(payload)

--- a/src/coreason_manifest/utils/recorder.py
+++ b/src/coreason_manifest/utils/recorder.py
@@ -28,6 +28,12 @@ class BlackBoxRecorder:
         timestamp: datetime | None = None,
         error: str | None = None,
         attributes: dict[str, Any] | None = None,
+        # Trace Context
+        request_id: str | None = None,
+        parent_request_id: str | None = None,
+        root_request_id: str | None = None,
+        traceparent: str | None = None,
+        tracestate: str | None = None,
     ) -> NodeExecution:
         """
         Records a single execution step.
@@ -58,9 +64,9 @@ class BlackBoxRecorder:
 
         # Architecture: Generate Trace IDs explicitly to ensure hash consistency.
         # NodeExecution would auto-generate them, but we need them for the hash calculation.
-        request_id = str(uuid4())
+        resolved_request_id = request_id or str(uuid4())
         # Default behavior: If we don't know parent, we are root.
-        root_request_id = request_id
+        resolved_root_request_id = root_request_id or resolved_request_id
 
         payload = {
             "node_id": node_id,
@@ -73,9 +79,17 @@ class BlackBoxRecorder:
             "attributes": attributes,
             "parent_hashes": sorted(parent_hashes),
             "hash_version": "v2",
-            "request_id": request_id,
-            "root_request_id": root_request_id,
+            "request_id": resolved_request_id,
+            "root_request_id": resolved_root_request_id,
         }
+
+        # Veritas Integrity Payload Construction: Add Context
+        if parent_request_id:
+            payload["parent_request_id"] = parent_request_id
+        if traceparent:
+            payload["traceparent"] = traceparent
+        if tracestate:
+            payload["tracestate"] = tracestate
 
         # 3. Compute Hash
         execution_hash = compute_hash(payload)
@@ -92,6 +106,9 @@ class BlackBoxRecorder:
             attributes=attributes,
             parent_hashes=sorted(parent_hashes),
             execution_hash=execution_hash,
-            request_id=request_id,
-            root_request_id=root_request_id,
+            request_id=resolved_request_id,
+            parent_request_id=parent_request_id,
+            root_request_id=resolved_root_request_id,
+            traceparent=traceparent,
+            tracestate=tracestate,
         )

--- a/tests/test_recorder_context.py
+++ b/tests/test_recorder_context.py
@@ -1,10 +1,11 @@
-from coreason_manifest.utils.recorder import BlackBoxRecorder
-from coreason_manifest.spec.interop.telemetry import NodeState
-from datetime import datetime
 import uuid
-import pytest
+from datetime import datetime
 
-def test_explicit_context():
+from coreason_manifest.spec.interop.telemetry import NodeState
+from coreason_manifest.utils.recorder import BlackBoxRecorder
+
+
+def test_explicit_context() -> None:
     recorder = BlackBoxRecorder()
     req_id = str(uuid.uuid4())
     root_id = str(uuid.uuid4())
@@ -23,7 +24,7 @@ def test_explicit_context():
         root_request_id=root_id,
         parent_request_id=parent_id,
         traceparent=traceparent,
-        tracestate=tracestate
+        tracestate=tracestate,
     )
 
     assert exec1.request_id == req_id
@@ -32,7 +33,8 @@ def test_explicit_context():
     assert exec1.traceparent == traceparent
     assert exec1.tracestate == tracestate
 
-def test_default_behavior():
+
+def test_default_behavior() -> None:
     recorder = BlackBoxRecorder()
     exec2 = recorder.record(
         node_id="test_node_2",
@@ -47,7 +49,8 @@ def test_default_behavior():
     assert exec2.root_request_id is not None
     assert exec2.request_id == exec2.root_request_id
 
-def test_hash_sensitivity():
+
+def test_hash_sensitivity() -> None:
     recorder = BlackBoxRecorder()
     req_id = str(uuid.uuid4())
     root_id = str(uuid.uuid4())
@@ -63,7 +66,7 @@ def test_hash_sensitivity():
         timestamp=ts,
         request_id=req_id,
         root_request_id=root_id,
-        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     )
 
     exec3b = recorder.record(
@@ -76,12 +79,13 @@ def test_hash_sensitivity():
         timestamp=ts,
         request_id=req_id,
         root_request_id=root_id,
-        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-02" # Different
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-02",  # Different
     )
 
     assert exec3a.execution_hash != exec3b.execution_hash
 
-def test_hash_stability():
+
+def test_hash_stability() -> None:
     recorder = BlackBoxRecorder()
     req_id = str(uuid.uuid4())
     root_id = str(uuid.uuid4())
@@ -97,7 +101,7 @@ def test_hash_stability():
         timestamp=ts,
         request_id=req_id,
         root_request_id=root_id,
-        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     )
 
     exec3c = recorder.record(
@@ -110,6 +114,6 @@ def test_hash_stability():
         timestamp=ts,
         request_id=req_id,
         root_request_id=root_id,
-        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
     )
     assert exec3a.execution_hash == exec3c.execution_hash

--- a/tests/test_recorder_context.py
+++ b/tests/test_recorder_context.py
@@ -1,0 +1,115 @@
+from coreason_manifest.utils.recorder import BlackBoxRecorder
+from coreason_manifest.spec.interop.telemetry import NodeState
+from datetime import datetime
+import uuid
+import pytest
+
+def test_explicit_context():
+    recorder = BlackBoxRecorder()
+    req_id = str(uuid.uuid4())
+    root_id = str(uuid.uuid4())
+    parent_id = str(uuid.uuid4())
+    traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    tracestate = "rojo=00f067aa0ba902b7"
+
+    exec1 = recorder.record(
+        node_id="test_node_1",
+        state=NodeState.COMPLETED,
+        inputs={"a": 1},
+        outputs={"b": 2},
+        duration_ms=100.0,
+        parent_hashes=[],
+        request_id=req_id,
+        root_request_id=root_id,
+        parent_request_id=parent_id,
+        traceparent=traceparent,
+        tracestate=tracestate
+    )
+
+    assert exec1.request_id == req_id
+    assert exec1.root_request_id == root_id
+    assert exec1.parent_request_id == parent_id
+    assert exec1.traceparent == traceparent
+    assert exec1.tracestate == tracestate
+
+def test_default_behavior():
+    recorder = BlackBoxRecorder()
+    exec2 = recorder.record(
+        node_id="test_node_2",
+        state=NodeState.COMPLETED,
+        inputs={"a": 1},
+        outputs={"b": 2},
+        duration_ms=100.0,
+        parent_hashes=[],
+    )
+
+    assert exec2.request_id is not None
+    assert exec2.root_request_id is not None
+    assert exec2.request_id == exec2.root_request_id
+
+def test_hash_sensitivity():
+    recorder = BlackBoxRecorder()
+    req_id = str(uuid.uuid4())
+    root_id = str(uuid.uuid4())
+    ts = datetime.now()
+
+    exec3a = recorder.record(
+        node_id="test_node_3",
+        state=NodeState.COMPLETED,
+        inputs={"a": 1},
+        outputs={"b": 2},
+        duration_ms=100.0,
+        parent_hashes=[],
+        timestamp=ts,
+        request_id=req_id,
+        root_request_id=root_id,
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    )
+
+    exec3b = recorder.record(
+        node_id="test_node_3",
+        state=NodeState.COMPLETED,
+        inputs={"a": 1},
+        outputs={"b": 2},
+        duration_ms=100.0,
+        parent_hashes=[],
+        timestamp=ts,
+        request_id=req_id,
+        root_request_id=root_id,
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-02" # Different
+    )
+
+    assert exec3a.execution_hash != exec3b.execution_hash
+
+def test_hash_stability():
+    recorder = BlackBoxRecorder()
+    req_id = str(uuid.uuid4())
+    root_id = str(uuid.uuid4())
+    ts = datetime.now()
+
+    exec3a = recorder.record(
+        node_id="test_node_3",
+        state=NodeState.COMPLETED,
+        inputs={"a": 1},
+        outputs={"b": 2},
+        duration_ms=100.0,
+        parent_hashes=[],
+        timestamp=ts,
+        request_id=req_id,
+        root_request_id=root_id,
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    )
+
+    exec3c = recorder.record(
+        node_id="test_node_3",
+        state=NodeState.COMPLETED,
+        inputs={"a": 1},
+        outputs={"b": 2},
+        duration_ms=100.0,
+        parent_hashes=[],
+        timestamp=ts,
+        request_id=req_id,
+        root_request_id=root_id,
+        traceparent="00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+    )
+    assert exec3a.execution_hash == exec3c.execution_hash


### PR DESCRIPTION
Refactor `BlackBoxRecorder.record` to support distributed tracing by accepting and propagating W3C trace context and lineage IDs. This ensures `NodeExecution` telemetry is correctly linked to its distributed root and parent, and that the integrity hash reflects this context.

---
*PR created automatically by Jules for task [13883185375916492507](https://jules.google.com/task/13883185375916492507) started by @gowthamrao*