### PR TITLE
feat: Implement custom YAML dumper for manifest export

### DIFF
--- a/src/coreason_manifest/utils/io.py
+++ b/src/coreason_manifest/utils/io.py
@@ -181,7 +181,9 @@ class ManifestIO:
 
 
 class ManifestDumper(yaml.SafeDumper):
-    PRIORITY_KEYS: ClassVar[list[str]] = [
+    """Custom PyYAML Dumper that enforces a strict 'Aesthetic Contract' for manifests."""
+
+    _PRIORITY_KEYS = [
         "apiVersion",
         "type",
         "kind",
@@ -192,50 +194,34 @@ class ManifestDumper(yaml.SafeDumper):
         "interface",
         "governance",
     ]
-    DEPRIORITY_KEYS: ClassVar[list[str]] = ["definitions", "sequence", "steps", "graph", "nodes", "edges"]
+    _DEPRIORITY_KEYS = ["definitions", "sequence", "steps", "graph", "nodes", "edges"]
 
-    def represent_mapping(self, tag: str, mapping: Any, flow_style: bool | None = None) -> yaml.MappingNode:
-        value: list[tuple[yaml.Node, yaml.Node]] = []
-        node = yaml.MappingNode(tag, value, flow_style=flow_style)
-        if self.alias_key is not None:
-            self.represented_objects[self.alias_key] = node
-        best_style = True
-
-        # We only support dict sorting for manifest export
-        mapping_list = list(mapping.items())
-
-        # Custom sorting logic
-        def sort_key(item: tuple[Any, Any]) -> tuple[int, int | str, str] | tuple[int, str]:
-            key = item[0]
-            # specific safe string conversion for sorting
-            key_str = str(key)
-
-            if key_str in self.PRIORITY_KEYS:
-                return (0, self.PRIORITY_KEYS.index(key_str), key_str)
-            if key_str in self.DEPRIORITY_KEYS:
-                return (2, self.DEPRIORITY_KEYS.index(key_str), key_str)
-            return (1, key_str)
-
-        mapping_list.sort(key=sort_key)
-
-        for item_key, item_value in mapping_list:
-            node_key = self.represent_data(item_key)
-            node_value = self.represent_data(item_value)
-            if not (isinstance(node_key, yaml.ScalarNode) and not node_key.style):
-                best_style = False
-            if not (isinstance(node_value, yaml.ScalarNode) and not node_value.style):
-                best_style = False
-            value.append((node_key, node_value))
-
-        if flow_style is None:
-            if self.default_flow_style is not None:
-                node.flow_style = self.default_flow_style
-            else:
-                node.flow_style = best_style
-        return node
+    # SOTA: Pre-compute O(1) lookup maps to prevent O(N) list scans during sorting
+    _PRIORITY_MAP: ClassVar[dict[str, int]] = {k: i for i, k in enumerate(_PRIORITY_KEYS)}
+    _DEPRIORITY_MAP: ClassVar[dict[str, int]] = {k: i for i, k in enumerate(_DEPRIORITY_KEYS)}
 
 
-yaml.add_representer(dict, ManifestDumper.represent_dict, Dumper=ManifestDumper)
+def _dict_representer(dumper: ManifestDumper, data: dict[str, Any]) -> yaml.MappingNode:
+    """Sorts dictionaries aesthetically before yielding them to the YAML engine."""
+
+    def sort_key(item: tuple[Any, Any]) -> tuple[int, int, str]:
+        key = str(item[0])
+        if key in ManifestDumper._PRIORITY_MAP:
+            return (0, ManifestDumper._PRIORITY_MAP[key], key)
+        if key in ManifestDumper._DEPRIORITY_MAP:
+            return (2, ManifestDumper._DEPRIORITY_MAP[key], key)
+        # Default middle priority. Use 0 as stable secondary sort index to maintain tuple symmetry.
+        return (1, 0, key)
+
+    # Python 3.7+ guarantees insertion order preservation
+    sorted_dict = dict(sorted(data.items(), key=sort_key))
+
+    # Safely delegate back to PyYAML's native node generation
+    return dumper.represent_mapping("tag:yaml.org,2002:map", sorted_dict)
+
+
+# Register strictly on our custom dumper to avoid polluting the global yaml.SafeDumper
+ManifestDumper.add_representer(dict, _dict_representer)
 
 
 def export_manifest(model: Any, filepath: str | Path) -> None:

--- a/src/coreason_manifest/utils/io.py
+++ b/src/coreason_manifest/utils/io.py
@@ -178,3 +178,74 @@ class ManifestIO:
 
         except yaml.YAMLError as e:
             raise ValueError(f"Failed to parse manifest file: {e}") from e
+
+
+class ManifestDumper(yaml.SafeDumper):
+    PRIORITY_KEYS = [
+        "apiVersion",
+        "type",
+        "kind",
+        "id",
+        "name",
+        "status",
+        "metadata",
+        "interface",
+        "governance",
+    ]
+    DEPRIORITY_KEYS = ["definitions", "sequence", "steps", "graph", "nodes", "edges"]
+
+    def represent_mapping(self, tag, mapping, flow_style=False):
+        value = []
+        node = yaml.MappingNode(tag, value, flow_style=flow_style)
+        if self.alias_key is not None:
+            self.represented_objects[self.alias_key] = node
+        best_style = True
+        if hasattr(mapping, "items"):
+            mapping = list(mapping.items())
+
+            # Custom sorting logic
+            def sort_key(item):
+                key = item[0]
+                # specific safe string conversion for sorting
+                key_str = str(key)
+
+                if key_str in self.PRIORITY_KEYS:
+                    return (0, self.PRIORITY_KEYS.index(key_str), key_str)
+                elif key_str in self.DEPRIORITY_KEYS:
+                    return (2, self.DEPRIORITY_KEYS.index(key_str), key_str)
+                else:
+                    return (1, key_str)
+
+            mapping.sort(key=sort_key)
+
+        for item_key, item_value in mapping:
+            node_key = self.represent_data(item_key)
+            node_value = self.represent_data(item_value)
+            if not (isinstance(node_key, yaml.ScalarNode) and not node_key.style):
+                best_style = False
+            if not (isinstance(node_value, yaml.ScalarNode) and not node_value.style):
+                best_style = False
+            value.append((node_key, node_value))
+
+        if flow_style is None:
+            if self.default_flow_style is not None:
+                node.flow_style = self.default_flow_style
+            else:
+                node.flow_style = best_style
+        return node
+
+
+yaml.add_representer(dict, ManifestDumper.represent_dict, Dumper=ManifestDumper)
+
+
+def export_manifest(model: Any, filepath: str | Path) -> None:
+    payload = model.model_dump(exclude_none=True, by_alias=True)
+    with open(filepath, "w", encoding="utf-8") as f:
+        yaml.dump(
+            payload,
+            f,
+            Dumper=ManifestDumper,
+            default_flow_style=False,
+            sort_keys=False,
+            allow_unicode=True,
+        )

--- a/src/coreason_manifest/utils/io.py
+++ b/src/coreason_manifest/utils/io.py
@@ -211,10 +211,9 @@ class ManifestDumper(yaml.SafeDumper):
 
                 if key_str in self.PRIORITY_KEYS:
                     return (0, self.PRIORITY_KEYS.index(key_str), key_str)
-                elif key_str in self.DEPRIORITY_KEYS:
+                if key_str in self.DEPRIORITY_KEYS:
                     return (2, self.DEPRIORITY_KEYS.index(key_str), key_str)
-                else:
-                    return (1, key_str)
+                return (1, key_str)
 
             mapping_list.sort(key=sort_key)
         else:

--- a/src/coreason_manifest/utils/io.py
+++ b/src/coreason_manifest/utils/io.py
@@ -183,7 +183,7 @@ class ManifestIO:
 class ManifestDumper(yaml.SafeDumper):
     """Custom PyYAML Dumper that enforces a strict 'Aesthetic Contract' for manifests."""
 
-    _PRIORITY_KEYS = [
+    _PRIORITY_KEYS: ClassVar[list[str]] = [
         "apiVersion",
         "type",
         "kind",
@@ -194,7 +194,7 @@ class ManifestDumper(yaml.SafeDumper):
         "interface",
         "governance",
     ]
-    _DEPRIORITY_KEYS = ["definitions", "sequence", "steps", "graph", "nodes", "edges"]
+    _DEPRIORITY_KEYS: ClassVar[list[str]] = ["definitions", "sequence", "steps", "graph", "nodes", "edges"]
 
     # SOTA: Pre-compute O(1) lookup maps to prevent O(N) list scans during sorting
     _PRIORITY_MAP: ClassVar[dict[str, int]] = {k: i for i, k in enumerate(_PRIORITY_KEYS)}

--- a/src/coreason_manifest/utils/io.py
+++ b/src/coreason_manifest/utils/io.py
@@ -4,7 +4,7 @@ import os
 import stat
 import warnings
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import yaml
 
@@ -181,7 +181,7 @@ class ManifestIO:
 
 
 class ManifestDumper(yaml.SafeDumper):
-    PRIORITY_KEYS = [
+    PRIORITY_KEYS: ClassVar[list[str]] = [
         "apiVersion",
         "type",
         "kind",
@@ -192,19 +192,19 @@ class ManifestDumper(yaml.SafeDumper):
         "interface",
         "governance",
     ]
-    DEPRIORITY_KEYS = ["definitions", "sequence", "steps", "graph", "nodes", "edges"]
+    DEPRIORITY_KEYS: ClassVar[list[str]] = ["definitions", "sequence", "steps", "graph", "nodes", "edges"]
 
-    def represent_mapping(self, tag, mapping, flow_style=False):
-        value = []
+    def represent_mapping(self, tag: str, mapping: Any, flow_style: bool | None = False) -> yaml.MappingNode:
+        value: list[tuple[yaml.Node, yaml.Node]] = []
         node = yaml.MappingNode(tag, value, flow_style=flow_style)
         if self.alias_key is not None:
             self.represented_objects[self.alias_key] = node
         best_style = True
         if hasattr(mapping, "items"):
-            mapping = list(mapping.items())
+            mapping_list = list(mapping.items())
 
             # Custom sorting logic
-            def sort_key(item):
+            def sort_key(item: tuple[Any, Any]) -> tuple[int, int | str, str] | tuple[int, str]:
                 key = item[0]
                 # specific safe string conversion for sorting
                 key_str = str(key)
@@ -216,9 +216,11 @@ class ManifestDumper(yaml.SafeDumper):
                 else:
                     return (1, key_str)
 
-            mapping.sort(key=sort_key)
+            mapping_list.sort(key=sort_key)
+        else:
+            mapping_list = []
 
-        for item_key, item_value in mapping:
+        for item_key, item_value in mapping_list:
             node_key = self.represent_data(item_key)
             node_value = self.represent_data(item_value)
             if not (isinstance(node_key, yaml.ScalarNode) and not node_key.style):

--- a/src/coreason_manifest/utils/io.py
+++ b/src/coreason_manifest/utils/io.py
@@ -194,30 +194,29 @@ class ManifestDumper(yaml.SafeDumper):
     ]
     DEPRIORITY_KEYS: ClassVar[list[str]] = ["definitions", "sequence", "steps", "graph", "nodes", "edges"]
 
-    def represent_mapping(self, tag: str, mapping: Any, flow_style: bool | None = False) -> yaml.MappingNode:
+    def represent_mapping(self, tag: str, mapping: Any, flow_style: bool | None = None) -> yaml.MappingNode:
         value: list[tuple[yaml.Node, yaml.Node]] = []
         node = yaml.MappingNode(tag, value, flow_style=flow_style)
         if self.alias_key is not None:
             self.represented_objects[self.alias_key] = node
         best_style = True
-        if hasattr(mapping, "items"):
-            mapping_list = list(mapping.items())
 
-            # Custom sorting logic
-            def sort_key(item: tuple[Any, Any]) -> tuple[int, int | str, str] | tuple[int, str]:
-                key = item[0]
-                # specific safe string conversion for sorting
-                key_str = str(key)
+        # We only support dict sorting for manifest export
+        mapping_list = list(mapping.items())
 
-                if key_str in self.PRIORITY_KEYS:
-                    return (0, self.PRIORITY_KEYS.index(key_str), key_str)
-                if key_str in self.DEPRIORITY_KEYS:
-                    return (2, self.DEPRIORITY_KEYS.index(key_str), key_str)
-                return (1, key_str)
+        # Custom sorting logic
+        def sort_key(item: tuple[Any, Any]) -> tuple[int, int | str, str] | tuple[int, str]:
+            key = item[0]
+            # specific safe string conversion for sorting
+            key_str = str(key)
 
-            mapping_list.sort(key=sort_key)
-        else:
-            mapping_list = []
+            if key_str in self.PRIORITY_KEYS:
+                return (0, self.PRIORITY_KEYS.index(key_str), key_str)
+            if key_str in self.DEPRIORITY_KEYS:
+                return (2, self.DEPRIORITY_KEYS.index(key_str), key_str)
+            return (1, key_str)
+
+        mapping_list.sort(key=sort_key)
 
         for item_key, item_value in mapping_list:
             node_key = self.represent_data(item_key)

--- a/tests/test_io_manifest_export.py
+++ b/tests/test_io_manifest_export.py
@@ -9,12 +9,12 @@ import yaml
 # Import the code to test
 # Assuming src is in python path or installed
 try:
-    from coreason_manifest.utils.io import ManifestDumper, export_manifest
+    from coreason_manifest.utils.io import export_manifest, ManifestDumper
 except ImportError:
     import sys
 
     sys.path.append(str(Path(__file__).parents[2] / "src"))
-    from coreason_manifest.utils.io import ManifestDumper, export_manifest
+    from coreason_manifest.utils.io import export_manifest, ManifestDumper
 
 
 class MockPydanticModel:
@@ -175,12 +175,15 @@ def test_export_manifest_mixed_types() -> None:
             with contextlib.suppress(OSError):
                 os.remove(tmp_path)
 
-
 def test_manifest_dumper_coverage() -> None:
     """Test edge cases for ManifestDumper to ensure full coverage."""
     # Test 1: Trigger 'best_style = False'
     # Use a key that requires quoting/complexity
-    complex_key_data = {"simple": "val", "key:with:colons": "val2", "multiline\nkey": "val3"}
+    complex_key_data = {
+        "simple": "val",
+        "key:with:colons": "val2",
+        "multiline\nkey": "val3"
+    }
 
     with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
         tmp_path = Path(tmp.name)
@@ -189,7 +192,12 @@ def test_manifest_dumper_coverage() -> None:
         tmp.close()
         # Direct dump with ManifestDumper
         with open(tmp_path, "w", encoding="utf-8") as f:
-            yaml.dump(complex_key_data, f, Dumper=ManifestDumper, sort_keys=False)
+            yaml.dump(
+                complex_key_data,
+                f,
+                Dumper=ManifestDumper,
+                sort_keys=False
+            )
 
         with open(tmp_path, encoding="utf-8") as f:
             content = f.read()
@@ -213,11 +221,67 @@ def test_manifest_dumper_coverage() -> None:
     try:
         tmp.close()
         with open(tmp_path, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, Dumper=ManifestDumper)  # default_flow_style is None implicitly
+            yaml.dump(data, f, Dumper=ManifestDumper) # default_flow_style is None implicitly
 
         # Also try explicitly None
         with open(tmp_path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, Dumper=ManifestDumper, default_flow_style=None)
+
+    finally:
+        if tmp_path.exists():
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
+
+class ComplexKey:
+    """A custom class to serve as a non-scalar key."""
+    def __init__(self, name: str):
+        self.name = name
+
+    def __hash__(self) -> int:
+        return hash(self.name)
+
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, ComplexKey):
+            return NotImplemented
+        return self.name == other.name
+
+    def __lt__(self, other: "ComplexKey") -> bool:
+        # Needed for sort_key if it compares keys directly?
+        # But sort_key converts to string. str(ComplexKey) uses repr?
+        return self.name < other.name
+
+    def __str__(self) -> str:
+        return self.name
+
+def represent_complex_key(dumper: yaml.BaseDumper, data: ComplexKey) -> yaml.Node:
+    # Represent as a sequence (non-scalar)
+    return dumper.represent_sequence('tag:yaml.org,2002:seq', [data.name])
+
+def test_manifest_dumper_non_scalar_key() -> None:
+    """Test with a non-scalar key to trigger 'best_style = False' via isinstance check."""
+
+    # Register the custom representer on ManifestDumper
+    yaml.add_representer(ComplexKey, represent_complex_key, Dumper=ManifestDumper)
+
+    key = ComplexKey("my_complex_key")
+    data = {
+        key: "value"
+    }
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        tmp.close()
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, Dumper=ManifestDumper)
+
+        # We don't necessarily need to load it back if we just want coverage of dumping logic
+        # But let's check it wrote something
+        with open(tmp_path, encoding="utf-8") as f:
+            content = f.read()
+            # Expecting ? - my_complex_key (complex key indicator)
+            assert "? - my_complex_key" in content
 
     finally:
         if tmp_path.exists():

--- a/tests/test_io_manifest_export.py
+++ b/tests/test_io_manifest_export.py
@@ -4,7 +4,6 @@ import tempfile
 from pathlib import Path
 from typing import Any
 
-import pytest
 import yaml
 
 # Import the code to test

--- a/tests/test_io_manifest_export.py
+++ b/tests/test_io_manifest_export.py
@@ -9,12 +9,12 @@ import yaml
 # Import the code to test
 # Assuming src is in python path or installed
 try:
-    from coreason_manifest.utils.io import export_manifest, ManifestDumper
+    from coreason_manifest.utils.io import ManifestDumper, export_manifest
 except ImportError:
     import sys
 
     sys.path.append(str(Path(__file__).parents[2] / "src"))
-    from coreason_manifest.utils.io import export_manifest, ManifestDumper
+    from coreason_manifest.utils.io import ManifestDumper, export_manifest
 
 
 class MockPydanticModel:
@@ -175,15 +175,12 @@ def test_export_manifest_mixed_types() -> None:
             with contextlib.suppress(OSError):
                 os.remove(tmp_path)
 
+
 def test_manifest_dumper_coverage() -> None:
     """Test edge cases for ManifestDumper to ensure full coverage."""
     # Test 1: Trigger 'best_style = False'
     # Use a key that requires quoting/complexity
-    complex_key_data = {
-        "simple": "val",
-        "key:with:colons": "val2",
-        "multiline\nkey": "val3"
-    }
+    complex_key_data = {"simple": "val", "key:with:colons": "val2", "multiline\nkey": "val3"}
 
     with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
         tmp_path = Path(tmp.name)
@@ -192,12 +189,7 @@ def test_manifest_dumper_coverage() -> None:
         tmp.close()
         # Direct dump with ManifestDumper
         with open(tmp_path, "w", encoding="utf-8") as f:
-            yaml.dump(
-                complex_key_data,
-                f,
-                Dumper=ManifestDumper,
-                sort_keys=False
-            )
+            yaml.dump(complex_key_data, f, Dumper=ManifestDumper, sort_keys=False)
 
         with open(tmp_path, encoding="utf-8") as f:
             content = f.read()
@@ -221,7 +213,7 @@ def test_manifest_dumper_coverage() -> None:
     try:
         tmp.close()
         with open(tmp_path, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, Dumper=ManifestDumper) # default_flow_style is None implicitly
+            yaml.dump(data, f, Dumper=ManifestDumper)  # default_flow_style is None implicitly
 
         # Also try explicitly None
         with open(tmp_path, "w", encoding="utf-8") as f:

--- a/tests/test_io_manifest_export.py
+++ b/tests/test_io_manifest_export.py
@@ -9,12 +9,12 @@ import yaml
 # Import the code to test
 # Assuming src is in python path or installed
 try:
-    from coreason_manifest.utils.io import export_manifest, ManifestDumper
+    from coreason_manifest.utils.io import ManifestDumper, export_manifest
 except ImportError:
     import sys
 
     sys.path.append(str(Path(__file__).parents[2] / "src"))
-    from coreason_manifest.utils.io import export_manifest, ManifestDumper
+    from coreason_manifest.utils.io import ManifestDumper, export_manifest
 
 
 class MockPydanticModel:
@@ -175,15 +175,12 @@ def test_export_manifest_mixed_types() -> None:
             with contextlib.suppress(OSError):
                 os.remove(tmp_path)
 
+
 def test_manifest_dumper_coverage() -> None:
     """Test edge cases for ManifestDumper to ensure full coverage."""
     # Test 1: Trigger 'best_style = False'
     # Use a key that requires quoting/complexity
-    complex_key_data = {
-        "simple": "val",
-        "key:with:colons": "val2",
-        "multiline\nkey": "val3"
-    }
+    complex_key_data = {"simple": "val", "key:with:colons": "val2", "multiline\nkey": "val3"}
 
     with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
         tmp_path = Path(tmp.name)
@@ -192,12 +189,7 @@ def test_manifest_dumper_coverage() -> None:
         tmp.close()
         # Direct dump with ManifestDumper
         with open(tmp_path, "w", encoding="utf-8") as f:
-            yaml.dump(
-                complex_key_data,
-                f,
-                Dumper=ManifestDumper,
-                sort_keys=False
-            )
+            yaml.dump(complex_key_data, f, Dumper=ManifestDumper, sort_keys=False)
 
         with open(tmp_path, encoding="utf-8") as f:
             content = f.read()
@@ -221,7 +213,7 @@ def test_manifest_dumper_coverage() -> None:
     try:
         tmp.close()
         with open(tmp_path, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, Dumper=ManifestDumper) # default_flow_style is None implicitly
+            yaml.dump(data, f, Dumper=ManifestDumper)  # default_flow_style is None implicitly
 
         # Also try explicitly None
         with open(tmp_path, "w", encoding="utf-8") as f:
@@ -232,8 +224,10 @@ def test_manifest_dumper_coverage() -> None:
             with contextlib.suppress(OSError):
                 os.remove(tmp_path)
 
+
 class ComplexKey:
     """A custom class to serve as a non-scalar key."""
+
     def __init__(self, name: str):
         self.name = name
 
@@ -253,9 +247,11 @@ class ComplexKey:
     def __str__(self) -> str:
         return self.name
 
+
 def represent_complex_key(dumper: yaml.BaseDumper, data: ComplexKey) -> yaml.Node:
     # Represent as a sequence (non-scalar)
-    return dumper.represent_sequence('tag:yaml.org,2002:seq', [data.name])
+    return dumper.represent_sequence("tag:yaml.org,2002:seq", [data.name])
+
 
 def test_manifest_dumper_non_scalar_key() -> None:
     """Test with a non-scalar key to trigger 'best_style = False' via isinstance check."""
@@ -264,9 +260,7 @@ def test_manifest_dumper_non_scalar_key() -> None:
     yaml.add_representer(ComplexKey, represent_complex_key, Dumper=ManifestDumper)
 
     key = ComplexKey("my_complex_key")
-    data = {
-        key: "value"
-    }
+    data = {key: "value"}
 
     with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
         tmp_path = Path(tmp.name)

--- a/tests/test_io_manifest_export.py
+++ b/tests/test_io_manifest_export.py
@@ -1,0 +1,183 @@
+import os
+import tempfile
+import yaml
+import pytest
+from pathlib import Path
+from typing import Any
+
+# Import the code to test
+# Assuming src is in python path or installed
+try:
+    from coreason_manifest.utils.io import export_manifest, ManifestDumper
+except ImportError:
+    import sys
+    sys.path.append(str(Path(__file__).parents[2] / "src"))
+    from coreason_manifest.utils.io import export_manifest, ManifestDumper
+
+class MockPydanticModel:
+    def __init__(self, data: dict[str, Any]):
+        self.data = data
+
+    def model_dump(self, exclude_none: bool = False, by_alias: bool = False) -> dict[str, Any]:
+        # Mimic Pydantic behavior:
+        # exclude_none: remove keys with None values
+        # by_alias: we'll just ignore it for this mock as we don't define aliases
+
+        result = {}
+        for k, v in self.data.items():
+            if exclude_none and v is None:
+                continue
+            result[k] = v
+        return result
+
+def test_export_manifest_sorting():
+    # Define data with mixed priority, depriority, and normal keys
+    # Intentionally unordered in the input dict
+    data = {
+        "nodes": ["node1", "node2"],          # Depriority (index 4 in list)
+        "zebra": "stripe",                    # Normal (z)
+        "apiVersion": "v1",                   # Priority (index 0)
+        "apple": "fruit",                     # Normal (a)
+        "kind": "Agent",                      # Priority (index 2)
+        "definitions": {"foo": "bar"},        # Depriority (index 0)
+        "name": "MyAgent",                    # Priority (index 4)
+        "type": "standard",                   # Priority (index 1)
+        "ignored": None,                      # Should be excluded
+        "graph": "graph_data",                # Depriority (index 3)
+    }
+
+    model = MockPydanticModel(data)
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        # Close the file so export_manifest can write to it (windows compatibility mostly, but good practice)
+        tmp.close()
+
+        export_manifest(model, tmp_path)
+
+        with open(tmp_path, "r", encoding="utf-8") as f:
+            content = f.read()
+            loaded = yaml.safe_load(content)
+
+        # Verify keys exist and None is excluded
+        assert "ignored" not in loaded
+        assert loaded["apiVersion"] == "v1"
+
+        keys_in_order = list(loaded.keys())
+
+        # Expected Order:
+        # Priority Keys (0):
+        # 1. apiVersion (index 0)
+        # 2. type (index 1)
+        # 3. kind (index 2)
+        # 4. name (index 4)
+
+        # Normal Keys (1):
+        # 5. apple (a)
+        # 6. zebra (z)
+
+        # Depriority Keys (2):
+        # 7. definitions (index 0)
+        # 8. graph (index 3)
+        # 9. nodes (index 4)
+
+        expected_order = [
+            "apiVersion",
+            "type",
+            "kind",
+            "name",
+            "apple",
+            "zebra",
+            "definitions",
+            "graph",
+            "nodes"
+        ]
+
+        assert keys_in_order == expected_order
+
+    finally:
+        if tmp_path.exists():
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+def test_export_manifest_nested_sorting():
+    # Test recursive sorting
+    data = {
+        "metadata": {
+            "version": "1.0",
+            "name": "meta",
+            "id": "123"
+        },
+        "apiVersion": "v1"
+    }
+    # "metadata" is priority.
+    # Inside "metadata":
+    # "id" (priority), "name" (priority), "version" (normal)
+
+    model = MockPydanticModel(data)
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        tmp.close()
+        export_manifest(model, tmp_path)
+
+        with open(tmp_path, "r", encoding="utf-8") as f:
+            content = f.read()
+            loaded = yaml.safe_load(content)
+
+        keys_in_order = list(loaded.keys())
+        assert keys_in_order == ["apiVersion", "metadata"]
+
+        metadata_keys = list(loaded["metadata"].keys())
+        # Inside metadata: "id", "name" are priority keys. "version" is normal.
+        # "id" is index 3 in priority list.
+        # "name" is index 4 in priority list.
+        # So "id" comes before "name".
+        assert metadata_keys == ["id", "name", "version"]
+
+    finally:
+        if tmp_path.exists():
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass
+
+def test_export_manifest_mixed_types():
+    # Test with non-string keys if possible (though JSON/YAML usually have string keys for mappings)
+    # But ManifestDumper logic casts to string.
+    # Let's test just string keys but that resemble numbers?
+
+    data = {
+        "10": "ten",
+        "2": "two",
+        "kind": "test"
+    }
+    # "kind" is priority.
+    # "10", "2" are normal.
+    # Alphabetical: "10" < "2".
+
+    model = MockPydanticModel(data)
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        tmp.close()
+        export_manifest(model, tmp_path)
+        with open(tmp_path, "r", encoding="utf-8") as f:
+            loaded = yaml.safe_load(f)
+
+        keys = list(loaded.keys())
+        assert keys == ["kind", "10", "2"]
+
+    finally:
+        if tmp_path.exists():
+            try:
+                os.remove(tmp_path)
+            except OSError:
+                pass

--- a/tests/test_io_manifest_export.py
+++ b/tests/test_io_manifest_export.py
@@ -9,12 +9,12 @@ import yaml
 # Import the code to test
 # Assuming src is in python path or installed
 try:
-    from coreason_manifest.utils.io import export_manifest
+    from coreason_manifest.utils.io import export_manifest, ManifestDumper
 except ImportError:
     import sys
 
     sys.path.append(str(Path(__file__).parents[2] / "src"))
-    from coreason_manifest.utils.io import export_manifest
+    from coreason_manifest.utils.io import export_manifest, ManifestDumper
 
 
 class MockPydanticModel:
@@ -169,6 +169,63 @@ def test_export_manifest_mixed_types() -> None:
 
         keys = list(loaded.keys())
         assert keys == ["kind", "10", "2"]
+
+    finally:
+        if tmp_path.exists():
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
+
+def test_manifest_dumper_coverage() -> None:
+    """Test edge cases for ManifestDumper to ensure full coverage."""
+    # Test 1: Trigger 'best_style = False'
+    # Use a key that requires quoting/complexity
+    complex_key_data = {
+        "simple": "val",
+        "key:with:colons": "val2",
+        "multiline\nkey": "val3"
+    }
+
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        tmp.close()
+        # Direct dump with ManifestDumper
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(
+                complex_key_data,
+                f,
+                Dumper=ManifestDumper,
+                sort_keys=False
+            )
+
+        with open(tmp_path, encoding="utf-8") as f:
+            content = f.read()
+            loaded = yaml.safe_load(content)
+
+        assert loaded["simple"] == "val"
+        assert loaded["key:with:colons"] == "val2"
+
+    finally:
+        if tmp_path.exists():
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
+
+    # Test 2: Trigger 'flow_style is None' branches
+    # By default yaml.dump sets default_flow_style=None
+
+    data = {"a": 1, "b": 2}
+    with tempfile.NamedTemporaryFile(suffix=".yaml", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+
+    try:
+        tmp.close()
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, Dumper=ManifestDumper) # default_flow_style is None implicitly
+
+        # Also try explicitly None
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, Dumper=ManifestDumper, default_flow_style=None)
 
     finally:
         if tmp_path.exists():

--- a/tests/test_io_manifest_export.py
+++ b/tests/test_io_manifest_export.py
@@ -248,7 +248,7 @@ class ComplexKey:
         return self.name
 
 
-def represent_complex_key(dumper: yaml.BaseDumper, data: ComplexKey) -> yaml.Node:
+def represent_complex_key(dumper: ManifestDumper, data: ComplexKey) -> yaml.Node:
     # Represent as a sequence (non-scalar)
     return dumper.represent_sequence("tag:yaml.org,2002:seq", [data.name])
 

--- a/tests/test_io_manifest_export.py
+++ b/tests/test_io_manifest_export.py
@@ -1,18 +1,22 @@
+import contextlib
 import os
 import tempfile
-import yaml
-import pytest
 from pathlib import Path
 from typing import Any
+
+import pytest
+import yaml
 
 # Import the code to test
 # Assuming src is in python path or installed
 try:
-    from coreason_manifest.utils.io import export_manifest, ManifestDumper
+    from coreason_manifest.utils.io import export_manifest
 except ImportError:
     import sys
+
     sys.path.append(str(Path(__file__).parents[2] / "src"))
-    from coreason_manifest.utils.io import export_manifest, ManifestDumper
+    from coreason_manifest.utils.io import export_manifest
+
 
 class MockPydanticModel:
     def __init__(self, data: dict[str, Any]):
@@ -22,6 +26,7 @@ class MockPydanticModel:
         # Mimic Pydantic behavior:
         # exclude_none: remove keys with None values
         # by_alias: we'll just ignore it for this mock as we don't define aliases
+        _ = by_alias  # Silence unused argument warning
 
         result = {}
         for k, v in self.data.items():
@@ -30,20 +35,21 @@ class MockPydanticModel:
             result[k] = v
         return result
 
-def test_export_manifest_sorting():
+
+def test_export_manifest_sorting() -> None:
     # Define data with mixed priority, depriority, and normal keys
     # Intentionally unordered in the input dict
     data = {
-        "nodes": ["node1", "node2"],          # Depriority (index 4 in list)
-        "zebra": "stripe",                    # Normal (z)
-        "apiVersion": "v1",                   # Priority (index 0)
-        "apple": "fruit",                     # Normal (a)
-        "kind": "Agent",                      # Priority (index 2)
-        "definitions": {"foo": "bar"},        # Depriority (index 0)
-        "name": "MyAgent",                    # Priority (index 4)
-        "type": "standard",                   # Priority (index 1)
-        "ignored": None,                      # Should be excluded
-        "graph": "graph_data",                # Depriority (index 3)
+        "nodes": ["node1", "node2"],  # Depriority (index 4 in list)
+        "zebra": "stripe",  # Normal (z)
+        "apiVersion": "v1",  # Priority (index 0)
+        "apple": "fruit",  # Normal (a)
+        "kind": "Agent",  # Priority (index 2)
+        "definitions": {"foo": "bar"},  # Depriority (index 0)
+        "name": "MyAgent",  # Priority (index 4)
+        "type": "standard",  # Priority (index 1)
+        "ignored": None,  # Should be excluded
+        "graph": "graph_data",  # Depriority (index 3)
     }
 
     model = MockPydanticModel(data)
@@ -57,7 +63,7 @@ def test_export_manifest_sorting():
 
         export_manifest(model, tmp_path)
 
-        with open(tmp_path, "r", encoding="utf-8") as f:
+        with open(tmp_path, encoding="utf-8") as f:
             content = f.read()
             loaded = yaml.safe_load(content)
 
@@ -92,27 +98,22 @@ def test_export_manifest_sorting():
             "zebra",
             "definitions",
             "graph",
-            "nodes"
+            "nodes",
         ]
 
         assert keys_in_order == expected_order
 
     finally:
         if tmp_path.exists():
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(tmp_path)
-            except OSError:
-                pass
 
-def test_export_manifest_nested_sorting():
+
+def test_export_manifest_nested_sorting() -> None:
     # Test recursive sorting
     data = {
-        "metadata": {
-            "version": "1.0",
-            "name": "meta",
-            "id": "123"
-        },
-        "apiVersion": "v1"
+        "metadata": {"version": "1.0", "name": "meta", "id": "123"},
+        "apiVersion": "v1",
     }
     # "metadata" is priority.
     # Inside "metadata":
@@ -127,7 +128,7 @@ def test_export_manifest_nested_sorting():
         tmp.close()
         export_manifest(model, tmp_path)
 
-        with open(tmp_path, "r", encoding="utf-8") as f:
+        with open(tmp_path, encoding="utf-8") as f:
             content = f.read()
             loaded = yaml.safe_load(content)
 
@@ -143,21 +144,16 @@ def test_export_manifest_nested_sorting():
 
     finally:
         if tmp_path.exists():
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(tmp_path)
-            except OSError:
-                pass
 
-def test_export_manifest_mixed_types():
+
+def test_export_manifest_mixed_types() -> None:
     # Test with non-string keys if possible (though JSON/YAML usually have string keys for mappings)
     # But ManifestDumper logic casts to string.
     # Let's test just string keys but that resemble numbers?
 
-    data = {
-        "10": "ten",
-        "2": "two",
-        "kind": "test"
-    }
+    data = {"10": "ten", "2": "two", "kind": "test"}
     # "kind" is priority.
     # "10", "2" are normal.
     # Alphabetical: "10" < "2".
@@ -169,7 +165,7 @@ def test_export_manifest_mixed_types():
     try:
         tmp.close()
         export_manifest(model, tmp_path)
-        with open(tmp_path, "r", encoding="utf-8") as f:
+        with open(tmp_path, encoding="utf-8") as f:
             loaded = yaml.safe_load(f)
 
         keys = list(loaded.keys())
@@ -177,7 +173,5 @@ def test_export_manifest_mixed_types():
 
     finally:
         if tmp_path.exists():
-            try:
+            with contextlib.suppress(OSError):
                 os.remove(tmp_path)
-            except OSError:
-                pass


### PR DESCRIPTION
This PR implements a custom YAML serialization layer for `coreason-manifest` v0.25.0 migration. 

It introduces `ManifestDumper`, a custom PyYAML dumper that enforces a specific field ordering to improve readability of exported manifests. Identity fields (e.g., `apiVersion`, `kind`, `name`) are sorted to the top, while bulky fields (e.g., `definitions`, `graph`) are pushed to the bottom.

The `export_manifest` utility function provides a standardized way to export Pydantic models to YAML files with the custom formatting.

Tests are included to verify the correct sorting of keys and handling of nested structures.

---
*PR created automatically by Jules for task [10753068535356199311](https://jules.google.com/task/10753068535356199311) started by @gowthamrao*