### PR TITLE
Refactor Governance with Three Budget Operational Limits

### DIFF
--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -200,10 +200,14 @@ class AgentBuilder:
         self,
         max_cost_usd: float | None = None,
         max_tokens: int | None = None,
-        max_steps: int | None = None,
         fallback_model: str | None = None,
+        max_steps: int | None = None,
+        max_execution_time_seconds: int | None = None,
+        max_rows_per_query: int | None = None,
+        max_payload_bytes: int | None = None,
+        max_search_results: int | None = None,
     ) -> "AgentBuilder":
-        """Configures the operational limits (Financial, Compute)."""
+        """Configures the operational limits (Financial, Compute, Data)."""
         financial = None
         if max_cost_usd is not None or max_tokens is not None or fallback_model is not None:
             financial = FinancialLimits(
@@ -213,11 +217,21 @@ class AgentBuilder:
             )
 
         compute = None
-        if max_steps is not None:
-            compute = ComputeLimits(max_cognitive_steps=max_steps)
+        if max_steps is not None or max_execution_time_seconds is not None:
+            compute = ComputeLimits(
+                max_cognitive_steps=max_steps, max_execution_time_seconds=max_execution_time_seconds
+            )
 
-        if financial or compute:
-            self.operational_policy = OperationalPolicy(financial=financial, compute=compute)
+        data = None
+        if max_rows_per_query is not None or max_payload_bytes is not None or max_search_results is not None:
+            data = DataLimits(
+                max_rows_per_query=max_rows_per_query,
+                max_payload_bytes=max_payload_bytes,
+                max_search_results=max_search_results,
+            )
+
+        if financial or compute or data:
+            self.operational_policy = OperationalPolicy(financial=financial, compute=compute, data=data)
         return self
 
     def with_escalation_rule(
@@ -336,10 +350,13 @@ class BaseFlowBuilder:
         self,
         max_cost_usd: float | None = None,
         max_tokens: int | None = None,
-        max_steps: int | None = None,
         fallback_model: str | None = None,
+        max_steps: int | None = None,
+        max_execution_time_seconds: int | None = None,
+        max_concurrent_agents: int | None = None,
         max_rows_per_query: int | None = None,
         max_payload_bytes: int | None = None,
+        max_search_results: int | None = None,
     ) -> Self:
         """Configures global operational limits (Financial, Data, Compute)."""
         financial = None
@@ -351,15 +368,20 @@ class BaseFlowBuilder:
             )
 
         data = None
-        if max_rows_per_query is not None or max_payload_bytes is not None:
+        if max_rows_per_query is not None or max_payload_bytes is not None or max_search_results is not None:
             data = DataLimits(
                 max_rows_per_query=max_rows_per_query,
                 max_payload_bytes=max_payload_bytes,
+                max_search_results=max_search_results,
             )
 
         compute = None
-        if max_steps is not None:
-            compute = ComputeLimits(max_cognitive_steps=max_steps)
+        if max_steps is not None or max_execution_time_seconds is not None or max_concurrent_agents is not None:
+            compute = ComputeLimits(
+                max_cognitive_steps=max_steps,
+                max_execution_time_seconds=max_execution_time_seconds,
+                max_concurrent_agents=max_concurrent_agents,
+            )
 
         op_policy = OperationalPolicy(financial=financial, data=data, compute=compute)
 

--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -29,7 +29,14 @@ from coreason_manifest.spec.core.flow import (
     LinearFlow,
     VariableDef,
 )
-from coreason_manifest.spec.core.governance import CircuitBreaker, Governance
+from coreason_manifest.spec.core.governance import (
+    CircuitBreaker,
+    ComputeLimits,
+    DataLimits,
+    FinancialLimits,
+    Governance,
+    OperationalPolicy,
+)
 from coreason_manifest.spec.core.memory import (
     EpisodicMemoryConfig,
     MemorySubsystem,
@@ -95,6 +102,7 @@ class AgentBuilder:
         self.fast_path: FastPath | None = None
         self.tools: list[str] = []
         self.resilience: ResilienceConfig | None = None
+        self.operational_policy: OperationalPolicy | None = None
         self.escalation_rules: list[EscalationCriteria] = []
         self.memory: MemorySubsystem | None = None
 
@@ -188,6 +196,30 @@ class AgentBuilder:
             )
         return self
 
+    def with_operational_policy(
+        self,
+        max_cost_usd: float | None = None,
+        max_tokens: int | None = None,
+        max_steps: int | None = None,
+        fallback_model: str | None = None,
+    ) -> "AgentBuilder":
+        """Configures the operational limits (Financial, Compute)."""
+        financial = None
+        if max_cost_usd is not None or max_tokens is not None or fallback_model is not None:
+            financial = FinancialLimits(
+                max_cost_usd=max_cost_usd,
+                max_tokens_total=max_tokens,
+                budget_depletion_routing=fallback_model,
+            )
+
+        compute = None
+        if max_steps is not None:
+            compute = ComputeLimits(max_cognitive_steps=max_steps)
+
+        if financial or compute:
+            self.operational_policy = OperationalPolicy(financial=financial, compute=compute)
+        return self
+
     def with_escalation_rule(
         self, condition: str, role: str, strategy: EscalationStrategy | None = None
     ) -> "AgentBuilder":
@@ -256,6 +288,7 @@ class AgentBuilder:
             type="agent",
             profile=profile,
             tools=self.tools,
+            operational_policy=self.operational_policy,
             escalation_rules=self.escalation_rules,
         )
 
@@ -297,6 +330,43 @@ class BaseFlowBuilder:
     def set_governance(self, gov: Governance) -> Self:
         """Sets the governance policy."""
         self.governance = gov
+        return self
+
+    def set_operational_policy(
+        self,
+        max_cost_usd: float | None = None,
+        max_tokens: int | None = None,
+        max_steps: int | None = None,
+        fallback_model: str | None = None,
+        max_rows_per_query: int | None = None,
+        max_payload_bytes: int | None = None,
+    ) -> Self:
+        """Configures global operational limits (Financial, Data, Compute)."""
+        financial = None
+        if max_cost_usd is not None or max_tokens is not None or fallback_model is not None:
+            financial = FinancialLimits(
+                max_cost_usd=max_cost_usd,
+                max_tokens_total=max_tokens,
+                budget_depletion_routing=fallback_model,
+            )
+
+        data = None
+        if max_rows_per_query is not None or max_payload_bytes is not None:
+            data = DataLimits(
+                max_rows_per_query=max_rows_per_query,
+                max_payload_bytes=max_payload_bytes,
+            )
+
+        compute = None
+        if max_steps is not None:
+            compute = ComputeLimits(max_cognitive_steps=max_steps)
+
+        op_policy = OperationalPolicy(financial=financial, data=data, compute=compute)
+
+        if self.governance:
+            self.governance = self.governance.model_copy(update={"operational_policy": op_policy})
+        else:
+            self.governance = Governance(operational_policy=op_policy)
         return self
 
     def set_circuit_breaker(self, error_threshold: int, reset_timeout: int, fallback_node: str | None = None) -> Self:

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -80,7 +80,9 @@ class FinancialLimits(CoreasonModel):
 
 class DataLimits(CoreasonModel):
     max_rows_per_query: int | None = Field(None, gt=0)
-    max_payload_bytes: int | None = Field(None, gt=0, description="Max bytes for active memory insertion/API responses.")
+    max_payload_bytes: int | None = Field(
+        None, gt=0, description="Max bytes for active memory insertion/API responses."
+    )
     max_search_results: int | None = Field(None, gt=0)
 
 

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -69,6 +69,33 @@ class ToolAccessPolicy(CoreasonModel):
         return data
 
 
+class FinancialLimits(CoreasonModel):
+    max_cost_usd: float | None = Field(None, ge=0.0)
+    max_tokens_total: int | None = Field(None, gt=0)
+    budget_depletion_routing: str | None = Field(
+        None,
+        description="Model ID to fallback to when budget hits 90% depletion (e.g., swap o1-pro to gpt-4o-mini).",
+    )
+
+
+class DataLimits(CoreasonModel):
+    max_rows_per_query: int | None = Field(None, gt=0)
+    max_payload_bytes: int | None = Field(None, gt=0, description="Max bytes for active memory insertion/API responses.")
+    max_search_results: int | None = Field(None, gt=0)
+
+
+class ComputeLimits(CoreasonModel):
+    max_execution_time_seconds: int | None = Field(None, gt=0)
+    max_cognitive_steps: int | None = Field(None, gt=0, description="Max turn/DAG transitions.")
+    max_concurrent_agents: int | None = Field(None, gt=0)
+
+
+class OperationalPolicy(CoreasonModel):
+    financial: FinancialLimits | None = None
+    data: DataLimits | None = None
+    compute: ComputeLimits | None = None
+
+
 class Governance(CoreasonModel):
     """Governance constraints and policies."""
 
@@ -87,9 +114,9 @@ class Governance(CoreasonModel):
             "entire manifest, regardless of individual tool policies."
         ),
     )
-    rate_limit_rpm: int | None = Field(None, description="Rate limit in requests per minute.", examples=[60])
-    timeout_seconds: int | None = Field(None, description="Global execution timeout.", examples=[300])
-    cost_limit_usd: float | None = Field(None, description="Cost limit in USD.", examples=[10.0])
+    operational_policy: OperationalPolicy | None = Field(
+        None, description="Global operational, financial, and compute constraints."
+    )
     safety: Safety | None = Field(
         None,
         description="Safety configuration.",

--- a/src/coreason_manifest/spec/core/nodes.py
+++ b/src/coreason_manifest/spec/core/nodes.py
@@ -11,6 +11,7 @@ from coreason_manifest.spec.core.engines import (
     Optimizer,
     ReasoningConfig,
 )
+from coreason_manifest.spec.core.governance import OperationalPolicy
 from coreason_manifest.spec.core.memory import MemorySubsystem
 from coreason_manifest.spec.core.resilience import EscalationStrategy, ResilienceConfig
 from coreason_manifest.spec.core.types import (
@@ -76,6 +77,9 @@ class AgentNode(Node):
         default_factory=list,
         description="List of tool names available to this agent.",
         examples=[["calculator", "web_search"]],
+    )
+    operational_policy: OperationalPolicy | None = Field(
+        None, description="Local operational limits. Overrides global Governance limits if set."
     )
     escalation_rules: list[EscalationCriteria] = Field(
         default_factory=list,
@@ -309,6 +313,9 @@ class SwarmNode(Node):
             examples=["gpt-4"],
         ),
     ] = None
+    operational_policy: OperationalPolicy | None = Field(
+        None, description="Local operational limits. Overrides global Governance limits if set."
+    )
     output_variable: VariableID = Field(
         ..., description="Variable to store the aggregated result.", examples=["final_report"]
     )

--- a/src/coreason_manifest/spec/core/resilience.py
+++ b/src/coreason_manifest/spec/core/resilience.py
@@ -14,9 +14,10 @@ class ErrorDomain(StrEnum):
     TOOL = "tool"
     SECURITY = "security"
     CONTEXT = "context"
-    DATA = "data"
-    RESOURCE = "resource"
+    DATA = "data"  # Maps to DataLimits
+    RESOURCE = "resource"  # Maps to ComputeLimits
     TIMEOUT = "timeout"
+    FINANCIAL = "financial"
 
 
 class ResilienceStrategy(BaseModel):

--- a/src/coreason_manifest/utils/validator.py
+++ b/src/coreason_manifest/utils/validator.py
@@ -326,22 +326,20 @@ def _validate_data_flow(
 
 def _validate_governance(gov: Governance, valid_ids: set[str]) -> list[ComplianceReport]:
     errors: list[ComplianceReport] = []
-    if gov.rate_limit_rpm is not None and gov.rate_limit_rpm < 0:
-        errors.append(
-            ComplianceReport(
-                code=ErrorCatalog.ERR_GOV_INVALID_CONFIG,
-                severity="violation",
-                message="Governance Error: rate_limit_rpm cannot be negative.",
-            )
-        )
-    if gov.cost_limit_usd is not None and gov.cost_limit_usd < 0:
-        errors.append(
-            ComplianceReport(
-                code=ErrorCatalog.ERR_GOV_INVALID_CONFIG,
-                severity="violation",
-                message="Governance Error: cost_limit_usd cannot be negative.",
-            )
-        )
+
+    # Check Operational Policy
+    if gov.operational_policy:
+        if gov.operational_policy.financial:
+            fin = gov.operational_policy.financial
+            if fin.max_cost_usd is not None and fin.max_cost_usd < 0:
+                 errors.append(
+                    ComplianceReport(
+                        code=ErrorCatalog.ERR_GOV_INVALID_CONFIG,
+                        severity="violation",
+                        message="Governance Error: max_cost_usd cannot be negative.",
+                    )
+                )
+
     if (
         gov.circuit_breaker
         and gov.circuit_breaker.fallback_node_id

--- a/src/coreason_manifest/utils/validator.py
+++ b/src/coreason_manifest/utils/validator.py
@@ -327,19 +327,6 @@ def _validate_data_flow(
 def _validate_governance(gov: Governance, valid_ids: set[str]) -> list[ComplianceReport]:
     errors: list[ComplianceReport] = []
 
-    # Check Operational Policy
-    if gov.operational_policy:
-        if gov.operational_policy.financial:
-            fin = gov.operational_policy.financial
-            if fin.max_cost_usd is not None and fin.max_cost_usd < 0:
-                 errors.append(
-                    ComplianceReport(
-                        code=ErrorCatalog.ERR_GOV_INVALID_CONFIG,
-                        severity="violation",
-                        message="Governance Error: max_cost_usd cannot be negative.",
-                    )
-                )
-
     if (
         gov.circuit_breaker
         and gov.circuit_breaker.fallback_node_id

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -28,8 +28,8 @@ def test_linear_builder() -> None:
     )
     builder.add_tool_pack(tp)
 
-    gov = Governance(rate_limit_rpm=10)
-    builder.set_governance(gov)
+    # Use new OperationalPolicy via builder
+    builder.set_operational_policy(max_cost_usd=10.0)
 
     flow = builder.build()
 
@@ -39,7 +39,9 @@ def test_linear_builder() -> None:
     assert flow.definitions is not None
     assert len(flow.definitions.tool_packs) == 1
     assert flow.governance is not None
-    assert flow.governance.rate_limit_rpm == 10
+    assert flow.governance.operational_policy is not None
+    assert flow.governance.operational_policy.financial is not None
+    assert flow.governance.operational_policy.financial.max_cost_usd == 10.0
 
 
 def test_graph_builder() -> None:
@@ -57,8 +59,8 @@ def test_graph_builder() -> None:
     )
     builder.add_tool_pack(tp)
 
-    gov = Governance(rate_limit_rpm=10)
-    builder.set_governance(gov)
+    # Use new OperationalPolicy via builder
+    builder.set_operational_policy(max_cost_usd=10.0)
 
     # Test set_interface and set_blackboard
     builder.set_interface(
@@ -79,7 +81,9 @@ def test_graph_builder() -> None:
     assert flow.definitions is not None
     assert len(flow.definitions.tool_packs) == 1
     assert flow.governance is not None
-    assert flow.governance.rate_limit_rpm == 10
+    assert flow.governance.operational_policy is not None
+    assert flow.governance.operational_policy.financial is not None
+    assert flow.governance.operational_policy.financial.max_cost_usd == 10.0
 
     # Assert new features
     assert flow.interface.inputs.json_schema == {"type": "object", "properties": {"in": {"type": "string"}}}  # type: ignore[union-attr]
@@ -109,14 +113,15 @@ def test_graph_builder_invalid() -> None:
 def test_builder_coverage_set_circuit_breaker_with_existing_governance() -> None:
     """Test setting circuit breaker when governance is already set."""
     builder = NewLinearFlow("Test", "1.0.0", "Desc")
-    gov = Governance(rate_limit_rpm=10)
-    builder.set_governance(gov)
+    builder.set_operational_policy(max_cost_usd=10.0)
 
     # This should trigger the `if self.governance:` branch in set_circuit_breaker
     builder.set_circuit_breaker(error_threshold=5, reset_timeout=30)
 
     assert builder.governance is not None
-    assert builder.governance.rate_limit_rpm == 10
+    assert builder.governance.operational_policy is not None
+    assert builder.governance.operational_policy.financial is not None
+    assert builder.governance.operational_policy.financial.max_cost_usd == 10.0
     assert builder.governance.circuit_breaker is not None
     assert builder.governance.circuit_breaker.error_threshold_count == 5
 

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,7 +2,6 @@ import pytest
 
 from coreason_manifest.builder import AgentBuilder, NewGraphFlow, NewLinearFlow
 from coreason_manifest.spec.core.flow import VariableDef
-from coreason_manifest.spec.core.governance import Governance
 from coreason_manifest.spec.core.nodes import AgentNode, CognitiveProfile, PlaceholderNode
 from coreason_manifest.spec.core.tools import ToolCapability, ToolPack
 

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -15,7 +15,6 @@ from coreason_manifest.spec.core.flow import (
     LinearFlow,
     VariableDef,
 )
-from coreason_manifest.spec.core.governance import Governance
 from coreason_manifest.spec.core.nodes import AgentNode, SwitchNode
 from coreason_manifest.spec.core.tools import ToolCapability, ToolPack
 from coreason_manifest.utils.validator import validate_flow
@@ -140,10 +139,10 @@ def test_validate_missing_tool(flow_metadata: FlowMetadata, agent_node_factory: 
     assert any(e.code == "ERR_CAP_MISSING_TOOL_001" and e.details.get("tool") == "tool1" for e in errors)
 
 
-def test_validate_governance_sanity(flow_metadata: FlowMetadata, agent_node_factory: Callable[..., AgentNode]) -> None:
+def test_validate_governance_sanity() -> None:
     from pydantic import ValidationError
 
-    from coreason_manifest.spec.core.governance import FinancialLimits, OperationalPolicy
+    from coreason_manifest.spec.core.governance import FinancialLimits
 
     # Test that Pydantic enforces the schema constraint (ge=0.0)
     with pytest.raises(ValidationError) as exc:

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -141,20 +141,16 @@ def test_validate_missing_tool(flow_metadata: FlowMetadata, agent_node_factory: 
 
 
 def test_validate_governance_sanity(flow_metadata: FlowMetadata, agent_node_factory: Callable[..., AgentNode]) -> None:
-    agent = agent_node_factory("agent1", tools=[])
-    graph = Graph(nodes={"agent1": agent}, edges=[], entry_point="agent1")
-    gov = Governance(rate_limit_rpm=-1, cost_limit_usd=-5.0)
-    flow = GraphFlow(
-        kind="GraphFlow",
-        metadata=flow_metadata,
-        interface=create_interface(),
-        blackboard=None,
-        graph=graph,
-        governance=gov,
-    )
-    errors = validate_flow(flow)
-    assert len(errors) == 2
-    assert all(e.code == "ERR_GOV_INVALID_CONFIG" for e in errors)
+    from pydantic import ValidationError
+
+    from coreason_manifest.spec.core.governance import FinancialLimits, OperationalPolicy
+
+    # Test that Pydantic enforces the schema constraint (ge=0.0)
+    with pytest.raises(ValidationError) as exc:
+        FinancialLimits(max_cost_usd=-5.0)
+
+    # Match the actual Pydantic error message
+    assert "Input should be greater than or equal to 0" in str(exc.value)
 
 
 def test_validate_linear_flow_valid(flow_metadata: FlowMetadata, agent_node_factory: Callable[..., AgentNode]) -> None:


### PR DESCRIPTION
Refactor Governance with Three Budget Operational Limits

This change implements a strict "Three Budget" (Financial, Data, Compute) finops and operational governance model, replacing flat, scattered limits with hierarchical Pydantic objects.

Changes include:
- Defined `FinancialLimits`, `DataLimits`, and `ComputeLimits` models in `src/coreason_manifest/spec/core/governance.py`.
- Created `OperationalPolicy` to group these limits.
- Updated `Governance` to use `OperationalPolicy` and removed legacy fields (`rate_limit_rpm`, `timeout_seconds`, `cost_limit_usd`).
- Added `operational_policy` override to `AgentNode` and `SwarmNode` in `src/coreason_manifest/spec/core/nodes.py`.
- Updated `ErrorDomain` in `src/coreason_manifest/spec/core/resilience.py` to include `FINANCIAL`.
- Enhanced `AgentBuilder` and `BaseFlowBuilder` in `src/coreason_manifest/builder.py` with fluent methods for configuring operational policies.
- Updated `src/coreason_manifest/utils/validator.py` to align with the new governance structure.

---
*PR created automatically by Jules for task [15769406216139969864](https://jules.google.com/task/15769406216139969864) started by @gowthamrao*