### PR TITLE
Refactor Governance and OperationalPolicy for v0.25.0

### DIFF
--- a/src/coreason_manifest/builder.py
+++ b/src/coreason_manifest/builder.py
@@ -30,9 +30,6 @@ from coreason_manifest.spec.core.flow import (
 )
 from coreason_manifest.spec.core.governance import (
     CircuitBreaker,
-    ComputeLimits,
-    DataLimits,
-    FinancialLimits,
     Governance,
     OperationalPolicy,
 )
@@ -278,6 +275,8 @@ class AgentBuilder:
     ) -> "AgentBuilder":
         """Configures operational limits for the agent (financial, compute, data).
 
+        Note: This method maps legacy arguments to the new dictionary-based OperationalPolicy.
+
         Args:
             max_cost_usd (float | None): Maximum allowed cost in USD.
             max_tokens (int | None): Maximum total tokens allowed.
@@ -291,30 +290,60 @@ class AgentBuilder:
         Returns:
             AgentBuilder: The builder instance for chaining.
         """
-        financial = None
-        if max_cost_usd is not None or max_tokens is not None or fallback_model is not None:
-            financial = FinancialLimits(
-                max_cost_usd=max_cost_usd,
-                max_tokens_total=max_tokens,
-                budget_depletion_routing=fallback_model,
-            )
+        # Map legacy args to new dict structures
+        custom_thresholds: dict[str, float] = {}
+        custom_limits: dict[str, int] = {}
+        row_limits: dict[str, int] = {}
+        search_limits: dict[str, int] = {}
+        timeout_durations: dict[str, int] = {}
+        model_switching: dict[str, float] = {}
 
-        compute = None
-        if max_steps is not None or max_execution_time_seconds is not None:
-            compute = ComputeLimits(
-                max_cognitive_steps=max_steps, max_execution_time_seconds=max_execution_time_seconds
-            )
+        # Financial mapping
+        if max_cost_usd is not None:
+            custom_thresholds["max_cost_usd"] = float(max_cost_usd)
 
-        data = None
-        if max_rows_per_query is not None or max_payload_bytes is not None or max_search_results is not None:
-            data = DataLimits(
-                max_rows_per_query=max_rows_per_query,
-                max_payload_bytes=max_payload_bytes,
-                max_search_results=max_search_results,
-            )
+        if max_tokens is not None:
+            custom_limits["max_tokens_total"] = max_tokens
 
-        if financial or compute or data:
-            self.operational_policy = OperationalPolicy(financial=financial, compute=compute, data=data)
+        if fallback_model is not None:
+            # Legacy fallback_model was a string (model ID).
+            # New model_switching is dict[str, float] (model->threshold).
+            # We can't map this perfectly without a threshold, so we store it in custom_limits/strings if possible?
+            # Or we just assume a default threshold like 0.9 (90% budget) as implied by old docstring.
+            # But values must be floats.
+            # Let's map it to a custom string-like field if possible, but strict typing prevents it.
+            # Best effort: use a convention in model_switching or custom keys.
+            # Since strict types are enforced (dict[str, float]), we can't put a string model ID as a value.
+            # We'll skip this mapping or log a warning in a real system.
+            # For now, we omit it to satisfy type safety, or we could add a threshold key.
+            # Let's put a placeholder threshold.
+            model_switching[fallback_model] = 0.9
+
+        # Compute mapping
+        if max_steps is not None:
+            custom_limits["max_cognitive_steps"] = max_steps
+
+        if max_execution_time_seconds is not None:
+            timeout_durations["default"] = max_execution_time_seconds
+
+        # Data mapping
+        if max_rows_per_query is not None:
+            row_limits["default"] = max_rows_per_query
+
+        if max_payload_bytes is not None:
+            custom_limits["max_payload_bytes"] = max_payload_bytes
+
+        if max_search_results is not None:
+            search_limits["default"] = max_search_results
+
+        self.operational_policy = OperationalPolicy(
+            row_limits=row_limits,
+            search_limits=search_limits,
+            timeout_durations=timeout_durations,
+            model_switching=model_switching,
+            custom_thresholds=custom_thresholds,
+            custom_limits=custom_limits
+        )
         return self
 
     def with_escalation_rule(
@@ -536,36 +565,64 @@ class BaseFlowBuilder:
         Returns:
             Self: The builder instance for chaining.
         """
-        financial = None
-        if max_cost_usd is not None or max_tokens is not None or fallback_model is not None:
-            financial = FinancialLimits(
-                max_cost_usd=max_cost_usd,
-                max_tokens_total=max_tokens,
-                budget_depletion_routing=fallback_model,
-            )
+        # Map to new OperationalPolicy structure
+        custom_thresholds: dict[str, float] = {}
+        custom_limits: dict[str, int] = {}
+        row_limits: dict[str, int] = {}
+        search_limits: dict[str, int] = {}
+        timeout_durations: dict[str, int] = {}
+        model_switching: dict[str, float] = {}
 
-        data = None
-        if max_rows_per_query is not None or max_payload_bytes is not None or max_search_results is not None:
-            data = DataLimits(
-                max_rows_per_query=max_rows_per_query,
-                max_payload_bytes=max_payload_bytes,
-                max_search_results=max_search_results,
-            )
+        # Top-level Governance fields
+        gov_updates: dict[str, Any] = {}
 
-        compute = None
-        if max_steps is not None or max_execution_time_seconds is not None or max_concurrent_agents is not None:
-            compute = ComputeLimits(
-                max_cognitive_steps=max_steps,
-                max_execution_time_seconds=max_execution_time_seconds,
-                max_concurrent_agents=max_concurrent_agents,
-            )
+        if max_cost_usd is not None:
+            # Set global cost limit on Governance
+            gov_updates["cost_limit_usd"] = float(max_cost_usd)
 
-        op_policy = OperationalPolicy(financial=financial, data=data, compute=compute)
+        if max_execution_time_seconds is not None:
+            # Set global timeout on Governance
+            gov_updates["timeout_seconds"] = max_execution_time_seconds
+            # Also map to operational policy as a default for good measure?
+            timeout_durations["default"] = max_execution_time_seconds
+
+        if max_tokens is not None:
+            custom_limits["max_tokens_total"] = max_tokens
+
+        if fallback_model is not None:
+            model_switching[fallback_model] = 0.9
+
+        if max_steps is not None:
+            custom_limits["max_cognitive_steps"] = max_steps
+
+        if max_concurrent_agents is not None:
+            custom_limits["max_concurrent_agents"] = max_concurrent_agents
+
+        if max_rows_per_query is not None:
+            row_limits["default"] = max_rows_per_query
+
+        if max_payload_bytes is not None:
+            custom_limits["max_payload_bytes"] = max_payload_bytes
+
+        if max_search_results is not None:
+            search_limits["default"] = max_search_results
+
+        op_policy = OperationalPolicy(
+            row_limits=row_limits,
+            search_limits=search_limits,
+            timeout_durations=timeout_durations,
+            model_switching=model_switching,
+            custom_thresholds=custom_thresholds,
+            custom_limits=custom_limits
+        )
 
         if self.governance:
-            self.governance = self.governance.model_copy(update={"operational_policy": op_policy})
+            gov_updates["operational_policy"] = op_policy
+            self.governance = self.governance.model_copy(update=gov_updates)
         else:
-            self.governance = Governance(operational_policy=op_policy)
+            # Initialize Governance with the new fields
+            self.governance = Governance(operational_policy=op_policy, **gov_updates)
+
         return self
 
     def set_circuit_breaker(self, error_threshold: int, reset_timeout: int, fallback_node: str | None = None) -> Self:

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -1,5 +1,5 @@
 import time
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Mapping
 
 from pydantic import Field, field_validator, model_validator
 
@@ -75,28 +75,28 @@ class OperationalPolicy(CoreasonModel):
     Replaces static nested models with flat dictionaries for zero-downtime extensibility.
     """
 
-    retry_counts: dict[NodeID | str, Annotated[int, Field(ge=0)]] = Field(
-        default_factory=dict, description="Granular control over retries per operation/node."
+    retry_counts: Mapping[str, Annotated[int, Field(ge=0)]] = Field(
+        default_factory=dict, description="Granular control over retries per operation/node (NodeID keys)."
     )
-    row_limits: dict[str, Annotated[int, Field(gt=0)]] = Field(
+    row_limits: Mapping[str, Annotated[int, Field(gt=0)]] = Field(
         default_factory=dict, description="Granular data retrieval limits (e.g., 'default', 'query_users')."
     )
-    search_limits: dict[str, Annotated[int, Field(gt=0)]] = Field(
+    search_limits: Mapping[str, Annotated[int, Field(gt=0)]] = Field(
         default_factory=dict, description="Dynamic search result limits (e.g., 'web', 'vector')."
     )
-    timeout_durations: dict[NodeID | str, Annotated[int, Field(gt=0)]] = Field(
-        default_factory=dict, description="Operation-specific timeouts in seconds."
+    timeout_durations: Mapping[str, Annotated[int, Field(gt=0)]] = Field(
+        default_factory=dict, description="Operation-specific timeouts in seconds (NodeID keys)."
     )
-    cost_multipliers: dict[NodeID | ToolID | str, Annotated[float, Field(gt=0.0)]] = Field(
-        default_factory=dict, description="Dynamic adjustment of cost thresholds."
+    cost_multipliers: Mapping[str, Annotated[float, Field(gt=0.0)]] = Field(
+        default_factory=dict, description="Dynamic adjustment of cost thresholds (NodeID/ToolID keys)."
     )
-    model_switching: dict[str, Annotated[float, Field(ge=0.0, le=1.0)]] = Field(
+    model_switching: Mapping[str, Annotated[float, Field(ge=0.0, le=1.0)]] = Field(
         default_factory=dict, description="Thresholds for tiered model degradation/swapping."
     )
-    custom_thresholds: dict[str, float] = Field(
+    custom_thresholds: Mapping[str, float] = Field(
         default_factory=dict, description="Generic extension dictionary for float limits."
     )
-    custom_limits: dict[str, int] = Field(
+    custom_limits: Mapping[str, int] = Field(
         default_factory=dict, description="Generic extension dictionary for integer limits."
     )
 
@@ -115,14 +115,17 @@ class Governance(CoreasonModel):
     # New Global Guardrails (Hoisted from deleted nested models)
     rate_limit_rpm: int | None = Field(
         None,
+        ge=0,
         description="Global requests per minute limit across the entire flow. PRECEDENCE: Acts as an absolute global ceiling, overriding any local node policies."
     )
     timeout_seconds: int | None = Field(
         None,
+        gt=0,
         description="Global execution timeout in seconds. PRECEDENCE: Acts as an absolute hard ceiling, overriding any local timeout_durations."
     )
     cost_limit_usd: float | None = Field(
         None,
+        ge=0.0,
         description="Global financial blast-radius limit (USD). PRECEDENCE: Triggers absolute halting, overriding any dynamic cost multipliers."
     )
 
@@ -145,7 +148,7 @@ class Governance(CoreasonModel):
         description="Circuit breaker policy.",
         examples=[{"error_threshold_count": 3, "reset_timeout_seconds": 30}],
     )
-    tool_policy: dict[ToolID, ToolAccessPolicy] | None = Field(
+    tool_policy: Mapping[ToolID, ToolAccessPolicy] | None = Field(
         None,
         description="Per-tool access policies.",
         examples=[{"web_search": {"risk_level": "standard", "require_auth": False}}],
@@ -182,6 +185,18 @@ class Governance(CoreasonModel):
             cleaned.append(canonicalize_domain(candidate))
 
         return cleaned
+
+    @model_validator(mode="after")
+    def validate_global_precedence(self) -> "Governance":
+        """SOTA defensive validation: ensure local dynamic policies do not exceed global hard ceilings."""
+        if self.timeout_seconds is not None and self.operational_policy is not None:
+            for node, local_timeout in self.operational_policy.timeout_durations.items():
+                if local_timeout > self.timeout_seconds:
+                    raise ValueError(
+                        f"Contradiction: Local timeout for '{node}' ({local_timeout}s) "
+                        f"cannot exceed the global hard ceiling timeout ({self.timeout_seconds}s)."
+                    )
+        return self
 
 
 class CircuitState(CoreasonModel):

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -5,7 +5,7 @@ from pydantic import Field, field_validator, model_validator
 
 from coreason_manifest.spec.common_base import CoreasonModel
 from coreason_manifest.spec.core.co_intelligence import CoIntelligencePolicy
-from coreason_manifest.spec.core.types import MiddlewareID, NodeID, RiskLevel, ToolID
+from coreason_manifest.spec.core.types import NodeID, RiskLevel, ToolID
 from coreason_manifest.spec.interop.exceptions import FaultSeverity, ManifestError, RecoveryAction, SemanticFault
 
 
@@ -69,46 +69,41 @@ class ToolAccessPolicy(CoreasonModel):
         return data
 
 
-class FinancialLimits(CoreasonModel):
-    max_cost_usd: float | None = Field(None, ge=0.0)
-    max_tokens_total: int | None = Field(None, gt=0)
-    budget_depletion_routing: str | None = Field(
-        None,
-        description="Model ID to fallback to when budget hits 90% depletion (e.g., swap o1-pro to gpt-4o-mini).",
-    )
-
-
-class DataLimits(CoreasonModel):
-    max_rows_per_query: int | None = Field(None, gt=0)
-    max_payload_bytes: int | None = Field(
-        None, gt=0, description="Max bytes for active memory insertion/API responses."
-    )
-    max_search_results: int | None = Field(None, gt=0)
-
-
-class ComputeLimits(CoreasonModel):
-    max_execution_time_seconds: int | None = Field(None, gt=0)
-    max_cognitive_steps: int | None = Field(None, gt=0, description="Max turn/DAG transitions.")
-    max_concurrent_agents: int | None = Field(None, gt=0)
-
-
 class OperationalPolicy(CoreasonModel):
-    financial: FinancialLimits | None = None
-    data: DataLimits | None = None
-    compute: ComputeLimits | None = None
+    """
+    Dynamic configuration for operational limits, routing, and economic model-switching.
+    Replaces static nested models with flat dictionaries for zero-downtime extensibility.
+    """
+
+    retry_counts: dict[str, int] = Field(
+        default_factory=dict, description="Granular control over retries per operation/node."
+    )
+    row_limits: dict[str, int] = Field(
+        default_factory=dict, description="Granular data retrieval limits (e.g., 'default', 'query_users')."
+    )
+    search_limits: dict[str, int] = Field(
+        default_factory=dict, description="Dynamic search result limits (e.g., 'web', 'vector')."
+    )
+    timeout_durations: dict[str, int] = Field(
+        default_factory=dict, description="Operation-specific timeouts in seconds."
+    )
+    cost_multipliers: dict[str, float] = Field(
+        default_factory=dict, description="Dynamic adjustment of cost thresholds."
+    )
+    model_switching: dict[str, float] = Field(
+        default_factory=dict, description="Thresholds for tiered model degradation/swapping."
+    )
+    custom_thresholds: dict[str, float] = Field(
+        default_factory=dict, description="Generic extension dictionary for float limits."
+    )
+    custom_limits: dict[str, int] = Field(
+        default_factory=dict, description="Generic extension dictionary for integer limits."
+    )
 
 
 class Governance(CoreasonModel):
     """Governance constraints and policies."""
 
-    active_middlewares: list[MiddlewareID] = Field(
-        default_factory=list,
-        description=(
-            "Ordered list of middleware references (from definitions.middlewares) to apply sequentially "
-            "to execution requests and streams."
-        ),
-        examples=[["pii_redactor", "toxicity_filter"]],
-    )
     max_risk_level: RiskLevel | None = Field(
         None,
         description=(
@@ -116,6 +111,18 @@ class Governance(CoreasonModel):
             "entire manifest, regardless of individual tool policies."
         ),
     )
+
+    # New Global Guardrails (Hoisted from deleted nested models)
+    rate_limit_rpm: int | None = Field(
+        None, description="Global requests per minute limit across the entire flow."
+    )
+    timeout_seconds: int | None = Field(
+        None, description="Global execution timeout in seconds."
+    )
+    cost_limit_usd: float | None = Field(
+        None, description="Global financial blast-radius limit (USD)."
+    )
+
     operational_policy: OperationalPolicy | None = Field(
         None, description="Global operational, financial, and compute constraints."
     )
@@ -146,12 +153,6 @@ class Governance(CoreasonModel):
     allowed_domains: list[str] = Field(
         default_factory=list, description="Allowed external domains.", examples=[["example.com"]]
     )
-
-    @field_validator("active_middlewares")
-    @classmethod
-    def deduplicate_middlewares(cls, v: list[MiddlewareID]) -> list[MiddlewareID]:
-        """Ensures middleware execution pipeline contains unique references while preserving order."""
-        return list(dict.fromkeys(v))
 
     @field_validator("allowed_domains")
     @classmethod

--- a/src/coreason_manifest/spec/core/governance.py
+++ b/src/coreason_manifest/spec/core/governance.py
@@ -1,5 +1,5 @@
 import time
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field, field_validator, model_validator
 
@@ -75,22 +75,22 @@ class OperationalPolicy(CoreasonModel):
     Replaces static nested models with flat dictionaries for zero-downtime extensibility.
     """
 
-    retry_counts: dict[str, int] = Field(
+    retry_counts: dict[NodeID | str, Annotated[int, Field(ge=0)]] = Field(
         default_factory=dict, description="Granular control over retries per operation/node."
     )
-    row_limits: dict[str, int] = Field(
+    row_limits: dict[str, Annotated[int, Field(gt=0)]] = Field(
         default_factory=dict, description="Granular data retrieval limits (e.g., 'default', 'query_users')."
     )
-    search_limits: dict[str, int] = Field(
+    search_limits: dict[str, Annotated[int, Field(gt=0)]] = Field(
         default_factory=dict, description="Dynamic search result limits (e.g., 'web', 'vector')."
     )
-    timeout_durations: dict[str, int] = Field(
+    timeout_durations: dict[NodeID | str, Annotated[int, Field(gt=0)]] = Field(
         default_factory=dict, description="Operation-specific timeouts in seconds."
     )
-    cost_multipliers: dict[str, float] = Field(
+    cost_multipliers: dict[NodeID | ToolID | str, Annotated[float, Field(gt=0.0)]] = Field(
         default_factory=dict, description="Dynamic adjustment of cost thresholds."
     )
-    model_switching: dict[str, float] = Field(
+    model_switching: dict[str, Annotated[float, Field(ge=0.0, le=1.0)]] = Field(
         default_factory=dict, description="Thresholds for tiered model degradation/swapping."
     )
     custom_thresholds: dict[str, float] = Field(
@@ -102,7 +102,7 @@ class OperationalPolicy(CoreasonModel):
 
 
 class Governance(CoreasonModel):
-    """Governance constraints and policies."""
+    """Governance constraints and SOTA Edge-First API routing policies."""
 
     max_risk_level: RiskLevel | None = Field(
         None,
@@ -114,13 +114,16 @@ class Governance(CoreasonModel):
 
     # New Global Guardrails (Hoisted from deleted nested models)
     rate_limit_rpm: int | None = Field(
-        None, description="Global requests per minute limit across the entire flow."
+        None,
+        description="Global requests per minute limit across the entire flow. PRECEDENCE: Acts as an absolute global ceiling, overriding any local node policies."
     )
     timeout_seconds: int | None = Field(
-        None, description="Global execution timeout in seconds."
+        None,
+        description="Global execution timeout in seconds. PRECEDENCE: Acts as an absolute hard ceiling, overriding any local timeout_durations."
     )
     cost_limit_usd: float | None = Field(
-        None, description="Global financial blast-radius limit (USD)."
+        None,
+        description="Global financial blast-radius limit (USD). PRECEDENCE: Triggers absolute halting, overriding any dynamic cost multipliers."
     )
 
     operational_policy: OperationalPolicy | None = Field(

--- a/src/coreason_manifest/spec/core/resilience.py
+++ b/src/coreason_manifest/spec/core/resilience.py
@@ -14,8 +14,8 @@ class ErrorDomain(StrEnum):
     TOOL = "tool"
     SECURITY = "security"
     CONTEXT = "context"
-    DATA = "data"  # Maps to DataLimits
-    RESOURCE = "resource"  # Maps to ComputeLimits
+    DATA = "data"  # Maps to data limits in OperationalPolicy
+    RESOURCE = "resource"  # Maps to compute limits in OperationalPolicy
     TIMEOUT = "timeout"
     FINANCIAL = "financial"
 

--- a/src/coreason_manifest/utils/validator.py
+++ b/src/coreason_manifest/utils/validator.py
@@ -30,7 +30,6 @@ from coreason_manifest.spec.core.resilience import (
 from coreason_manifest.spec.core.tools import ToolCapability, ToolPack
 from coreason_manifest.spec.core.types import RiskLevel
 from coreason_manifest.spec.interop.compliance import ComplianceReport, ErrorCatalog, RemediationAction
-from coreason_manifest.spec.interop.exceptions import ManifestError, ManifestErrorCode
 from coreason_manifest.utils.topology import get_strongly_connected_components, get_unified_topology
 
 
@@ -140,8 +139,7 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
     if flow.governance and flow.governance.max_risk_level:
         errors.extend(_validate_kill_switch(flow))
 
-    # 6. Middleware References
-    errors.extend(_validate_middleware_refs(flow))
+    # 6. Middleware References - REMOVED
 
     return errors
 
@@ -809,57 +807,5 @@ def _validate_kill_switch(flow: LinearFlow | GraphFlow) -> list[ComplianceReport
         _check(flow.definitions)
 
     _check(nodes)
-
-    return errors
-
-
-def _validate_middleware_refs(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
-    errors: list[ComplianceReport] = []
-    if not flow.governance or not flow.governance.active_middlewares:
-        return errors
-
-    defined = set()
-    if flow.definitions and flow.definitions.middlewares:
-        defined = set(flow.definitions.middlewares.keys())
-
-    for mw_id in flow.governance.active_middlewares:
-        if mw_id not in defined:
-            # SOTA RFC 6902 JSON Pointer Escaping
-            mw_id_escaped = mw_id.replace("~", "~0").replace("/", "~1")
-
-            # Construct patch
-            patch: list[dict[str, Any]]
-            if not flow.definitions:
-                patch = [
-                    {
-                        "op": "add",
-                        "path": "/definitions",
-                        "value": {"middlewares": {mw_id: {"ref": "file.py:Class"}}},
-                    }
-                ]
-            elif not flow.definitions.middlewares:
-                patch = [{"op": "add", "path": "/definitions/middlewares", "value": {mw_id: {"ref": "file.py:Class"}}}]
-            else:
-                patch = [
-                    {
-                        "op": "add",
-                        "path": f"/definitions/middlewares/{mw_id_escaped}",
-                        "value": {"ref": "file.py:Class"},
-                    }
-                ]
-
-            errors.append(
-                ComplianceReport(
-                    code=ErrorCatalog.ERR_CAP_MISSING_MIDDLEWARE,
-                    severity="violation",
-                    message=f"Middleware Error: Active middleware '{mw_id}' is not defined.",
-                    details={"middleware_id": mw_id},
-                    remediation=RemediationAction(
-                        type="update_field",
-                        description=f"Add definition for middleware '{mw_id}'.",
-                        patch_data=patch,
-                    ),
-                )
-            )
 
     return errors

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -37,9 +37,11 @@ def test_linear_builder() -> None:
     assert flow.definitions is not None
     assert len(flow.definitions.tool_packs) == 1
     assert flow.governance is not None
+    # Verify new Governance structure
+    assert flow.governance.cost_limit_usd == 10.0
     assert flow.governance.operational_policy is not None
-    assert flow.governance.operational_policy.financial is not None
-    assert flow.governance.operational_policy.financial.max_cost_usd == 10.0
+    # Verify new OperationalPolicy structure (financial limits are gone/mapped)
+    assert not hasattr(flow.governance.operational_policy, "financial")
 
 
 def test_graph_builder() -> None:
@@ -79,9 +81,11 @@ def test_graph_builder() -> None:
     assert flow.definitions is not None
     assert len(flow.definitions.tool_packs) == 1
     assert flow.governance is not None
+
+    # Verify new Governance structure
+    assert flow.governance.cost_limit_usd == 10.0
     assert flow.governance.operational_policy is not None
-    assert flow.governance.operational_policy.financial is not None
-    assert flow.governance.operational_policy.financial.max_cost_usd == 10.0
+    assert not hasattr(flow.governance.operational_policy, "financial")
 
     # Assert new features
     assert flow.interface.inputs.json_schema == {"type": "object", "properties": {"in": {"type": "string"}}}  # type: ignore[union-attr]
@@ -117,9 +121,7 @@ def test_builder_coverage_set_circuit_breaker_with_existing_governance() -> None
     builder.set_circuit_breaker(error_threshold=5, reset_timeout=30)
 
     assert builder.governance is not None
-    assert builder.governance.operational_policy is not None
-    assert builder.governance.operational_policy.financial is not None
-    assert builder.governance.operational_policy.financial.max_cost_usd == 10.0
+    assert builder.governance.cost_limit_usd == 10.0
     assert builder.governance.circuit_breaker is not None
     assert builder.governance.circuit_breaker.error_threshold_count == 5
 
@@ -213,11 +215,19 @@ def test_agent_builder() -> None:
     # with_supervision deprecated/removed, assume replaced or removed from builder tests for now
     # builder.with_supervision(retries=3)
 
+    # New Operational Policy mapping
+    builder.with_operational_policy(max_cost_usd=5.0)
+
     agent = builder.build()
     assert isinstance(agent.profile, CognitiveProfile)
     assert agent.profile.reasoning is not None
     assert agent.profile.fast_path is not None
     assert agent.tools == ["tool1"]
+
+    # Assert custom threshold mapping
+    assert agent.operational_policy is not None
+    assert agent.operational_policy.custom_thresholds.get("max_cost_usd") == 5.0
+
     # assert isinstance(agent.supervision, SupervisionPolicy)
     # assert isinstance(agent.supervision.default_strategy, EscalationStrategy)
 

--- a/tests/test_middleware_integration_v2.py
+++ b/tests/test_middleware_integration_v2.py
@@ -122,11 +122,18 @@ def workspace(tmp_path: Path) -> Path:
         p.chmod(0o600)
 
     # Dependencies in ROOT (jail root) so they are found by SandboxedPathFinder
-    (tmp_path / "dependency.py").write_text(DEPENDENCY_CODE)
-    (tmp_path / "fail_dep.py").write_text(FAIL_DEP_CODE)
+    dep_path = tmp_path / "dependency.py"
+    dep_path.write_text(DEPENDENCY_CODE)
+    dep_path.chmod(0o600)  # Ensure strict permissions for dependency
+
+    fail_dep_path = tmp_path / "fail_dep.py"
+    fail_dep_path.write_text(FAIL_DEP_CODE)
+    fail_dep_path.chmod(0o600)  # Ensure strict permissions for failing dependency
 
     # loop_link.py needed for symlink loop test - mock creates symlink logic but file needs to exist for importlib
-    (tmp_path / "loop_link.py").touch()
+    loop_link_path = tmp_path / "loop_link.py"
+    loop_link_path.touch()
+    loop_link_path.chmod(0o600)
 
     return tmp_path
 
@@ -149,9 +156,8 @@ definitions:
   middlewares:
     my_mw:
       ref: middlewares/valid.py:MyMiddleware
-governance:
-  active_middlewares:
-    - my_mw
+# Governance active_middlewares removed in v0.25.0
+governance: {}
 """
     data = yaml.safe_load(manifest_yaml)
     flow = GraphFlow.model_validate(data)
@@ -162,142 +168,7 @@ governance:
     assert flow.definitions.middlewares["my_mw"].ref == "middlewares/valid.py:MyMiddleware"
 
     assert flow.governance is not None
-    assert "my_mw" in flow.governance.active_middlewares
-
-
-def test_missing_definition_validation() -> None:
-    manifest_yaml = """
-kind: GraphFlow
-metadata:
-  name: test-flow
-  version: 1.0.0
-interface: {}
-graph:
-  nodes:
-    start:
-      type: placeholder
-      id: start
-  edges: []
-  entry_point: start
-definitions:
-  middlewares: {}
-governance:
-  active_middlewares:
-    - missing_mw
-"""
-    data = yaml.safe_load(manifest_yaml)
-    flow = GraphFlow.model_validate(data)
-    errors = validate_flow(flow)
-    assert any(
-        e.code == "ERR_CAP_MISSING_MIDDLEWARE" and e.details.get("middleware_id") == "missing_mw" for e in errors
-    )
-
-
-def test_validation_no_definitions() -> None:
-    # Test case where 'definitions' is completely missing
-    manifest_yaml = """
-kind: GraphFlow
-metadata:
-  name: test-flow
-  version: 1.0.0
-interface: {}
-graph:
-  nodes:
-    start:
-      type: placeholder
-      id: start
-  edges: []
-  entry_point: start
-# definitions block omitted
-governance:
-  active_middlewares:
-    - missing_mw
-"""
-    data = yaml.safe_load(manifest_yaml)
-    flow = GraphFlow.model_validate(data)
-    errors = validate_flow(flow)
-    assert any(
-        e.code == "ERR_CAP_MISSING_MIDDLEWARE" and e.details.get("middleware_id") == "missing_mw" for e in errors
-    )
-
-
-def test_validation_no_middlewares() -> None:
-    # Test case where 'definitions' exists but 'middlewares' is missing (default empty dict in model)
-    # Actually, if we omit it in YAML, Pydantic defaults it to empty dict.
-    # To hit `elif not definitions.middlewares:` we need definitions object but empty middlewares dict.
-    manifest_yaml = """
-kind: GraphFlow
-metadata:
-  name: test-flow
-  version: 1.0.0
-interface: {}
-graph:
-  nodes:
-    start:
-      type: placeholder
-      id: start
-  edges: []
-  entry_point: start
-definitions:
-    # middlewares omitted
-    tools: {}
-governance:
-  active_middlewares:
-    - missing_mw
-"""
-    data = yaml.safe_load(manifest_yaml)
-    flow = GraphFlow.model_validate(data)
-    errors = validate_flow(flow)
-    assert any(
-        e.code == "ERR_CAP_MISSING_MIDDLEWARE" and e.details.get("middleware_id") == "missing_mw" for e in errors
-    )
-
-
-def test_validation_missing_key_with_existing_middlewares() -> None:
-    # Test case where 'definitions.middlewares' exists and is not empty,
-    # but 'active_middlewares' references a key that is missing.
-    # This hits the `else` block in `_validate_middleware_references` for patch generation.
-    manifest_yaml = """
-kind: GraphFlow
-metadata:
-  name: test-flow
-  version: 1.0.0
-interface: {}
-graph:
-  nodes:
-    start:
-      type: placeholder
-      id: start
-  edges: []
-  entry_point: start
-definitions:
-  middlewares:
-    existing_mw:
-      ref: middlewares/valid.py:MyMiddleware
-governance:
-  active_middlewares:
-    - missing_mw
-"""
-    data = yaml.safe_load(manifest_yaml)
-    flow = GraphFlow.model_validate(data)
-    errors = validate_flow(flow)
-
-    error = next(
-        (
-            e
-            for e in errors
-            if e.code == "ERR_CAP_MISSING_MIDDLEWARE" and e.details.get("middleware_id") == "missing_mw"
-        ),
-        None,
-    )
-    assert error is not None
-
-    # Verify remediation
-    assert error.remediation is not None
-    assert error.remediation.type == "update_field"
-    # patch_data is typically list of dicts for JSON Patch
-    assert isinstance(error.remediation.patch_data, list)
-    assert error.remediation.patch_data[0]["path"] == "/definitions/middlewares/missing_mw"
+    # active_middlewares checks removed
 
 
 def test_loader_valid_middleware(workspace: Path) -> None:

--- a/tests/test_validator_phase3a.py
+++ b/tests/test_validator_phase3a.py
@@ -139,17 +139,7 @@ def test_validate_missing_tool(flow_metadata: FlowMetadata, agent_node_factory: 
     assert any(e.code == "ERR_CAP_MISSING_TOOL_001" and e.details.get("tool") == "tool1" for e in errors)
 
 
-def test_validate_governance_sanity() -> None:
-    from pydantic import ValidationError
-
-    from coreason_manifest.spec.core.governance import FinancialLimits
-
-    # Test that Pydantic enforces the schema constraint (ge=0.0)
-    with pytest.raises(ValidationError) as exc:
-        FinancialLimits(max_cost_usd=-5.0)
-
-    # Match the actual Pydantic error message
-    assert "Input should be greater than or equal to 0" in str(exc.value)
+# Removed FinancialLimits test as the class was deleted.
 
 
 def test_validate_linear_flow_valid(flow_metadata: FlowMetadata, agent_node_factory: Callable[..., AgentNode]) -> None:


### PR DESCRIPTION
This PR executes the "Greenfield Refactor" of the `coreason-manifest` governance module for the v0.25.0 migration.

**Key Changes:**
1.  **Deleted Legacy Models:** `FinancialLimits`, `DataLimits`, and `ComputeLimits` have been removed from `src/coreason_manifest/spec/core/governance.py`.
2.  **New `OperationalPolicy`:** Introduced a dynamic, dictionary-backed `OperationalPolicy` class to support fine-grained resilience and economic routing (e.g., `retry_counts`, `model_switching`, `custom_thresholds`).
3.  **Hoisted Guardrails:** Global limits like `cost_limit_usd` and `timeout_seconds` are now top-level fields in the `Governance` model.
4.  **Middleware Decoupling:** Removed `active_middlewares` from `Governance` to decouple orchestration.
5.  **Builder Update:** Updated `AgentBuilder` and `BaseFlowBuilder` in `src/coreason_manifest/builder.py` to populate the new fields, maintaining a degree of API compatibility where possible via mapping.
6.  **Test Updates:** Updated `test_builder.py`, `test_validator_phase3a.py`, and `test_middleware_integration_v2.py` to match the new schema and fix a test environment permission issue.

This refactor enables topology-aware fault tolerance and advanced economic model switching required for the 2026 roadmap.


---
*PR created automatically by Jules for task [16531128112303860337](https://jules.google.com/task/16531128112303860337) started by @gowthamrao*