### PR TITLE
feat: Support dynamic node registration via rebuild_manifest()

### DIFF
--- a/src/coreason_manifest/spec/core/rebuild.py
+++ b/src/coreason_manifest/spec/core/rebuild.py
@@ -1,0 +1,57 @@
+from typing import TYPE_CHECKING, Any
+
+from coreason_manifest.spec.core.registry import resolve_engine_union, resolve_node_union
+
+if TYPE_CHECKING:
+    from coreason_manifest.spec.core import engines, flow, nodes
+
+
+def rebuild_manifest() -> None:
+    """
+    Rebuilds the Pydantic models in the manifest to include newly registered nodes and engines.
+    This is necessary because Pydantic V2 resolves unions at import time, so dynamic
+    additions to the registry require an explicit rebuild of the schema.
+    """
+    # Import modules lazily to avoid circular dependencies
+    from coreason_manifest.spec.core import engines, flow, nodes
+
+    # 1. Resolve fresh unions
+    new_node_union = resolve_node_union()
+    new_engine_union = resolve_engine_union()
+
+    # 2. Patch Node-dependent models
+    # Graph uses dict[str, AnyNode]
+    # We must update the annotation on the field itself
+
+    # Update AnyNode alias in nodes module (affects future imports)
+    nodes.AnyNode = new_node_union
+
+    # Patch Graph
+    if "nodes" in flow.Graph.model_fields:
+        flow.Graph.model_fields["nodes"].annotation = dict[str, new_node_union]  # type: ignore
+        flow.Graph.model_rebuild(force=True)
+
+    # Patch LinearFlow
+    if "steps" in flow.LinearFlow.model_fields:
+        flow.LinearFlow.model_fields["steps"].annotation = list[new_node_union]  # type: ignore
+        flow.LinearFlow.model_rebuild(force=True)
+
+    # Patch Engine-dependent models
+    # CognitiveProfile uses ReasoningConfig
+
+    # Update ReasoningConfig alias in engines module
+    engines.ReasoningConfig = new_engine_union
+
+    if "reasoning" in nodes.CognitiveProfile.model_fields:
+        nodes.CognitiveProfile.model_fields["reasoning"].annotation = new_engine_union | None  # type: ignore
+        nodes.CognitiveProfile.model_rebuild(force=True)
+
+    # 3. Rebuild downstream dependencies
+    # AgentNode depends on CognitiveProfile
+    nodes.AgentNode.model_rebuild(force=True)
+
+    # GraphFlow depends on Graph
+    flow.GraphFlow.model_rebuild(force=True)
+
+    # AgentRequest depends on GraphFlow | LinearFlow
+    flow.AgentRequest.model_rebuild(force=True)

--- a/tests/test_rebuild.py
+++ b/tests/test_rebuild.py
@@ -1,0 +1,79 @@
+from typing import Annotated, Literal
+
+from pydantic import Field, ValidationError
+
+from coreason_manifest.spec.core.flow import GraphFlow
+from coreason_manifest.spec.core.nodes import Node, register_node
+from coreason_manifest.spec.core.rebuild import rebuild_manifest
+
+
+# 1. Define a custom node
+@register_node
+class CustomTestNode(Node):
+    type: Literal["custom_test"] = "custom_test"
+    custom_field: str = Field(..., description="A custom field")
+
+
+def test_rebuild_manifest():
+    # 2. Construct a manifest payload using the custom node
+    manifest_data = {
+        "type": "graph",
+        "kind": "GraphFlow",
+        "metadata": {
+            "name": "Test Flow",
+            "version": "1.0.0"
+        },
+        "interface": {}, # Fix: Added interface
+        "graph": {
+            "nodes": {
+                "node_1": {
+                    "id": "node_1",
+                    "type": "custom_test",
+                    "custom_field": "hello world"
+                }
+            },
+            "edges": []
+        }
+    }
+
+    print("Attempting validation (expecting failure)...")
+    try:
+        GraphFlow.model_validate(manifest_data)
+        print("UNEXPECTED SUCCESS: Validation passed without rebuild.")
+        failed = False
+    except ValidationError as e:
+        print("Expected Failure caught:")
+        print(e)
+        failed = True
+
+        # Verify it failed because of the union tag, not just missing field
+        error_str = str(e)
+        if "union_tag_invalid" not in error_str:
+            print("WARNING: Validation failed but not due to union tag invalidity?")
+            raise e
+
+    if not failed:
+        raise AssertionError("Validation should have failed before rebuild.")
+
+    # 4. Rebuild the manifest
+    print("Rebuilding manifest...")
+    rebuild_manifest()
+
+    # 5. Validation should SUCCEED now
+    print("Attempting validation (expecting success)...")
+    try:
+        flow = GraphFlow.model_validate(manifest_data)
+        print("SUCCESS: Validation passed after rebuild.")
+        # Access the node to ensure it is typed correctly
+        node = flow.graph.nodes["node_1"]
+        # Since the static type checker doesn't know about CustomTestNode being in AnyNode union,
+        # we check at runtime.
+        assert node.type == "custom_test"
+        assert getattr(node, "custom_field") == "hello world"
+    except ValidationError as e:
+        print("UNEXPECTED FAILURE after rebuild:")
+        print(e)
+        raise e
+
+if __name__ == "__main__":
+    test_rebuild_manifest()


### PR DESCRIPTION
Implemented `rebuild_manifest()` to allow dynamic registration of nodes and engines. This function updates the type annotations of key Pydantic models (`Graph`, `LinearFlow`, `CognitiveProfile`) with fresh unions and triggers `model_rebuild(force=True)` to propagate the changes. Verified with a new test case that simulates the import-time race condition.

---
*PR created automatically by Jules for task [11936524458479901387](https://jules.google.com/task/11936524458479901387) started by @gowthamrao*