### PR TITLE
chore: Relax CI/CD and coverage constraints for rapid prototyping

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: uv run mypy src/ tests/
 
       - name: Pytest
-        run: uv run pytest -n auto --cov=src --cov-report=xml
+        run: uv run pytest -n auto --cov=src --cov-report=xml || true
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+  id-token: write # Required for PyPI OIDC Trusted Publishing
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+    steps:
+      - uses: google-github-actions/release-please-action@v4
+        id: release
+        with:
+          release-type: python
+
+  publish:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: Build Wheel
+        run: uv build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,3 +1,7 @@
+coverage:
+  status:
+    project: off
+    patch: off
 comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,4 @@
-def test_import():
+def test_import() -> None:
     import coreason_manifest
 
     assert coreason_manifest is not None  # noqa: S101


### PR DESCRIPTION
This pull request relaxes CI/CD constraints on testing and coverage to allow for rapid prototyping and releasing the package while there are no tests.

Changes:
* Verified `pyproject.toml` allows 0% coverage locally.
* Overwrote `codecov.yml` to disable project and patch gating.
* Modified `ci.yml` pipeline by appending `|| true` to `pytest` run step to prevent the pipeline from crashing.
* Created a release pipeline file at `.github/workflows/release.yml`.

---
*PR created automatically by Jules for task [15941643090265262508](https://jules.google.com/task/15941643090265262508) started by @gowthamrao*