### PR TITLE
feat: implement pre-execution meta-cognition schemas and builder SDK integration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,9 @@ select = [
 ]
 ignore = []
 
+[tool.ruff.lint.per-file-ignores]
+"tests/*" = ["S101"]
+
 [tool.ruff.lint.isort]
 known-first-party = ["coreason_manifest"]
 

--- a/src/coreason_manifest/core/compute/reasoning.py
+++ b/src/coreason_manifest/core/compute/reasoning.py
@@ -1,6 +1,7 @@
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from coreason_manifest.core.primitives.constants import NodeCapability
 from coreason_manifest.core.primitives.registry import register_engine, resolve_engine_union
@@ -65,6 +66,40 @@ ModelRef = str | ModelCriteria
 # =========================================================================
 
 
+class ReviewStrategy(StrEnum):
+    """Review strategy for cognitive reasoning."""
+
+    NONE = "none"
+    BASIC = "basic"
+    ADVERSARIAL = "adversarial"
+    CAUSAL = "causal"
+    CONSENSUS = "consensus"
+
+
+class AdversarialConfig(BaseModel):
+    """Configuration for adversarial review."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    persona: str = Field(
+        default="skeptic", description="The persona adopted by the reviewer (e.g., 'security_auditor')."
+    )
+    attack_vectors: list[str] = Field(
+        default_factory=list, description="Specific angles of critique (e.g., 'pii_leakage')."
+    )
+
+
+class GapScanConfig(BaseModel):
+    """Configuration for gap scanning (pre-execution meta-cognition)."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    enabled: bool = Field(default=False, description="Scan context for missing prerequisites before execution.")
+    confidence_threshold: float = Field(
+        default=0.8, description="Minimum confidence to proceed without asking clarifying questions."
+    )
+
+
 class ConstitutionalScope(BaseModel):
     """
     Defines the ethical and safety boundaries for the cognitive process.
@@ -94,6 +129,17 @@ class BaseReasoning(BaseModel):
 
     # *** UPGRADE: CONSTITUTIONAL AI ***
     constitution: Annotated[ConstitutionalScope | None, Field(description="Intrinsic safety constraints.")] = None
+
+    review_strategy: ReviewStrategy = Field(default=ReviewStrategy.NONE)
+    adversarial_config: AdversarialConfig | None = Field(default=None)
+    gap_scan: GapScanConfig | None = Field(default=None)
+    max_revisions: int = Field(default=1, description="Maximum self-correction loops allowed.")
+
+    @model_validator(mode="after")
+    def _validate_adversarial_config(self) -> "BaseReasoning":
+        if self.review_strategy == ReviewStrategy.ADVERSARIAL and self.adversarial_config is None:
+            raise ValueError("adversarial_config must be provided when review_strategy is 'adversarial'")
+        return self
 
     def required_capabilities(self) -> list[str]:
         """Returns a list of high-risk capabilities required by this engine."""
@@ -452,6 +498,7 @@ __all__ = [
     "Optimizer",
     "ReasoningConfig",
     "RedTeamingReasoning",
+    "ReviewStrategy",
     "StandardReasoning",
     "TreeSearchReasoning",
     "WasmExecutionReasoning",

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -11,8 +11,11 @@
 from typing import Any, Self, cast
 
 from coreason_manifest.core.compute.reasoning import (
+    AdversarialConfig,
     FastPath,
+    GapScanConfig,
     ReasoningConfig,
+    ReviewStrategy,
     StandardReasoning,
 )
 from coreason_manifest.core.oversight.governance import (
@@ -119,6 +122,39 @@ class AgentBuilder:
         self.operational_policy: OperationalPolicy | None = None
         self.escalation_rules: list[EscalationCriteria] = []
         self.memory: MemorySubsystem | None = None
+        # Meta-Cognition state
+        self.review_strategy: str = "none"
+        self.adversarial_persona: str | None = None
+        self.gap_scan_enabled: bool = False
+        self.gap_scan_threshold: float = 0.8
+        self.max_revisions: int = 1
+
+    def with_meta_cognition(
+        self,
+        review_strategy: str = "none",
+        adversarial_persona: str | None = None,
+        gap_scan_enabled: bool = False,
+        gap_scan_threshold: float = 0.8,
+        max_revisions: int = 1,
+    ) -> "AgentBuilder":
+        """Configures meta-cognitive features for the agent.
+
+        Args:
+            review_strategy (str): The review strategy to use. Defaults to "none".
+            adversarial_persona (str | None): The persona for adversarial review.
+            gap_scan_enabled (bool): Whether gap scanning is enabled. Defaults to False.
+            gap_scan_threshold (float): The threshold for gap scanning. Defaults to 0.8.
+            max_revisions (int): Maximum self-correction loops. Defaults to 1.
+
+        Returns:
+            AgentBuilder: The builder instance for chaining.
+        """
+        self.review_strategy = review_strategy
+        self.adversarial_persona = adversarial_persona
+        self.gap_scan_enabled = gap_scan_enabled
+        self.gap_scan_threshold = gap_scan_threshold
+        self.max_revisions = max_revisions
+        return self
 
     def with_identity(self, role: str, persona: str) -> "AgentBuilder":
         """Configures the agent's identity.
@@ -405,10 +441,38 @@ class AgentBuilder:
         if not self.role or not self.persona:
             raise ValueError("Agent identity (role, persona) must be set.")
 
+        reasoning = self.reasoning
+        if reasoning is not None:
+            gap_scan_config = None
+            if self.gap_scan_enabled:
+                gap_scan_config = GapScanConfig(
+                    enabled=self.gap_scan_enabled, confidence_threshold=self.gap_scan_threshold
+                )
+
+            adversarial_config = None
+            if self.review_strategy == "adversarial":
+                adversarial_config = AdversarialConfig(persona=self.adversarial_persona or "skeptic")
+
+            # Map string to ReviewStrategy Enum
+            try:
+                review_strategy_enum = ReviewStrategy(self.review_strategy)
+            except ValueError:
+                review_strategy_enum = ReviewStrategy.NONE
+
+            # Since BaseModel models are immutable (frozen=True), we must use model_copy
+            reasoning = reasoning.model_copy(
+                update={
+                    "review_strategy": review_strategy_enum,
+                    "adversarial_config": adversarial_config,
+                    "gap_scan": gap_scan_config,
+                    "max_revisions": self.max_revisions,
+                }
+            )
+
         profile = CognitiveProfile(
             role=self.role,
             persona=self.persona,
-            reasoning=self.reasoning,
+            reasoning=reasoning,
             fast_path=self.fast_path,
             memory=self.memory,
         )

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,4 +1,4 @@
 def test_import() -> None:
     import coreason_manifest
 
-    assert coreason_manifest is not None  # noqa: S101
+    assert coreason_manifest is not None

--- a/tests/test_meta_cognition.py
+++ b/tests/test_meta_cognition.py
@@ -1,0 +1,110 @@
+import pytest
+
+from coreason_manifest.core.compute.reasoning import (
+    AdversarialConfig,
+    GapScanConfig,
+    ReviewStrategy,
+    StandardReasoning,
+)
+from coreason_manifest.toolkit.builder import AgentBuilder
+
+
+def test_gapscan_adversarial_instantiation() -> None:
+    """Test successful instantiation of GapScanConfig and AdversarialConfig."""
+    gap_scan = GapScanConfig(enabled=True, confidence_threshold=0.9)
+    assert gap_scan.enabled is True
+    assert gap_scan.confidence_threshold == 0.9
+
+    adversarial = AdversarialConfig(persona="auditor", attack_vectors=["injection"])
+    assert adversarial.persona == "auditor"
+    assert adversarial.attack_vectors == ["injection"]
+
+    # Test default values
+    gap_scan_default = GapScanConfig()
+    assert gap_scan_default.enabled is False
+    assert gap_scan_default.confidence_threshold == 0.8
+
+    adversarial_default = AdversarialConfig()
+    assert adversarial_default.persona == "skeptic"
+    assert adversarial_default.attack_vectors == []
+
+
+def test_base_reasoning_adversarial_validation() -> None:
+    """Test that BaseReasoning model validator raises ValueError appropriately."""
+    # Should work fine without adversarial config if strategy is not adversarial
+    reasoning_basic = StandardReasoning(model="gpt-4o", review_strategy=ReviewStrategy.BASIC)
+    assert reasoning_basic.review_strategy == ReviewStrategy.BASIC
+
+    # Should raise ValueError when review_strategy is adversarial but config is None
+    with pytest.raises(ValueError, match="adversarial_config must be provided when review_strategy is 'adversarial'"):
+        StandardReasoning(
+            model="gpt-4o",
+            review_strategy=ReviewStrategy.ADVERSARIAL,
+        )
+
+    # Should work fine when review_strategy is adversarial and config is provided
+    adv_config = AdversarialConfig(persona="devil_advocate")
+    reasoning_adv = StandardReasoning(
+        model="gpt-4o",
+        review_strategy=ReviewStrategy.ADVERSARIAL,
+        adversarial_config=adv_config,
+    )
+    assert reasoning_adv.review_strategy == ReviewStrategy.ADVERSARIAL
+    assert reasoning_adv.adversarial_config is not None
+    assert reasoning_adv.adversarial_config.persona == "devil_advocate"
+
+
+def test_agent_builder_with_meta_cognition() -> None:
+    """Test that AgentBuilder.with_meta_cognition() constructs AgentNode with correct params."""
+    builder = (
+        AgentBuilder("test_agent")
+        .with_identity(role="reviewer", persona="You review stuff")
+        .with_reasoning(model="gpt-4o")
+        .with_meta_cognition(
+            review_strategy="adversarial",
+            adversarial_persona="security_auditor",
+            gap_scan_enabled=True,
+            gap_scan_threshold=0.85,
+            max_revisions=3,
+        )
+    )
+
+    agent_node = builder.build()
+
+    assert agent_node.profile is not None
+    assert not isinstance(agent_node.profile, str)
+    assert agent_node.profile.reasoning is not None
+
+    reasoning = agent_node.profile.reasoning
+
+    assert reasoning.review_strategy == ReviewStrategy.ADVERSARIAL
+    assert reasoning.max_revisions == 3
+
+    assert reasoning.gap_scan is not None
+    assert reasoning.gap_scan.enabled is True
+    assert reasoning.gap_scan.confidence_threshold == 0.85
+
+    assert reasoning.adversarial_config is not None
+    assert reasoning.adversarial_config.persona == "security_auditor"
+    assert reasoning.adversarial_config.attack_vectors == []
+
+    # Test with standard meta cognition
+    builder_basic = (
+        AgentBuilder("test_agent_basic")
+        .with_identity(role="assistant", persona="You help")
+        .with_reasoning(model="gpt-4o")
+        .with_meta_cognition(
+            review_strategy="basic",
+            gap_scan_enabled=False,
+        )
+    )
+
+    agent_node_basic = builder_basic.build()
+    assert agent_node_basic.profile is not None
+    assert not isinstance(agent_node_basic.profile, str)
+    assert agent_node_basic.profile.reasoning is not None
+    reasoning_basic = agent_node_basic.profile.reasoning
+
+    assert reasoning_basic.review_strategy == ReviewStrategy.BASIC
+    assert reasoning_basic.adversarial_config is None
+    assert reasoning_basic.gap_scan is None


### PR DESCRIPTION
Implemented the schemas for SOTA Meta-Cognitive reasoning as part of Epic 1.

Specifically, this adds "Gap Scan" capabilities and adversarial self-critique configurations by defining `GapScanConfig`, `AdversarialConfig`, and `ReviewStrategy` schemas. These are integrated into `BaseReasoning` and enforced locally using Pydantic V2 `@model_validator`s to avoid merge conflicts with parallel epics. 

Additionally, the `AgentBuilder` SDK was updated to support a new `with_meta_cognition()` method. Comprehensive type-checked tests were written and verified via local strict workflows (mypy, pytest, ruff).

---
*PR created automatically by Jules for task [11883650874735348659](https://jules.google.com/task/11883650874735348659) started by @gowthamrao*