### PR TITLE
Epic 5: Add Status and Progressive Strictness to Workflow Topologies

### DIFF
--- a/src/coreason_manifest/core/workflow/flow.py
+++ b/src/coreason_manifest/core/workflow/flow.py
@@ -257,6 +257,25 @@ class GraphFlow(CoreasonModel):
     definitions: FlowDefinitions | None = None
     graph: Graph
 
+    @model_validator(mode="after")
+    def enforce_lifecycle_constraints(self) -> "GraphFlow":
+        if self.status != "published":
+            return self
+
+        from coreason_manifest.core.workflow.nodes import PlaceholderNode
+
+        for node in self.graph.nodes.values():
+            if isinstance(node, PlaceholderNode):
+                raise ValueError(
+                    "Published flow contains abstract PlaceholderNode(s). "
+                    "Replace them with concrete implementations before publishing."
+                )
+
+        if not self.graph.entry_point:
+            raise ValueError("Published GraphFlow MUST have a defined entry_point.")
+
+        return self
+
 
 class LinearFlow(CoreasonModel):
     """
@@ -270,6 +289,22 @@ class LinearFlow(CoreasonModel):
     steps: list[AnyNode] = Field(default_factory=list)
     governance: Governance | None = None
     definitions: FlowDefinitions | None = None
+
+    @model_validator(mode="after")
+    def enforce_lifecycle_constraints(self) -> "LinearFlow":
+        if self.status != "published":
+            return self
+
+        from coreason_manifest.core.workflow.nodes import PlaceholderNode
+
+        for node in self.steps:
+            if isinstance(node, PlaceholderNode):
+                raise ValueError(
+                    "Published flow contains abstract PlaceholderNode(s). "
+                    "Replace them with concrete implementations before publishing."
+                )
+
+        return self
 
     @model_validator(mode="after")
     def validate_linear_structure(self) -> "LinearFlow":

--- a/src/coreason_manifest/core/workflow/nodes.py
+++ b/src/coreason_manifest/core/workflow/nodes.py
@@ -371,9 +371,11 @@ class SwarmNode(Node):
 
 @register_node
 class PlaceholderNode(Node):
+    """An abstract node used during draft design. Must be resolved before publishing."""
+
     type: Literal["placeholder"] = "placeholder"
     required_capabilities: CoercibleStringList = Field(
-        ..., description="List of required capabilities.", examples=[["image_generation"]]
+        default_factory=list, description="List of required capabilities.", examples=[["image_generation"]]
     )
 
 

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -8,7 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, Self, cast
+from typing import Any, Literal, Self, cast
 
 from coreason_manifest.core.compute.reasoning import (
     AdversarialConfig,
@@ -517,6 +517,19 @@ class BaseFlowBuilder:
         self._tool_packs: dict[str, ToolPack] = {}
         self._supervision_templates: dict[str, SupervisionPolicy] = {}
         self.governance: Governance | None = None
+        self.status: Literal["draft", "published", "archived"] = "draft"
+
+    def set_status(self, status: Literal["draft", "published", "archived"]) -> Self:
+        """Sets the status of the flow.
+
+        Args:
+            status (Literal["draft", "published", "archived"]): The status to set.
+
+        Returns:
+            Self: The builder instance for chaining.
+        """
+        self.status = status
+        return self
 
     def define_supervision_template(self, template_id: str, policy: SupervisionPolicy) -> Self:
         """Registers a reusable supervision policy.
@@ -837,7 +850,7 @@ class NewLinearFlow(BaseFlowBuilder):
     def _create_flow_instance(self) -> LinearFlow:
         return LinearFlow(
             kind="LinearFlow",
-            status="published",
+            status=self.status,
             metadata=self.metadata,
             steps=self.steps,
             definitions=self._build_definitions(),
@@ -976,7 +989,7 @@ class NewGraphFlow(BaseFlowBuilder):
 
         return GraphFlow(
             kind="GraphFlow",
-            status="published",
+            status=self.status,
             metadata=self.metadata,
             interface=self.interface,
             blackboard=self.blackboard,

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -558,15 +558,47 @@ def _validate_orphan_nodes(flow: GraphFlow) -> list[ComplianceReport]:
     if entry_point in orphans:
         orphans.remove(entry_point)
 
-    return [
-        ComplianceReport(
-            code=ErrorCatalog.ERR_TOPOLOGY_ORPHAN_001,
-            severity="warning",
-            message=f"Orphan Node Warning: Node '{oid}' has no incoming edges or implicit routes.",
-            node_id=oid,
+    if not orphans:
+        return []
+
+    if flow.status != "published":
+        return [
+            ComplianceReport(
+                code=ErrorCatalog.ERR_TOPOLOGY_ORPHAN_001,
+                severity="info",
+                message="Non-Published Topology Info: Found disconnected node (Safe Dead Code).",
+                node_id=oid,
+            )
+            for oid in orphans
+        ]
+
+    # For published status, create a warning/violation with remediation
+    reports = []
+    for oid in orphans:
+        patch_data = [{"op": "remove", "path": f"/graph/nodes/{oid}"}]
+        # Remove any edges that start from this orphan node to other nodes,
+        # as pruning the node implies pruning its outbound edges.
+        edges_to_remove = []
+        for i, edge in enumerate(flow.graph.edges):
+            if edge.from_node == oid or edge.to_node == oid:
+                edges_to_remove.append(i)
+        # Reverse order removal to keep indices valid during sequential removal via patch
+        patch_data.extend({"op": "remove", "path": f"/graph/edges/{i}"} for i in reversed(edges_to_remove))
+
+        reports.append(
+            ComplianceReport(
+                code=ErrorCatalog.ERR_TOPOLOGY_ORPHAN_001,
+                severity="warning",
+                message=f"Orphan Node Warning: Node '{oid}' has no incoming edges or implicit routes.",
+                node_id=oid,
+                remediation=RemediationAction(
+                    type="prune_node",
+                    description=f"Prune orphaned node '{oid}' and its connected edges.",
+                    patch_data=patch_data,
+                ),
+            )
         )
-        for oid in orphans
-    ]
+    return reports
 
 
 def _validate_referential_integrity(

--- a/test_flow.py
+++ b/test_flow.py
@@ -1,0 +1,4 @@
+from coreason_manifest.core.workflow.flow import GraphFlow, LinearFlow
+
+print("GraphFlow enforce_lifecycle_constraints:", hasattr(GraphFlow, "enforce_lifecycle_constraints"))
+print("LinearFlow enforce_lifecycle_constraints:", hasattr(LinearFlow, "enforce_lifecycle_constraints"))

--- a/test_nodes.py
+++ b/test_nodes.py
@@ -1,0 +1,3 @@
+from coreason_manifest.core.workflow.nodes import PlaceholderNode
+
+print(PlaceholderNode)

--- a/test_union.py
+++ b/test_union.py
@@ -1,0 +1,30 @@
+from typing import Annotated, Literal
+
+from pydantic import BaseModel, Field
+
+
+class A(BaseModel):
+    type: Literal["a"] = "a"
+
+
+class B(BaseModel):
+    type: Literal["b"] = "b"
+
+
+_UnionAB = Annotated[A | B, Field(discriminator="type")]
+
+
+class C(BaseModel):
+    type: Literal["c"] = "c"
+
+
+# Try combining
+Combined = Annotated[_UnionAB | C, Field(discriminator="type")]
+
+
+class Container(BaseModel):
+    node: Combined
+
+
+print(Container(node={"type": "c"}).node)
+print(Container(node={"type": "a"}).node)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,104 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.workflow.flow import GraphFlow
+from coreason_manifest.core.workflow.nodes import PlaceholderNode
+from coreason_manifest.toolkit.validator import _validate_orphan_nodes
+
+
+def create_minimal_flow(status: str, include_placeholder: bool = False, include_orphan: bool = False) -> dict:
+    nodes = {}
+    edges = []
+
+    # Valid entry point
+    nodes["start_node"] = {
+        "id": "start_node",
+        "type": "agent",
+        "profile": {"role": "Agent", "persona": "Test"},
+        "tools": [],
+    }
+
+    if include_placeholder:
+        nodes["draft_node"] = {"id": "draft_node", "type": "placeholder", "required_capabilities": ["image_generation"]}
+        edges.append({"from_node": "start_node", "to_node": "draft_node"})
+    elif not include_orphan:
+        nodes["end_node"] = {
+            "id": "end_node",
+            "type": "agent",
+            "profile": {"role": "Agent", "persona": "Test"},
+            "tools": [],
+        }
+        edges.append({"from_node": "start_node", "to_node": "end_node"})
+
+    if include_orphan:
+        nodes["orphan_node"] = {
+            "id": "orphan_node",
+            "type": "agent",
+            "profile": {"role": "Orphan", "persona": "Test"},
+            "tools": [],
+        }
+
+    return {
+        "kind": "GraphFlow",
+        "type": "graph",
+        "status": status,
+        "metadata": {"name": "test_flow", "version": "1.0", "description": "Test"},
+        "interface": {"inputs": {"json_schema": {}}, "outputs": {"json_schema": {}}},
+        "graph": {"nodes": nodes, "edges": edges, "entry_point": "start_node"},
+    }
+
+
+def test_draft_flow_with_placeholder():
+    """Verify that a GraphFlow with a PlaceholderNode parses successfully when status="draft"."""
+    data = create_minimal_flow(status="draft", include_placeholder=True)
+    flow = GraphFlow.model_validate(data)
+    assert flow.status == "draft"
+    assert "draft_node" in flow.graph.nodes
+    assert isinstance(flow.graph.nodes["draft_node"], PlaceholderNode)
+
+
+def test_published_flow_with_placeholder_raises_error():
+    """Verify that setting status="published" on a flow with PlaceholderNode raises ValidationError."""
+    data = create_minimal_flow(status="published", include_placeholder=True)
+    with pytest.raises(ValidationError, match="Published flow contains abstract PlaceholderNode"):
+        GraphFlow.model_validate(data)
+
+
+def test_published_flow_without_entry_point_raises_error():
+    """Verify that setting status="published" on a flow without an entry point raises ValidationError."""
+    data = create_minimal_flow(status="published")
+    del data["graph"]["entry_point"]
+    # Pydantic core structure expects entry_point normally to be optional, but our validator enforces it
+    with pytest.raises(ValidationError, match=r"Published GraphFlow MUST have a defined entry_point\."):
+        GraphFlow.model_validate(data)
+
+
+def test_validate_orphan_nodes_lifecycle():
+    """
+    Verify _validate_orphan_nodes returns an info report in draft mode,
+    but a warning with a remediation patch in published mode.
+    """
+    # 1. Test Draft Mode
+    draft_data = create_minimal_flow(status="draft", include_orphan=True)
+    draft_flow = GraphFlow.model_validate(draft_data)
+
+    draft_reports = _validate_orphan_nodes(draft_flow)
+    assert len(draft_reports) == 1
+    assert draft_reports[0].severity == "info"
+    assert "Safe Dead Code" in draft_reports[0].message
+    assert draft_reports[0].remediation is None
+
+    # 2. Test Published Mode
+    published_data = create_minimal_flow(status="published", include_orphan=True)
+    published_flow = GraphFlow.model_validate(published_data)
+
+    published_reports = _validate_orphan_nodes(published_flow)
+    assert len(published_reports) == 1
+    assert published_reports[0].severity == "warning"
+    assert "no incoming edges" in published_reports[0].message
+    assert published_reports[0].remediation is not None
+    assert published_reports[0].remediation.type == "prune_node"
+
+    # Verify the patch removes the node
+    patch = published_reports[0].remediation.patch_data
+    assert any(op["op"] == "remove" and "orphan_node" in op["path"] for op in patch)

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import pytest
 from pydantic import ValidationError
 
@@ -6,9 +8,9 @@ from coreason_manifest.core.workflow.nodes import PlaceholderNode
 from coreason_manifest.toolkit.validator import _validate_orphan_nodes
 
 
-def create_minimal_flow(status: str, include_placeholder: bool = False, include_orphan: bool = False) -> dict:
-    nodes = {}
-    edges = []
+def create_minimal_flow(status: str, include_placeholder: bool = False, include_orphan: bool = False) -> dict[str, Any]:
+    nodes: dict[str, Any] = {}
+    edges: list[dict[str, Any]] = []
 
     # Valid entry point
     nodes["start_node"] = {
@@ -48,7 +50,7 @@ def create_minimal_flow(status: str, include_placeholder: bool = False, include_
     }
 
 
-def test_draft_flow_with_placeholder():
+def test_draft_flow_with_placeholder() -> None:
     """Verify that a GraphFlow with a PlaceholderNode parses successfully when status="draft"."""
     data = create_minimal_flow(status="draft", include_placeholder=True)
     flow = GraphFlow.model_validate(data)
@@ -57,14 +59,14 @@ def test_draft_flow_with_placeholder():
     assert isinstance(flow.graph.nodes["draft_node"], PlaceholderNode)
 
 
-def test_published_flow_with_placeholder_raises_error():
+def test_published_flow_with_placeholder_raises_error() -> None:
     """Verify that setting status="published" on a flow with PlaceholderNode raises ValidationError."""
     data = create_minimal_flow(status="published", include_placeholder=True)
     with pytest.raises(ValidationError, match="Published flow contains abstract PlaceholderNode"):
         GraphFlow.model_validate(data)
 
 
-def test_published_flow_without_entry_point_raises_error():
+def test_published_flow_without_entry_point_raises_error() -> None:
     """Verify that setting status="published" on a flow without an entry point raises ValidationError."""
     data = create_minimal_flow(status="published")
     del data["graph"]["entry_point"]
@@ -73,7 +75,7 @@ def test_published_flow_without_entry_point_raises_error():
         GraphFlow.model_validate(data)
 
 
-def test_validate_orphan_nodes_lifecycle():
+def test_validate_orphan_nodes_lifecycle() -> None:
     """
     Verify _validate_orphan_nodes returns an info report in draft mode,
     but a warning with a remediation patch in published mode.
@@ -101,4 +103,10 @@ def test_validate_orphan_nodes_lifecycle():
 
     # Verify the patch removes the node
     patch = published_reports[0].remediation.patch_data
-    assert any(op["op"] == "remove" and "orphan_node" in op["path"] for op in patch)
+    assert any(
+        isinstance(op, dict)
+        and op.get("op") == "remove"
+        and isinstance(op.get("path"), str)
+        and "orphan_node" in str(op.get("path"))
+        for op in patch
+    )

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -6,9 +6,9 @@ def test_episodic_memory_config_default_strategy() -> None:
     config = EpisodicMemoryConfig(
         salience_threshold=0.5,
     )
-    assert config.consolidation_strategy == ConsolidationStrategy.SESSION_CLOSE  # noqa: S101
-    assert config.salience_threshold == 0.5  # noqa: S101
-    assert config.consolidation_interval_turns is None  # noqa: S101
+    assert config.consolidation_strategy == ConsolidationStrategy.SESSION_CLOSE
+    assert config.salience_threshold == 0.5
+    assert config.consolidation_interval_turns is None
 
 
 def test_episodic_memory_config_custom_strategy() -> None:
@@ -18,5 +18,5 @@ def test_episodic_memory_config_custom_strategy() -> None:
         consolidation_strategy=ConsolidationStrategy.SUMMARY_WINDOW,
         consolidation_interval_turns=10,
     )
-    assert config.consolidation_strategy == ConsolidationStrategy.SUMMARY_WINDOW  # noqa: S101
-    assert config.consolidation_interval_turns == 10  # noqa: S101
+    assert config.consolidation_strategy == ConsolidationStrategy.SUMMARY_WINDOW
+    assert config.consolidation_interval_turns == 10

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -12,7 +12,7 @@ def test_tool_capability_lazy_loading_without_intent() -> None:
             description="A lazy tool",
             load_strategy=LoadStrategy.LAZY,
         )
-    assert "Lazy loading requires a trigger_intent" in str(exc_info.value)  # noqa: S101
+    assert "Lazy loading requires a trigger_intent" in str(exc_info.value)
 
 
 def test_tool_capability_lazy_loading_with_intent() -> None:
@@ -23,9 +23,9 @@ def test_tool_capability_lazy_loading_with_intent() -> None:
         load_strategy=LoadStrategy.LAZY,
         trigger_intent="A semantic description of what this tool does",
     )
-    assert tool.name == "lazy_tool"  # noqa: S101
-    assert tool.load_strategy == LoadStrategy.LAZY  # noqa: S101
-    assert tool.trigger_intent == "A semantic description of what this tool does"  # noqa: S101
+    assert tool.name == "lazy_tool"
+    assert tool.load_strategy == LoadStrategy.LAZY
+    assert tool.trigger_intent == "A semantic description of what this tool does"
 
 
 def test_tool_capability_eager_loading_without_intent() -> None:
@@ -35,6 +35,6 @@ def test_tool_capability_eager_loading_without_intent() -> None:
         description="An eager tool",
         load_strategy=LoadStrategy.EAGER,
     )
-    assert tool.name == "eager_tool"  # noqa: S101
-    assert tool.load_strategy == LoadStrategy.EAGER  # noqa: S101
-    assert tool.trigger_intent is None  # noqa: S101
+    assert tool.name == "eager_tool"
+    assert tool.load_strategy == LoadStrategy.EAGER
+    assert tool.trigger_intent is None


### PR DESCRIPTION
This change addresses Epic 5 by implementing progressive strictness for workflows through a draft-to-published lifecycle. In draft mode, abstract `PlaceholderNode`s and disconnected subgraphs are tolerated. However, upon transitioning to published mode, the validation engine rejects any incomplete paths and issues remediation actions to prune disconnected edges.

---
*PR created automatically by Jules for task [6595625937390014758](https://jules.google.com/task/6595625937390014758) started by @gowthamrao*