### PR TITLE
feat: add constraint schemas and pre-flight gatekeeper checks

### DIFF
--- a/src/coreason_manifest/core/workflow/nodes.py
+++ b/src/coreason_manifest/core/workflow/nodes.py
@@ -1,3 +1,4 @@
+from enum import StrEnum
 from typing import Annotated, Any, Literal
 
 from pydantic import Field, model_validator
@@ -23,6 +24,27 @@ from coreason_manifest.core.primitives.types import (
     VariableID,
 )
 from coreason_manifest.core.state.memory import MemorySubsystem
+
+
+class ConstraintOperator(StrEnum):
+    EQ = "eq"
+    NEQ = "neq"
+    GT = "gt"
+    GTE = "gte"
+    LT = "lt"
+    LTE = "lte"
+    IN = "in"
+    CONTAINS = "contains"
+
+
+class Constraint(CoreasonModel):
+    """Declarative constraint evaluated before node execution."""
+
+    variable: str = Field(..., description="The Blackboard variable path to check.")
+    operator: ConstraintOperator
+    value: Any = Field(..., description="The threshold or reference value.")
+    required: bool = Field(True, description="If True, failure halts execution. If False, emits a warning.")
+    error_message: str | None = Field(None, description="Optional custom error message.")
 
 
 class LockConfig(CoreasonModel):
@@ -52,6 +74,9 @@ class Node(CoreasonModel):
         Field(description="UI rendering hints.", examples=[{"x": 100, "y": 200}]),
     ] = None
     type: str = Field(..., description="The type of the node.")
+    constraints: list[Constraint] = Field(
+        default_factory=list, description="Pre-flight checks evaluated before node execution."
+    )
 
 
 class CognitiveProfile(CoreasonModel):
@@ -385,6 +410,8 @@ __all__ = [
     "AgentNode",
     "AnyNode",
     "CognitiveProfile",
+    "Constraint",
+    "ConstraintOperator",
     "EmergenceInspectorNode",
     "HumanNode",
     "InspectorNode",

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -8,7 +8,10 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, Self, cast
+from typing import TYPE_CHECKING, Any, Self, cast
+
+if TYPE_CHECKING:
+    from coreason_manifest.core.workflow.nodes import Constraint
 
 from coreason_manifest.core.compute.reasoning import (
     FastPath,
@@ -119,6 +122,7 @@ class AgentBuilder:
         self.operational_policy: OperationalPolicy | None = None
         self.escalation_rules: list[EscalationCriteria] = []
         self.memory: MemorySubsystem | None = None
+        self.constraints: list[Constraint] = []
 
     def with_identity(self, role: str, persona: str) -> "AgentBuilder":
         """Configures the agent's identity.
@@ -390,6 +394,34 @@ class AgentBuilder:
         )
         return self
 
+    def with_constraint(
+        self, variable: str, operator: str, value: Any, required: bool = True, error_message: str | None = None
+    ) -> "AgentBuilder":
+        """Adds a constraint to the agent node.
+
+        Args:
+            variable (str): The Blackboard variable path to check.
+            operator (str): The operator to use (e.g., 'eq', 'gt').
+            value (Any): The threshold or reference value.
+            required (bool): Whether the constraint is required. Defaults to True.
+            error_message (str | None): Custom error message.
+
+        Returns:
+            AgentBuilder: The builder instance for chaining.
+        """
+        from coreason_manifest.core.workflow.nodes import Constraint, ConstraintOperator
+
+        self.constraints.append(
+            Constraint(
+                variable=variable,
+                operator=ConstraintOperator(operator),
+                value=value,
+                required=required,
+                error_message=error_message,
+            )
+        )
+        return self
+
     def build(self) -> AgentNode:
         """Validates configuration and builds the AgentNode.
 
@@ -400,10 +432,14 @@ class AgentBuilder:
             ValueError: If agent identity (role, persona) is not set.
         """
         # Ensure schema is built
+        from coreason_manifest.core.rebuild import rebuild_manifest
+
         rebuild_manifest()
 
         if not self.role or not self.persona:
             raise ValueError("Agent identity (role, persona) must be set.")
+
+        from coreason_manifest.core.workflow.nodes import AgentNode, CognitiveProfile
 
         profile = CognitiveProfile(
             role=self.role,
@@ -422,6 +458,7 @@ class AgentBuilder:
             tools=self.tools,
             operational_policy=self.operational_policy,
             escalation_rules=self.escalation_rules,
+            constraints=self.constraints,
         )
 
 

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -186,6 +186,23 @@ def _validate_data_flow(
     available_vars = set(symbol_table.keys())
 
     for node in nodes:
+        if hasattr(node, "constraints"):
+            for constraint in node.constraints:
+                base_var = constraint.variable.split(".")[0]
+                if base_var not in available_vars:
+                    errors.append(
+                        ComplianceReport(
+                            code=ErrorCatalog.ERR_CAP_MISSING_VAR,
+                            severity="violation",
+                            message=(
+                                f"Constraint Error: Node '{node.id}' references "
+                                f"missing variable '{constraint.variable}'."
+                            ),
+                            node_id=node.id,
+                            details={"variable": constraint.variable},
+                        )
+                    )
+
         if isinstance(node, SwarmNode):
             if node.workload_variable not in available_vars:
                 errors.append(

--- a/tests/test_constraints.py
+++ b/tests/test_constraints.py
@@ -1,0 +1,55 @@
+from coreason_manifest.core.workflow.nodes import Constraint, ConstraintOperator
+from coreason_manifest.toolkit.builder import AgentBuilder
+from coreason_manifest.toolkit.validator import _validate_data_flow
+
+
+def test_constraint_schema() -> None:
+    c = Constraint(variable="foo", operator=ConstraintOperator.EQ, value=42)
+    assert c.variable == "foo"  # noqa: S101
+    assert c.operator == ConstraintOperator.EQ  # noqa: S101
+    assert c.value == 42  # noqa: S101
+    assert c.required is True  # noqa: S101
+
+
+def test_builder_with_constraint() -> None:
+    builder = (
+        AgentBuilder("test_agent")
+        .with_identity("Analyst", "You analyze data.")
+        .with_constraint("data.row_count", "gt", 100)
+    )
+    agent = builder.build()
+    assert len(agent.constraints) == 1  # noqa: S101
+    assert agent.constraints[0].variable == "data.row_count"  # noqa: S101
+    assert agent.constraints[0].operator == ConstraintOperator.GT  # noqa: S101
+    assert agent.constraints[0].value == 100  # noqa: S101
+
+
+def test_validate_data_flow_missing_var() -> None:
+    builder = (
+        AgentBuilder("test_agent")
+        .with_identity("Analyst", "You analyze data.")
+        .with_constraint("data.row_count", "gt", 100)
+    )
+    agent = builder.build()
+
+    # Empty symbol table -> "data" is missing
+    reports = _validate_data_flow([agent], {}, None)
+
+    assert len(reports) == 1  # noqa: S101
+    assert reports[0].code == "ERR_CAP_MISSING_VAR"  # noqa: S101
+    assert "Constraint Error" in reports[0].message  # noqa: S101
+    assert "missing variable 'data.row_count'" in reports[0].message  # noqa: S101
+
+
+def test_validate_data_flow_existing_var() -> None:
+    builder = (
+        AgentBuilder("test_agent")
+        .with_identity("Analyst", "You analyze data.")
+        .with_constraint("data.row_count", "gt", 100)
+    )
+    agent = builder.build()
+
+    # "data" exists in symbol table
+    reports = _validate_data_flow([agent], {"data": "object"}, None)
+
+    assert len(reports) == 0  # noqa: S101


### PR DESCRIPTION
Implements Epic 3: Feasibility Constraints (Pre-Flight Guardrails).

Provides a Shift-Left approach to Agentic Workflow reliability by introducing a declarative Constraint contract that attaches to execution nodes. The builder API provides a fluent `with_constraint()` configuration pattern. A new validation rule ensures variables referenced in these constraints exist in the Blackboard symbol table during manifest compilation.

---
*PR created automatically by Jules for task [1150917051067815394](https://jules.google.com/task/1150917051067815394) started by @gowthamrao*