### PR TITLE
Recreate strict HTN contracts and planner schema guardrail

### DIFF
--- a/src/coreason_manifest/core/workflow/contracts.py
+++ b/src/coreason_manifest/core/workflow/contracts.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.core.common_base import CoreasonModel
+
+
+class AtomicSkill(CoreasonModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    id: str = Field(..., description="Unique identifier for this skill step")
+    description: str = Field(..., description="Description of the action to be performed")
+    immutable: bool = Field(False, description="If True, this step cannot be modified or removed by the planner")
+    tool_ref: str | None = Field(None, description="Reference to the tool to be used")
+    params: dict[str, Any] = Field(default_factory=dict, description="Parameters for the tool")
+
+
+class ActionNode(CoreasonModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    id: str = Field(..., description="Unique identifier for this action")
+    description: str = Field(..., description="Description of the action")
+    skill: AtomicSkill = Field(..., description="The atomic skill to execute")
+    inputs: dict[str, Any] = Field(default_factory=dict, description="Inputs for the action")
+
+
+class StrategyNode(CoreasonModel):
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+    id: str = Field(..., description="Unique identifier for this strategy node")
+    goal: str = Field(..., description="High-level goal description")
+    strategy_name: str = Field(..., description="Name of the strategy used (e.g., 'ReAct', 'TreeOfThoughts')")
+    children: list["PlanTree"] = Field(..., description="Child nodes (sub-goals)")
+
+
+type PlanTree = StrategyNode | ActionNode | AtomicSkill | list["PlanTree"] | dict[str, Any]

--- a/src/coreason_manifest/core/workflow/nodes.py
+++ b/src/coreason_manifest/core/workflow/nodes.py
@@ -1,6 +1,6 @@
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from coreason_manifest.core.common.presentation import PresentationHints
 from coreason_manifest.core.common_base import CoreasonModel
@@ -175,6 +175,13 @@ class PlannerNode(Node):
         description="JSON Schema for the plan output.",
         examples=[{"type": "object", "properties": {"steps": {"type": "array"}}}],
     )
+
+    @field_validator("output_schema")
+    @classmethod
+    def validate_planner_output_schema(cls, v: dict[str, Any]) -> dict[str, Any]:
+        if v.get("type") not in ["object", "array"]:
+            raise ValueError("PlannerNode output_schema must define an object or array representing the PlanTree.")
+        return v
 
 
 class SteeringConfig(CoreasonModel):

--- a/tests/test_htn_contracts.py
+++ b/tests/test_htn_contracts.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.workflow.contracts import ActionNode, AtomicSkill, StrategyNode
+from coreason_manifest.core.workflow.nodes import PlannerNode
+
+
+def test_htn_immutability() -> None:
+    skill = AtomicSkill(id="s1", description="skill")
+    action = ActionNode(id="a1", description="action", skill=skill)
+    strategy = StrategyNode(id="str1", goal="goal", strategy_name="ReAct", children=[])
+
+    with pytest.raises(ValidationError):
+        setattr(skill, "id", "s2")  # noqa: B010
+
+    with pytest.raises(ValidationError):
+        setattr(action, "id", "a2")  # noqa: B010
+
+    with pytest.raises(ValidationError):
+        setattr(strategy, "id", "str2")  # noqa: B010
+
+
+def test_planner_node_output_schema_validation() -> None:
+    # Valid output_schema
+    PlannerNode(id="p1", type="planner", goal="goal", output_schema={"type": "object"})
+    PlannerNode(id="p2", type="planner", goal="goal", output_schema={"type": "array"})
+
+    # Invalid output_schema
+    with pytest.raises(
+        ValidationError, match=r"PlannerNode output_schema must define an object or array representing the PlanTree\."
+    ):
+        PlannerNode(id="p3", type="planner", goal="goal", output_schema={"type": "string"})
+
+    with pytest.raises(
+        ValidationError, match=r"PlannerNode output_schema must define an object or array representing the PlanTree\."
+    ):
+        PlannerNode(id="p4", type="planner", goal="goal", output_schema={"type": "integer"})


### PR DESCRIPTION
Resolves Epic 7 - Declarative HTN (Hierarchical Task Network) Specification by:
1. Re-creating `contracts.py` in `core/workflow/` with strict, passive, immutable data models.
2. Adding an `output_schema` field validator to `PlannerNode` to guarantee structural constraints (`"type": "object"` or `"array"`).
3. Providing full test coverage for the changes in `tests/test_htn_contracts.py`.

---
*PR created automatically by Jules for task [14608520723848052574](https://jules.google.com/task/14608520723848052574) started by @gowthamrao*