### PR TITLE
Fix Critical Architectural Vulnerabilities in Sandbox, Antibody, and Request Context

### DIFF
--- a/src/coreason_manifest/adapters/security/antibody.py
+++ b/src/coreason_manifest/adapters/security/antibody.py
@@ -45,29 +45,31 @@ def _get_anomaly(v: Any, path: str) -> dict[str, Any] | None:
     return None
 
 
-def _scan_and_quarantine(data: Any, path: str) -> None:
+def _scan_and_quarantine(data: Any, path: str) -> Any:
     """
-    Recursively scans the raw input structure and MUTATES it in-place
-    to replace anomalies (NaN, Inf) or un-serializable types with
-    DataAnomaly dictionaries.
+    Recursively scans and functionally rebuilds the input structure,
+    replacing anomalies (NaN, Inf, Un-serializable) with DataAnomaly dicts.
     """
     if isinstance(data, dict):
-        for k, v in list(data.items()):
-            current_path = f"{path}.{k}" if path else k
-            anomaly = _get_anomaly(v, current_path)
-            if anomaly:
-                data[k] = anomaly
-            elif isinstance(v, (dict, list, tuple)):
-                _scan_and_quarantine(v, current_path)
-
-    elif isinstance(data, list):
-        for i, v in enumerate(data):
-            current_path = f"{path}[{i}]"
-            anomaly = _get_anomaly(v, current_path)
-            if anomaly:
-                data[i] = anomaly
-            elif isinstance(v, (dict, list, tuple)):
-                _scan_and_quarantine(v, current_path)
+        return {
+            k: _get_anomaly(v, f"{path}.{k}" if path else k)
+            or (_scan_and_quarantine(v, f"{path}.{k}" if path else k) if isinstance(v, (dict, list, tuple)) else v)
+            for k, v in data.items()
+        }
+    if isinstance(data, list):
+        return [
+            _get_anomaly(v, f"{path}[{i}]")
+            or (_scan_and_quarantine(v, f"{path}[{i}]") if isinstance(v, (dict, list, tuple)) else v)
+            for i, v in enumerate(data)
+        ]
+    if isinstance(data, tuple):
+        # Tuples are immutable; reconstruct them functionally
+        return tuple(
+            _get_anomaly(v, f"{path}[{i}]")
+            or (_scan_and_quarantine(v, f"{path}[{i}]") if isinstance(v, (dict, list, tuple)) else v)
+            for i, v in enumerate(data)
+        )
+    return data
 
 
 class AntibodyBase(BaseModel):
@@ -81,14 +83,7 @@ class AntibodyBase(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def run_quarantine(cls, data: Any) -> Any:
-        """
-        Stage 1: Quarantine.
-        Scans for anomalies and MUTATES them into DataAnomaly objects
-        before Pydantic attempts strict validation.
-        """
-        if isinstance(data, (dict, list)):
-            # We must mutate the data in-place.
-            # If data is a dict (likely for a Model), we scan it.
-            _scan_and_quarantine(data, "$")
-
+        if isinstance(data, (dict, list, tuple)):
+            # Assign the functionally rebuilt structure
+            data = _scan_and_quarantine(data, "$")
         return data

--- a/src/coreason_manifest/adapters/system/dynamic_loader.py
+++ b/src/coreason_manifest/adapters/system/dynamic_loader.py
@@ -130,7 +130,13 @@ class SandboxedPathFinder(importlib.abc.MetaPathFinder):
         """
         Attempt to find the module in the current jail root using standard importlib machinery.
         """
-        # Security: Prevent standard library shadowing (Dependency Confusion)
+        # 1. CRITICAL: Block sandbox escapes via Wasm/threading or direct OS execution
+        if fullname in ("threading", "multiprocessing", "concurrent", "_thread", "os", "subprocess"):
+            from coreason_manifest.core.exceptions import SecurityJailViolationError
+
+            raise SecurityJailViolationError(f"Module '{fullname}' is strictly forbidden in the sandbox.")
+
+        # 2. Prevent standard library shadowing (Dependency Confusion)
         if fullname in sys.stdlib_module_names:
             return None
 

--- a/src/coreason_manifest/core/request.py
+++ b/src/coreason_manifest/core/request.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from coreason_manifest.core.exceptions import LineageIntegrityError
+from coreason_manifest.core.exceptions import LineageIntegrityError, ManifestError, ManifestErrorCode
 
 
 class AgentRequest(BaseModel):
@@ -108,6 +108,10 @@ class AgentRequest(BaseModel):
             errors.append(err)
 
         if errors:
-            raise ExceptionGroup("Trace Integrity Violations", errors)
+            raise ManifestError.critical_halt(
+                code=ManifestErrorCode.CRSN_SEC_LINEAGE_001,
+                message="Multiple Trace Integrity Violations detected.",
+                context={"violations": [str(e) for e in errors]},
+            )
 
         return self


### PR DESCRIPTION
This PR addresses three critical architectural vulnerabilities in the `coreason-manifest` framework:

1.  **Sandbox Escape (RCE Vulnerability):** The `SandboxedPathFinder` was vulnerable to RCE because `ContextVar` does not propagate to native threads, allowing agents to import `threading` and bypass the audit hook. This is fixed by explicitly blocking concurrency and OS modules within `find_spec`.
2.  **Data Poisoning via Immutable Tuples:** The quarantine logic in `AntibodyBase` attempted to mutate data structures in-place. If a tuple was encountered, mutation failed silently, potentially bypassing quarantine and crashing the canonical hasher downstream. The scanner has been rewritten to functionally rebuild data structures.
3.  **Semantic Error Envelope Leak:** Lineage integrity violations in `AgentRequest` raised naked `ExceptionGroup`s, breaking the semantic error contract expected by downstream execution engines. These errors are now correctly wrapped in a `ManifestError.critical_halt`.

---
*PR created automatically by Jules for task [3187484352315569196](https://jules.google.com/task/3187484352315569196) started by @gowthamrao*