### PR TITLE
Refactor: Schema-First Documentation Standard for Core Workflow & Oversight Nodes

### DIFF
--- a/src/coreason_manifest/core/oversight/governance.py
+++ b/src/coreason_manifest/core/oversight/governance.py
@@ -18,17 +18,23 @@ class RequestCriticality(IntEnum):
 
 
 class SemanticCacheConfig(CoreasonModel):
-    enabled: bool = Field(True, description="Enable semantic caching.")
-    similarity_threshold: float = Field(0.85, ge=0.0, le=1.0, description="Similarity threshold for cache hits.")
-    ttl_seconds: int | None = Field(3600, description="Time to live for cache entries in seconds.")
+    enabled: bool = Field(True, description="Enable semantic caching.", examples=[True])
+    similarity_threshold: float = Field(
+        0.85, ge=0.0, le=1.0, description="Similarity threshold for cache hits.", examples=[0.85]
+    )
+    ttl_seconds: int | None = Field(3600, description="Time to live for cache entries in seconds.", examples=[3600])
 
 
 class TrafficPolicy(CoreasonModel):
-    criticality: RequestCriticality = Field(RequestCriticality.STANDARD, description="Request criticality level.")
-    rate_limit_rpm: int | None = Field(None, gt=0, description="Rate limit in requests per minute.")
-    rate_limit_tpm: int | None = Field(None, gt=0, description="Rate limit in tokens per minute.")
+    criticality: RequestCriticality = Field(
+        RequestCriticality.STANDARD, description="Request criticality level.", examples=[RequestCriticality.STANDARD]
+    )
+    rate_limit_rpm: int | None = Field(None, gt=0, description="Rate limit in requests per minute.", examples=[60])
+    rate_limit_tpm: int | None = Field(None, gt=0, description="Rate limit in tokens per minute.", examples=[10000])
     semantic_cache: SemanticCacheConfig | None = Field(
-        default_factory=SemanticCacheConfig, description="Semantic cache configuration."
+        default_factory=SemanticCacheConfig,
+        description="Semantic cache configuration.",
+        examples=[{"enabled": True, "similarity_threshold": 0.85, "ttl_seconds": 3600}],
     )
 
 
@@ -93,33 +99,38 @@ class ToolAccessPolicy(CoreasonModel):
 
 
 class FinancialLimits(CoreasonModel):
-    max_cost_usd: float | None = Field(None, ge=0.0)
-    max_tokens_total: int | None = Field(None, gt=0)
+    max_cost_usd: float | None = Field(None, ge=0.0, description="Maximum cost in USD.", examples=[100.0])
+    max_tokens_total: int | None = Field(None, gt=0, description="Maximum total tokens allowed.", examples=[50000])
     budget_depletion_routing: str | None = Field(
         None,
         description="Model ID to fallback to when budget hits 90% depletion (e.g., swap o1-pro to gpt-4o-mini).",
+        examples=["gpt-4o-mini"],
     )
 
 
 class DataLimits(CoreasonModel):
-    max_rows_per_query: int | None = Field(None, gt=0)
+    max_rows_per_query: int | None = Field(None, gt=0, description="Maximum rows returned per query.", examples=[100])
     max_payload_bytes: int | None = Field(
-        None, gt=0, description="Max bytes for active memory insertion/API responses."
+        None, gt=0, description="Max bytes for active memory insertion/API responses.", examples=[1048576]
     )
-    max_search_results: int | None = Field(None, gt=0)
+    max_search_results: int | None = Field(None, gt=0, description="Maximum search results to return.", examples=[10])
 
 
 class ComputeLimits(CoreasonModel):
-    max_execution_time_seconds: int | None = Field(None, gt=0)
-    max_cognitive_steps: int | None = Field(None, gt=0, description="Max turn/DAG transitions.")
-    max_concurrent_agents: int | None = Field(None, gt=0)
+    max_execution_time_seconds: int | None = Field(
+        None, gt=0, description="Maximum execution time in seconds.", examples=[300]
+    )
+    max_cognitive_steps: int | None = Field(None, gt=0, description="Max turn/DAG transitions.", examples=[50])
+    max_concurrent_agents: int | None = Field(
+        None, gt=0, description="Maximum number of concurrent agents.", examples=[10]
+    )
 
 
 class OperationalPolicy(CoreasonModel):
-    financial: FinancialLimits | None = None
-    data: DataLimits | None = None
-    compute: ComputeLimits | None = None
-    traffic: TrafficPolicy | None = None
+    financial: FinancialLimits | None = Field(None, description="Financial limits configuration.")
+    data: DataLimits | None = Field(None, description="Data usage limits configuration.")
+    compute: ComputeLimits | None = Field(None, description="Compute resources limits configuration.")
+    traffic: TrafficPolicy | None = Field(None, description="Traffic and rate limit configuration.")
 
 
 class Governance(CoreasonModel):
@@ -212,9 +223,9 @@ class Governance(CoreasonModel):
 class CircuitState(CoreasonModel):
     """Runtime state of a circuit breaker for a specific node."""
 
-    state: Literal["open", "closed", "half-open"] = Field("closed", description="Current state.")
-    failure_count: int = Field(0, description="Consecutive failure count.")
-    last_failure_time: float | None = Field(None, description="Timestamp of last failure.")
+    state: Literal["open", "closed", "half-open"] = Field("closed", description="Current state.", examples=["closed"])
+    failure_count: int = Field(0, description="Consecutive failure count.", examples=[0])
+    last_failure_time: float | None = Field(None, description="Timestamp of last failure.", examples=[1633024800.0])
 
 
 class CircuitOpenError(Exception):
@@ -222,16 +233,10 @@ class CircuitOpenError(Exception):
 
 
 def check_circuit(node_id: str, policy: CircuitBreaker, state_store: dict[str, CircuitState]) -> None:
-    """
-    Middleware hook to enforce circuit breaker policy.
-
-    Args:
-        node_id: The ID of the node being executed.
-        policy: The circuit breaker policy configuration.
-        state_store: A mutable dictionary mapping node IDs to CircuitState objects.
+    """Enforce circuit breaker policy prior to execution.
 
     Raises:
-        ManifestError: If the circuit is open and timeout has not expired (ExecutionFault).
+        ManifestError: If the circuit is open and timeout has not expired.
     """
     # Get or create state
     state = state_store.get(node_id)
@@ -264,9 +269,7 @@ def check_circuit(node_id: str, policy: CircuitBreaker, state_store: dict[str, C
 
 
 def record_failure(node_id: str, policy: CircuitBreaker, state_store: dict[str, CircuitState]) -> None:
-    """
-    Record a failure for the given node and open the circuit if threshold is reached.
-    """
+    """Record an execution failure and conditionally open the circuit."""
     state = state_store.get(node_id)
     if not state:
         state = CircuitState()
@@ -289,9 +292,7 @@ def record_failure(node_id: str, policy: CircuitBreaker, state_store: dict[str, 
 
 
 def record_success(node_id: str, state_store: dict[str, CircuitState]) -> None:
-    """
-    Record a success, resetting the circuit state to closed.
-    """
+    """Record an execution success and reset the circuit to a closed state."""
     state = state_store.get(node_id)
     if state:
         new_state = state.model_copy(update={"state": "closed", "failure_count": 0, "last_failure_time": None})

--- a/src/coreason_manifest/core/oversight/intervention.py
+++ b/src/coreason_manifest/core/oversight/intervention.py
@@ -11,9 +11,7 @@ InterventionMode = Literal["blocking", "shadow", "hijack_only"]
 
 
 class EscalationCriteria(CoreasonModel):
-    """
-    Defines conditions under which an agent should escalate to a human.
-    """
+    """Defines conditions under which an agent should escalate to a human."""
 
     condition: str = Field(
         ...,
@@ -25,9 +23,13 @@ class EscalationCriteria(CoreasonModel):
         description="The human role required to handle this escalation.",
         examples=["supervisor", "legal_compliance"],
     )
-    priority: Literal["low", "medium", "high", "critical"] = "medium"
+    priority: Literal["low", "medium", "high", "critical"] = Field(
+        "medium", description="The priority level of the escalation.", examples=["medium"]
+    )
     strategy: EscalationStrategy | None = Field(
-        None, description="Local SLA/Queue routing. Overrides global default_sla if set."
+        None,
+        description="Local SLA/Queue routing. Overrides global default_sla if set.",
+        examples=[{"strategy": "escalate"}],
     )
 
     @field_validator("condition")
@@ -44,21 +46,18 @@ class EscalationCriteria(CoreasonModel):
 
 
 class CoIntelligencePolicy(CoreasonModel):
-    """
-    Global policy for Human-AI Co-Intelligence.
-    """
+    """Global policy for Human-AI Co-Intelligence."""
 
     global_intervention_mode: InterventionMode = Field(
-        "blocking",
-        description="Default intervention mode for the entire flow.",
+        "blocking", description="Default intervention mode for the entire flow.", examples=["blocking"]
     )
     escalation_rules: list[EscalationCriteria] = Field(
         default_factory=list,
         description="Global list of conditions that trigger escalation.",
+        examples=[[{"condition": "confidence < 0.5", "role": "supervisor"}]],
     )
     default_sla: EscalationStrategy | None = Field(
-        None,
-        description="Default escalation strategy for global interventions.",
+        None, description="Default escalation strategy for global interventions.", examples=[{"strategy": "escalate"}]
     )
 
 

--- a/src/coreason_manifest/core/oversight/mixed_initiative.py
+++ b/src/coreason_manifest/core/oversight/mixed_initiative.py
@@ -8,8 +8,10 @@ from coreason_manifest.core.compliance import SecurityVisitor
 
 
 class AllocationRule(CoreasonModel):
-    condition: str
-    target_queue: str
+    """Rule defining condition for dynamic allocation to a target queue."""
+
+    condition: str = Field(..., description="Python expression (AST-whitelisted) to evaluate.", examples=["risk > 5"])
+    target_queue: str = Field(..., description="Queue to route to if the condition is met.", examples=["review_queue"])
 
     @field_validator("condition", mode="before")
     @classmethod
@@ -25,11 +27,29 @@ class AllocationRule(CoreasonModel):
 
 
 class BoundedAutonomyConfig(CoreasonModel):
-    intervention_window_seconds: int
-    timeout_behavior: Literal["proceed", "escalate", "fail"]
+    """Configuration for bounding agent autonomy during human intervention."""
+
+    intervention_window_seconds: int = Field(
+        ..., description="Seconds to wait for a human intervention.", examples=[30]
+    )
+    timeout_behavior: Literal["proceed", "escalate", "fail"] = Field(
+        ..., description="Behavior when the intervention window times out.", examples=["escalate"]
+    )
 
 
 class MixedInitiativePolicy(CoreasonModel):
-    enable_shadow_telemetry: bool = False
-    bounded_autonomy: BoundedAutonomyConfig | None = None
-    dynamic_allocation_rules: list[AllocationRule] = Field(default_factory=list)
+    """Policy configuring mixed initiative human-AI interaction."""
+
+    enable_shadow_telemetry: bool = Field(
+        False, description="Enable shadow telemetry for observability.", examples=[True]
+    )
+    bounded_autonomy: BoundedAutonomyConfig | None = Field(
+        None,
+        description="Configuration for bounded autonomy.",
+        examples=[{"intervention_window_seconds": 60, "timeout_behavior": "proceed"}],
+    )
+    dynamic_allocation_rules: list[AllocationRule] = Field(
+        default_factory=list,
+        description="Rules for dynamic task allocation.",
+        examples=[[{"condition": "confidence < 0.5", "target_queue": "human_review"}]],
+    )

--- a/src/coreason_manifest/core/oversight/resilience.py
+++ b/src/coreason_manifest/core/oversight/resilience.py
@@ -26,9 +26,12 @@ class ResilienceStrategy(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
     name: Annotated[
-        str | None, Field(description="Human-readable ID for this strategy (e.g. 'gpt4-rate-limit-handler').")
+        str | None,
+        Field(description="Human-readable ID for this strategy.", examples=["gpt4-rate-limit-handler"]),
     ] = None
-    trace_activation: Annotated[bool, Field(description="Emit telemetry event when this strategy triggers.")] = True
+    trace_activation: Annotated[
+        bool, Field(description="Emit telemetry event when this strategy triggers.", examples=[True])
+    ] = True
 
     @field_validator("name")
     @classmethod
@@ -41,49 +44,54 @@ class ResilienceStrategy(BaseModel):
 
 
 class RetryStrategy(ResilienceStrategy):
-    """Network/System focus: Retry with backoff."""
+    """Strategy for retrying operations with exponential backoff."""
 
-    type: Literal["retry"] = "retry"
+    type: Literal["retry"] = Field("retry", description="The strategy type.", examples=["retry"])
 
-    max_attempts: int = Field(..., gt=0, description="Hard limit on recovery loops.")
-    backoff_factor: Annotated[float, Field(ge=1.0, description="Exponential backoff multiplier.")] = 2.0
-    initial_delay_seconds: Annotated[float, Field(description="Initial wait time.")] = 1.0
-    max_delay_seconds: Annotated[
-        float, Field(description="Ceiling for the backoff calculation (e.g., never sleep more than 60s).")
-    ] = 60.0
-    jitter: Annotated[bool, Field(description="Add random jitter to delay.")] = True
+    max_attempts: int = Field(..., gt=0, description="Hard limit on recovery loops.", examples=[3])
+    backoff_factor: Annotated[float, Field(ge=1.0, description="Exponential backoff multiplier.", examples=[2.0])] = 2.0
+    initial_delay_seconds: Annotated[float, Field(description="Initial wait time.", examples=[1.0])] = 1.0
+    max_delay_seconds: Annotated[float, Field(description="Ceiling for the backoff calculation.", examples=[60.0])] = (
+        60.0
+    )
+    jitter: Annotated[bool, Field(description="Add random jitter to delay.", examples=[True])] = True
 
 
 class FallbackStrategy(ResilienceStrategy):
-    """Redundancy focus: Switch to a backup node."""
+    """Strategy for falling back to an alternative node or payload upon failure."""
 
-    type: Literal["fallback"] = "fallback"
+    type: Literal["fallback"] = Field("fallback", description="The strategy type.", examples=["fallback"])
 
-    fallback_node_id: str = Field(..., description="The ID of the backup node/agent.")
+    fallback_node_id: str = Field(..., description="The ID of the backup node/agent.", examples=["backup_agent"])
     fallback_payload: Annotated[
-        dict[str, Any] | None, Field(description="Static data to inject if the node is skipped.")
+        dict[str, Any] | None,
+        Field(description="Static data to inject if the node is skipped.", examples=[{"status": "degraded"}]),
     ] = None
 
 
 class ReflexionStrategy(ResilienceStrategy):
-    """Cognitive Correction focus: Use a critic to analyze and fix."""
+    """Strategy that uses an LLM critic to analyze and correct errors."""
 
-    type: Literal["reflexion"] = "reflexion"
+    type: Literal["reflexion"] = Field("reflexion", description="The strategy type.", examples=["reflexion"])
 
-    max_attempts: int = Field(..., gt=0, description="Hard limit on recovery loops.")
-    critic_model: ModelRef = Field(..., description="The model used to analyze the error.")
-    critic_prompt: str = Field(..., description="Instructions for the critic (e.g., 'Identify logic errors').")
-    include_trace: Annotated[bool, Field(description="Whether to feed the execution trace to the critic.")] = True
+    max_attempts: int = Field(..., gt=0, description="Hard limit on recovery loops.", examples=[3])
+    critic_model: ModelRef = Field(..., description="The model used to analyze the error.", examples=["gpt-4"])
+    critic_prompt: str = Field(..., description="Instructions for the critic.", examples=["Identify logic errors"])
+    include_trace: Annotated[
+        bool, Field(description="Whether to feed the execution trace to the critic.", examples=[True])
+    ] = True
     max_trace_turns: Annotated[
         int | None,
-        Field(description="Limit the history feed to the Critic to the last N turns. Prevents context overflow."),
+        Field(
+            description="Limit the history feed to the Critic to the last N turns. Prevents context overflow.",
+            examples=[3],
+        ),
     ] = 3
     critic_schema: Annotated[
         dict[str, Any] | None,
         Field(
-            description=(
-                "JSON Schema to enforce structured output from the critic (e.g. {'properties': {'fix': ...}})."
-            )
+            description="JSON Schema to enforce structured output from the critic.",
+            examples=[{"type": "object", "properties": {"fix": {"type": "string"}}}],
         ),
     ] = None
 
@@ -119,20 +127,27 @@ class ReflexionStrategy(ResilienceStrategy):
 
 
 class EscalationStrategy(ResilienceStrategy):
-    """Human-in-the-Loop focus: Pause and wait for intervention."""
+    """Strategy that escalates execution to a human operator."""
 
-    type: Literal["escalate"] = "escalate"
+    type: Literal["escalate"] = Field("escalate", description="The strategy type.", examples=["escalate"])
 
-    queue_name: str = Field(..., min_length=1, description="The task queue for suspended sessions.")
-    notification_level: Literal["info", "warning", "critical"] = Field(..., description="Severity level.")
-    timeout_seconds: int = Field(..., description="Max wait for human intervention.")
+    queue_name: str = Field(
+        ..., min_length=1, description="The task queue for suspended sessions.", examples=["review_queue"]
+    )
+    notification_level: Literal["info", "warning", "critical"] = Field(
+        ..., description="Severity level.", examples=["critical"]
+    )
+    timeout_seconds: int = Field(..., description="Max wait for human intervention.", examples=[3600])
     fallback_node_id: str | None = Field(
-        None, description="Graceful degradation target if timeout is reached (overrides global SLA)."
+        None,
+        description="Graceful degradation target if timeout is reached (overrides global SLA).",
+        examples=["fallback_agent"],
     )
     template: Annotated[
         str | None,
         Field(
-            description=("Jinja2 template for notification. Context: {{ node_id }}, {{ error_type }}, {{ message }}.")
+            description="Jinja2 template for notification. Context: {{ node_id }}, {{ error_type }}, {{ message }}.",
+            examples=["Alert: {{ error_type }} in {{ node_id }}"],
         ),
     ] = None
 
@@ -147,21 +162,24 @@ class EscalationStrategy(ResilienceStrategy):
 
 
 class DiagnosisReasoning(ResilienceStrategy):
-    """
-    Agentic Error Recovery: Spawns a mini-agent to diagnose and fix inputs.
-    Mandate 4: Agentic Error Recovery.
-    """
+    """Agentic Error Recovery: Spawns a mini-agent to diagnose and fix inputs."""
 
-    type: Literal["diagnosis"] = "diagnosis"
-    diagnostic_model: ModelRef
-    fix_strategies: list[Literal["schema_repair", "parameter_tuning", "context_pruning"]]
+    type: Literal["diagnosis"] = Field("diagnosis", description="The strategy type.", examples=["diagnosis"])
+    diagnostic_model: ModelRef = Field(..., description="The model used to diagnose the issue.", examples=["gpt-4"])
+    fix_strategies: list[Literal["schema_repair", "parameter_tuning", "context_pruning"]] = Field(
+        ..., description="Allowed strategies for automatic fixing.", examples=[["schema_repair", "context_pruning"]]
+    )
 
 
 class HumanHandoffStrategy(ResilienceStrategy):
-    """Human-in-the-Loop focus: Urgent handoff."""
+    """Strategy for an urgent human handoff."""
 
-    type: Literal["human_handoff"] = "human_handoff"
-    urgency: Literal["low", "medium", "high", "critical"]
+    type: Literal["human_handoff"] = Field(
+        "human_handoff", description="The strategy type.", examples=["human_handoff"]
+    )
+    urgency: Literal["low", "medium", "high", "critical"] = Field(
+        ..., description="Urgency of the handoff.", examples=["critical"]
+    )
 
 
 # Polymorphic Union
@@ -177,20 +195,23 @@ RecoveryStrategy = Annotated[
 
 
 class ErrorHandler(BaseModel):
-    """
-    Maps specific failure types to a specific strategy.
-
-    Matching Logic:
-    1. Inter-field: AND. If 'match_domain' AND 'match_error_code' are set, BOTH must match.
-    2. Intra-field: OR. If 'match_domain' is ['LLM', 'SYSTEM'], the error can be EITHER.
-    """
+    """Maps specific failure types to a recovery strategy."""
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    match_domain: Annotated[list[ErrorDomain] | None, Field(description="List of error domains to handle.")] = None
-    match_pattern: Annotated[str | None, Field(description="Regex for fine-grained error message matching.")] = None
-    match_error_code: Annotated[list[str] | None, Field(description="List of specific error codes to match.")] = None
-    strategy: RecoveryStrategy = Field(..., description="The polymorphic strategy to execute.")
+    match_domain: Annotated[
+        list[ErrorDomain] | None,
+        Field(description="List of error domains to handle.", examples=[["llm", "system"]]),
+    ] = None
+    match_pattern: Annotated[
+        str | None, Field(description="Regex for fine-grained error message matching.", examples=[".*Timeout.*"])
+    ] = None
+    match_error_code: Annotated[
+        list[str] | None, Field(description="List of specific error codes to match.", examples=[["CRSN-VAL-001"]])
+    ] = None
+    strategy: RecoveryStrategy = Field(
+        ..., description="The polymorphic strategy to execute.", examples=[{"type": "retry", "max_attempts": 3}]
+    )
 
     @field_validator("match_error_code", mode="before")
     @classmethod
@@ -233,31 +254,32 @@ class ErrorHandler(BaseModel):
 
 
 class SupervisionPolicy(BaseModel):
-    """
-    The container attached to every Node.
-
-    Note: Local supervision executes *before* global governance circuit breakers trip,
-    unless the error is a GovernanceViolation.
-
-    Evaluation Logic:
-    1. Iterate through 'handlers' list in order (Index 0 -> N).
-    2. First handler to match the error triggers its strategy.
-    3. If no handlers match:
-       - If 'default_strategy' is set, execute it.
-       - If 'default_strategy' is None, raise the original exception.
-    """
+    """Supervision policy defining error handlers and default strategies for a node."""
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    type: Literal["supervision"] = "supervision"
-    handlers: list[ErrorHandler] = Field(..., description="An ordered list of specific rules.")
+    type: Literal["supervision"] = Field("supervision", description="The policy type.", examples=["supervision"])
+    handlers: list[ErrorHandler] = Field(
+        ...,
+        description="An ordered list of specific rules.",
+        examples=[[{"match_domain": ["llm"], "strategy": {"type": "retry", "max_attempts": 3}}]],
+    )
     default_strategy: Annotated[
-        RecoveryStrategy | None, Field(description="Catch-all strategy. If None, unhandled errors bubble up.")
-    ] = None
+        RecoveryStrategy | None,
+        Field(
+            None,
+            description="Catch-all strategy. If None, unhandled errors bubble up.",
+            examples=[{"type": "escalate", "queue_name": "default"}],
+        ),
+    ]
     max_cumulative_actions: Annotated[
         int,
-        Field(description=("Total number of recovery actions (retries + reflexions + fallbacks) allowed.")),
-    ] = 10
+        Field(
+            10,
+            description="Total number of recovery actions (retries + reflexions + fallbacks) allowed.",
+            examples=[10],
+        ),
+    ]
 
     @model_validator(mode="after")
     def validate_limits(self) -> "SupervisionPolicy":

--- a/src/coreason_manifest/core/workflow/nodes/agent.py
+++ b/src/coreason_manifest/core/workflow/nodes/agent.py
@@ -27,24 +27,20 @@ class CognitiveProfile(CoreasonModel):
     fast_path: FastPath | None = Field(
         None, description="Fast path configuration for low-latency responses.", examples=[{"model": "gpt-3.5-turbo"}]
     )
-    memory: MemorySubsystem | None = Field(None, description="The 4-tier hierarchical memory configuration.")
+    memory: MemorySubsystem | None = Field(
+        None, description="The 4-tier hierarchical memory configuration.", examples=[{"working_memory": {}}]
+    )
 
 
 @register_node
 class AgentNode(Node):
-    """
-    Executes a cognitive task using a CognitiveProfile configuration.
+    """Executes a cognitive task using a CognitiveProfile configuration."""
 
-    The 'profile' field is polymorphic:
-    - Pass a CognitiveProfile object for inline definition (Scripting mode).
-    - Pass a string ID to reference 'definitions.profiles' (Production mode).
-    """
-
-    type: Literal["agent"] = "agent"
+    type: Literal["agent"] = Field("agent", description="The type of the node.", examples=["agent"])
     profile: CognitiveProfile | ProfileID = Field(
         ...,
         description="The cognitive profile configuration or a reference ID.",
-        examples=["profile_1", {"role": "Assistant", "persona": "..."}],
+        examples=["profile_1", {"role": "Assistant", "persona": "You are a helpful assistant."}],
     )
     tools: CoercibleStringList = Field(
         default_factory=list,
@@ -53,10 +49,14 @@ class AgentNode(Node):
     )
     operational_policy: Annotated[
         OperationalPolicy | None,
-        Field(None, description="Local operational limits. Overrides global Governance limits if set."),
+        Field(
+            None,
+            description="Local operational limits. Overrides global Governance limits if set.",
+            examples=[{"financial": {"max_cost_usd": 10.0}}],
+        ),
     ]
     escalation_rules: list[EscalationCriteria] = Field(
         default_factory=list,
         description="Local escalation rules for this agent.",
-        examples=[{"condition": "confidence < 0.5", "role": "supervisor"}],
+        examples=[[{"condition": "confidence < 0.5", "role": "supervisor"}]],
     )

--- a/src/coreason_manifest/core/workflow/nodes/base.py
+++ b/src/coreason_manifest/core/workflow/nodes/base.py
@@ -24,22 +24,28 @@ class ConstraintOperator(StrEnum):
 class Constraint(CoreasonModel):
     """Declarative constraint evaluated before node execution."""
 
-    variable: str = Field(..., description="The Blackboard variable path to check.")
-    operator: ConstraintOperator
-    value: Any = Field(..., description="The threshold or reference value.")
-    required: bool = Field(True, description="If True, failure halts execution. If False, emits a warning.")
-    error_message: str | None = Field(None, description="Optional custom error message.")
+    variable: str = Field(..., description="The Blackboard variable path to check.", examples=["user_sentiment"])
+    operator: ConstraintOperator = Field(..., description="The comparison operator to apply.", examples=["eq"])
+    value: Any = Field(..., description="The threshold or reference value.", examples=["positive"])
+    required: bool = Field(
+        True, description="If True, failure halts execution. If False, emits a warning.", examples=[True]
+    )
+    error_message: str | None = Field(
+        None, description="Optional custom error message.", examples=["Sentiment must be positive."]
+    )
 
 
 class LockConfig(CoreasonModel):
-    """
-    Configuration for atomic locks to prevent race conditions during concurrent execution.
-    """
+    """Configuration for atomic locks to prevent race conditions during concurrent execution."""
 
     write_locks: list[VariableID] = Field(
-        default_factory=list, description="Variables requiring mutually exclusive write access."
+        default_factory=list,
+        description="Variables requiring mutually exclusive write access.",
+        examples=[["user_data"]],
     )
-    read_locks: list[VariableID] = Field(default_factory=list, description="Variables requiring shared read access.")
+    read_locks: list[VariableID] = Field(
+        default_factory=list, description="Variables requiring shared read access.", examples=[["global_config"]]
+    )
 
 
 class Node(CoreasonModel):
@@ -57,7 +63,9 @@ class Node(CoreasonModel):
         PresentationHints | None,
         Field(description="UI rendering hints.", examples=[{"x": 100, "y": 200}]),
     ] = None
-    type: str = Field(..., description="The type of the node.")
+    type: str = Field(..., description="The type of the node.", examples=["agent"])
     constraints: list[Constraint] = Field(
-        default_factory=list, description="Pre-flight checks evaluated before node execution."
+        default_factory=list,
+        description="Pre-flight checks evaluated before node execution.",
+        examples=[[{"variable": "user_sentiment", "operator": "eq", "value": "positive"}]],
     )

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -14,13 +14,15 @@ from .base import Node
 
 
 class SteeringConfig(CoreasonModel):
-    """
-    Configuration for human steering permissions.
-    """
+    """Configuration for human steering permissions."""
 
-    allow_variable_mutation: bool = Field(False, description="Whether the human can mutate blackboard variables.")
+    allow_variable_mutation: bool = Field(
+        False, description="Whether the human can mutate blackboard variables.", examples=[True]
+    )
     allowed_targets: list[VariableID] | None = Field(
-        None, description="List of variable IDs that can be mutated. If None, all are allowed (if mutation is enabled)."
+        None,
+        description="List of variable IDs that can be mutated. If None, all are allowed (if mutation is enabled).",
+        examples=[["user_preference"]],
     )
 
     @model_validator(mode="after")
@@ -54,17 +56,17 @@ class SteeringConfig(CoreasonModel):
 
 @register_node
 class HumanNode(Node):
-    """
-    Human-in-the-Loop interaction node.
-    Supports blocking approval, or 'shadow' mode where the agent streams intent
-    and proceeds if no signal is received, while 'hijack_only' allows mid-flight plan alteration.
-    """
+    """Human-in-the-Loop interaction node for approval, shadow, or hijack modes."""
 
-    type: Literal["human"] = "human"
+    type: Literal["human"] = Field("human", description="The type of the node.", examples=["human"])
     prompt: str = Field(..., description="Prompt to display to the human.", examples=["Approve this plan?"])
-    escalation: EscalationStrategy = Field(..., description="The escalation configuration.")
+    escalation: EscalationStrategy = Field(
+        ..., description="The escalation configuration.", examples=[{"strategy": "escalate"}]
+    )
     input_schema: dict[str, Any] | None = Field(
-        None, description="JSON Schema for expected human input.", examples=[{"type": "object"}]
+        None,
+        description="JSON Schema for expected human input.",
+        examples=[{"type": "object", "properties": {"reason": {"type": "string"}}}],
     )
     options: list[str] | None = Field(
         None, description="List of valid options for the human.", examples=[["approve", "reject"]]
@@ -72,10 +74,12 @@ class HumanNode(Node):
 
     interaction_mode: Annotated[
         Literal["blocking", "shadow", "hijack_only"],
-        Field(description="Wait for input vs shadow execution.", examples=["blocking"]),
-    ] = "blocking"
+        Field("blocking", description="Wait for input vs shadow execution.", examples=["blocking"]),
+    ]
 
-    steering_config: SteeringConfig | None = Field(None, description="Configuration for steering permissions.")
+    steering_config: SteeringConfig | None = Field(
+        None, description="Configuration for steering permissions.", examples=[{"allow_variable_mutation": True}]
+    )
 
     @model_validator(mode="after")
     def validate_interaction_mode(self) -> "HumanNode":

--- a/src/coreason_manifest/core/workflow/nodes/oversight.py
+++ b/src/coreason_manifest/core/workflow/nodes/oversight.py
@@ -20,7 +20,9 @@ class InspectorNodeBase(Node):
         ModelRef | None,
         Field(description="Model/Policy to use for semantic evaluation.", examples=["gpt-4"]),
     ] = None
-    optimizer: Optimizer | None = Field(None, description="Optimization configuration.")
+    optimizer: Optimizer | None = Field(
+        None, description="Optimization configuration.", examples=[{"strategy": "greedy"}]
+    )
 
     @property
     def to_node_variable(self) -> VariableID:
@@ -29,12 +31,9 @@ class InspectorNodeBase(Node):
 
 @register_node
 class InspectorNode(InspectorNodeBase):
-    """
-    A node that evaluates a variable against criteria.
-    Can operate in deterministic mode (regex/numeric) or semantic mode (LLM Judge).
-    """
+    """A node that evaluates a variable against criteria in deterministic or semantic mode."""
 
-    type: Literal["inspector"] = "inspector"
+    type: Literal["inspector"] = Field("inspector", description="The type of the node.", examples=["inspector"])
 
     mode: Literal["programmatic", "semantic"] = Field(
         "programmatic", description="Evaluation mode.", examples=["semantic"]
@@ -45,17 +44,15 @@ class InspectorNode(InspectorNodeBase):
 
 @register_node
 class EmergenceInspectorNode(InspectorNodeBase):
-    """
-    Specialized inspector for detecting novel/emergent behaviors.
-    """
+    """Specialized inspector for detecting novel/emergent behaviors."""
 
-    type: Literal["emergence_inspector"] = "emergence_inspector"
+    type: Literal["emergence_inspector"] = Field(
+        "emergence_inspector", description="The type of the node.", examples=["emergence_inspector"]
+    )
 
-    # Pre-defined behavioral markers to scan for
-    detect_sycophancy: bool = Field(True, description="Detect if the agent is being sycophantic.")
-    detect_power_seeking: bool = Field(True, description="Detect power-seeking behavior.")
-    detect_deception: bool = Field(True, description="Detect deceptive behavior.")
+    detect_sycophancy: bool = Field(True, description="Detect if the agent is being sycophantic.", examples=[True])
+    detect_power_seeking: bool = Field(True, description="Detect power-seeking behavior.", examples=[True])
+    detect_deception: bool = Field(True, description="Detect deceptive behavior.", examples=[True])
 
-    # Override defaults - Forced semantic mode
-    mode: Literal["semantic"] = "semantic"
-    judge_model: ModelRef = Field(..., description="Model required for emergence detection")
+    mode: Literal["semantic"] = Field("semantic", description="Forced semantic evaluation mode.", examples=["semantic"])
+    judge_model: ModelRef = Field(..., description="Model required for emergence detection.", examples=["gpt-4"])

--- a/src/coreason_manifest/core/workflow/nodes/planner.py
+++ b/src/coreason_manifest/core/workflow/nodes/planner.py
@@ -11,9 +11,13 @@ from .base import Node
 
 @register_node
 class PlannerNode(Node):
-    type: Literal["planner"] = "planner"
+    """A node that generates a structured plan to achieve a goal."""
+
+    type: Literal["planner"] = Field("planner", description="The type of the node.", examples=["planner"])
     goal: str = Field(..., description="The high-level goal to plan for.", examples=["Build a website"])
-    optimizer: Optimizer | None = Field(None, description="Optimization configuration.")
+    optimizer: Optimizer | None = Field(
+        None, description="Optimization configuration.", examples=[{"strategy": "greedy"}]
+    )
     output_schema: dict[str, Any] = Field(
         ...,
         description="JSON Schema for the plan output.",

--- a/src/coreason_manifest/core/workflow/nodes/routing.py
+++ b/src/coreason_manifest/core/workflow/nodes/routing.py
@@ -11,7 +11,9 @@ from .base import Node
 
 @register_node
 class SwitchNode(Node):
-    type: Literal["switch"] = "switch"
+    """A node that routes execution based on the value of a blackboard variable."""
+
+    type: Literal["switch"] = Field("switch", description="The type of the node.", examples=["switch"])
     variable: VariableID = Field(..., description="The blackboard variable to evaluate.", examples=["user_sentiment"])
     cases: dict[str, NodeID] = Field(
         ...,

--- a/src/coreason_manifest/core/workflow/nodes/swarm.py
+++ b/src/coreason_manifest/core/workflow/nodes/swarm.py
@@ -15,14 +15,10 @@ from .base import LockConfig, Node
 
 @register_node
 class SwarmNode(Node):
-    """
-    Dynamic Swarm Spawning (The "Hive").
-    Spins up N ephemeral worker agents to process a dataset/workload in parallel.
-    """
+    """Dynamic Swarm Spawning. Spins up N ephemeral worker agents to process a dataset/workload in parallel."""
 
-    type: Literal["swarm"] = "swarm"
+    type: Literal["swarm"] = Field("swarm", description="The type of the node.", examples=["swarm"])
 
-    # Worker Config
     worker_profile: ProfileID = Field(
         ..., description="Reference to a CognitiveProfile ID.", examples=["researcher_profile"]
     )
@@ -30,7 +26,6 @@ class SwarmNode(Node):
         ..., description="The Blackboard list/dataset to process.", examples=["urls_to_scrape"]
     )
 
-    # Topology
     distribution_strategy: Literal["sharded", "replicated"] = Field(
         ..., description="Sharded=split data; Replicated=same data, many attempts.", examples=["sharded"]
     )
@@ -39,7 +34,6 @@ class SwarmNode(Node):
         Field(description="Limit parallel workers. Use 'infinite' for no limit.", examples=[10]),
     ]
 
-    # Architecture: Reliability (Partial Failure)
     failure_tolerance_percent: Annotated[
         float,
         Field(
@@ -54,7 +48,6 @@ class SwarmNode(Node):
         ),
     ] = 0.0
 
-    # Aggregation
     reducer_function: Literal["concat", "vote", "summarize"] | None = Field(
         ..., description="How to combine results.", examples=["concat"]
     )
@@ -67,14 +60,20 @@ class SwarmNode(Node):
     ] = None
     operational_policy: Annotated[
         OperationalPolicy | None,
-        Field(None, description="Local operational limits. Overrides global Governance limits if set."),
+        Field(
+            None,
+            description="Local operational limits. Overrides global Governance limits if set.",
+            examples=[{"financial": {"max_cost_usd": 50.0}}],
+        ),
     ]
     output_variable: VariableID = Field(
         ..., description="Variable to store the aggregated result.", examples=["final_report"]
     )
 
     lock_config: LockConfig | None = Field(
-        None, description="Atomic lock configuration for preventing race conditions."
+        None,
+        description="Atomic lock configuration for preventing race conditions.",
+        examples=[{"write_locks": ["shared_resource"]}],
     )
 
     @model_validator(mode="after")

--- a/src/coreason_manifest/core/workflow/nodes/system.py
+++ b/src/coreason_manifest/core/workflow/nodes/system.py
@@ -11,7 +11,9 @@ from .base import Node
 
 @register_node
 class PlaceholderNode(Node):
-    type: Literal["placeholder"] = "placeholder"
+    """A node that acts as a placeholder requiring specific capabilities to be fulfilled."""
+
+    type: Literal["placeholder"] = Field("placeholder", description="The type of the node.", examples=["placeholder"])
     required_capabilities: CoercibleStringList = Field(
         ..., description="List of required capabilities.", examples=[["image_generation"]]
     )


### PR DESCRIPTION
Systematically refactored Pydantic models to adhere to the Schema-First standard. All models now use `Field` (or `Annotated[..., Field(...)]`) attributes with descriptive text, dropping redundant `Attributes:` docstrings and incorporating `examples=[...]`.

Function docstrings are stripped of purely typological parameters, maintaining explicit LLM tool-calling imperatives and exception declarations.

Coverage passes all local verifications (`ruff format`, `ruff check`, `mypy`, and `pytest`) successfully, without bypassing strict type hints or altering runtime execution paths.

---
*PR created automatically by Jules for task [14754594095069463294](https://jules.google.com/task/14754594095069463294) started by @gowthamrao*