### PR TITLE
feat(core): epic 1 - implement the identity context envelope

### DIFF
--- a/src/coreason_manifest/core/common/identity.py
+++ b/src/coreason_manifest/core/common/identity.py
@@ -8,9 +8,8 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from datetime import datetime
 
-from pydantic import ConfigDict, Field
+from pydantic import AwareDatetime, ConfigDict, Field
 
 from coreason_manifest.core.common_base import CoreasonModel
 
@@ -51,7 +50,9 @@ class DelegationScope(CoreasonModel):
         default_factory=list, description="Strictly scoped tool whitelist for this specific request."
     )
     max_budget_usd: float | None = Field(None, description="Financial cap for this trace.")
-    session_expiry: datetime | None = Field(None, description="When this context envelope expires.")
+    session_expiry: AwareDatetime | None = Field(
+        None, description="When this context envelope expires. Must be TZ-aware."
+    )
 
 
 class SessionContext(CoreasonModel):
@@ -65,4 +66,8 @@ class SessionContext(CoreasonModel):
     user: UserIdentity = Field(..., description="The delegating principal.")
     agent: AgentIdentity = Field(..., description="The acting agent.")
     delegation: DelegationScope = Field(..., description="The authority granted.")
-    trace_id: str | None = Field(None, description="W3C Trace Context ID for distributed secure tracking.")
+    trace_id: str | None = Field(
+        None,
+        pattern=r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$",
+        description="W3C Trace Context ID for distributed secure tracking.",
+    )

--- a/src/coreason_manifest/core/common/identity.py
+++ b/src/coreason_manifest/core/common/identity.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from datetime import datetime
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.core.common_base import CoreasonModel
+
+
+class AgentIdentity(CoreasonModel):
+    model_config = ConfigDict(frozen=True)
+    """
+    Cryptographic identity of the agent operating within the Zero-Trust Prompt paradigm.
+    Proves the acting software entity.
+    """
+
+    agent_id: str = Field(..., description="Unique, verifiable ID for the agent instance.")
+    version: str = Field(..., description="Version of the agent.")
+    software_hash: str | None = Field(None, description="Cryptographic hash of the agent's manifest definition.")
+
+
+class UserIdentity(CoreasonModel):
+    model_config = ConfigDict(frozen=True)
+    """
+    The principal human or service account initiating the trace in the On-Behalf-Of (OBO) flow.
+    Includes Persona-Based Access Control (PBAC) roles.
+    """
+
+    user_id: str = Field(..., description="The principal human or service account initiating the trace.")
+    roles: list[str] = Field(
+        default_factory=list, description="Persona-Based Access Control (PBAC) roles assigned to the user."
+    )
+
+
+class DelegationScope(CoreasonModel):
+    model_config = ConfigDict(frozen=True)
+    """
+    The strict boundaries of authority granted to the agent for this specific trace.
+    Part of the Zero-Trust Identity Context Envelope.
+    """
+
+    allowed_tools: list[str] = Field(
+        default_factory=list, description="Strictly scoped tool whitelist for this specific request."
+    )
+    max_budget_usd: float | None = Field(None, description="Financial cap for this trace.")
+    session_expiry: datetime | None = Field(None, description="When this context envelope expires.")
+
+
+class SessionContext(CoreasonModel):
+    model_config = ConfigDict(frozen=True)
+    """
+    The Zero-Trust Identity Context Envelope for this request.
+    Proves cryptographically who is making the request, who the agent is, and what its delegated authority is.
+    """
+
+    session_id: str = Field(..., description="ID of the interaction session.")
+    user: UserIdentity = Field(..., description="The delegating principal.")
+    agent: AgentIdentity = Field(..., description="The acting agent.")
+    delegation: DelegationScope = Field(..., description="The authority granted.")
+    trace_id: str | None = Field(None, description="W3C Trace Context ID for distributed secure tracking.")

--- a/src/coreason_manifest/core/request.py
+++ b/src/coreason_manifest/core/request.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from coreason_manifest.core.common.identity import SessionContext
 from coreason_manifest.core.exceptions import LineageIntegrityError, ManifestError, ManifestErrorCode
 
 
@@ -34,6 +35,25 @@ class AgentRequest(BaseModel):
 
     # Versioning
     hash_version: Literal["v2"] = Field(default="v2", description="Versioning for integrity strategies.")
+
+    # Context Envelope
+    context: SessionContext | None = Field(
+        None, description="The Zero-Trust Identity Context Envelope for this request."
+    )
+
+    def is_authorized(self, required_roles: list[str]) -> bool:
+        """
+        Safely checks if the user's PBAC roles intersect with the required roles.
+        If context is missing and roles are required, this fails closed (returns False).
+        """
+        if not required_roles:
+            return True
+        if self.context is None:
+            return False
+
+        # Check for intersection of required roles with user's roles
+        user_roles = set(self.context.user.roles)
+        return any(role in user_roles for role in required_roles)
 
     def create_child(self, metadata: dict[str, Any]) -> Self:
         return self.model_copy(

--- a/src/coreason_manifest/core/request.py
+++ b/src/coreason_manifest/core/request.py
@@ -55,6 +55,21 @@ class AgentRequest(BaseModel):
         user_roles = set(self.context.user.roles)
         return any(role in user_roles for role in required_roles)
 
+    def can_execute_tool(self, tool_name: str) -> bool:
+        """
+        Safely checks if the requested tool is within the agent's strictly delegated scope.
+        Fails closed if the context or delegation scope is missing.
+        """
+        if self.context is None or self.context.delegation is None:
+            return False
+
+        # SOTA Pattern: Support explicit wildcard delegation or exact match
+        allowed = self.context.delegation.allowed_tools
+        if "*" in allowed:
+            return True
+
+        return tool_name in allowed
+
     def create_child(self, metadata: dict[str, Any]) -> Self:
         return self.model_copy(
             update={

--- a/tests/test_request_identity.py
+++ b/tests/test_request_identity.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import json
+from datetime import UTC, datetime
 
 import pytest
 from pydantic import ValidationError
@@ -106,6 +107,44 @@ def test_delegation_scope_budget_serialization() -> None:
     # Check JSON serialization
     json_data = json.loads(scope.model_dump_json())
     assert json_data["max_budget_usd"] == 150.50
+
+
+def test_can_execute_tool() -> None:
+    """Ensure can_execute_tool properly checks delegated tool scope."""
+    user = UserIdentity(user_id="user-123")
+    agent = AgentIdentity(agent_id="agent-123", version="1.0.0")
+
+    # Test strict allowlist
+    scope_strict = DelegationScope(allowed_tools=["safe_tool", "read_db"])
+    context_strict = SessionContext(session_id="session-123", user=user, agent=agent, delegation=scope_strict)
+    request_strict = AgentRequest(agent_id="agent-123", session_id="session-123", inputs={}, context=context_strict)
+
+    assert request_strict.can_execute_tool("safe_tool") is True
+    assert request_strict.can_execute_tool("delete_db") is False
+
+    # Test wildcard
+    scope_wildcard = DelegationScope(allowed_tools=["*"])
+    context_wildcard = SessionContext(session_id="session-123", user=user, agent=agent, delegation=scope_wildcard)
+    request_wildcard = AgentRequest(agent_id="agent-123", session_id="session-123", inputs={}, context=context_wildcard)
+
+    assert request_wildcard.can_execute_tool("any_tool") is True
+
+    # Test fail-closed (no context)
+    request_no_context = AgentRequest(agent_id="agent-123", session_id="session-123", inputs={})
+    assert request_no_context.can_execute_tool("any_tool") is False
+
+
+def test_session_expiry_aware_datetime() -> None:
+    """Ensure session_expiry strictly enforces timezone-aware datetimes."""
+    # Aware datetime should succeed
+    aware_dt = datetime.now(UTC)
+    scope = DelegationScope(allowed_tools=[], session_expiry=aware_dt)
+    assert scope.session_expiry == aware_dt
+
+    # Naive datetime should fail validation
+    naive_dt = datetime.now()
+    with pytest.raises(ValidationError):
+        DelegationScope(allowed_tools=[], session_expiry=naive_dt)
 
 
 def test_w3c_trace_id_serialization() -> None:

--- a/tests/test_request_identity.py
+++ b/tests/test_request_identity.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.common.identity import (
+    AgentIdentity,
+    DelegationScope,
+    SessionContext,
+    UserIdentity,
+)
+from coreason_manifest.core.request import AgentRequest
+
+
+def test_models_are_frozen() -> None:
+    """Ensure that the identity models enforce immutability."""
+    agent = AgentIdentity(agent_id="agent-123", version="1.0.0")
+    with pytest.raises(ValidationError):
+        agent.agent_id = "agent-456"  # type: ignore
+
+    user = UserIdentity(user_id="user-123", roles=["admin"])
+    with pytest.raises(ValidationError):
+        user.user_id = "user-456"  # type: ignore
+
+    scope = DelegationScope(allowed_tools=["tool-1"])
+    with pytest.raises(ValidationError):
+        scope.max_budget_usd = 100.0  # type: ignore
+
+    context = SessionContext(
+        session_id="session-123",
+        user=user,
+        agent=agent,
+        delegation=scope,
+    )
+    with pytest.raises(ValidationError):
+        context.session_id = "session-456"  # type: ignore
+
+
+def test_is_authorized_fail_closed_missing_context() -> None:
+    """Ensure is_authorized fails-closed when no context is provided but roles are required."""
+    request = AgentRequest(
+        agent_id="agent-123",
+        session_id="session-123",
+        inputs={},
+    )
+
+    assert request.is_authorized(["admin"]) is False
+
+
+def test_is_authorized_empty_required_roles() -> None:
+    """Ensure is_authorized returns True when no roles are required."""
+    request = AgentRequest(
+        agent_id="agent-123",
+        session_id="session-123",
+        inputs={},
+    )
+
+    assert request.is_authorized([]) is True
+
+
+def test_is_authorized_with_roles() -> None:
+    """Ensure is_authorized correctly evaluates role intersections."""
+    user = UserIdentity(user_id="user-123", roles=["user", "editor"])
+    agent = AgentIdentity(agent_id="agent-123", version="1.0.0")
+    scope = DelegationScope(allowed_tools=[])
+    context = SessionContext(
+        session_id="session-123",
+        user=user,
+        agent=agent,
+        delegation=scope,
+    )
+
+    request = AgentRequest(
+        agent_id="agent-123",
+        session_id="session-123",
+        inputs={},
+        context=context,
+    )
+
+    # Exact match
+    assert request.is_authorized(["editor"]) is True
+
+    # Intersection match
+    assert request.is_authorized(["admin", "user"]) is True
+
+    # No match
+    assert request.is_authorized(["admin", "superadmin"]) is False
+
+
+def test_delegation_scope_budget_serialization() -> None:
+    """Ensure DelegationScope max_budget_usd serialization correctly preserves float values."""
+    scope = DelegationScope(allowed_tools=[], max_budget_usd=150.50)
+    data = scope.model_dump()
+    assert data["max_budget_usd"] == 150.50
+
+    # Check JSON serialization
+    json_data = json.loads(scope.model_dump_json())
+    assert json_data["max_budget_usd"] == 150.50
+
+
+def test_w3c_trace_id_serialization() -> None:
+    """Ensure SessionContext trace_id serialization preserves the string."""
+    user = UserIdentity(user_id="user-123")
+    agent = AgentIdentity(agent_id="agent-123", version="1.0.0")
+    scope = DelegationScope(allowed_tools=[])
+
+    trace_id_value = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+
+    context = SessionContext(
+        session_id="session-123",
+        user=user,
+        agent=agent,
+        delegation=scope,
+        trace_id=trace_id_value,
+    )
+
+    data = context.model_dump()
+    assert data["trace_id"] == trace_id_value
+
+    # Check JSON serialization
+    json_data = json.loads(context.model_dump_json())
+    assert json_data["trace_id"] == trace_id_value


### PR DESCRIPTION
Epic 1: The Identity Context Envelope.

Adds the required Zero-Trust Identity models (AgentIdentity, UserIdentity, DelegationScope, SessionContext) into the Coreason Manifest Shared Kernel, representing the On-Behalf-Of (OBO) flow logic without side-effects or execution capabilities. Injects the Context Envelope into the core `AgentRequest` model, alongside fail-closed Persona-Based Access Control logic for strict tool and trace limits. Includes full type safety, code linters, immutability tests (`frozen=True` compliance), and documentation.

---
*PR created automatically by Jules for task [7032418331567500797](https://jules.google.com/task/7032418331567500797) started by @gowthamrao*