### PR TITLE
Implement Deterministic Chaos Engineering and Eval Primitives

### DIFF
--- a/src/coreason_manifest/core/workflow/evals.py
+++ b/src/coreason_manifest/core/workflow/evals.py
@@ -31,8 +31,12 @@ class TestCase(CoreasonModel):
         default_factory=list, description="List of Node IDs that MUST be hit in sequence."
     )
     assertions: dict[str, Any] = Field(default_factory=dict, description="JSON Schema validations on the final output.")
-    chaos_config: ChaosConfig | None = Field(default=None, description="Infrastructure faults to apply during this test.")
-    adversary: AdversaryProfile | None = Field(default=None, description="Red-team configuration for semantic fuzzing.")
+    chaos_config: ChaosConfig | None = Field(
+        default=None, description="Infrastructure faults to apply during this test."
+    )
+    adversary: AdversaryProfile | None = Field(
+        default=None, description="Red-team configuration for semantic fuzzing."
+    )
 
 
 class FuzzingTarget(CoreasonModel):

--- a/src/coreason_manifest/core/workflow/evals.py
+++ b/src/coreason_manifest/core/workflow/evals.py
@@ -7,7 +7,7 @@ from coreason_manifest.core.primitives.types import NodeID
 
 
 class ChaosConfig(CoreasonModel, frozen=True):
-    latency_ms: int = Field(default=0, description="Artificial latency to inject into node execution.")
+    latency_ms: int = Field(default=0, ge=0, description="Artificial latency to inject into node execution.")
     error_rate: float = Field(
         default=0.0, ge=0.0, le=1.0, description="Probability of forcing a node failure (0.0 to 1.0)."
     )
@@ -47,6 +47,9 @@ class FuzzingTarget(CoreasonModel):
         default_factory=list, description="Mutator strategies to employ (e.g. 'edge_cases', 'adversarial')."
     )
     invariants: dict[str, Any] = Field(default_factory=dict, description="JSON Schema invariants that must hold true.")
+    adversary: AdversaryProfile | None = Field(
+        default=None, description="Red-team configuration for stochastic semantic fuzzing."
+    )
 
 
 class EvalsManifest(CoreasonModel):

--- a/src/coreason_manifest/core/workflow/evals.py
+++ b/src/coreason_manifest/core/workflow/evals.py
@@ -34,9 +34,7 @@ class TestCase(CoreasonModel):
     chaos_config: ChaosConfig | None = Field(
         default=None, description="Infrastructure faults to apply during this test."
     )
-    adversary: AdversaryProfile | None = Field(
-        default=None, description="Red-team configuration for semantic fuzzing."
-    )
+    adversary: AdversaryProfile | None = Field(default=None, description="Red-team configuration for semantic fuzzing.")
 
 
 class FuzzingTarget(CoreasonModel):

--- a/src/coreason_manifest/core/workflow/evals.py
+++ b/src/coreason_manifest/core/workflow/evals.py
@@ -6,6 +6,19 @@ from coreason_manifest.core.common_base import CoreasonModel
 from coreason_manifest.core.primitives.types import NodeID
 
 
+class ChaosConfig(CoreasonModel, frozen=True):
+    latency_ms: int = Field(default=0, description="Artificial latency to inject into node execution.")
+    error_rate: float = Field(
+        default=0.0, ge=0.0, le=1.0, description="Probability of forcing a node failure (0.0 to 1.0)."
+    )
+    token_throttle: bool = Field(default=False, description="Simulate a constricted context window.")
+
+
+class AdversaryProfile(CoreasonModel, frozen=True):
+    goal: str = Field(..., description="The adversary's objective.")
+    attack_strategy: str = Field(..., description="Methodology.")
+
+
 class TestCase(CoreasonModel):
     """
     A deterministic test case for an agent graph.
@@ -18,6 +31,8 @@ class TestCase(CoreasonModel):
         default_factory=list, description="List of Node IDs that MUST be hit in sequence."
     )
     assertions: dict[str, Any] = Field(default_factory=dict, description="JSON Schema validations on the final output.")
+    chaos_config: ChaosConfig | None = Field(default=None, description="Infrastructure faults to apply during this test.")
+    adversary: AdversaryProfile | None = Field(default=None, description="Red-team configuration for semantic fuzzing.")
 
 
 class FuzzingTarget(CoreasonModel):

--- a/src/coreason_manifest/toolkit/mock.py
+++ b/src/coreason_manifest/toolkit/mock.py
@@ -11,7 +11,7 @@ from referencing.exceptions import PointerToNowhere, Unresolvable
 from referencing.jsonschema import DRAFT202012
 
 from coreason_manifest.core.telemetry_schemas import NodeExecution, NodeState
-from coreason_manifest.core.workflow.evals import EvalsManifest
+from coreason_manifest.core.workflow.evals import ChaosConfig, EvalsManifest
 from coreason_manifest.core.workflow.flow import GraphFlow, LinearFlow
 from coreason_manifest.core.workflow.nodes import HumanNode, Node, PlannerNode, SwarmNode
 
@@ -163,10 +163,16 @@ class MockFactory:
         resolver = registry.resolver()
 
         if isinstance(flow, LinearFlow):
+            chaos_config = None
+            if evals and evals.test_cases and evals.test_cases[0].chaos_config:
+                chaos_config = evals.test_cases[0].chaos_config
+
             nodes = flow.steps
             prev_hashes: list[str] = []
             for node in nodes:
-                exec_records = self._execute_node(node, execution_map, prev_hashes, resolver, fuzzing_vars)
+                exec_records = self._execute_node(
+                    node, execution_map, prev_hashes, resolver, fuzzing_vars, chaos_config
+                )
                 trace.extend(exec_records)
                 last_record = exec_records[-1]
                 execution_map[node.id] = last_record
@@ -180,6 +186,7 @@ class MockFactory:
             if evals and evals.test_cases:
                 # Execute based on the first test case for simplicity in the mock
                 tc = evals.test_cases[0]
+                chaos_config = tc.chaos_config if tc else None
                 expected_path = tc.expected_traversal_path
                 prev_hashes = []
 
@@ -190,7 +197,9 @@ class MockFactory:
                         logger.warning(f"Eval requested node {n_id} not in graph.")
                         break
 
-                    exec_records = self._execute_node(node, execution_map, prev_hashes, resolver, fuzzing_vars)
+                    exec_records = self._execute_node(
+                        node, execution_map, prev_hashes, resolver, fuzzing_vars, chaos_config
+                    )
 
                     # Override outputs with mock inputs if it's the start node
                     if tc.mock_inputs and len(trace) == 0 and exec_records:
@@ -203,6 +212,7 @@ class MockFactory:
 
                 # We do not evaluate assertions here (done by evaluator), just trace creation.
             else:
+                chaos_config = None
                 # Find start nodes (indegree 0)
                 all_targets = {e.to_node for e in graph.edges}
                 start_nodes = [n for n_id, n in graph.nodes.items() if n_id not in all_targets]
@@ -222,7 +232,9 @@ class MockFactory:
                 prev_hashes = []
 
                 while current_node and steps < max_steps:
-                    exec_records = self._execute_node(current_node, execution_map, prev_hashes, resolver, fuzzing_vars)
+                    exec_records = self._execute_node(
+                        current_node, execution_map, prev_hashes, resolver, fuzzing_vars, chaos_config
+                    )
                     trace.extend(exec_records)
                     last_record = exec_records[-1]
                     execution_map[current_node.id] = last_record
@@ -250,6 +262,7 @@ class MockFactory:
         prev_hashes: list[str] | None = None,
         resolver: Any | None = None,
         fuzzing_vars: set[str] | None = None,
+        chaos_config: ChaosConfig | None = None,
     ) -> list[NodeExecution]:
         timestamp = datetime.now(UTC)
 
@@ -270,6 +283,16 @@ class MockFactory:
                 w_inputs = {"worker_id": i, "workload": "mock_item"}
                 w_outputs = {"result": "processed"}
                 w_duration = self.rng.uniform(10, 100)
+                if chaos_config:
+                    w_duration += chaos_config.latency_ms
+
+                w_state = NodeState.COMPLETED
+                w_error = None
+
+                if chaos_config and self.rng.random() < chaos_config.error_rate:
+                    w_state = NodeState.FAILED
+                    w_error = "HTTP 500 Internal Server Error"
+                    w_outputs["error"] = w_error
 
                 w_hash = self._generate_hash(
                     f"{w_id}{json.dumps(w_inputs, sort_keys=True)}{json.dumps(w_outputs, sort_keys=True)}"
@@ -278,9 +301,10 @@ class MockFactory:
                 workers.append(
                     NodeExecution(
                         node_id=w_id,
-                        state=NodeState.COMPLETED,
+                        state=w_state,
                         inputs=w_inputs,
                         outputs=w_outputs,
+                        error=w_error,
                         timestamp=timestamp,
                         duration_ms=w_duration,
                         execution_hash=w_hash,
@@ -294,15 +318,27 @@ class MockFactory:
             agg_inputs = {"results": [w.outputs for w in workers]}
             agg_outputs = {"final": "aggregated_result"}
             agg_duration = self.rng.uniform(10, 50)
+            if chaos_config:
+                agg_duration += chaos_config.latency_ms
+
+            agg_state = NodeState.COMPLETED
+            agg_error = None
+
+            if chaos_config and self.rng.random() < chaos_config.error_rate:
+                agg_state = NodeState.FAILED
+                agg_error = "HTTP 500 Internal Server Error"
+                agg_outputs["error"] = agg_error
+
             agg_hash = self._generate_hash(
                 f"{node.id}{json.dumps(agg_inputs, sort_keys=True)}{json.dumps(agg_outputs, sort_keys=True)}"
             )
 
             aggregator = NodeExecution(
                 node_id=node.id,
-                state=NodeState.COMPLETED,
+                state=agg_state,
                 inputs=agg_inputs,
                 outputs=agg_outputs,
+                error=agg_error,
                 timestamp=timestamp,
                 duration_ms=agg_duration,
                 execution_hash=agg_hash,
@@ -343,6 +379,16 @@ class MockFactory:
                     outputs[key] = self.rng.choice(payloads)
 
         duration = self.rng.uniform(10, 500)
+        if chaos_config:
+            duration += chaos_config.latency_ms
+
+        state = NodeState.COMPLETED
+        error = None
+
+        if chaos_config and self.rng.random() < chaos_config.error_rate:
+            state = NodeState.FAILED
+            error = "HTTP 500 Internal Server Error"
+            outputs["error"] = error
 
         # Calculate hash
         data_to_hash = f"{node.id}{json.dumps(inputs, sort_keys=True)}{json.dumps(outputs, sort_keys=True)}"
@@ -351,9 +397,10 @@ class MockFactory:
         return [
             NodeExecution(
                 node_id=node.id,
-                state=NodeState.COMPLETED,
+                state=state,
                 inputs=inputs,
                 outputs=outputs,
+                error=error,
                 timestamp=timestamp,
                 duration_ms=duration,
                 execution_hash=exec_hash,

--- a/src/coreason_manifest/toolkit/mock.py
+++ b/src/coreason_manifest/toolkit/mock.py
@@ -292,7 +292,6 @@ class MockFactory:
                 if chaos_config and self.rng.random() < chaos_config.error_rate:
                     w_state = NodeState.FAILED
                     w_error = "HTTP 500 Internal Server Error"
-                    w_outputs["error"] = w_error
 
                 w_hash = self._generate_hash(
                     f"{w_id}{json.dumps(w_inputs, sort_keys=True)}{json.dumps(w_outputs, sort_keys=True)}"
@@ -327,7 +326,6 @@ class MockFactory:
             if chaos_config and self.rng.random() < chaos_config.error_rate:
                 agg_state = NodeState.FAILED
                 agg_error = "HTTP 500 Internal Server Error"
-                agg_outputs["error"] = agg_error
 
             agg_hash = self._generate_hash(
                 f"{node.id}{json.dumps(agg_inputs, sort_keys=True)}{json.dumps(agg_outputs, sort_keys=True)}"
@@ -388,7 +386,6 @@ class MockFactory:
         if chaos_config and self.rng.random() < chaos_config.error_rate:
             state = NodeState.FAILED
             error = "HTTP 500 Internal Server Error"
-            outputs["error"] = error
 
         # Calculate hash
         data_to_hash = f"{node.id}{json.dumps(inputs, sort_keys=True)}{json.dumps(outputs, sort_keys=True)}"

--- a/tests/test_chaos_engineering.py
+++ b/tests/test_chaos_engineering.py
@@ -3,7 +3,7 @@ from pydantic import ValidationError
 
 from coreason_manifest.core.telemetry_schemas import NodeState
 from coreason_manifest.core.workflow.evals import AdversaryProfile, ChaosConfig, EvalsManifest, TestCase
-from coreason_manifest.core.workflow.flow import LinearFlow
+from coreason_manifest.core.workflow.flow import FlowMetadata, LinearFlow
 from coreason_manifest.core.workflow.nodes import AgentNode
 from coreason_manifest.toolkit.mock import MockFactory
 
@@ -41,7 +41,8 @@ def test_mock_factory_inflates_duration() -> None:
     # Base configuration without chaos
     evals_no_chaos = EvalsManifest(test_cases=[TestCase(expected_traversal_path=["node_1"])])
     flow = LinearFlow(
-        metadata={"name": "test_flow", "version": "1.0"}, steps=[AgentNode(id="node_1", profile="test_agent")]
+        metadata=FlowMetadata(name="test_flow", version="1.0"),
+        steps=[AgentNode(id="node_1", profile="test_agent", operational_policy=None)],
     )
     trace_no_chaos = factory.simulate_trace(flow, evals=evals_no_chaos)
 
@@ -79,7 +80,8 @@ def test_mock_factory_forces_failure() -> None:
         ]
     )
     flow = LinearFlow(
-        metadata={"name": "test_flow", "version": "1.0"}, steps=[AgentNode(id="node_1", profile="test_agent")]
+        metadata=FlowMetadata(name="test_flow", version="1.0"),
+        steps=[AgentNode(id="node_1", profile="test_agent", operational_policy=None)],
     )
     trace_fail = factory.simulate_trace(flow, evals=evals_fail)
 

--- a/tests/test_chaos_engineering.py
+++ b/tests/test_chaos_engineering.py
@@ -25,8 +25,11 @@ def test_chaos_config_and_adversary_parsing() -> None:
     assert test_case.adversary.attack_strategy == "crescendo"
 
 
-def test_chaos_config_validation_error_rate() -> None:
-    """Test validation of error_rate fails if out of bounds."""
+def test_chaos_config_validation() -> None:
+    """Test validation of chaos fields."""
+    with pytest.raises(ValidationError):
+        ChaosConfig(latency_ms=-1)  # Less than 0
+
     with pytest.raises(ValidationError):
         ChaosConfig(error_rate=1.5)  # Greater than 1.0
 
@@ -90,5 +93,4 @@ def test_mock_factory_forces_failure() -> None:
 
     assert execution.state == NodeState.FAILED
     assert execution.error == "HTTP 500 Internal Server Error"
-    assert "error" in execution.outputs
-    assert execution.outputs["error"] == "HTTP 500 Internal Server Error"
+    assert "error" not in execution.outputs

--- a/tests/test_chaos_engineering.py
+++ b/tests/test_chaos_engineering.py
@@ -1,0 +1,92 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.telemetry_schemas import NodeState
+from coreason_manifest.core.workflow.evals import AdversaryProfile, ChaosConfig, EvalsManifest, TestCase
+from coreason_manifest.core.workflow.flow import LinearFlow
+from coreason_manifest.core.workflow.nodes import AgentNode
+from coreason_manifest.toolkit.mock import MockFactory
+
+
+def test_chaos_config_and_adversary_parsing() -> None:
+    """Test Pydantic correctly parses ChaosConfig and AdversaryProfile."""
+    test_case = TestCase(
+        expected_traversal_path=["node_1"],
+        chaos_config=ChaosConfig(latency_ms=1000, error_rate=0.5, token_throttle=True),
+        adversary=AdversaryProfile(goal="Extract PII", attack_strategy="crescendo"),
+    )
+
+    assert test_case.chaos_config is not None
+    assert test_case.chaos_config.latency_ms == 1000
+    assert test_case.chaos_config.error_rate == 0.5
+    assert test_case.chaos_config.token_throttle is True
+    assert test_case.adversary is not None
+    assert test_case.adversary.goal == "Extract PII"
+    assert test_case.adversary.attack_strategy == "crescendo"
+
+
+def test_chaos_config_validation_error_rate() -> None:
+    """Test validation of error_rate fails if out of bounds."""
+    with pytest.raises(ValidationError):
+        ChaosConfig(error_rate=1.5)  # Greater than 1.0
+
+    with pytest.raises(ValidationError):
+        ChaosConfig(error_rate=-0.1)  # Less than 0.0
+
+
+def test_mock_factory_inflates_duration() -> None:
+    """Test MockFactory duration trace increases with latency_ms."""
+    factory = MockFactory(seed=42)
+
+    # Base configuration without chaos
+    evals_no_chaos = EvalsManifest(test_cases=[TestCase(expected_traversal_path=["node_1"])])
+    flow = LinearFlow(
+        metadata={"name": "test_flow", "version": "1.0"}, steps=[AgentNode(id="node_1", profile="test_agent")]
+    )
+    trace_no_chaos = factory.simulate_trace(flow, evals=evals_no_chaos)
+
+    # Configuration with latency
+    evals_latency = EvalsManifest(
+        test_cases=[
+            TestCase(
+                expected_traversal_path=["node_1"],
+                chaos_config=ChaosConfig(latency_ms=5000),
+            )
+        ]
+    )
+    # Using same seed for deterministic output (base duration should be exactly the same)
+    factory2 = MockFactory(seed=42)
+    trace_latency = factory2.simulate_trace(flow, evals=evals_latency)
+
+    assert len(trace_no_chaos) == 1
+    assert len(trace_latency) == 1
+
+    base_duration = trace_no_chaos[0].duration_ms
+    inflated_duration = trace_latency[0].duration_ms
+
+    assert inflated_duration == pytest.approx(base_duration + 5000)
+
+
+def test_mock_factory_forces_failure() -> None:
+    """Test MockFactory node fails and state is FAILED with error when error_rate = 1.0."""
+    factory = MockFactory(seed=42)
+    evals_fail = EvalsManifest(
+        test_cases=[
+            TestCase(
+                expected_traversal_path=["node_1"],
+                chaos_config=ChaosConfig(error_rate=1.0),
+            )
+        ]
+    )
+    flow = LinearFlow(
+        metadata={"name": "test_flow", "version": "1.0"}, steps=[AgentNode(id="node_1", profile="test_agent")]
+    )
+    trace_fail = factory.simulate_trace(flow, evals=evals_fail)
+
+    assert len(trace_fail) == 1
+    execution = trace_fail[0]
+
+    assert execution.state == NodeState.FAILED
+    assert execution.error == "HTTP 500 Internal Server Error"
+    assert "error" in execution.outputs
+    assert execution.outputs["error"] == "HTTP 500 Internal Server Error"


### PR DESCRIPTION
Implemented Epic 3 by adding chaos engineering primitives to the deterministic evaluation suite. Modifies the `MockFactory` execution engine to mathematically simulate API degradation, forced node failures, and latency spikes across standard nodes, swarm workers, and swarm aggregators based on a provided `ChaosConfig`.

---
*PR created automatically by Jules for task [2032713844102750668](https://jules.google.com/task/2032713844102750668) started by @gowthamrao*