### PR TITLE
Refactor: Unify AgentRequest Envelope and Update Architecture primitives

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -8,6 +8,14 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from coreason_manifest.core.common.identity import (
+    AgentIdentity,
+    SessionContext,
+    UserIdentity,
+)
+from coreason_manifest.core.common.semantic import (
+    SemanticRef,
+)
 from coreason_manifest.core.compute.reasoning import (
     BaseReasoning,
     CouncilReasoning,
@@ -27,6 +35,10 @@ from coreason_manifest.core.oversight.resilience import SupervisionPolicy
 from coreason_manifest.core.state.tools import (
     Dependency,
     ToolPack,
+)
+from coreason_manifest.core.workflow.evals import (
+    AdversaryProfile,
+    ChaosConfig,
 )
 from coreason_manifest.core.workflow.flow import (
     AnyNode,
@@ -54,11 +66,14 @@ from coreason_manifest.toolkit.builder import (
 )
 
 __all__ = [
+    "AdversaryProfile",
+    "AgentIdentity",
     "AgentNode",
     "AnyNode",
     "Audit",
     "BaseReasoning",
     "Blackboard",
+    "ChaosConfig",
     "CognitiveProfile",
     "CouncilReasoning",
     "DecompositionReasoning",
@@ -80,10 +95,13 @@ __all__ = [
     "PlannerNode",
     "ReasoningConfig",
     "Safety",
+    "SemanticRef",
+    "SessionContext",
     "StandardReasoning",
     "SupervisionPolicy",
     "SwitchNode",
     "ToolPack",
     "TreeSearchReasoning",
+    "UserIdentity",
     "VariableDef",
 ]

--- a/src/coreason_manifest/core/rebuild.py
+++ b/src/coreason_manifest/core/rebuild.py
@@ -85,7 +85,9 @@ def rebuild_manifest() -> None:
     # Actually, Governance doesn't depend on new unions, we might not need to rebuild it explicitly.
 
     # AgentRequest depends on GraphFlow | LinearFlow
-    flow.AgentRequest.model_rebuild(force=True)
+    from coreason_manifest.core.request import AgentRequest
+
+    AgentRequest.model_rebuild(force=True)
 
     # 4. Rebuild newly added isolated models that don't depend on unions
     # but still might need to resolve types

--- a/src/coreason_manifest/core/request.py
+++ b/src/coreason_manifest/core/request.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 from coreason_manifest.core.common.identity import SessionContext
 from coreason_manifest.core.exceptions import LineageIntegrityError, ManifestError, ManifestErrorCode
+from coreason_manifest.core.workflow.flow import GraphFlow, LinearFlow
 
 
 class AgentRequest(BaseModel):
@@ -35,6 +36,9 @@ class AgentRequest(BaseModel):
 
     # Versioning
     hash_version: Literal["v2"] = Field(default="v2", description="Versioning for integrity strategies.")
+
+    # Execution Manifest
+    manifest: GraphFlow | LinearFlow = Field(..., description="The AOT-compiled execution graph.")
 
     # Context Envelope
     context: SessionContext | None = Field(

--- a/src/coreason_manifest/core/workflow/evals.py
+++ b/src/coreason_manifest/core/workflow/evals.py
@@ -50,6 +50,9 @@ class FuzzingTarget(CoreasonModel):
     adversary: AdversaryProfile | None = Field(
         default=None, description="Red-team configuration for stochastic semantic fuzzing."
     )
+    chaos_config: ChaosConfig | None = Field(
+        default=None, description="Allow the fuzzer to mutate infrastructure conditions (latency/errors) dynamically."
+    )
 
 
 class EvalsManifest(CoreasonModel):

--- a/src/coreason_manifest/core/workflow/flow.py
+++ b/src/coreason_manifest/core/workflow/flow.py
@@ -4,7 +4,7 @@ from uuid import uuid4
 
 import jsonschema  # type: ignore[import-untyped]
 from jsonschema.exceptions import SchemaError  # type: ignore[import-untyped]
-from pydantic import ConfigDict, Field, field_validator, model_validator
+from pydantic import Field, field_validator, model_validator
 
 from coreason_manifest.core.common.semantic import SemanticRef
 from coreason_manifest.core.common_base import CoreasonModel
@@ -20,7 +20,6 @@ from coreason_manifest.core.workflow.nodes import (
 
 # Export AnyNode so it can be imported from here as well
 __all__ = [
-    "AgentRequest",
     "AnyNode",
     "Blackboard",
     "DataSchema",
@@ -298,14 +297,3 @@ class LinearFlow(CoreasonModel):
                 )
                 raise ManifestError.critical_halt(code=ManifestErrorCode.CRSN_VAL_LIFECYCLE_UNRESOLVED, message=msg)
         return self
-
-
-class AgentRequest(CoreasonModel):
-    """
-    Strict envelope for agent execution requests.
-    """
-
-    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-
-    manifest: GraphFlow | LinearFlow
-    metadata: dict[str, Any] = Field(default_factory=dict)

--- a/tests/test_request_identity.py
+++ b/tests/test_request_identity.py
@@ -21,6 +21,7 @@ from coreason_manifest.core.common.identity import (
     UserIdentity,
 )
 from coreason_manifest.core.request import AgentRequest
+from coreason_manifest.core.workflow.flow import FlowMetadata, LinearFlow
 
 
 def test_models_are_frozen() -> None:
@@ -49,10 +50,14 @@ def test_models_are_frozen() -> None:
 
 def test_is_authorized_fail_closed_missing_context() -> None:
     """Ensure is_authorized fails-closed when no context is provided but roles are required."""
+    from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
+
+    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1")])
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
         inputs={},
+        manifest=dummy_manifest,
     )
 
     assert request.is_authorized(["admin"]) is False
@@ -60,10 +65,14 @@ def test_is_authorized_fail_closed_missing_context() -> None:
 
 def test_is_authorized_empty_required_roles() -> None:
     """Ensure is_authorized returns True when no roles are required."""
+    from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
+
+    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1")])
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
         inputs={},
+        manifest=dummy_manifest,
     )
 
     assert request.is_authorized([]) is True
@@ -81,10 +90,14 @@ def test_is_authorized_with_roles() -> None:
         delegation=scope,
     )
 
+    from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
+
+    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1")])
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
         inputs={},
+        manifest=dummy_manifest,
         context=context,
     )
 
@@ -113,11 +126,16 @@ def test_can_execute_tool() -> None:
     """Ensure can_execute_tool properly checks delegated tool scope."""
     user = UserIdentity(user_id="user-123")
     agent = AgentIdentity(agent_id="agent-123", version="1.0.0")
+    from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
+
+    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1")])
 
     # Test strict allowlist
     scope_strict = DelegationScope(allowed_tools=["safe_tool", "read_db"])
     context_strict = SessionContext(session_id="session-123", user=user, agent=agent, delegation=scope_strict)
-    request_strict = AgentRequest(agent_id="agent-123", session_id="session-123", inputs={}, context=context_strict)
+    request_strict = AgentRequest(
+        agent_id="agent-123", session_id="session-123", inputs={}, manifest=dummy_manifest, context=context_strict
+    )
 
     assert request_strict.can_execute_tool("safe_tool") is True
     assert request_strict.can_execute_tool("delete_db") is False
@@ -125,12 +143,16 @@ def test_can_execute_tool() -> None:
     # Test wildcard
     scope_wildcard = DelegationScope(allowed_tools=["*"])
     context_wildcard = SessionContext(session_id="session-123", user=user, agent=agent, delegation=scope_wildcard)
-    request_wildcard = AgentRequest(agent_id="agent-123", session_id="session-123", inputs={}, context=context_wildcard)
+    request_wildcard = AgentRequest(
+        agent_id="agent-123", session_id="session-123", inputs={}, manifest=dummy_manifest, context=context_wildcard
+    )
 
     assert request_wildcard.can_execute_tool("any_tool") is True
 
     # Test fail-closed (no context)
-    request_no_context = AgentRequest(agent_id="agent-123", session_id="session-123", inputs={})
+    request_no_context = AgentRequest(
+        agent_id="agent-123", session_id="session-123", inputs={}, manifest=dummy_manifest
+    )
     assert request_no_context.can_execute_tool("any_tool") is False
 
 

--- a/tests/test_request_identity.py
+++ b/tests/test_request_identity.py
@@ -52,7 +52,7 @@ def test_is_authorized_fail_closed_missing_context() -> None:
     """Ensure is_authorized fails-closed when no context is provided but roles are required."""
     from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
 
-    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1")])
+    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])])
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
@@ -67,7 +67,7 @@ def test_is_authorized_empty_required_roles() -> None:
     """Ensure is_authorized returns True when no roles are required."""
     from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
 
-    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1")])
+    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])])
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
@@ -92,7 +92,7 @@ def test_is_authorized_with_roles() -> None:
 
     from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
 
-    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1")])
+    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])])
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
@@ -128,7 +128,7 @@ def test_can_execute_tool() -> None:
     agent = AgentIdentity(agent_id="agent-123", version="1.0.0")
     from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
 
-    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1")])
+    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])])
 
     # Test strict allowlist
     scope_strict = DelegationScope(allowed_tools=["safe_tool", "read_db"])

--- a/tests/test_request_identity.py
+++ b/tests/test_request_identity.py
@@ -52,7 +52,9 @@ def test_is_authorized_fail_closed_missing_context() -> None:
     """Ensure is_authorized fails-closed when no context is provided but roles are required."""
     from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
 
-    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])])
+    dummy_manifest = LinearFlow(
+        metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])]
+    )
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
@@ -67,7 +69,9 @@ def test_is_authorized_empty_required_roles() -> None:
     """Ensure is_authorized returns True when no roles are required."""
     from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
 
-    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])])
+    dummy_manifest = LinearFlow(
+        metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])]
+    )
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
@@ -92,7 +96,9 @@ def test_is_authorized_with_roles() -> None:
 
     from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
 
-    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])])
+    dummy_manifest = LinearFlow(
+        metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])]
+    )
     request = AgentRequest(
         agent_id="agent-123",
         session_id="session-123",
@@ -128,7 +134,9 @@ def test_can_execute_tool() -> None:
     agent = AgentIdentity(agent_id="agent-123", version="1.0.0")
     from coreason_manifest.core.workflow.nodes.system import PlaceholderNode
 
-    dummy_manifest = LinearFlow(metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])])
+    dummy_manifest = LinearFlow(
+        metadata=FlowMetadata(name="test", version="1.0"), steps=[PlaceholderNode(id="step1", required_capabilities=[])]
+    )
 
     # Test strict allowlist
     scope_strict = DelegationScope(allowed_tools=["safe_tool", "read_db"])


### PR DESCRIPTION
Resolves split-brain AgentRequest models, unifies Zero-Trust Envelopes, enables chaos fuzzing, and exports unified SOTA primitives for easier external consumption.

---
*PR created automatically by Jules for task [12153450460842643549](https://jules.google.com/task/12153450460842643549) started by @gowthamrao*