### PR TITLE
Refactor: Enforce schema-first documentation standard across repository

### DIFF
--- a/src/coreason_manifest/adapters/security/antibody.py
+++ b/src/coreason_manifest/adapters/security/antibody.py
@@ -2,7 +2,7 @@ import math
 from datetime import datetime
 from typing import Any
 
-from pydantic import BaseModel, ConfigDict, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 
 
 class DataAnomaly(BaseModel):
@@ -13,17 +13,21 @@ class DataAnomaly(BaseModel):
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    code: str
-    path: str
-    value_repr: str
-    description: str
+    code: str = Field(..., description="The error code associated with the anomaly.", examples=["CRSN-ANTIBODY-FLOAT"])
+    path: str = Field(..., description="The JSON Pointer path to the anomalous data.", examples=["$.metrics.accuracy"])
+    value_repr: str = Field(..., description="The string representation of the anomalous value.", examples=["NaN"])
+    description: str = Field(
+        ...,
+        description="A human-readable description of the anomaly.",
+        examples=["Floating point value is not finite (NaN/Inf)."],
+    )
 
 
 VALID_PRIMITIVES = (str, int, float, bool, type(None), datetime)
 
 
 def _get_anomaly(v: Any, path: str) -> dict[str, Any] | None:
-    """Evaluates a single value and returns a serialized anomaly if invalid."""
+    """Evaluate a single value and return a serialized anomaly if invalid."""
     if isinstance(v, BaseModel):
         # We can recursively validate BaseModels later, or just trust their serialization
         return None
@@ -46,9 +50,9 @@ def _get_anomaly(v: Any, path: str) -> dict[str, Any] | None:
 
 
 def _scan_and_quarantine(data: Any, path: str) -> Any:
-    """
-    Recursively scans and functionally rebuilds the input structure,
-    replacing anomalies (NaN, Inf, Un-serializable) with DataAnomaly dicts.
+    """Recursively scan and functionally rebuild the input structure.
+
+    Replaces anomalies (NaN, Inf, Un-serializable) with DataAnomaly dicts.
     """
     if isinstance(data, dict):
         return {

--- a/src/coreason_manifest/adapters/system/dynamic_loader.py
+++ b/src/coreason_manifest/adapters/system/dynamic_loader.py
@@ -596,31 +596,23 @@ def _load_sandboxed_class(reference: str, root_dir: Path, component_name: str) -
 
 
 def load_agent_from_ref(reference: str, root_dir: Path) -> type:
-    """
-    Load an Agent class from a Python file reference (file.py:ClassName).
-    WARNING: Executes arbitrary code. Ensure source is trusted.
+    """Load an Agent class from a Python file reference.
+
+    WARNING: Executes arbitrary code within the host process. Ensure the source is strictly trusted.
 
     Args:
-        reference: string in format "path/to/file.py:ClassName"
-        root_dir: The root directory for file access confinement.
-
-    Returns:
-        The loaded Agent class.
+        reference: Must be in the exact format 'path/to/file.py:ClassName'.
     """
     return _load_sandboxed_class(reference, root_dir, "agent")
 
 
 def load_middleware_from_ref(reference: str, root_dir: Path) -> type:
-    """
-    Load a Middleware class from a Python file reference (file.py:ClassName).
-    WARNING: Executes arbitrary code. Ensure source is trusted.
+    """Load a Middleware class from a Python file reference.
+
+    WARNING: Executes arbitrary code within the host process. Ensure the source is strictly trusted.
 
     Args:
-        reference: string in format "path/to/file.py:ClassName"
-        root_dir: The root directory for file access confinement.
-
-    Returns:
-        The loaded Middleware class.
+        reference: Must be in the exact format 'path/to/file.py:ClassName'.
     """
     middleware_class = _load_sandboxed_class(reference, root_dir, "middleware")
 

--- a/src/coreason_manifest/core/common/identity.py
+++ b/src/coreason_manifest/core/common/identity.py
@@ -15,59 +15,90 @@ from coreason_manifest.core.common_base import CoreasonModel
 
 
 class AgentIdentity(CoreasonModel):
-    model_config = ConfigDict(frozen=True)
     """
     Cryptographic identity of the agent operating within the Zero-Trust Prompt paradigm.
     Proves the acting software entity.
     """
 
-    agent_id: str = Field(..., description="Unique, verifiable ID for the agent instance.")
-    version: str = Field(..., description="Version of the agent.")
-    software_hash: str | None = Field(None, description="Cryptographic hash of the agent's manifest definition.")
+    model_config = ConfigDict(frozen=True)
+
+    agent_id: str = Field(..., description="Unique, verifiable ID for the agent instance.", examples=["agent_alpha_01"])
+    version: str = Field(..., description="Version of the agent.", examples=["1.2.0"])
+    software_hash: str | None = Field(
+        None,
+        description="Cryptographic hash of the agent's manifest definition.",
+        examples=["e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"],
+    )
 
 
 class UserIdentity(CoreasonModel):
-    model_config = ConfigDict(frozen=True)
     """
     The principal human or service account initiating the trace in the On-Behalf-Of (OBO) flow.
     Includes Persona-Based Access Control (PBAC) roles.
     """
 
-    user_id: str = Field(..., description="The principal human or service account initiating the trace.")
+    model_config = ConfigDict(frozen=True)
+
+    user_id: str = Field(
+        ..., description="The principal human or service account initiating the trace.", examples=["user_789"]
+    )
     roles: list[str] = Field(
-        default_factory=list, description="Persona-Based Access Control (PBAC) roles assigned to the user."
+        default_factory=list,
+        description="Persona-Based Access Control (PBAC) roles assigned to the user.",
+        examples=[["admin", "reviewer"]],
     )
 
 
 class DelegationScope(CoreasonModel):
-    model_config = ConfigDict(frozen=True)
     """
     The strict boundaries of authority granted to the agent for this specific trace.
     Part of the Zero-Trust Identity Context Envelope.
     """
 
+    model_config = ConfigDict(frozen=True)
+
     allowed_tools: list[str] = Field(
-        default_factory=list, description="Strictly scoped tool whitelist for this specific request."
+        default_factory=list,
+        description="Strictly scoped tool whitelist for this specific request.",
+        examples=[["search_tool", "calculator_tool"]],
     )
-    max_budget_usd: float | None = Field(None, description="Financial cap for this trace.")
+    max_budget_usd: float | None = Field(None, description="Financial cap for this trace.", examples=[10.00])
     session_expiry: AwareDatetime | None = Field(
-        None, description="When this context envelope expires. Must be TZ-aware."
+        None, description="When this context envelope expires. Must be TZ-aware.", examples=["2025-01-01T12:00:00Z"]
     )
 
 
 class SessionContext(CoreasonModel):
-    model_config = ConfigDict(frozen=True)
     """
     The Zero-Trust Identity Context Envelope for this request.
     Proves cryptographically who is making the request, who the agent is, and what its delegated authority is.
     """
 
-    session_id: str = Field(..., description="ID of the interaction session.")
-    user: UserIdentity = Field(..., description="The delegating principal.")
-    agent: AgentIdentity = Field(..., description="The acting agent.")
-    delegation: DelegationScope = Field(..., description="The authority granted.")
+    model_config = ConfigDict(frozen=True)
+
+    session_id: str = Field(..., description="ID of the interaction session.", examples=["sess_001"])
+    user: UserIdentity = Field(
+        ..., description="The delegating principal.", examples=[{"user_id": "user_789", "roles": ["admin"]}]
+    )
+    agent: AgentIdentity = Field(
+        ...,
+        description="The acting agent.",
+        examples=[
+            {
+                "agent_id": "agent_alpha_01",
+                "version": "1.2.0",
+                "software_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            }
+        ],
+    )
+    delegation: DelegationScope = Field(
+        ...,
+        description="The authority granted.",
+        examples=[{"allowed_tools": ["search_tool"], "max_budget_usd": 5.0, "session_expiry": "2025-01-01T12:00:00Z"}],
+    )
     trace_id: str | None = Field(
         None,
         pattern=r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$",
         description="W3C Trace Context ID for distributed secure tracking.",
+        examples=["00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"],
     )

--- a/src/coreason_manifest/core/common/semantic.py
+++ b/src/coreason_manifest/core/common/semantic.py
@@ -44,4 +44,5 @@ class SemanticRef(CoreasonModel):
     optimization: OptimizationIntent | None = Field(
         None,
         description="Directives for Weaver synthesis optimization.",
+        examples=[{"improvement_goal": "Maximize throughput", "metric_name": "accuracy", "teacher_model": "gpt-4"}],
     )

--- a/src/coreason_manifest/core/state/memory.py
+++ b/src/coreason_manifest/core/state/memory.py
@@ -10,10 +10,13 @@ class WorkingMemoryConfig(CoreasonModel):
     Configuration for the agent's short-term working memory (RAM).
     """
 
-    max_tokens: int = Field(..., gt=0, description="Maximum token limit for the working memory context window.")
+    max_tokens: int = Field(
+        ..., gt=0, description="Maximum token limit for the working memory context window.", examples=[4096]
+    )
     enable_active_paging: bool = Field(
         ...,
         description=("If true, the runtime engine equips the agent with tools to load/evict context pages explicitly."),
+        examples=[True],
     )
 
 
@@ -47,6 +50,7 @@ class EpisodicMemoryConfig(CoreasonModel):
         ge=0.0,
         le=1.0,
         description="Minimum importance score (0.0-1.0) for a memory to be retained in long-term storage.",
+        examples=[0.75],
     )
     consolidation_interval_turns: int | None = Field(
         None,
@@ -55,8 +59,13 @@ class EpisodicMemoryConfig(CoreasonModel):
             "Number of conversation turns before the background loop compresses the journal. "
             "None means no auto-consolidation."
         ),
+        examples=[10],
     )
-    consolidation_strategy: ConsolidationStrategy = Field(default=ConsolidationStrategy.SESSION_CLOSE)
+    consolidation_strategy: ConsolidationStrategy = Field(
+        default=ConsolidationStrategy.SESSION_CLOSE,
+        description="The strategy to use for memory consolidation.",
+        examples=[ConsolidationStrategy.SESSION_CLOSE],
+    )
 
 
 class SemanticMemoryConfig(CoreasonModel):
@@ -64,16 +73,21 @@ class SemanticMemoryConfig(CoreasonModel):
     Configuration for the agent's semantic knowledge graph (Knowledge Graph).
     """
 
-    graph_namespace: str = Field(..., description="Namespace identifier for the knowledge graph partition.")
+    graph_namespace: str = Field(
+        ..., description="Namespace identifier for the knowledge graph partition.", examples=["global_knowledge_base"]
+    )
     bitemporal_tracking: bool = Field(
         ...,
         description=(
             "If true, requires the runtime to track both 'valid_from' (business time) "
             "and 'recorded_at' (system time) metadata."
         ),
+        examples=[True],
     )
     allowed_entity_types: list[str] | None = Field(
-        None, description="List of allowed entity types for the graph. If None, all types are allowed."
+        None,
+        description="List of allowed entity types for the graph. If None, all types are allowed.",
+        examples=[["Person", "Organization"]],
     )
     retrieval_strategy: RetrievalStrategy = Field(
         RetrievalStrategy.HYBRID,
@@ -81,6 +95,7 @@ class SemanticMemoryConfig(CoreasonModel):
             "The algorithmic approach required by this agent. "
             "(e.g., GRAPH_RAG for multi-hop clinical ontology traversal)"
         ),
+        examples=[RetrievalStrategy.GRAPH_RAG],
     )
     scope: KnowledgeScope = Field(
         ...,
@@ -88,9 +103,14 @@ class SemanticMemoryConfig(CoreasonModel):
             "The epistemic boundary of the knowledge access. "
             "Must be explicitly declared to prevent cross-tenant data leaks."
         ),
+        examples=[KnowledgeScope.USER],
     )
     min_score_threshold: float = Field(
-        0.75, ge=0.0, le=1.0, description="Minimum confidence score for the runtime to inject the context."
+        0.75,
+        ge=0.0,
+        le=1.0,
+        description="Minimum confidence score for the runtime to inject the context.",
+        examples=[0.85],
     )
 
 
@@ -100,7 +120,9 @@ class ProceduralMemoryConfig(CoreasonModel):
     """
 
     skill_library_ref: str | None = Field(
-        None, description="Pointer to a global registry or library of procedural tool execution rules."
+        None,
+        description="Pointer to a global registry or library of procedural tool execution rules.",
+        examples=["company_skill_library_v1"],
     )
 
 
@@ -109,9 +131,34 @@ class MemorySubsystem(CoreasonModel):
     The master blueprint for the agent's 4-tier hierarchical memory system.
     """
 
-    working: WorkingMemoryConfig | None = Field(None, description="Configuration for Working Memory (RAM).")
-    episodic: EpisodicMemoryConfig | None = Field(None, description="Configuration for Episodic Memory (Journal).")
-    semantic: SemanticMemoryConfig | None = Field(
-        None, description="Configuration for Semantic Memory (Knowledge Graph)."
+    working: WorkingMemoryConfig | None = Field(
+        None,
+        description="Configuration for Working Memory (RAM).",
+        examples=[{"max_tokens": 4096, "enable_active_paging": True}],
     )
-    procedural: ProceduralMemoryConfig | None = Field(None, description="Configuration for Procedural Memory (Skills).")
+    episodic: EpisodicMemoryConfig | None = Field(
+        None,
+        description="Configuration for Episodic Memory (Journal).",
+        examples=[
+            {"salience_threshold": 0.5, "consolidation_interval_turns": 5, "consolidation_strategy": "session_close"}
+        ],
+    )
+    semantic: SemanticMemoryConfig | None = Field(
+        None,
+        description="Configuration for Semantic Memory (Knowledge Graph).",
+        examples=[
+            {
+                "graph_namespace": "tenant_123",
+                "bitemporal_tracking": False,
+                "allowed_entity_types": None,
+                "retrieval_strategy": "hybrid",
+                "scope": "session",
+                "min_score_threshold": 0.8,
+            }
+        ],
+    )
+    procedural: ProceduralMemoryConfig | None = Field(
+        None,
+        description="Configuration for Procedural Memory (Skills).",
+        examples=[{"skill_library_ref": "global_skills"}],
+    )

--- a/src/coreason_manifest/core/state/persistence.py
+++ b/src/coreason_manifest/core/state/persistence.py
@@ -16,15 +16,20 @@ class StateDiff(CoreasonModel):
     A single operation in an RFC 6902 JSON Patch document.
     """
 
-    op: Annotated[PatchOp, Field(description="The operation to perform.")]
-    path: Annotated[str, Field(description="A JSON Pointer path pointing to the target location.")]
-    value: Annotated[Any | None, Field(default=None, description="The value to add, replace, or test.")]
+    op: Annotated[PatchOp, Field(description="The operation to perform.", examples=["add"])]
+    path: Annotated[
+        str, Field(description="A JSON Pointer path pointing to the target location.", examples=["/user/name"])
+    ]
+    value: Annotated[
+        Any | None, Field(default=None, description="The value to add, replace, or test.", examples=["Alice"])
+    ]
     from_: Annotated[
         str | None,
         Field(
             default=None,
             alias="from",
             description="A JSON Pointer path pointing to the source location (for move and copy).",
+            examples=["/user/old_name"],
         ),
     ]
 
@@ -52,9 +57,19 @@ class Checkpoint(CoreasonModel):
     A strictly typed contract for a human-in-the-loop rollback and state hydration point.
     """
 
-    thread_id: Annotated[str, Field(description="The unique identifier for the execution thread.")]
-    node_id: Annotated[str, Field(description="The ID of the Node where this checkpoint was taken.")]
-    state_diff: Annotated[list[StateDiff], Field(description="The RFC 6902 JSON Patch representing the state delta.")]
+    thread_id: Annotated[
+        str, Field(description="The unique identifier for the execution thread.", examples=["thread_abc123"])
+    ]
+    node_id: Annotated[
+        str, Field(description="The ID of the Node where this checkpoint was taken.", examples=["node_42"])
+    ]
+    state_diff: Annotated[
+        list[StateDiff],
+        Field(
+            description="The RFC 6902 JSON Patch representing the state delta.",
+            examples=[[{"op": "add", "path": "/status", "value": "paused"}]],
+        ),
+    ]
 
 
 # =========================================================================
@@ -69,7 +84,9 @@ class PersistenceConfig(CoreasonModel):
     Configuration for state persistence backend.
     """
 
-    backend_type: Annotated[BackendType, Field(description="The type of the backend storage system.")]
-    ttl_seconds: Annotated[int | None, Field(ge=0, description="Time-to-live for the persisted state in seconds.")] = (
-        None
-    )
+    backend_type: Annotated[
+        BackendType, Field(description="The type of the backend storage system.", examples=["redis"])
+    ]
+    ttl_seconds: Annotated[
+        int | None, Field(ge=0, description="Time-to-live for the persisted state in seconds.", examples=[3600])
+    ] = None

--- a/src/coreason_manifest/core/workflow/contracts.py
+++ b/src/coreason_manifest/core/workflow/contracts.py
@@ -7,27 +7,68 @@ from coreason_manifest.core.common_base import CoreasonModel
 
 class AtomicSkill(CoreasonModel):
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-    id: str = Field(..., description="Unique identifier for this skill step")
-    description: str = Field(..., description="Description of the action to be performed")
-    immutable: bool = Field(False, description="If True, this step cannot be modified or removed by the planner")
-    tool_ref: str | None = Field(None, description="Reference to the tool to be used")
-    params: dict[str, Any] = Field(default_factory=dict, description="Parameters for the tool")
+    id: str = Field(..., description="Unique identifier for this skill step.", examples=["skill_123"])
+    description: str = Field(
+        ..., description="Description of the action to be performed.", examples=["Fetch user details."]
+    )
+    immutable: bool = Field(
+        False, description="If True, this step cannot be modified or removed by the planner.", examples=[False]
+    )
+    tool_ref: str | None = Field(None, description="Reference to the tool to be used.", examples=["fetch_user_tool"])
+    params: dict[str, Any] = Field(
+        default_factory=dict, description="Parameters for the tool.", examples=[{"user_id": 42}]
+    )
 
 
 class ActionNode(CoreasonModel):
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-    id: str = Field(..., description="Unique identifier for this action")
-    description: str = Field(..., description="Description of the action")
-    skill: AtomicSkill = Field(..., description="The atomic skill to execute")
-    inputs: dict[str, Any] = Field(default_factory=dict, description="Inputs for the action")
+    id: str = Field(..., description="Unique identifier for this action.", examples=["action_456"])
+    description: str = Field(..., description="Description of the action.", examples=["Execute user fetch."])
+    skill: AtomicSkill = Field(
+        ...,
+        description="The atomic skill to execute.",
+        examples=[
+            {
+                "id": "skill_123",
+                "description": "Fetch user details.",
+                "immutable": False,
+                "tool_ref": "fetch_user_tool",
+                "params": {},
+            }
+        ],
+    )
+    inputs: dict[str, Any] = Field(
+        default_factory=dict, description="Inputs for the action.", examples=[{"user_id": 42}]
+    )
 
 
 class StrategyNode(CoreasonModel):
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
-    id: str = Field(..., description="Unique identifier for this strategy node")
-    goal: str = Field(..., description="High-level goal description")
-    strategy_name: str = Field(..., description="Name of the strategy used (e.g., 'ReAct', 'TreeOfThoughts')")
-    children: list["PlanTree"] = Field(..., description="Child nodes (sub-goals)")
+    id: str = Field(..., description="Unique identifier for this strategy node.", examples=["strategy_789"])
+    goal: str = Field(..., description="High-level goal description.", examples=["Gather all relevant customer data."])
+    strategy_name: str = Field(
+        ..., description="Name of the strategy used (e.g., 'ReAct', 'TreeOfThoughts').", examples=["ReAct"]
+    )
+    children: list["PlanTree"] = Field(
+        ...,
+        description="Child nodes (sub-goals).",
+        examples=[
+            [
+                {
+                    "id": "action_456",
+                    "description": "Execute user fetch.",
+                    "skill": {
+                        "id": "skill_123",
+                        "description": "Fetch user details.",
+                        "immutable": False,
+                        "tool_ref": "fetch_user_tool",
+                        "params": {},
+                    },
+                    "inputs": {},
+                }
+            ]
+        ],
+    )
 
 
 type PlanTree = StrategyNode | ActionNode | AtomicSkill | list["PlanTree"]

--- a/src/coreason_manifest/core/workflow/evals.py
+++ b/src/coreason_manifest/core/workflow/evals.py
@@ -7,16 +7,18 @@ from coreason_manifest.core.primitives.types import NodeID
 
 
 class ChaosConfig(CoreasonModel, frozen=True):
-    latency_ms: int = Field(default=0, ge=0, description="Artificial latency to inject into node execution.")
-    error_rate: float = Field(
-        default=0.0, ge=0.0, le=1.0, description="Probability of forcing a node failure (0.0 to 1.0)."
+    latency_ms: int = Field(
+        default=0, ge=0, description="Artificial latency to inject into node execution.", examples=[150]
     )
-    token_throttle: bool = Field(default=False, description="Simulate a constricted context window.")
+    error_rate: float = Field(
+        default=0.0, ge=0.0, le=1.0, description="Probability of forcing a node failure (0.0 to 1.0).", examples=[0.05]
+    )
+    token_throttle: bool = Field(default=False, description="Simulate a constricted context window.", examples=[True])
 
 
 class AdversaryProfile(CoreasonModel, frozen=True):
-    goal: str = Field(..., description="The adversary's objective.")
-    attack_strategy: str = Field(..., description="Methodology.")
+    goal: str = Field(..., description="The adversary's objective.", examples=["Extract PII data."])
+    attack_strategy: str = Field(..., description="Methodology.", examples=["Prompt injection via SQL payload."])
 
 
 class TestCase(CoreasonModel):
@@ -25,16 +27,28 @@ class TestCase(CoreasonModel):
     """
 
     mock_inputs: dict[str, Any] = Field(
-        default_factory=dict, description="Variables to inject into the blackboard at start."
+        default_factory=dict,
+        description="Variables to inject into the blackboard at start.",
+        examples=[{"user_id": 42}],
     )
     expected_traversal_path: list[NodeID] = Field(
-        default_factory=list, description="List of Node IDs that MUST be hit in sequence."
+        default_factory=list,
+        description="List of Node IDs that MUST be hit in sequence.",
+        examples=[["auth_node", "db_node", "response_node"]],
     )
-    assertions: dict[str, Any] = Field(default_factory=dict, description="JSON Schema validations on the final output.")
+    assertions: dict[str, Any] = Field(
+        default_factory=dict, description="JSON Schema validations on the final output.", examples=[{"type": "object"}]
+    )
     chaos_config: ChaosConfig | None = Field(
-        default=None, description="Infrastructure faults to apply during this test."
+        default=None,
+        description="Infrastructure faults to apply during this test.",
+        examples=[{"latency_ms": 100, "error_rate": 0.0, "token_throttle": False}],
     )
-    adversary: AdversaryProfile | None = Field(default=None, description="Red-team configuration for semantic fuzzing.")
+    adversary: AdversaryProfile | None = Field(
+        default=None,
+        description="Red-team configuration for semantic fuzzing.",
+        examples=[{"goal": "Bypass filters.", "attack_strategy": "roleplay"}],
+    )
 
 
 class FuzzingTarget(CoreasonModel):
@@ -42,13 +56,21 @@ class FuzzingTarget(CoreasonModel):
     Definition of a fuzzing target for automated adversarial probing.
     """
 
-    variables: list[str] = Field(default_factory=list, description="Input variables to fuzz.")
-    mutators: list[str] = Field(
-        default_factory=list, description="Mutator strategies to employ (e.g. 'edge_cases', 'adversarial')."
+    variables: list[str] = Field(
+        default_factory=list, description="Input variables to fuzz.", examples=[["user_prompt"]]
     )
-    invariants: dict[str, Any] = Field(default_factory=dict, description="JSON Schema invariants that must hold true.")
+    mutators: list[str] = Field(
+        default_factory=list,
+        description="Mutator strategies to employ (e.g. 'edge_cases', 'adversarial').",
+        examples=[["adversarial"]],
+    )
+    invariants: dict[str, Any] = Field(
+        default_factory=dict, description="JSON Schema invariants that must hold true.", examples=[{"type": "object"}]
+    )
     adversary: AdversaryProfile | None = Field(
-        default=None, description="Red-team configuration for stochastic semantic fuzzing."
+        default=None,
+        description="Red-team configuration for stochastic semantic fuzzing.",
+        examples=[{"goal": "Leak secrets.", "attack_strategy": "obfuscation"}],
     )
 
 
@@ -57,5 +79,13 @@ class EvalsManifest(CoreasonModel):
     Manifest defining how an agent graph is deterministically tested.
     """
 
-    test_cases: list[TestCase] = Field(default_factory=list, description="List of test cases to execute.")
-    fuzzing_targets: list[FuzzingTarget] = Field(default_factory=list, description="List of fuzzing targets.")
+    test_cases: list[TestCase] = Field(
+        default_factory=list,
+        description="List of test cases to execute.",
+        examples=[[{"mock_inputs": {}, "expected_traversal_path": [], "assertions": {}}]],
+    )
+    fuzzing_targets: list[FuzzingTarget] = Field(
+        default_factory=list,
+        description="List of fuzzing targets.",
+        examples=[[{"variables": ["input"], "mutators": ["edge_cases"], "invariants": {}}]],
+    )

--- a/src/coreason_manifest/core/workflow/flow.py
+++ b/src/coreason_manifest/core/workflow/flow.py
@@ -36,18 +36,38 @@ __all__ = [
 
 
 class FlowMetadata(CoreasonModel):
-    name: str
-    version: str
-    description: str | None = None
-    tags: list[str] = Field(default_factory=list)
-    created_at: str | None = None
-    updated_at: str | None = None
+    name: str = Field(..., description="The name of the flow.", examples=["customer_onboarding_flow"])
+    version: str = Field(..., description="The semantic version of the flow.", examples=["1.0.0"])
+    description: str | None = Field(
+        default=None, description="A description of the flow's purpose.", examples=["Flow to onboard new customers."]
+    )
+    tags: list[str] = Field(
+        default_factory=list,
+        description="A list of tags for categorizing the flow.",
+        examples=[["onboarding", "customer"]],
+    )
+    created_at: str | None = Field(
+        default=None, description="The ISO-8601 timestamp when the flow was created.", examples=["2025-01-01T00:00:00Z"]
+    )
+    updated_at: str | None = Field(
+        default=None,
+        description="The ISO-8601 timestamp when the flow was last updated.",
+        examples=["2025-01-02T00:00:00Z"],
+    )
 
 
 class DataSchema(CoreasonModel):
     # Compatibility: Field is 'json_schema' to avoid shadowing BaseModel.schema
-    id: str = Field(default_factory=lambda: str(uuid4()))
-    json_schema: dict[str, Any] = Field(default_factory=dict)
+    id: str = Field(
+        default_factory=lambda: str(uuid4()),
+        description="The unique identifier for the schema.",
+        examples=["550e8400-e29b-41d4-a716-446655440000"],
+    )
+    json_schema: dict[str, Any] = Field(
+        default_factory=dict,
+        description="The JSON schema definition.",
+        examples=[{"type": "object", "properties": {"name": {"type": "string"}}}],
+    )
 
     @model_validator(mode="after")
     def validate_schema_validity(self) -> "DataSchema":
@@ -69,17 +89,40 @@ class DataSchema(CoreasonModel):
 
 
 class Blackboard(CoreasonModel):
-    variables: dict[str, Any] = Field(default_factory=dict)
-    schemas: list[DataSchema] = Field(default_factory=list)
-    persistence: PersistenceConfig | None = None
+    variables: dict[str, Any] = Field(
+        default_factory=dict, description="The variables stored in the blackboard.", examples=[{"customer_id": "12345"}]
+    )
+    schemas: list[DataSchema] = Field(
+        default_factory=list,
+        description="The schemas available on the blackboard.",
+        examples=[
+            [
+                {
+                    "id": "550e8400-e29b-41d4-a716-446655440000",
+                    "json_schema": {"type": "object", "properties": {"name": {"type": "string"}}},
+                }
+            ]
+        ],
+    )
+    persistence: PersistenceConfig | None = Field(
+        default=None,
+        description="The persistence configuration for the blackboard state.",
+        examples=[{"backend_type": "redis", "ttl_seconds": 3600}],
+    )
 
 
 class Edge(CoreasonModel):
-    from_node: NodeID
-    to_node: NodeID
-    condition: str | None = None
-    cost_weight: float = Field(0.0, ge=0.0, description="Estimated financial cost (USD) to traverse this edge.")
-    latency_weight_ms: float = Field(0.0, ge=0.0, description="Estimated latency in milliseconds.")
+    from_node: NodeID = Field(..., description="The ID of the source node.", examples=["node_a"])
+    to_node: NodeID = Field(..., description="The ID of the target node.", examples=["node_b"])
+    condition: str | None = Field(
+        default=None,
+        description="A python expression string evaluated to determine if the edge should be traversed.",
+        examples=["x > 10"],
+    )
+    cost_weight: float = Field(
+        0.0, ge=0.0, description="Estimated financial cost (USD) to traverse this edge.", examples=[0.05]
+    )
+    latency_weight_ms: float = Field(0.0, ge=0.0, description="Estimated latency in milliseconds.", examples=[150.0])
 
     @field_validator("condition", mode="before")
     @classmethod
@@ -97,9 +140,19 @@ class Edge(CoreasonModel):
 
 
 class Graph(CoreasonModel):
-    nodes: dict[str, AnyNode]
-    edges: list[Edge]
-    entry_point: NodeID | None = None
+    nodes: dict[str, AnyNode] = Field(
+        ...,
+        description="A dictionary of nodes in the graph, keyed by their ID.",
+        examples=[{"node_a": {"id": "node_a", "type": "agent"}}],
+    )
+    edges: list[Edge] = Field(
+        ...,
+        description="A list of edges connecting the nodes.",
+        examples=[[{"from_node": "node_a", "to_node": "node_b", "cost_weight": 0.0, "latency_weight_ms": 0.0}]],
+    )
+    entry_point: NodeID | None = Field(
+        default=None, description="The ID of the entry node for the graph.", examples=["node_a"]
+    )
 
     @model_validator(mode="after")
     def validate_graph_structure(self) -> "Graph":
@@ -169,24 +222,60 @@ class Graph(CoreasonModel):
 
 
 class FlowInterface(CoreasonModel):
-    inputs: dict[str, Any] | DataSchema = Field(default_factory=dict)
-    outputs: dict[str, Any] | DataSchema = Field(default_factory=dict)
+    inputs: dict[str, Any] | DataSchema = Field(
+        default_factory=dict, description="The expected inputs for the flow.", examples=[{"user_id": "123"}]
+    )
+    outputs: dict[str, Any] | DataSchema = Field(
+        default_factory=dict, description="The expected outputs from the flow.", examples=[{"status": "success"}]
+    )
 
 
 class FlowDefinitions(CoreasonModel):
-    profiles: dict[str, Any] = Field(default_factory=dict)
-    schemas: dict[str, Any] = Field(default_factory=dict)
-    tools: dict[str, AnyTool] = Field(default_factory=dict)
-    tool_packs: dict[str, ToolPack] = Field(default_factory=dict)
-    skills: dict[str, Any] = Field(default_factory=dict)
-    middlewares: dict[MiddlewareID, MiddlewareDef] = Field(default_factory=dict)
-    supervision_templates: Any | None = None
+    profiles: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Agent profiles available in the flow.",
+        examples=[{"sales_agent": {"role": "sales"}}],
+    )
+    schemas: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Schemas referenced in the flow.",
+        examples=[{"customer_schema": {"type": "object"}}],
+    )
+    tools: dict[str, AnyTool] = Field(
+        default_factory=dict,
+        description="Tools available to agents in the flow.",
+        examples=[{"search_tool": {"id": "search", "name": "search", "description": "Search the web"}}],
+    )
+    tool_packs: dict[str, ToolPack] = Field(
+        default_factory=dict,
+        description="Tool packs available in the flow.",
+        examples=[{"research_pack": {"tools": ["search_tool"]}}],
+    )
+    skills: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Skills available to agents.",
+        examples=[{"negotiation": {"level": "advanced"}}],
+    )
+    middlewares: dict[MiddlewareID, MiddlewareDef] = Field(
+        default_factory=dict,
+        description="Middlewares defined for the flow.",
+        examples=[{"logger": {"id": "logger", "type": "logging"}}],
+    )
+    supervision_templates: Any | None = Field(
+        default=None, description="Supervision templates for oversight.", examples=[{"approval": {"type": "human"}}]
+    )
 
 
 class VariableDef(CoreasonModel):
-    id: str = Field(default_factory=lambda: str(uuid4()))
-    type: str
-    description: str | None = None
+    id: str = Field(
+        default_factory=lambda: str(uuid4()),
+        description="The unique identifier for the variable definition.",
+        examples=["550e8400-e29b-41d4-a716-446655440000"],
+    )
+    type: str = Field(..., description="The type of the variable.", examples=["string"])
+    description: str | None = Field(
+        default=None, description="A description of the variable.", examples=["The user's first name."]
+    )
 
 
 class GraphFlow(CoreasonModel):
@@ -194,15 +283,60 @@ class GraphFlow(CoreasonModel):
     Standard graph-based execution flow.
     """
 
-    type: Literal["graph"] = "graph"
-    kind: Literal["GraphFlow"] = "GraphFlow"
-    status: Literal["draft", "published", "archived"] = "draft"
-    metadata: FlowMetadata
-    interface: FlowInterface
-    governance: Governance | None = None
-    blackboard: Blackboard | None = Field(default_factory=Blackboard)
-    definitions: FlowDefinitions | None = None
-    graph: Graph
+    type: Literal["graph"] = Field("graph", description="The flow type.", examples=["graph"])
+    kind: Literal["GraphFlow"] = Field(
+        "GraphFlow", description="The kind of the flow manifest.", examples=["GraphFlow"]
+    )
+    status: Literal["draft", "published", "archived"] = Field(
+        "draft", description="The publication status of the flow.", examples=["published"]
+    )
+    metadata: FlowMetadata = Field(
+        ...,
+        description="Metadata describing the flow.",
+        examples=[
+            {
+                "name": "sales_flow",
+                "version": "1.0.0",
+                "description": "Flow for sales",
+                "tags": [],
+                "created_at": None,
+                "updated_at": None,
+            }
+        ],
+    )
+    interface: FlowInterface = Field(
+        ..., description="The input/output interface of the flow.", examples=[{"inputs": {}, "outputs": {}}]
+    )
+    governance: Governance | None = Field(
+        default=None,
+        description="Governance policies applied to the flow.",
+        examples=[{"operational_policy": {"max_cost_usd": 10.0}}],
+    )
+    blackboard: Blackboard | None = Field(
+        default_factory=Blackboard,
+        description="The blackboard state for the flow.",
+        examples=[{"variables": {}, "schemas": [], "persistence": None}],
+    )
+    definitions: FlowDefinitions | None = Field(
+        default=None,
+        description="Definitions for components used in the flow.",
+        examples=[
+            {
+                "profiles": {},
+                "schemas": {},
+                "tools": {},
+                "tool_packs": {},
+                "skills": {},
+                "middlewares": {},
+                "supervision_templates": None,
+            }
+        ],
+    )
+    graph: Graph = Field(
+        ...,
+        description="The execution graph topology.",
+        examples=[{"nodes": {"n1": {"id": "n1", "type": "agent"}}, "edges": [], "entry_point": "n1"}],
+    )
 
     @model_validator(mode="after")
     def enforce_lifecycle_constraints(self) -> "GraphFlow":
@@ -242,13 +376,52 @@ class LinearFlow(CoreasonModel):
     Simplified linear execution flow (sequence of steps).
     """
 
-    type: Literal["linear"] = "linear"
-    kind: Literal["LinearFlow"] = "LinearFlow"
-    status: Literal["draft", "published", "archived"] = "draft"
-    metadata: FlowMetadata
-    steps: list[AnyNode] = Field(default_factory=list)
-    governance: Governance | None = None
-    definitions: FlowDefinitions | None = None
+    type: Literal["linear"] = Field("linear", description="The flow type.", examples=["linear"])
+    kind: Literal["LinearFlow"] = Field(
+        "LinearFlow", description="The kind of the flow manifest.", examples=["LinearFlow"]
+    )
+    status: Literal["draft", "published", "archived"] = Field(
+        "draft", description="The publication status of the flow.", examples=["draft"]
+    )
+    metadata: FlowMetadata = Field(
+        ...,
+        description="Metadata describing the flow.",
+        examples=[
+            {
+                "name": "simple_linear",
+                "version": "1.0.0",
+                "description": "A simple sequence of steps",
+                "tags": [],
+                "created_at": None,
+                "updated_at": None,
+            }
+        ],
+    )
+    steps: list[AnyNode] = Field(
+        default_factory=list,
+        description="An ordered list of nodes to execute sequentially.",
+        examples=[[{"id": "step_1", "type": "agent"}]],
+    )
+    governance: Governance | None = Field(
+        default=None,
+        description="Governance policies applied to the flow.",
+        examples=[{"operational_policy": {"max_cost_usd": 10.0}}],
+    )
+    definitions: FlowDefinitions | None = Field(
+        default=None,
+        description="Definitions for components used in the flow.",
+        examples=[
+            {
+                "profiles": {},
+                "schemas": {},
+                "tools": {},
+                "tool_packs": {},
+                "skills": {},
+                "middlewares": {},
+                "supervision_templates": None,
+            }
+        ],
+    )
 
     @model_validator(mode="after")
     def validate_linear_structure(self) -> "LinearFlow":
@@ -307,5 +480,22 @@ class AgentRequest(CoreasonModel):
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    manifest: GraphFlow | LinearFlow
-    metadata: dict[str, Any] = Field(default_factory=dict)
+    manifest: GraphFlow | LinearFlow = Field(
+        ...,
+        description="The flow manifest detailing the execution logic.",
+        examples=[
+            {
+                "type": "linear",
+                "kind": "LinearFlow",
+                "status": "draft",
+                "metadata": {"name": "f", "version": "1"},
+                "steps": [],
+                "interface": {"inputs": {}, "outputs": {}},
+            }
+        ],
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional context or metadata for the request.",
+        examples=[{"client_id": "abc-123"}],
+    )


### PR DESCRIPTION
Enforce a strict "Schema-First, Machine-Readable Documentation" standard across the `coreason_manifest` repository by ensuring every Pydantic field has `description` and `examples` metadata, and docstrings are optimized for LLM tool calling.

---
*PR created automatically by Jules for task [13291741983707315416](https://jules.google.com/task/13291741983707315416) started by @gowthamrao*