### PR TITLE
feat: implement semantic FinOps and resource contracts

### DIFF
--- a/src/coreason_manifest/core/compute/reasoning.py
+++ b/src/coreason_manifest/core/compute/reasoning.py
@@ -3,10 +3,10 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
+from coreason_manifest.core.compute.resources import ModelProfile
 from coreason_manifest.core.primitives.constants import NodeCapability
 from coreason_manifest.core.primitives.registry import register_engine, resolve_engine_union
 from coreason_manifest.core.primitives.types import WasiCapability
-from coreason_manifest.core.compute.resources import ModelProfile
 
 # =========================================================================
 #  TYPE DEFINITIONS & ALIASES
@@ -56,11 +56,15 @@ class ModelCriteria(BaseModel):
     specific_models: Annotated[list[str] | None, Field(description="Explicit list of model IDs to route between.")] = (
         None
     )
-    primary_profile: "ModelProfile | None" = Field(
-        None, description="Explicit profile of the main model to use.", examples=[{"provider": "openai", "model_id": "gpt-4o"}]
+    primary_profile: ModelProfile | None = Field(
+        None,
+        description="Explicit profile of the main model to use.",
+        examples=[{"provider": "openai", "model_id": "gpt-4o"}],
     )
-    escalation_profile: "ModelProfile | None" = Field(
-        None, description="Explicit profile of the fallback model to use.", examples=[{"provider": "openai", "model_id": "o1-preview"}]
+    escalation_profile: ModelProfile | None = Field(
+        None,
+        description="Explicit profile of the fallback model to use.",
+        examples=[{"provider": "openai", "model_id": "o1-preview"}],
     )
 
 

--- a/src/coreason_manifest/core/compute/reasoning.py
+++ b/src/coreason_manifest/core/compute/reasoning.py
@@ -6,6 +6,7 @@ from pydantic import BaseModel, ConfigDict, Field, model_validator
 from coreason_manifest.core.primitives.constants import NodeCapability
 from coreason_manifest.core.primitives.registry import register_engine, resolve_engine_union
 from coreason_manifest.core.primitives.types import WasiCapability
+from coreason_manifest.core.compute.resources import ModelProfile
 
 # =========================================================================
 #  TYPE DEFINITIONS & ALIASES
@@ -54,6 +55,12 @@ class ModelCriteria(BaseModel):
     provider_whitelist: list[str] | None = None
     specific_models: Annotated[list[str] | None, Field(description="Explicit list of model IDs to route between.")] = (
         None
+    )
+    primary_profile: "ModelProfile | None" = Field(
+        None, description="Explicit profile of the main model to use.", examples=[{"provider": "openai", "model_id": "gpt-4o"}]
+    )
+    escalation_profile: "ModelProfile | None" = Field(
+        None, description="Explicit profile of the fallback model to use.", examples=[{"provider": "openai", "model_id": "o1-preview"}]
     )
 
 

--- a/src/coreason_manifest/core/compute/resources.py
+++ b/src/coreason_manifest/core/compute/resources.py
@@ -1,4 +1,5 @@
 from enum import StrEnum
+
 from pydantic import Field
 
 from coreason_manifest.core.common.base import CoreasonModel
@@ -11,8 +12,8 @@ class Currency(StrEnum):
 
 
 class PricingUnit(StrEnum):
-    TOKEN_1K = "TOKEN_1K"
-    TOKEN_1M = "TOKEN_1M"
+    TOKEN_1K = "TOKEN_1K"  # noqa: S105
+    TOKEN_1M = "TOKEN_1M"  # noqa: S105
     REQUEST = "REQUEST"
 
 
@@ -25,7 +26,11 @@ class RateCard(CoreasonModel):
         description="Cost specifically for internal reasoning or thinking tokens per unit.",
         examples=[0.05],
     )
-    unit: PricingUnit = Field(default=PricingUnit.TOKEN_1M, description="The unit of measurement for the cost.", examples=["TOKEN_1M"])
+    unit: PricingUnit = Field(
+        default=PricingUnit.TOKEN_1M,
+        description="The unit of measurement for the cost.",
+        examples=["TOKEN_1M"]
+    )
 
 
 class ModelProfile(CoreasonModel):

--- a/src/coreason_manifest/core/compute/resources.py
+++ b/src/coreason_manifest/core/compute/resources.py
@@ -1,0 +1,34 @@
+from enum import StrEnum
+from pydantic import Field
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class Currency(StrEnum):
+    USD = "USD"
+    EUR = "EUR"
+    CREDITS = "CREDITS"
+
+
+class PricingUnit(StrEnum):
+    TOKEN_1K = "TOKEN_1K"
+    TOKEN_1M = "TOKEN_1M"
+    REQUEST = "REQUEST"
+
+
+class RateCard(CoreasonModel):
+    input_cost: float = Field(..., ge=0.0, description="Cost for input processing per unit.", examples=[0.01])
+    output_cost: float = Field(..., ge=0.0, description="Cost for output generation per unit.", examples=[0.03])
+    reasoning_cost: float | None = Field(
+        None,
+        ge=0.0,
+        description="Cost specifically for internal reasoning or thinking tokens per unit.",
+        examples=[0.05],
+    )
+    unit: PricingUnit = Field(default=PricingUnit.TOKEN_1M, description="The unit of measurement for the cost.", examples=["TOKEN_1M"])
+
+
+class ModelProfile(CoreasonModel):
+    provider: str = Field(..., description="The provider of the model.", examples=["openai", "anthropic"])
+    model_id: str = Field(..., description="The unique identifier of the model.", examples=["o1-preview", "gpt-4o"])
+    pricing: RateCard | None = Field(None, description="The rate card associated with the model's pricing.")

--- a/src/coreason_manifest/core/compute/resources.py
+++ b/src/coreason_manifest/core/compute/resources.py
@@ -27,9 +27,7 @@ class RateCard(CoreasonModel):
         examples=[0.05],
     )
     unit: PricingUnit = Field(
-        default=PricingUnit.TOKEN_1M,
-        description="The unit of measurement for the cost.",
-        examples=["TOKEN_1M"]
+        default=PricingUnit.TOKEN_1M, description="The unit of measurement for the cost.", examples=["TOKEN_1M"]
     )
 
 

--- a/src/coreason_manifest/core/oversight/governance.py
+++ b/src/coreason_manifest/core/oversight/governance.py
@@ -106,6 +106,9 @@ class FinancialLimits(CoreasonModel):
         description="Model ID to fallback to when budget hits 90% depletion (e.g., swap o1-pro to gpt-4o-mini).",
         examples=["gpt-4o-mini"],
     )
+    max_transaction_cost_usd: float | None = Field(
+        None, ge=0.0, description="Maximum allowed cost for a single transaction or branch.", examples=[5.0]
+    )
 
 
 class DataLimits(CoreasonModel):
@@ -123,6 +126,12 @@ class ComputeLimits(CoreasonModel):
     max_cognitive_steps: int | None = Field(None, gt=0, description="Max turn/DAG transitions.", examples=[50])
     max_concurrent_agents: int | None = Field(
         None, gt=0, description="Maximum number of concurrent agents.", examples=[10]
+    )
+    max_tokens_per_turn: int | None = Field(
+        None, gt=0, description="Maximum allowed tokens per execution turn.", examples=[4000]
+    )
+    context_compression_strategy: Literal["none", "summarize", "truncate_oldest"] = Field(
+        "none", description="Strategy to compress context when it exceeds bounds.", examples=["summarize"]
     )
 
 

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -132,6 +132,23 @@ class AgentBuilder:
         self.gap_scan_enabled = False
         self.gap_scan_threshold = 0.8
         self.max_revisions = 1
+        self._rate_card_config: dict[str, Any] | None = None
+
+    def with_rate_card(
+        self,
+        input_cost: float,
+        output_cost: float,
+        reasoning_cost: float | None = None,
+        unit: str = "TOKEN_1M",
+    ) -> "AgentBuilder":
+        """Attaches a FinOps rate card to the primary model profile."""
+        self._rate_card_config = {
+            "input_cost": input_cost,
+            "output_cost": output_cost,
+            "reasoning_cost": reasoning_cost,
+            "unit": unit,
+        }
+        return self
 
     def with_meta_cognition(
         self,
@@ -511,14 +528,44 @@ class AgentBuilder:
             if self.gap_scan_enabled:
                 gap_scan = GapScanConfig(enabled=True, confidence_threshold=self.gap_scan_threshold)
 
-            self.reasoning = self.reasoning.model_copy(
-                update={
-                    "review_strategy": ReviewStrategy(self.review_strategy),
-                    "adversarial_config": adversarial_config,
-                    "gap_scan": gap_scan,
-                    "max_revisions": self.max_revisions,
-                }
-            )
+            updates: dict[str, Any] = {
+                "review_strategy": ReviewStrategy(self.review_strategy),
+                "adversarial_config": adversarial_config,
+                "gap_scan": gap_scan,
+                "max_revisions": self.max_revisions,
+            }
+
+            if self._rate_card_config:
+                from coreason_manifest.core.compute.resources import RateCard, ModelProfile, PricingUnit
+
+                rc = RateCard(
+                    input_cost=self._rate_card_config["input_cost"],
+                    output_cost=self._rate_card_config["output_cost"],
+                    reasoning_cost=self._rate_card_config["reasoning_cost"],
+                    unit=PricingUnit(self._rate_card_config["unit"]),
+                )
+
+                # Retrieve existing primary_profile if models is already ModelCriteria
+                existing_models = self.reasoning.models
+                from coreason_manifest.core.compute.reasoning import ModelCriteria
+
+                if isinstance(existing_models, ModelCriteria):
+                    models_copy = existing_models.model_copy()
+                    if models_copy.primary_profile:
+                        # Append the pricing to the existing profile
+                        new_profile = models_copy.primary_profile.model_copy(update={"pricing": rc})
+                        models_copy = models_copy.model_copy(update={"primary_profile": new_profile})
+                    else:
+                        # Fallback to create a default model profile assuming a primary one is omitted
+                        new_profile = ModelProfile(provider="unknown", model_id="unknown", pricing=rc)
+                        models_copy = models_copy.model_copy(update={"primary_profile": new_profile})
+                    updates["models"] = models_copy
+                elif isinstance(existing_models, str):
+                    # Convert string to ModelCriteria with primary_profile
+                    new_profile = ModelProfile(provider="unknown", model_id=existing_models, pricing=rc)
+                    updates["models"] = ModelCriteria(specific_models=[existing_models], primary_profile=new_profile)
+
+            self.reasoning = self.reasoning.model_copy(update=updates)
 
         from coreason_manifest.core.workflow.nodes import AgentNode, CognitiveProfile
 

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -536,7 +536,7 @@ class AgentBuilder:
             }
 
             if self._rate_card_config:
-                from coreason_manifest.core.compute.resources import RateCard, ModelProfile, PricingUnit
+                from coreason_manifest.core.compute.resources import ModelProfile, PricingUnit, RateCard
 
                 rc = RateCard(
                     input_cost=self._rate_card_config["input_cost"],

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -964,6 +964,33 @@ def _validate_budget_constraints(flow: LinearFlow | GraphFlow) -> list[Complianc
             )
         )
 
+    nodes, _ = get_unified_topology(flow)
+    for node in nodes:
+        if node.type == "agent" and node.resilience:
+            resolved_policy = _resolve_resilience_policy(node.resilience, getattr(flow, "definitions", None))
+            if resolved_policy:
+                strategies = _extract_strategies(resolved_policy)
+                for strategy in strategies:
+                    if getattr(strategy, "type", None) == "retry":
+                        attempts = getattr(strategy, "max_attempts", 0)
+                        if attempts > 5:
+                            # Check for high cost model or RateCard
+                            is_high_cost = False
+                            if getattr(node, "profile", None) and getattr(node.profile, "reasoning", None):
+                                primary_prof = getattr(node.profile.reasoning.models, "primary_profile", None)
+                                if primary_prof and getattr(primary_prof, "pricing", None):
+                                    is_high_cost = True
+
+                            if is_high_cost:
+                                errors.append(
+                                    ComplianceReport(
+                                        code="ERR_GOV_FINANCIAL_RISK",
+                                        severity="warning",
+                                        message=f"Financial Risk: Agent node '{node.id}' has aggressive retry loop (max_attempts > 5) while using a cost-bearing model.",
+                                        details={"node_id": node.id, "max_attempts": attempts}
+                                    )
+                                )
+
     return errors
 
 

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -986,8 +986,11 @@ def _validate_budget_constraints(flow: LinearFlow | GraphFlow) -> list[Complianc
                                     ComplianceReport(
                                         code="ERR_GOV_FINANCIAL_RISK",
                                         severity="warning",
-                                        message=f"Financial Risk: Agent node '{node.id}' has aggressive retry loop (max_attempts > 5) while using a cost-bearing model.",
-                                        details={"node_id": node.id, "max_attempts": attempts}
+                                        message=(
+                                            f"Financial Risk: Agent node '{node.id}' has aggressive retry "
+                                            "loop (max_attempts > 5) while using a cost-bearing model."
+                                        ),
+                                        details={"node_id": node.id, "max_attempts": attempts},
                                     )
                                 )
 


### PR DESCRIPTION
Implements **Epic 1: Semantic FinOps & Resource Contracts** for `coreason-manifest` (version 0.25.0).
Introduced cost-schema definitions ensuring strict, passive Pydantic V2 definitions that capture emerging costs, like "reasoning" (o1/o3 thinking tokens).

Upgrades include:
- `resources.py`: Core FinOps Primitives.
- `reasoning.py`: Added `primary_profile` and `escalation_profile` to `ModelCriteria` for Confidence-Based Escalation.
- `governance.py`: Implemented quadratic cost limits (per turn, per transaction, context compression).
- `validator.py`: Static DAG analysis via SOTA validation checks using `_resolve_resilience_policy`.
- `builder.py`: Added `with_rate_card` to automatically inject economic tracking models.

Passed static type checkers (`mypy`) and all existing functional tests. Resolved reviewer feedback about proper usage of discriminator type extraction.

---
*PR created automatically by Jules for task [15682656207661573305](https://jules.google.com/task/15682656207661573305) started by @gowthamrao*