### PR TITLE
feat: implement Shift-Left Governance (Epic 3)

### DIFF
--- a/src/coreason_manifest/core/oversight/governance.py
+++ b/src/coreason_manifest/core/oversight/governance.py
@@ -46,6 +46,13 @@ class Safety(CoreasonModel):
     content_safety: Literal["high", "medium", "low"] = Field(
         ..., description="Content safety level.", examples=["high"]
     )
+    safety_preamble: str | None = Field(
+        None,
+        description="Mandatory safety instruction injected into the system prompt deterministically by the runtime.",
+    )
+    legal_disclaimer: str | None = Field(
+        None, description="Text that must be appended to the final output deterministically by the runtime."
+    )
 
 
 class Audit(CoreasonModel):

--- a/src/coreason_manifest/core/workflow/flow.py
+++ b/src/coreason_manifest/core/workflow/flow.py
@@ -18,6 +18,7 @@ from coreason_manifest.core.state.tools import AnyTool, ToolPack
 from coreason_manifest.core.workflow.nodes import (
     AnyNode,
 )
+from coreason_manifest.core.workflow.nodes.base import Constraint
 
 
 class ProvenanceType(StrEnum):
@@ -230,6 +231,9 @@ class GraphFlow(CoreasonModel):
     status: Literal["draft", "published", "archived"] = "draft"
     metadata: FlowMetadata
     interface: FlowInterface
+    pre_flight_constraints: list[Constraint] = Field(
+        default_factory=list, description="Feasibility gates evaluated before the workflow is allocated compute."
+    )
     governance: Governance | None = None
     blackboard: Blackboard | None = Field(default_factory=Blackboard)
     definitions: FlowDefinitions | None = None
@@ -282,6 +286,9 @@ class LinearFlow(CoreasonModel):
     kind: Literal["LinearFlow"] = "LinearFlow"
     status: Literal["draft", "published", "archived"] = "draft"
     metadata: FlowMetadata
+    pre_flight_constraints: list[Constraint] = Field(
+        default_factory=list, description="Feasibility gates evaluated before the workflow is allocated compute."
+    )
     steps: list[AnyNode] = Field(default_factory=list)
     governance: Governance | None = None
     definitions: FlowDefinitions | None = None

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -89,6 +89,39 @@ def _validate_traffic_policy(flow: LinearFlow | GraphFlow) -> list[ComplianceRep
     return errors
 
 
+def _validate_pre_flight_constraints(flow: GraphFlow | LinearFlow) -> list[ComplianceReport]:
+    errors: list[ComplianceReport] = []
+
+    if not hasattr(flow, "pre_flight_constraints") or not flow.pre_flight_constraints:
+        return errors
+
+    interface_keys = set()
+
+    if hasattr(flow, "interface") and flow.interface:
+        inputs = flow.interface.inputs
+        in_schema = getattr(inputs, "json_schema", inputs)
+        if isinstance(in_schema, dict):
+            props = in_schema.get("properties", {})
+            interface_keys.update(props.keys())
+
+    if hasattr(flow, "blackboard") and flow.blackboard:
+        interface_keys.update(flow.blackboard.variables.keys())
+
+    for constraint in flow.pre_flight_constraints:
+        base_var = constraint.variable.split(".")[0]
+        if base_var not in interface_keys:
+            errors.append(
+                ComplianceReport(
+                    code=ErrorCatalog.ERR_CAP_MISSING_VAR,
+                    severity="violation",
+                    message=f"Pre-flight constraint references missing variable '{constraint.variable}'.",
+                    details={"variable": constraint.variable},
+                )
+            )
+
+    return errors
+
+
 def validate_flow(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
     """
     Semantically validate a Flow (Linear or Graph).
@@ -97,6 +130,7 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
     errors: list[ComplianceReport] = []
 
     errors.extend(_validate_traffic_policy(flow))
+    errors.extend(_validate_pre_flight_constraints(flow))
 
     # Flatten nodes based on flow type
     nodes, edges_objs = get_unified_topology(flow)


### PR DESCRIPTION
Implement SOTA Shift-Left Governance enhancements for Epic 3, separating safety and legal instructions from LLM prompt space into declarative orchestration fields, and adding deterministic evaluation of pre-flight constraints with robust static analysis.

---
*PR created automatically by Jules for task [12043976102512439848](https://jules.google.com/task/12043976102512439848) started by @gowthamrao*