### PR TITLE
feat: embed evals-as-code and topological test validation

### DIFF
--- a/src/coreason_manifest/core/workflow/flow.py
+++ b/src/coreason_manifest/core/workflow/flow.py
@@ -15,6 +15,7 @@ from coreason_manifest.core.primitives.types import MiddlewareDef, MiddlewareID,
 from coreason_manifest.core.security.compliance import RemediationAction, SecurityVisitor
 from coreason_manifest.core.state.persistence import PersistenceConfig
 from coreason_manifest.core.state.tools import AnyTool, ToolPack
+from coreason_manifest.core.workflow.evals import EvalsManifest
 from coreason_manifest.core.workflow.nodes import (
     AnyNode,
 )
@@ -234,6 +235,7 @@ class GraphFlow(CoreasonModel):
     blackboard: Blackboard | None = Field(default_factory=Blackboard)
     definitions: FlowDefinitions | None = None
     graph: Graph
+    evals: EvalsManifest | None = Field(None, description="Embedded executable specifications and test scenarios.")
 
     @model_validator(mode="after")
     def enforce_lifecycle_constraints(self) -> "GraphFlow":
@@ -285,6 +287,7 @@ class LinearFlow(CoreasonModel):
     steps: list[AnyNode] = Field(default_factory=list)
     governance: Governance | None = None
     definitions: FlowDefinitions | None = None
+    evals: EvalsManifest | None = Field(None, description="Embedded executable specifications and test scenarios.")
 
     @model_validator(mode="after")
     def validate_linear_structure(self) -> "LinearFlow":

--- a/src/coreason_manifest/toolkit/diff_engine.py
+++ b/src/coreason_manifest/toolkit/diff_engine.py
@@ -6,9 +6,9 @@ from pydantic import BaseModel, ConfigDict, Field, computed_field
 
 from coreason_manifest.core.workflow.flow import GraphFlow, LinearFlow
 
-type DomainType = Literal["resource", "topology", "governance"]
+type DomainType = Literal["resource", "topology", "governance", "evals"]
 type MutationOp = Literal["add", "remove", "replace", "move", "copy", "test"]
-type CategoryType = Literal["BREAKING", "FEATURE", "GOVERNANCE", "RESOURCE"]
+type CategoryType = Literal["BREAKING", "FEATURE", "GOVERNANCE", "RESOURCE", "TEST"]
 
 
 class BaseOperation(BaseModel):
@@ -43,8 +43,14 @@ class GovernanceMutation(BaseOperation):
     mutation_type: Literal["governance"] = "governance"
 
 
+class EvalsMutation(BaseOperation):
+    """Mutation affecting embedded tests and executable specifications."""
+
+    mutation_type: Literal["evals"] = "evals"
+
+
 ChangeOperation = Annotated[
-    ResourceMutation | TopologyMutation | GovernanceMutation, Field(discriminator="mutation_type")
+    ResourceMutation | TopologyMutation | GovernanceMutation | EvalsMutation, Field(discriminator="mutation_type")
 ]
 
 
@@ -71,6 +77,9 @@ def _determine_category(op: str, path: str, domain: DomainType) -> CategoryType:
     """
     Determines the semantic category of an operation.
     """
+    if domain == "evals" or "/evals" in path:
+        return "TEST"
+
     if domain == "governance" or "/policy" in path or "/governance" in path:
         return "GOVERNANCE"
 
@@ -105,6 +114,8 @@ def _create_mutation(
         return TopologyMutation(op=op, path=path, value=value, category=category)
     if domain == "governance":
         return GovernanceMutation(op=op, path=path, value=value, category=category)
+    if domain == "evals":
+        return EvalsMutation(op=op, path=path, value=value, category=category)
 
     # Should be unreachable with strict types
     return ResourceMutation(op=op, path=path, value=value, category=category)  # pragma: no cover
@@ -147,6 +158,8 @@ def _diff_dicts(
             next_override = "resource"
         elif key == "governance":
             next_domain = "governance"
+        elif key == "evals":
+            next_domain = "evals"
 
         if key not in obj1:
             changes.append(_create_mutation(op="add", path=new_path, value=obj2[key], domain=next_domain))

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -89,6 +89,24 @@ def _validate_traffic_policy(flow: LinearFlow | GraphFlow) -> list[ComplianceRep
     return errors
 
 
+def _validate_evals_topology(flow: GraphFlow | LinearFlow, valid_ids: set[str]) -> list[ComplianceReport]:
+    errors: list[ComplianceReport] = []
+
+    if hasattr(flow, "evals") and flow.evals and flow.evals.test_cases:
+        for test_case in flow.evals.test_cases:
+            if test_case.expected_traversal_path:
+                errors.extend(
+                    ComplianceReport(
+                        code=ErrorCatalog.ERR_TOPOLOGY_ID_MISMATCH,
+                        severity="violation",
+                        message=f"Eval Test Case expects traversal of missing Node ID '{node_id}'.",
+                    )
+                    for node_id in test_case.expected_traversal_path
+                    if node_id not in valid_ids
+                )
+    return errors
+
+
 def validate_flow(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
     """
     Semantically validate a Flow (Linear or Graph).
@@ -203,6 +221,8 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
 
     # 6. Middleware References
     errors.extend(_validate_middleware_refs(flow))
+
+    errors.extend(_validate_evals_topology(flow, valid_ids))
 
     return errors
 


### PR DESCRIPTION
This PR introduces Evals-as-Code to the `coreason-manifest` repository as part of Epic 4 (Executable Specifications).

- **Attached Evals-as-Code**: Added `EvalsManifest` to `GraphFlow` and `LinearFlow` at the absolute bottom of properties to avoid merge conflicts.
- **Topologically-Aware Validation**: Implemented a helper function `_validate_evals_topology` in `validator.py` to statically guarantee that expected test traversal paths do not reference "ghost nodes".
- **Domain-Aware Semantic Diffing**: Updated the diff engine to categorize `evals` changes as `TEST` mutations to prevent CI/CD false-positive alerts.

---
*PR created automatically by Jules for task [4299208580146724161](https://jules.google.com/task/4299208580146724161) started by @gowthamrao*