### PR TITLE
feat: Epic 2 Zero-Trust Identity Envelope Models

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -10,7 +10,12 @@
 
 from coreason_manifest.core.common.identity import (
     AgentIdentity,
+    DelegationContract,
+    IdentityPassport,
+    ResourceCaveat,
     SessionContext,
+    SystemContext,
+    UserContext,
     UserIdentity,
 )
 from coreason_manifest.core.common.semantic import (
@@ -77,6 +82,7 @@ __all__ = [
     "CognitiveProfile",
     "CouncilReasoning",
     "DecompositionReasoning",
+    "DelegationContract",
     "Dependency",
     "Edge",
     "FastPath",
@@ -86,6 +92,7 @@ __all__ = [
     "Graph",
     "GraphFlow",
     "HumanNode",
+    "IdentityPassport",
     "LinearFlow",
     "NewGraphFlow",
     "NewLinearFlow",
@@ -94,14 +101,17 @@ __all__ = [
     "PlaceholderNode",
     "PlannerNode",
     "ReasoningConfig",
+    "ResourceCaveat",
     "Safety",
     "SemanticRef",
     "SessionContext",
     "StandardReasoning",
     "SupervisionPolicy",
     "SwitchNode",
+    "SystemContext",
     "ToolPack",
     "TreeSearchReasoning",
+    "UserContext",
     "UserIdentity",
     "VariableDef",
 ]

--- a/src/coreason_manifest/core/common/identity.py
+++ b/src/coreason_manifest/core/common/identity.py
@@ -9,7 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 
-from pydantic import AwareDatetime, ConfigDict, Field
+from pydantic import AwareDatetime, ConfigDict, Field, SecretStr, model_validator
 
 from coreason_manifest.core.common.base import CoreasonModel
 
@@ -70,4 +70,91 @@ class SessionContext(CoreasonModel):
         None,
         pattern=r"^00-[0-9a-f]{32}-[0-9a-f]{16}-[0-9a-f]{2}$",
         description="W3C Trace Context ID for distributed secure tracking.",
+    )
+
+
+class ResourceCaveat(CoreasonModel):
+    """
+    SOTA UCAN/Macaroon-style capability attenuation.
+    Defines strict boundaries on a delegated resource.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    target_resource: str = Field(..., description="The tool or capability being restricted (e.g., 'db_query', '*').")
+    constraint: str = Field(
+        ..., description="AST-safe Python expression representing the boundary (e.g., 'cost < 5.00')."
+    )
+
+
+class DelegationContract(CoreasonModel):
+    """
+    The strictly bounded and time-limited authority granted for a specific execution trace.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    allowed_tools: list[str] = Field(default=["*"], description="Whitelist of permitted tools.")
+    caveats: list[ResourceCaveat] = Field(default_factory=list, description="Cryptographic attenuations on authority.")
+    max_budget_usd: float | None = Field(None, description="Financial circuit breaker for this specific trace.")
+
+    # SOTA Temporal Bounding
+    issued_at: float = Field(..., description="Unix epoch timestamp of delegation issuance.")
+    expires_at: float = Field(..., description="Unix epoch timestamp of delegation expiry.")
+
+    @model_validator(mode="after")
+    def validate_temporal_bounds(self) -> "DelegationContract":
+        if self.expires_at <= self.issued_at:
+            raise ValueError("Delegation expires_at must be strictly greater than issued_at.")
+        return self
+
+
+class UserContext(CoreasonModel):
+    """
+    Privacy-first representation of the human principal.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    raw_user_id: SecretStr | None = Field(
+        None, description="The actual IdP subject. SecretStr prevents accidental logging leakage."
+    )
+    anonymized_user_id: str = Field(
+        ..., description="Deterministic HMAC-SHA256 ID used for cache keys and telemetry routing without exposing PII."
+    )
+    tenant_id: str | None = Field(None, description="Cryptographic boundary for data segregation.")
+    roles: list[str] = Field(default_factory=list, description="Standardized PBAC roles mapped from the IdP.")
+
+
+class SystemContext(CoreasonModel):
+    """
+    Cryptographic identity of the acting software entity (Agent/Worker).
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    agent_id: str = Field(..., description="The ID of the autonomous agent.")
+    version: str = Field(..., description="SemVer of the agent manifest.")
+    software_hash: str | None = Field(
+        None, description="SHA-256 hash of the agent's definition, proving execution integrity."
+    )
+
+
+class IdentityPassport(CoreasonModel):
+    """
+    The Supreme Zero-Trust Context Envelope.
+    Replaces legacy SessionContext. Travels alongside the W3C Trace Context.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    passport_id: str = Field(..., description="Unique JTI for this exact passport instance to prevent replay attacks.")
+    user: UserContext
+    system: SystemContext
+    delegation: DelegationContract
+
+    # Cryptographic Lineage
+    issuer_uri: str = Field(..., description="The verified IdP that established the root of trust.")
+    signature_hash: str = Field(
+        ..., description="Hash of the originating JWT/Token signature. Anchors the passport to reality."
     )


### PR DESCRIPTION
Epic 2: The Zero-Trust Identity Envelope implementation for coreason-manifest.

This PR introduces new SOTA, UCAN-inspired cryptographic identity models:
- `IdentityPassport`: The supreme zero-trust context envelope.
- `SystemContext`: Cryptographic identity of the acting agent.
- `UserContext`: Privacy-first representation of the principal with `SecretStr`.
- `DelegationContract`: Time-bound and bounded authority delegation.
- `ResourceCaveat`: Capability attenuation boundaries.

These models are appended safely alongside existing classes to ensure zero disruption to parallel epic work. All definitions correctly utilize Pydantic `Field`, `SecretStr`, and strict typing without any runtime or execution side-effects, fully compliant with the Shared Kernel protocol.

Strict mypy and pytest verifications pass successfully.

---
*PR created automatically by Jules for task [10007983397945221121](https://jules.google.com/task/10007983397945221121) started by @gowthamrao*