### PR TITLE
Epic 4: Reconciliation & Integration

### DIFF
--- a/src/coreason_manifest/core/telemetry/request.py
+++ b/src/coreason_manifest/core/telemetry/request.py
@@ -45,6 +45,64 @@ class AgentRequest(BaseModel):
         None, description="The Zero-Trust Identity Context Envelope for this request."
     )
 
+    # SOTA 2026: The Zero-Trust Identity Envelope.
+    # Typed as Any during parallel development; will be strictly bound to IdentityPassport post-merge.
+    passport: Any | None = Field(None, description="The cryptographic Zero-Trust Identity Passport for this request.")
+
+    def verify_passport_authorization(self, required_roles: list[str]) -> bool:
+        """
+        Safely checks if the passport's PBAC roles intersect with the required roles.
+        Fails closed (returns False) if the passport or roles are missing.
+        """
+        if not required_roles:
+            return True
+        if not self.passport:
+            return False
+
+        # Duck-typing access for parallel development phase
+        user_context = (
+            getattr(self.passport, "user", {}) if not isinstance(self.passport, dict) else self.passport.get("user", {})
+        )
+        user_roles = set(
+            getattr(user_context, "roles", []) if not isinstance(user_context, dict) else user_context.get("roles", [])
+        )
+
+        return any(role in user_roles for role in required_roles)
+
+    def verify_tool_delegation(self, tool_name: str, current_timestamp: float) -> bool:
+        """
+        SOTA 2026: Time-bound, Caveat-aware capability verification.
+        Evaluates the tool request against the passport's temporal bounds and whitelists.
+        Requires current_timestamp to be passed in to maintain functional purity.
+        """
+        if not self.passport:
+            return False
+
+        delegation = (
+            getattr(self.passport, "delegation", {})
+            if not isinstance(self.passport, dict)
+            else self.passport.get("delegation", {})
+        )
+        if not delegation:
+            return False
+
+        # 1. Temporal Bounding (Fail Closed if Expired)
+        expires_at = (
+            getattr(delegation, "expires_at", 0.0)
+            if not isinstance(delegation, dict)
+            else delegation.get("expires_at", 0.0)
+        )
+        if current_timestamp > expires_at:
+            return False
+
+        # 2. Strict Tool Whitelist Check
+        allowed_tools = (
+            getattr(delegation, "allowed_tools", [])
+            if not isinstance(delegation, dict)
+            else delegation.get("allowed_tools", [])
+        )
+        return not ("*" not in allowed_tools and tool_name not in allowed_tools)
+
     def is_authorized(self, required_roles: list[str]) -> bool:
         """
         Safely checks if the user's PBAC roles intersect with the required roles.

--- a/src/coreason_manifest/toolkit/mock.py
+++ b/src/coreason_manifest/toolkit/mock.py
@@ -25,6 +25,39 @@ class MockFactory:
         else:
             self.rng = secrets.SystemRandom()
 
+    def generate_mock_passport(self) -> dict[str, Any]:
+        """
+        Generates a perfectly valid SOTA IdentityPassport payload for local UI and Graph testing.
+        Returned as a dict to prevent import conflicts during parallel epic execution.
+        """
+        import time
+
+        current_time = time.time()
+
+        return {
+            "passport_id": f"mock_jti_{self.rng.randint(1000, 9999)}",
+            "user": {
+                "raw_user_id": "auth0|mock_admin",
+                "anonymized_user_id": "mock_hmac_hash_12345",
+                "tenant_id": "tenant_abc",
+                "roles": ["system_admin", "operator"],
+            },
+            "system": {
+                "agent_id": "mock_agent",
+                "version": "1.0.0",
+                "software_hash": self._generate_hash("mock_agent_v1"),
+            },
+            "delegation": {
+                "allowed_tools": ["*"],
+                "caveats": [],
+                "max_budget_usd": 100.0,
+                "issued_at": current_time - 100,
+                "expires_at": current_time + 3600,
+            },
+            "issuer_uri": "https://mock.auth.coreason.ai",
+            "signature_hash": "mock_sig_hash",
+        }
+
     def _generate_hash(self, data: str) -> str:
         return hashlib.sha256(data.encode()).hexdigest()
 


### PR DESCRIPTION
Upgraded `AgentRequest` in `src/coreason_manifest/core/telemetry/request.py` to evaluate SOTA temporal bounds and decentralized capability attenuations by adding a new `passport` field and two new evaluation methods: `verify_passport_authorization` and `verify_tool_delegation`.

Updated `MockFactory` in `src/coreason_manifest/toolkit/mock.py` by adding `generate_mock_passport` to generate mathematically sound dummy passport payloads.

Ensured strict isolated parallel development typing and adhered to all AGENTS.md laws regarding no active side effects.
Ran pre-commit local verifications, including strict `mypy` and `ruff` checks.

---
*PR created automatically by Jules for task [10830635631490403254](https://jules.google.com/task/10830635631490403254) started by @gowthamrao*