### PR TITLE
feat: add Swarm lineage and PQC agility fields to IdentityPassport

### DIFF
--- a/src/coreason_manifest/core/common/identity.py
+++ b/src/coreason_manifest/core/common/identity.py
@@ -158,3 +158,17 @@ class IdentityPassport(CoreasonModel):
     signature_hash: str = Field(
         ..., description="Hash of the originating JWT/Token signature. Anchors the passport to reality."
     )
+    parent_passport_id: str | None = Field(
+        None,
+        description=(
+            "ID of the parent's passport if this agent was spawned by a "
+            "Swarm delegation. Enables recursive lineage tracking."
+        ),
+    )
+    signature_algorithm: str = Field(
+        default="ES256",
+        description=(
+            "Algorithm used for the root signature (e.g., 'ES256', 'EdDSA', "
+            "or NIST FIPS 204 PQC 'ML-DSA-65'). Protects against downgrade attacks."
+        ),
+    )


### PR DESCRIPTION
Epic 6.1: Add `parent_passport_id` and `signature_algorithm` to `IdentityPassport` below `signature_hash`. All verifications passed.

---
*PR created automatically by Jules for task [14284203343845970024](https://jules.google.com/task/14284203343845970024) started by @gowthamrao*