### PR TITLE
feat: Inject Multi-Dimensional Compute and CAEP Fields

### DIFF
--- a/src/coreason_manifest/core/common/identity.py
+++ b/src/coreason_manifest/core/common/identity.py
@@ -98,6 +98,26 @@ class DelegationContract(CoreasonModel):
     caveats: list[ResourceCaveat] = Field(default_factory=list, description="Cryptographic attenuations on authority.")
     max_budget_usd: float | None = Field(None, description="Financial circuit breaker for this specific trace.")
 
+    # --- BEGIN EPIC 6.2 INSERTION ---
+    max_tokens: int | None = Field(
+        None,
+        description=(
+            "Physical circuit breaker: Maximum LLM tokens (in+out) authorized to prevent local compute exhaustion."
+        ),
+    )
+    max_compute_time_ms: int | None = Field(
+        None,
+        description="Temporal circuit breaker: Maximum asynchronous wall-time before forced execution termination.",
+    )
+    caep_stream_uri: str | None = Field(
+        None,
+        description=(
+            "Shared Signals Framework (SSF) URI. The orchestrator subscribes "
+            "to this for real-time instantaneous passport revocation."
+        ),
+    )
+    # --- END EPIC 6.2 INSERTION ---
+
     # SOTA Temporal Bounding
     issued_at: float = Field(..., description="Unix epoch timestamp of delegation issuance.")
     expires_at: float = Field(..., description="Unix epoch timestamp of delegation expiry.")


### PR DESCRIPTION
Upgraded `DelegationContract` by injecting `max_tokens`, `max_compute_time_ms`, and `caep_stream_uri` fields right below the `max_budget_usd` boundary to support physical local-compute boundaries (Edge AI) and Continuous Access Evaluation Profile (CAEP) mid-flight revocation via the Shared Signals Framework.

This satisfies Epic 6.2 for coreason-manifest and complies with the strictly typed parallelization constraints and anchor line strategy. Local tests, typing, and linting checks all passed.

---
*PR created automatically by Jules for task [15078887509210095549](https://jules.google.com/task/15078887509210095549) started by @gowthamrao*