### PR TITLE
feat(core): Add Information Flow Control clearance levels and inject capability bounds

### DIFF
--- a/src/coreason_manifest/core/common/identity.py
+++ b/src/coreason_manifest/core/common/identity.py
@@ -102,6 +102,16 @@ class DelegationContract(CoreasonModel):
     issued_at: float = Field(..., description="Unix epoch timestamp of delegation issuance.")
     expires_at: float = Field(..., description="Unix epoch timestamp of delegation expiry.")
 
+    # --- BEGIN EPIC 6.3 INSERTION ---
+    max_data_classification: str = Field(
+        default="internal",
+        description=(
+            "Information Flow Control bound (e.g., 'public', 'internal', 'confidential', 'restricted'). "
+            "Dictates the highest sensitivity of data this trace can ingest."
+        ),
+    )
+    # --- END EPIC 6.3 INSERTION ---
+
     @model_validator(mode="after")
     def validate_temporal_bounds(self) -> "DelegationContract":
         if self.expires_at <= self.issued_at:

--- a/src/coreason_manifest/core/primitives/types.py
+++ b/src/coreason_manifest/core/primitives/types.py
@@ -197,3 +197,14 @@ class SystemRole(StrEnum):
     AUDITOR = "auditor"
     VIEWER = "viewer"
     MACHINE_SERVICE = "machine_service"
+
+
+class DataClassification(StrEnum):
+    """
+    SOTA 2026: Standardized Information Flow Control (IFC) clearance levels.
+    """
+
+    PUBLIC = "public"
+    INTERNAL = "internal"
+    CONFIDENTIAL = "confidential"
+    RESTRICTED = "restricted"


### PR DESCRIPTION
Implemented Epic 6.3: Zero-Trust Memory Boundaries.

- Established the standardized Information Flow Vocabulary by appending `DataClassification` to `src/coreason_manifest/core/primitives/types.py`.
- Injected the capability bound `max_data_classification` into `DelegationContract` exactly below `expires_at` in `src/coreason_manifest/core/common/identity.py`.
- Used `str` type to avoid import modification as requested.
- Verified changes with `uv run ruff format`, `uv run ruff check`, `uv run mypy`, and `uv run pytest`.

---
*PR created automatically by Jules for task [6313364922216194164](https://jules.google.com/task/6313364922216194164) started by @gowthamrao*