### PR TITLE
feat(manifest): add generative ui declarative contracts

### DIFF
--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -1,5 +1,5 @@
 from enum import StrEnum
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 
@@ -15,6 +15,29 @@ class RenderStrategy(StrEnum):
     JSON_FORMS = "json_forms"
     ADAPTIVE_CARD = "adaptive_card"
     CUSTOM_IFRAME = "custom_iframe"
+    GEN_UI = "gen_ui"
+
+
+class UIEventMap(CoreasonModel):
+    trigger: str = Field(..., description="The name of the event emitted by the widget (e.g., 'on_approve').")
+    action: str = Field(..., description="The semantic SteeringCommand or target route ID this translates to.")
+    mutates_variables: list[str] | None = Field(None, description="Blackboard variables updated by this event.")
+
+
+class AdaptiveUIContract(CoreasonModel):
+    widget_id: str = Field(..., description="The abstract identifier for the frontend component registry.")
+    props_schema: dict[str, Any] = Field(
+        ..., description="JSON Schema defining the data required to render the widget."
+    )
+    props_mapping: dict[str, str] = Field(
+        default_factory=dict, description="Maps Blackboard variables (values) to widget props (keys)."
+    )
+    events: list[UIEventMap] = Field(
+        default_factory=list, description="Maps widget interactions to orchestrator commands."
+    )
+    fallback_to_text: bool = Field(
+        True, description="Gracefully degrade to JSON Form or Text input if widget is unavailable."
+    )
 
 
 class NotificationRouting(CoreasonModel):

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -5,7 +5,7 @@ from typing import Any, Literal
 from pydantic import Field, model_validator
 
 from coreason_manifest.core.common.base import CoreasonModel
-from coreason_manifest.core.common.presentation import RenderStrategy
+from coreason_manifest.core.common.presentation import AdaptiveUIContract, RenderStrategy
 from coreason_manifest.core.exceptions import ManifestError, ManifestErrorCode
 from coreason_manifest.core.oversight.resilience import EscalationStrategy
 from coreason_manifest.core.primitives.registry import register_node
@@ -96,6 +96,9 @@ class HumanNode(Node):
 
     collaboration_mode: CollaborationMode = Field(default=CollaborationMode.APPROVAL_ONLY)
     render_strategy: RenderStrategy = Field(default=RenderStrategy.JSON_FORMS)
+    ui_contract: AdaptiveUIContract | None = Field(
+        None, description="The Generative UI contract. Required if render_strategy is GEN_UI."
+    )
 
     steering_config: SteeringConfig | None = Field(
         None, description="Configuration for steering permissions.", examples=[{"allow_variable_mutation": True}]
@@ -142,5 +145,10 @@ class HumanNode(Node):
                         ],
                     ).model_dump()
                 },
+            )
+        if self.render_strategy == RenderStrategy.GEN_UI and self.ui_contract is None:
+            raise ManifestError.critical_halt(
+                code=ManifestErrorCode.CRSN_VAL_HUMAN_STEERING,
+                message="HumanNode requires 'ui_contract' when render_strategy is 'GEN_UI'.",
             )
         return self

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Any, Literal, Self, cast
 if TYPE_CHECKING:
     from coreason_manifest.core.workflow.nodes import Constraint
 
-from coreason_manifest.core.common.presentation import NotificationRouting, RenderStrategy
+from coreason_manifest.core.common.presentation import AdaptiveUIContract, NotificationRouting, RenderStrategy
 from coreason_manifest.core.compute.reasoning import (
     FastPath,
     ReasoningConfig,
@@ -962,6 +962,34 @@ class BaseFlowBuilder:
             type="human",
             prompt=prompt,
             collaboration_mode=CollaborationMode.APPROVAL_ONLY,
+            routes=routes,
+            escalation=EscalationStrategy(
+                queue_name="steering_queue",
+                notification_level="info",
+                timeout_seconds=shadow_timeout,
+            ),
+        )
+        self._register_node(node)
+        return self
+
+    def add_gen_ui_gate(
+        self,
+        node_id: str,
+        prompt: str,
+        contract: AdaptiveUIContract,
+        routes: dict[str, str] | None = None,
+        shadow_timeout: int = 300,
+    ) -> Self:
+        from coreason_manifest.core.workflow.nodes.human import CollaborationMode
+
+        node = HumanNode(
+            id=node_id,
+            metadata={},
+            type="human",
+            prompt=prompt,
+            collaboration_mode=CollaborationMode.APPROVAL_ONLY,
+            render_strategy=RenderStrategy.GEN_UI,
+            ui_contract=contract,
             routes=routes,
             escalation=EscalationStrategy(
                 queue_name="steering_queue",

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -348,16 +348,16 @@ def _validate_ui_contracts(
     errors: list[ComplianceReport] = []
     for node in nodes:
         if isinstance(node, HumanNode) and node.render_strategy == "gen_ui" and node.ui_contract:
-            for mapped_var in node.ui_contract.props_mapping.values():
-                if mapped_var not in symbol_table:
-                    errors.append(
-                        ComplianceReport(
-                            code=ErrorCatalog.ERR_CAP_MISSING_VAR,
-                            severity="violation",
-                            message=f"GenUI Error: Widget maps to missing variable '{mapped_var}'.",
-                            node_id=node.id,
-                        )
-                    )
+            errors.extend(
+                ComplianceReport(
+                    code=ErrorCatalog.ERR_CAP_MISSING_VAR,
+                    severity="violation",
+                    message=f"GenUI Error: Widget maps to missing variable '{mapped_var}'.",
+                    node_id=node.id,
+                )
+                for mapped_var in node.ui_contract.props_mapping.values()
+                if mapped_var not in symbol_table
+            )
 
             for event in node.ui_contract.events:
                 valid_action = False
@@ -369,22 +369,25 @@ def _validate_ui_contracts(
                         ComplianceReport(
                             code=ErrorCatalog.ERR_TOPOLOGY_BROKEN_SWITCH,
                             severity="violation",
-                            message=f"GenUI Error: Event action '{event.action}' does not map to a known route or node ID.",
+                            message=(
+                                f"GenUI Error: Event action '{event.action}' "
+                                "does not map to a known route or node ID."
+                            ),
                             node_id=node.id,
                         )
                     )
 
                 if event.mutates_variables:
-                    for var in event.mutates_variables:
-                        if var not in symbol_table:
-                            errors.append(
-                                ComplianceReport(
-                                    code=ErrorCatalog.ERR_CAP_MISSING_VAR,
-                                    severity="violation",
-                                    message=f"GenUI Error: Event mutates missing variable '{var}'.",
-                                    node_id=node.id,
-                                )
-                            )
+                    errors.extend(
+                        ComplianceReport(
+                            code=ErrorCatalog.ERR_CAP_MISSING_VAR,
+                            severity="violation",
+                            message=f"GenUI Error: Event mutates missing variable '{var}'.",
+                            node_id=node.id,
+                        )
+                        for var in event.mutates_variables
+                        if var not in symbol_table
+                    )
     return errors
 
 

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -370,8 +370,7 @@ def _validate_ui_contracts(
                             code=ErrorCatalog.ERR_TOPOLOGY_BROKEN_SWITCH,
                             severity="violation",
                             message=(
-                                f"GenUI Error: Event action '{event.action}' "
-                                "does not map to a known route or node ID."
+                                f"GenUI Error: Event action '{event.action}' does not map to a known route or node ID."
                             ),
                             node_id=node.id,
                         )

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -288,6 +288,7 @@ def validate_flow(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
             _extract_schema_types(in_schema)
 
         errors.extend(_validate_data_flow(nodes, symbol_table, flow.definitions, adj_map))
+        errors.extend(_validate_ui_contracts(nodes, symbol_table, valid_ids))
 
     # 5. Security & Kill Switch
     if flow.governance and flow.governance.max_risk_level:
@@ -339,6 +340,52 @@ def _scan_agent_templates(node: AgentNode, definitions: FlowDefinitions | None) 
             refs.update(_scan_string_for_vars(val))
 
     return refs
+
+
+def _validate_ui_contracts(
+    nodes: list[AnyNode], symbol_table: dict[str, str], valid_ids: set[str]
+) -> list[ComplianceReport]:
+    errors: list[ComplianceReport] = []
+    for node in nodes:
+        if isinstance(node, HumanNode) and node.render_strategy == "gen_ui" and node.ui_contract:
+            for mapped_var in node.ui_contract.props_mapping.values():
+                if mapped_var not in symbol_table:
+                    errors.append(
+                        ComplianceReport(
+                            code=ErrorCatalog.ERR_CAP_MISSING_VAR,
+                            severity="violation",
+                            message=f"GenUI Error: Widget maps to missing variable '{mapped_var}'.",
+                            node_id=node.id,
+                        )
+                    )
+
+            for event in node.ui_contract.events:
+                valid_action = False
+                if (node.routes and event.action in node.routes) or event.action in valid_ids:
+                    valid_action = True
+
+                if not valid_action:
+                    errors.append(
+                        ComplianceReport(
+                            code=ErrorCatalog.ERR_TOPOLOGY_BROKEN_SWITCH,
+                            severity="violation",
+                            message=f"GenUI Error: Event action '{event.action}' does not map to a known route or node ID.",
+                            node_id=node.id,
+                        )
+                    )
+
+                if event.mutates_variables:
+                    for var in event.mutates_variables:
+                        if var not in symbol_table:
+                            errors.append(
+                                ComplianceReport(
+                                    code=ErrorCatalog.ERR_CAP_MISSING_VAR,
+                                    severity="violation",
+                                    message=f"GenUI Error: Event mutates missing variable '{var}'.",
+                                    node_id=node.id,
+                                )
+                            )
+    return errors
 
 
 def _validate_data_flow(


### PR DESCRIPTION
This PR introduces strictly declarative schemas and static validation rules for "Generative UI" in the coreason-manifest.

Changes include:
1. `AdaptiveUIContract` and `UIEventMap` models in `presentation.py` to dictate abstract frontend widget mounts, prop bindings, and event routing.
2. `GEN_UI` flag in `RenderStrategy` and `ui_contract` requirement in `HumanNode` with corresponding Pydantic validation.
3. `add_gen_ui_gate` method in `BaseFlowBuilder` for ergonomic graph construction.
4. `_validate_ui_contracts` helper function in `validator.py` injected after `_validate_data_flow` to mathematically prove that widget prop bindings and event mutations map to existing Blackboard variables and valid orchestrator routes.

These changes strictly adhere to the Zero Execution Directive and avoid file conflicts with parallel security epics.

---
*PR created automatically by Jules for task [4039022183008164941](https://jules.google.com/task/4039022183008164941) started by @gowthamrao*