### PR TITLE
feat(toolkit): integrate GenUI routing and AppSec fields into static analysis

### DIFF
--- a/src/coreason_manifest/toolkit/diff_engine.py
+++ b/src/coreason_manifest/toolkit/diff_engine.py
@@ -80,10 +80,16 @@ def _determine_category(op: str, path: str, domain: DomainType) -> CategoryType:
     if domain == "evals" or "/evals" in path:
         return "TEST"
 
-    if domain == "governance" or "/policy" in path or "/governance" in path:
+    if (
+        domain == "governance"
+        or "/policy" in path
+        or "/governance" in path
+        or "/attestation" in path
+        or "/unicode_sanitization" in path
+    ):
         return "GOVERNANCE"
 
-    if "/presentation" in path or "/routing" in path or "/render_strategy" in path:
+    if "/presentation" in path or "/routing" in path or "/render_strategy" in path or "/ui_contract" in path:
         return "FEATURE"
 
     if domain == "resource":

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -1083,7 +1083,12 @@ def _build_unified_adjacency_map(flow: LinearFlow | GraphFlow) -> dict[str, set[
                     adj[node.id].add(target_id)
 
         # GenUI Contract routing
-        if isinstance(node, HumanNode) and getattr(node, "ui_contract", None) and node.ui_contract.events:
+        if (
+            isinstance(node, HumanNode)
+            and getattr(node, "ui_contract", None)
+            and node.ui_contract is not None
+            and node.ui_contract.events
+        ):
             for event in node.ui_contract.events:
                 # event.action could be a SteeringCommand OR a target NodeID
                 if event.action in adj:

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -1082,6 +1082,13 @@ def _build_unified_adjacency_map(flow: LinearFlow | GraphFlow) -> dict[str, set[
                 if target_id in adj:
                     adj[node.id].add(target_id)
 
+        # GenUI Contract routing
+        if isinstance(node, HumanNode) and getattr(node, "ui_contract", None) and node.ui_contract.events:
+            for event in node.ui_contract.events:
+                # event.action could be a SteeringCommand OR a target NodeID
+                if event.action in adj:
+                    adj[node.id].add(event.action)
+
         # Local Fallback routing (Resolving templates to catch Trojan cycles)
         if node.resilience:
             resolved_policy = _resolve_resilience_policy(node.resilience, getattr(flow, "definitions", None))

--- a/src/coreason_manifest/toolkit/visualizer.py
+++ b/src/coreason_manifest/toolkit/visualizer.py
@@ -148,6 +148,7 @@ def to_mermaid(flow: GraphFlow | LinearFlow, snapshot: ExecutionSnapshot | None 
                 and source_node
                 and isinstance(source_node, HumanNode)
                 and getattr(source_node, "ui_contract", None)
+                and source_node.ui_contract is not None
             ):
                 for event in source_node.ui_contract.events:
                     if event.action == target_id:

--- a/src/coreason_manifest/toolkit/visualizer.py
+++ b/src/coreason_manifest/toolkit/visualizer.py
@@ -143,6 +143,18 @@ def to_mermaid(flow: GraphFlow | LinearFlow, snapshot: ExecutionSnapshot | None 
                         label = f"|{_escape_label(str(cmd))} ⚙️|"
                         break
 
+            if (
+                not label
+                and source_node
+                and isinstance(source_node, HumanNode)
+                and getattr(source_node, "ui_contract", None)
+            ):
+                for event in source_node.ui_contract.events:
+                    if event.action == target_id:
+                        # Use the trigger name as the edge label, with a UI sparkle emoji
+                        label = f"|{_escape_label(str(event.trigger))} ✨|"
+                        break
+
         lines.append(f"    {s_safe} -->{label} {t_safe}")
 
     # Styling Classes


### PR DESCRIPTION
This PR implements the Integration Pass for the `coreason-manifest` toolkit, updating the declarative static analyzers to support new features from Epics 5 and 6.

1. **DAG Math (`validator.py`)**: Extends the unified adjacency map builder to recognize implicit routing edges defined within a `HumanNode`'s `ui_contract.events`. This prevents valid GenUI-routed nodes from being falsely flagged as orphan nodes.
2. **Visualizer (`visualizer.py`)**: Updates the Mermaid JS generator to visually render edges created by GenUI contracts, labeling them with the event trigger name and a sparkle emoji (✨) to differentiate them from standard routes.
3. **Semantic Diffing (`diff_engine.py`)**: Updates the CI/CD Semantic Diff engine to correctly categorize new JSON Pointers for AppSec artifacts (`/attestation`, `/unicode_sanitization`) as `GOVERNANCE` and UI contracts (`/ui_contract`) as `FEATURE`, avoiding incorrect `BREAKING` classifications.

---
*PR created automatically by Jules for task [5286828619803571722](https://jules.google.com/task/5286828619803571722) started by @gowthamrao*