### PR TITLE
feat: Epic 2: Dynamic Agent-Driven UIs & Composability

### DIFF
--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -26,8 +26,12 @@ class UIEventMap(CoreasonModel):
 
 class UIComponentNode(CoreasonModel):
     type: str = Field(..., description="The component registry ID, e.g., 'LineChart', 'DataTable'.")
-    props: dict[str, Any] = Field(default_factory=dict, description="The evaluated property data to bind to the widget.")
-    children: list["UIComponentNode"] = Field(default_factory=list, description="Child component nodes for recursive nesting.")
+    props: dict[str, Any] = Field(
+        default_factory=dict, description="The evaluated property data to bind to the widget."
+    )
+    children: list["UIComponentNode"] = Field(
+        default_factory=list, description="Child component nodes for recursive nesting."
+    )
 
 
 class AdaptiveUIContract(CoreasonModel):

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -24,14 +24,14 @@ class UIEventMap(CoreasonModel):
     mutates_variables: list[str] | None = Field(None, description="Blackboard variables updated by this event.")
 
 
+class UIComponentNode(CoreasonModel):
+    type: str = Field(..., description="The component registry ID, e.g., 'LineChart', 'DataTable'.")
+    props: dict[str, Any] = Field(default_factory=dict, description="The evaluated property data to bind to the widget.")
+    children: list["UIComponentNode"] = Field(default_factory=list, description="Child component nodes for recursive nesting.")
+
+
 class AdaptiveUIContract(CoreasonModel):
-    widget_id: str = Field(..., description="The abstract identifier for the frontend component registry.")
-    props_schema: dict[str, Any] = Field(
-        ..., description="JSON Schema defining the data required to render the widget."
-    )
-    props_mapping: dict[str, str] = Field(
-        default_factory=dict, description="Maps Blackboard variables (values) to widget props (keys)."
-    )
+    layout: list[UIComponentNode] = Field(..., description="The root elements of the generated UI.")
     events: list[UIEventMap] = Field(
         default_factory=list, description="Maps widget interactions to orchestrator commands."
     )

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -1,7 +1,7 @@
 from enum import StrEnum
 from typing import Annotated, Any, Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from coreason_manifest.core.common.base import CoreasonModel
 
@@ -35,7 +35,7 @@ class UIComponentNode(CoreasonModel):
 
 
 class AdaptiveUIContract(CoreasonModel):
-    layout: list[UIComponentNode] = Field(..., description="The root elements of the generated UI.")
+    layout: list[UIComponentNode] = Field(default_factory=list, description="The root elements of the generated UI.")
     widget_id: str | None = Field(
         None, description="[DEPRECATED] The abstract identifier for the frontend component registry."
     )
@@ -51,6 +51,24 @@ class AdaptiveUIContract(CoreasonModel):
     fallback_to_text: bool = Field(
         True, description="Gracefully degrade to JSON Form or Text input if widget is unavailable."
     )
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_legacy_widget(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            layout = data.get("layout")
+            widget_id = data.get("widget_id")
+
+            # If layout is empty/missing but widget_id is provided, auto-migrate to the new structure
+            if not layout and widget_id:
+                props = data.get("props_mapping", {})
+                node = {
+                    "type": widget_id,
+                    "props": props,
+                    "children": []
+                }
+                data["layout"] = [node]
+        return data
 
 
 class NotificationRouting(CoreasonModel):
@@ -140,3 +158,6 @@ class PresentationHints(CoreasonModel):
         Literal["basic", "detailed", "debug"],
         Field(description="Preferred metadata detail level."),
     ] = "basic"
+
+
+UIComponentNode.model_rebuild()

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -62,11 +62,7 @@ class AdaptiveUIContract(CoreasonModel):
             # If layout is empty/missing but widget_id is provided, auto-migrate to the new structure
             if not layout and widget_id:
                 props = data.get("props_mapping", {})
-                node = {
-                    "type": widget_id,
-                    "props": props,
-                    "children": []
-                }
+                node = {"type": widget_id, "props": props, "children": []}
                 data["layout"] = [node]
         return data
 

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -36,6 +36,15 @@ class UIComponentNode(CoreasonModel):
 
 class AdaptiveUIContract(CoreasonModel):
     layout: list[UIComponentNode] = Field(..., description="The root elements of the generated UI.")
+    widget_id: str | None = Field(
+        None, description="[DEPRECATED] The abstract identifier for the frontend component registry."
+    )
+    props_schema: dict[str, Any] | None = Field(
+        None, description="[DEPRECATED] JSON Schema defining the data required to render the widget."
+    )
+    props_mapping: dict[str, str] = Field(
+        default_factory=dict, description="[DEPRECATED] Maps Blackboard variables (values) to widget props (keys)."
+    )
     events: list[UIEventMap] = Field(
         default_factory=list, description="Maps widget interactions to orchestrator commands."
     )

--- a/src/coreason_manifest/core/workflow/nodes/agent.py
+++ b/src/coreason_manifest/core/workflow/nodes/agent.py
@@ -31,6 +31,9 @@ class CognitiveProfile(CoreasonModel):
     memory: MemorySubsystem | None = Field(
         None, description="The 4-tier hierarchical memory configuration.", examples=[{"working_memory": {}}]
     )
+    ui_capabilities: list[str] | None = Field(
+        default=None, description="List of frontend component registry IDs this agent is permitted to render."
+    )
 
 
 @register_node

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -148,7 +148,7 @@ class HumanNode(Node):
             )
         if self.render_strategy == RenderStrategy.GEN_UI and self.ui_contract is None:
             raise ManifestError.critical_halt(
-                code=ManifestErrorCode.VAL_HUMAN_STEERING,
+                code=ManifestErrorCode.CRSN_VAL_HUMAN_STEERING,
                 message="HumanNode requires 'ui_contract' when render_strategy is 'GEN_UI'.",
             )
         return self

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -148,7 +148,7 @@ class HumanNode(Node):
             )
         if self.render_strategy == RenderStrategy.GEN_UI and self.ui_contract is None:
             raise ManifestError.critical_halt(
-                code=ManifestErrorCode.CRSN_VAL_HUMAN_STEERING,
+                code=ManifestErrorCode.VAL_HUMAN_STEERING,
                 message="HumanNode requires 'ui_contract' when render_strategy is 'GEN_UI'.",
             )
         return self

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -136,6 +136,19 @@ class AgentBuilder:
         self.gap_scan_threshold = 0.8
         self.max_revisions = 1
         self._rate_card_config: dict[str, Any] | None = None
+        self.ui_capabilities: list[str] | None = None
+
+    def with_ui_capabilities(self, registry_ids: list[str]) -> "AgentBuilder":
+        """Assigns UI capabilities to the agent.
+
+        Args:
+            registry_ids (list[str]): List of frontend component registry IDs this agent is permitted to render.
+
+        Returns:
+            AgentBuilder: The builder instance for chaining.
+        """
+        self.ui_capabilities = registry_ids
+        return self
 
     def with_rate_card(
         self,
@@ -608,6 +621,7 @@ class AgentBuilder:
             reasoning=self.reasoning,
             fast_path=self.fast_path,
             memory=self.memory,
+            ui_capabilities=self.ui_capabilities,
         )
 
         return AgentNode(

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -1031,11 +1031,15 @@ class BaseFlowBuilder:
         self,
         node_id: str,
         prompt: str,
-        contract: AdaptiveUIContract,
+        contract: AdaptiveUIContract | dict[str, Any],
         routes: dict[str, str] | None = None,
         shadow_timeout: int = 300,
     ) -> Self:
         from coreason_manifest.core.workflow.nodes.human import CollaborationMode
+
+        # Validate and coerce if dictionary provided
+        if isinstance(contract, dict):
+            contract = AdaptiveUIContract.model_validate(contract)
 
         node = HumanNode(
             id=node_id,


### PR DESCRIPTION
This pull request implements Epic 2: Dynamic Agent-Driven UIs & Composability. It upgrades the UI engine from static, hardcoded single widgets into a dynamic, recursively composable Generative UI (GenUI) system.

The following changes were made:
- Added `UIComponentNode` to `presentation.py` to represent the component registry ID, evaluated property data, and child component nodes.
- Updated `AdaptiveUIContract` in `presentation.py` to deprecate `widget_id`, `props_schema`, and `props_mapping`, and introduced `layout` to represent the root elements of the generated UI.
- Updated `CognitiveProfile` in `agent.py` to include `ui_capabilities` to restrict agents to generating permitted frontend component registry IDs.
- Updated `AgentBuilder` in `builder.py` to include the `with_ui_capabilities` method, which stores the permitted registry IDs and passes them to the `CognitiveProfile` during flow construction.

---
*PR created automatically by Jules for task [12206259540180643199](https://jules.google.com/task/12206259540180643199) started by @gowthamrao*