### PR TITLE
feat: native mcp integration

### DIFF
--- a/src/coreason_manifest/adapters/providers/mcp.py
+++ b/src/coreason_manifest/adapters/providers/mcp.py
@@ -1,13 +1,21 @@
+from enum import StrEnum
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field
 
+from coreason_manifest.core.common.presentation import UIEventMap
 from coreason_manifest.core.state.tools import MCPTool, ToolPack
+
+
+class MCPRequestMethod(StrEnum):
+    EMIT_INTENT = "mcp.ui.emit_intent"
+    READY = "mcp.ui.ready"
+    ERROR = "mcp.ui.error"
 
 
 class MCPClientMessage(BaseModel):
     jsonrpc: Literal["2.0"] = Field(default="2.0", description="JSON-RPC version")
-    method: Literal["mcp.ui.emit_intent"] = Field(..., description="The intent bubbling method emitted from the UI")
+    method: MCPRequestMethod = Field(..., description="The lifecycle or intent bubbling method emitted from the UI")
     params: dict[str, Any] = Field(default_factory=dict, description="Intent parameters payload")
     id: str | int = Field(..., description="Message ID")
 
@@ -20,11 +28,15 @@ class MCPUIBroker:
         """
         return MCPClientMessage.model_validate(payload)
 
-    def translate_intent_to_action(self, message: MCPClientMessage) -> dict[str, Any]:
+    def translate_intent_to_action(
+        self, message: MCPClientMessage, event_map: UIEventMap | None = None
+    ) -> dict[str, Any]:
         """
         Safely unpacks the `params` (the user's intent) so the execution
         engine can route it to the Blackboard or the Agent's context.
         """
+        # Event map is currently unused until Epic 3 integration
+        _ = event_map
         return message.params
 
 

--- a/src/coreason_manifest/adapters/providers/mcp.py
+++ b/src/coreason_manifest/adapters/providers/mcp.py
@@ -7,9 +7,7 @@ from coreason_manifest.core.state.tools import MCPTool, ToolPack
 
 class MCPClientMessage(BaseModel):
     jsonrpc: Literal["2.0"] = Field(default="2.0", description="JSON-RPC version")
-    method: Literal["mcp.ui.emit_intent"] = Field(
-        ..., description="The intent bubbling method emitted from the UI"
-    )
+    method: Literal["mcp.ui.emit_intent"] = Field(..., description="The intent bubbling method emitted from the UI")
     params: dict[str, Any] = Field(default_factory=dict, description="Intent parameters payload")
     id: str | int = Field(..., description="Message ID")
 

--- a/src/coreason_manifest/adapters/providers/mcp.py
+++ b/src/coreason_manifest/adapters/providers/mcp.py
@@ -1,6 +1,33 @@
-from typing import Any
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
 
 from coreason_manifest.core.state.tools import MCPTool, ToolPack
+
+
+class MCPClientMessage(BaseModel):
+    jsonrpc: Literal["2.0"] = Field(default="2.0", description="JSON-RPC version")
+    method: Literal["mcp.ui.emit_intent"] = Field(
+        ..., description="The intent bubbling method emitted from the UI"
+    )
+    params: dict[str, Any] = Field(default_factory=dict, description="Intent parameters payload")
+    id: str | int = Field(..., description="Message ID")
+
+
+class MCPUIBroker:
+    def validate_iframe_payload(self, payload: dict[str, Any]) -> MCPClientMessage:
+        """
+        Validates the raw dictionary payload from the WebView iframe
+        into a strict MCPClientMessage schema.
+        """
+        return MCPClientMessage.model_validate(payload)
+
+    def translate_intent_to_action(self, message: MCPClientMessage) -> dict[str, Any]:
+        """
+        Safely unpacks the `params` (the user's intent) so the execution
+        engine can route it to the Blackboard or the Agent's context.
+        """
+        return message.params
 
 
 def pack_to_mcp_resources(pack: ToolPack) -> list[dict[str, Any]]:

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -131,5 +131,5 @@ class PresentationHints(CoreasonModel):
 
     mcp_ui_resource_uri: str | None = Field(
         default=None,
-        description="The ui:// scheme URI pointing to the bundled HTML/JS for sandboxed execution (SEP-1865)."
+        description="The ui:// scheme URI pointing to the bundled HTML/JS for sandboxed execution (SEP-1865).",
     )

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -16,6 +16,7 @@ class RenderStrategy(StrEnum):
     ADAPTIVE_CARD = "adaptive_card"
     CUSTOM_IFRAME = "custom_iframe"
     GEN_UI = "gen_ui"
+    MCP_APPS = "mcp_apps"
 
 
 class UIEventMap(CoreasonModel):
@@ -127,3 +128,8 @@ class PresentationHints(CoreasonModel):
         Literal["basic", "detailed", "debug"],
         Field(description="Preferred metadata detail level."),
     ] = "basic"
+
+    mcp_ui_resource_uri: str | None = Field(
+        default=None,
+        description="The ui:// scheme URI pointing to the bundled HTML/JS for sandboxed execution (SEP-1865)."
+    )

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -148,7 +148,7 @@ class HumanNode(Node):
             )
         if self.render_strategy == RenderStrategy.GEN_UI and self.ui_contract is None:
             raise ManifestError.critical_halt(
-                code=ManifestErrorCode.VAL_HUMAN_STEERING,
+                code=ManifestErrorCode.CRSN_VAL_HUMAN_STEERING,
                 message="HumanNode requires 'ui_contract' when render_strategy is 'GEN_UI'.",
             )
         return self

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -148,7 +148,7 @@ class HumanNode(Node):
             )
         if self.render_strategy == RenderStrategy.GEN_UI and self.ui_contract is None:
             raise ManifestError.critical_halt(
-                code=ManifestErrorCode.CRSN_VAL_HUMAN_STEERING,
+                code=ManifestErrorCode.VAL_HUMAN_STEERING,
                 message="HumanNode requires 'ui_contract' when render_strategy is 'GEN_UI'.",
             )
         return self


### PR DESCRIPTION
# Epic 4: Native Model Context Protocol (MCP) Integration

This pull request implements the necessary presentation logic and Model Context Protocol (MCP) JSON-RPC broker for executing fully custom, third-party web applications safely inside sandboxed iframes.

## Changes Included
- Extended `RenderStrategy` in `presentation.py` to support `MCP_APPS`
- Added `mcp_ui_resource_uri` to `PresentationHints` for specifying the bundled HTML/JS for sandboxed execution
- Implemented `MCPClientMessage` structure in `mcp.py` to enforce strict JSON-RPC 2.0 payloads for intent bubbling
- Created `MCPUIBroker` to validate incoming UI payloads and translate intents into actionable parameters

This implementation strictly obeys parallel execution boundaries, limiting modifications to `presentation.py` and `mcp.py` without modifying forbidden components.

---
*PR created automatically by Jules for task [4709456660352465304](https://jules.google.com/task/4709456660352465304) started by @gowthamrao*