### PR TITLE
feat: Implement Epistemic Memory & Bayesian Tracking

### DIFF
--- a/src/coreason_manifest/core/state/memory.py
+++ b/src/coreason_manifest/core/state/memory.py
@@ -1,6 +1,6 @@
 from enum import StrEnum
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from coreason_manifest.core.common.base import CoreasonModel
 
@@ -100,6 +100,14 @@ class SemanticMemoryConfig(CoreasonModel):
     min_score_threshold: float = Field(
         0.75, ge=0.0, le=1.0, description="Minimum confidence score for the runtime to inject the context."
     )
+
+    @model_validator(mode="after")
+    def validate_epistemic_strategy(self) -> "SemanticMemoryConfig":
+        if self.retrieval_strategy == RetrievalStrategy.EPISTEMIC and not self.epistemic_tracking:
+            raise ValueError(
+                "If retrieval_strategy is set to EPISTEMIC, epistemic_tracking must be True."
+            )
+        return self
 
 
 class ProceduralMemoryConfig(CoreasonModel):

--- a/src/coreason_manifest/core/state/memory.py
+++ b/src/coreason_manifest/core/state/memory.py
@@ -29,6 +29,7 @@ class RetrievalStrategy(StrEnum):
     HYBRID = "hybrid"
     GRAPH = "graph"
     GRAPH_RAG = "graph_rag"
+    EPISTEMIC = "epistemic"
 
 
 class KnowledgeScope(StrEnum):
@@ -65,6 +66,13 @@ class SemanticMemoryConfig(CoreasonModel):
     """
 
     graph_namespace: str = Field(..., description="Namespace identifier for the knowledge graph partition.")
+    epistemic_tracking: bool = Field(
+        False,
+        description=(
+            "If true, requires the runtime to track Bayesian confidence scores "
+            "and falsification counts for every node in the graph, enabling scientific peer-validation."
+        ),
+    )
     bitemporal_tracking: bool = Field(
         ...,
         description=(

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -148,7 +148,7 @@ class HumanNode(Node):
             )
         if self.render_strategy == RenderStrategy.GEN_UI and self.ui_contract is None:
             raise ManifestError.critical_halt(
-                code=ManifestErrorCode.VAL_HUMAN_STEERING,
+                code=ManifestErrorCode.CRSN_VAL_HUMAN_STEERING,
                 message="HumanNode requires 'ui_contract' when render_strategy is 'GEN_UI'.",
             )
         return self

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -148,7 +148,7 @@ class HumanNode(Node):
             )
         if self.render_strategy == RenderStrategy.GEN_UI and self.ui_contract is None:
             raise ManifestError.critical_halt(
-                code=ManifestErrorCode.CRSN_VAL_HUMAN_STEERING,
+                code=ManifestErrorCode.VAL_HUMAN_STEERING,
                 message="HumanNode requires 'ui_contract' when render_strategy is 'GEN_UI'.",
             )
         return self

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -36,3 +36,26 @@ def test_sota_passport_instantiation(mock_factory: Any) -> None:
     child_passport = mock_factory.generate_mock_passport(is_swarm_child=True)
     assert child_passport.parent_passport_id is not None
     assert "mock_parent_jti_" in child_passport.parent_passport_id
+
+
+def test_epistemic_tracking_config() -> None:
+    from coreason_manifest.core.state.memory import KnowledgeScope, RetrievalStrategy, SemanticMemoryConfig
+
+    # Default behavior: epistemic_tracking should be False
+    config_default = SemanticMemoryConfig(
+        graph_namespace="test_default",
+        bitemporal_tracking=False,
+        scope=KnowledgeScope.SESSION,
+    )
+    assert config_default.epistemic_tracking is False
+
+    # Explicit behavior: testing EPISTEMIC retrieval strategy and epistemic_tracking=True
+    config_epistemic = SemanticMemoryConfig(
+        graph_namespace="test_epistemic",
+        bitemporal_tracking=True,
+        scope=KnowledgeScope.USER,
+        epistemic_tracking=True,
+        retrieval_strategy=RetrievalStrategy.EPISTEMIC,
+    )
+    assert config_epistemic.epistemic_tracking is True
+    assert config_epistemic.retrieval_strategy == RetrievalStrategy.EPISTEMIC

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -59,3 +59,16 @@ def test_epistemic_tracking_config() -> None:
     )
     assert config_epistemic.epistemic_tracking is True
     assert config_epistemic.retrieval_strategy == RetrievalStrategy.EPISTEMIC
+
+    from pydantic import ValidationError
+
+    # 3. Invalid behavior: testing EPISTEMIC strategy without tracking enabled
+    with pytest.raises(ValidationError) as exc_info:
+        SemanticMemoryConfig(
+            graph_namespace="test_invalid",
+            bitemporal_tracking=True,
+            scope=KnowledgeScope.SESSION,
+            epistemic_tracking=False,  # This should trigger the failure
+            retrieval_strategy=RetrievalStrategy.EPISTEMIC,
+        )
+    assert "epistemic_tracking must be True" in str(exc_info.value)


### PR DESCRIPTION
Implement Epic 2: Epistemic Memory & Bayesian Tracking for the coreason-manifest repository. This adds the ability to track epistemic uncertainty for the knowledge graph by introducing an `EPISTEMIC` retrieval strategy and an `epistemic_tracking` configuration flag on `SemanticMemoryConfig`. Includes tests to verify default configuration behavior.

---
*PR created automatically by Jules for task [10857220090550315699](https://jules.google.com/task/10857220090550315699) started by @gowthamrao*