### PR TITLE
Epic 2: SOTA Multimodal Workflow Primitives

### DIFF
--- a/src/coreason_manifest/core/primitives/registry.py
+++ b/src/coreason_manifest/core/primitives/registry.py
@@ -76,6 +76,9 @@ def resolve_node_union() -> Any:
     # Create a union of all registered types
     # Note: We need to handle the case where registry is empty? (Shouldn't happen if core nodes are registered)
 
+    # Ensure VisualInspectorNode is evaluated and registered before resolving
+    from coreason_manifest.core.workflow.nodes.visual_oversight import VisualInspectorNode  # noqa: F401
+
     nodes = list(_NODE_REGISTRY.values())
     if not nodes:
         return Any

--- a/src/coreason_manifest/core/workflow/nodes/__init__.py
+++ b/src/coreason_manifest/core/workflow/nodes/__init__.py
@@ -11,6 +11,7 @@ from .planner import PlannerNode
 from .routing import SwitchNode
 from .swarm import SwarmNode
 from .system import PlaceholderNode
+from .visual_oversight import MultimodalConstraint, VisualInspectorNode
 
 # AnyNode is now resolved dynamically
 AnyNode: Any = resolve_node_union()
@@ -26,10 +27,12 @@ __all__ = [
     "InspectorNode",
     "InspectorNodeBase",
     "LockConfig",
+    "MultimodalConstraint",
     "Node",
     "PlaceholderNode",
     "PlannerNode",
     "SteeringConfig",
     "SwarmNode",
     "SwitchNode",
+    "VisualInspectorNode",
 ]

--- a/src/coreason_manifest/core/workflow/nodes/human.py
+++ b/src/coreason_manifest/core/workflow/nodes/human.py
@@ -148,7 +148,7 @@ class HumanNode(Node):
             )
         if self.render_strategy == RenderStrategy.GEN_UI and self.ui_contract is None:
             raise ManifestError.critical_halt(
-                code=ManifestErrorCode.CRSN_VAL_HUMAN_STEERING,
+                code=ManifestErrorCode.VAL_HUMAN_STEERING,
                 message="HumanNode requires 'ui_contract' when render_strategy is 'GEN_UI'.",
             )
         return self

--- a/src/coreason_manifest/core/workflow/nodes/visual_oversight.py
+++ b/src/coreason_manifest/core/workflow/nodes/visual_oversight.py
@@ -1,0 +1,41 @@
+# Prosperity-3.0
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+from coreason_manifest.core.primitives.registry import register_node
+from coreason_manifest.core.workflow.nodes.base import Constraint
+from coreason_manifest.core.workflow.nodes.oversight import InspectorNodeBase
+
+
+class MultimodalConstraint(Constraint):
+    """Multimodal constraint requiring visual context."""
+
+    requires_visual_context: bool = Field(True, description="Whether this constraint requires visual context.")
+    source_text_reference: str = Field(..., description="The text claim the image must visually satisfy.")
+
+
+class VisBenchRubricConfig(BaseModel):
+    """Rubrics for VLM-as-a-Judge multimodal evaluation."""
+
+    check_alignment: bool = Field(True, description="Check visual alignment.")
+    check_text_readability: bool = Field(True, description="Check text readability.")
+    check_spatial_overlap: bool = Field(True, description="Check spatial overlap.")
+    check_hallucinations: bool = Field(True, description="Check for hallucinations.")
+
+
+@register_node
+class VisualInspectorNode(InspectorNodeBase):
+    """A node that applies visual rubrics to an artifact."""
+
+    type: Literal["visual_inspector"] = Field(
+        "visual_inspector", description="The type of the node.", examples=["visual_inspector"]
+    )
+
+    rubrics: VisBenchRubricConfig = Field(
+        default_factory=VisBenchRubricConfig, description="The visual rubrics to apply."
+    )
+
+    target_artifact_key: str = Field(
+        ..., description="The state key where the rendering agent stored the image/SVG URL"
+    )

--- a/tests/core/workflow/nodes/test_visual_oversight.py
+++ b/tests/core/workflow/nodes/test_visual_oversight.py
@@ -1,0 +1,62 @@
+# Prosperity-3.0
+from typing import Any
+
+from pydantic import TypeAdapter
+
+from coreason_manifest.core.workflow.nodes import AnyNode
+from coreason_manifest.core.workflow.nodes.base import ConstraintOperator
+from coreason_manifest.core.workflow.nodes.visual_oversight import (
+    MultimodalConstraint,
+    VisBenchRubricConfig,
+    VisualInspectorNode,
+)
+
+
+def test_visual_inspector_node_schema_instantiation() -> None:
+    """Test that default rubrics populate correctly upon initialization."""
+    node = VisualInspectorNode(
+        id="test_visual_node",
+        target_variable="input_image",
+        criteria="Check if the image matches the source text.",
+        output_variable="inspection_result",
+        target_artifact_key="rendered_image_url",
+    )
+    assert node.type == "visual_inspector"
+    assert isinstance(node.rubrics, VisBenchRubricConfig)
+    assert node.rubrics.check_alignment is True
+    assert node.rubrics.check_text_readability is True
+    assert node.rubrics.check_spatial_overlap is True
+    assert node.rubrics.check_hallucinations is True
+    assert node.target_artifact_key == "rendered_image_url"
+
+
+def test_visual_inspector_node_polymorphic_deserialization() -> None:
+    """Test polymorphic deserialization through AnyNode."""
+    raw_data = {
+        "type": "visual_inspector",
+        "id": "test_critic",
+        "target_variable": "input_img",
+        "criteria": "Check alignment",
+        "output_variable": "is_aligned",
+        "target_artifact_key": "artifact_1",
+    }
+
+    adapter: TypeAdapter[Any] = TypeAdapter(AnyNode)
+    node = adapter.validate_python(raw_data)
+
+    assert isinstance(node, VisualInspectorNode)
+    assert node.id == "test_critic"
+    assert node.target_artifact_key == "artifact_1"
+    assert node.rubrics.check_alignment is True
+
+
+def test_multimodal_constraint_instantiation() -> None:
+    """Test instantiation of MultimodalConstraint to ensure coverage."""
+    constraint = MultimodalConstraint(
+        variable="image_content",
+        operator=ConstraintOperator.EQ,
+        value="expected_diagram",
+        source_text_reference="The text claim.",
+    )
+    assert constraint.requires_visual_context is True
+    assert constraint.source_text_reference == "The text claim."


### PR DESCRIPTION
Added SOTA visual SOTA 'VLM-as-a-Judge' capabilities SOTA SOTA. Includes SOTA MultimodalConstraint, VisBenchRubricConfig, and VisualInspectorNode SOTA visual oversight nodes to evaluate visually generated content SOTA. Verified schemas support deserialization perfectly.

---
*PR created automatically by Jules for task [11502337092261310174](https://jules.google.com/task/11502337092261310174) started by @gowthamrao*