### PR TITLE
refactor: Final Reconciliation Refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,7 +93,7 @@ testpaths = ["tests"]
 asyncio_mode = "auto"
 filterwarnings = ["ignore:Pydantic serializer warnings:UserWarning"]
 markers = [
-    "evals: mark test as part of the trajectory evals suite",
+    "evals: Agentic UX Trajectory Evals",
 ]
 
 [tool.coverage.run]

--- a/src/coreason_manifest/adapters/providers/mcp.py
+++ b/src/coreason_manifest/adapters/providers/mcp.py
@@ -35,9 +35,18 @@ class MCPUIBroker:
         Safely unpacks the `params` (the user's intent) so the execution
         engine can route it to the Blackboard or the Agent's context.
         """
-        # Event map is currently unused until Epic 3 integration
-        _ = event_map
-        return message.params
+        if event_map is None:
+            raise ValueError("Untethered state mutation from an MCP iframe is forbidden.")
+
+        payload_mapping = event_map.payload_mapping or {}
+        action_payload: dict[str, Any] = {}
+
+        for param_key, param_value in message.params.items():
+            if param_key in payload_mapping:
+                target_var = payload_mapping[param_key]
+                action_payload[target_var] = param_value
+
+        return action_payload
 
 
 def pack_to_mcp_resources(pack: ToolPack) -> list[dict[str, Any]]:

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -67,6 +67,10 @@ class AdaptiveUIContract(CoreasonModel):
     fallback_to_text: bool = Field(
         True, description="Gracefully degrade to JSON Form or Text input if widget is unavailable."
     )
+    mcp_ui_resource_uri: str | None = Field(
+        default=None,
+        description="The ui:// scheme URI pointing to the bundled HTML/JS for sandboxed execution (SEP-1865).",
+    )
 
     @model_validator(mode="before")
     @classmethod
@@ -173,7 +177,3 @@ class PresentationHints(CoreasonModel):
 
 
 UIComponentNode.model_rebuild()
-    mcp_ui_resource_uri: str | None = Field(
-        default=None,
-        description="The ui:// scheme URI pointing to the bundled HTML/JS for sandboxed execution (SEP-1865).",
-    )

--- a/src/coreason_manifest/core/state/persistence.py
+++ b/src/coreason_manifest/core/state/persistence.py
@@ -66,7 +66,9 @@ class Checkpoint(CoreasonModel):
 
     thread_id: Annotated[str, Field(description="The unique identifier for the execution thread.")]
     node_id: Annotated[str, Field(description="The ID of the Node where this checkpoint was taken.")]
-    state_diff: Annotated[list[JSONPatchOperation], Field(description="The RFC 6902 JSON Patch representing the state delta.")]
+    state_diff: Annotated[
+        list[JSONPatchOperation], Field(description="The RFC 6902 JSON Patch representing the state delta.")
+    ]
 
 
 # =========================================================================

--- a/src/coreason_manifest/core/state/persistence.py
+++ b/src/coreason_manifest/core/state/persistence.py
@@ -46,37 +46,6 @@ class JSONPatchOperation(CoreasonModel):
         return self
 
 
-class StateDiff(CoreasonModel):
-    """
-    A single operation in an RFC 6902 JSON Patch document.
-    """
-
-    op: Annotated[PatchOp, Field(description="The operation to perform.")]
-    path: Annotated[str, Field(description="A JSON Pointer path pointing to the target location.")]
-    value: Annotated[Any | None, Field(default=None, description="The value to add, replace, or test.")]
-    from_: Annotated[
-        str | None,
-        Field(
-            default=None,
-            alias="from",
-            description="A JSON Pointer path pointing to the source location (for move and copy).",
-        ),
-    ]
-
-    @model_validator(mode="after")
-    def validate_rfc6902_semantics(self) -> "StateDiff":
-        # Rule A: Move/Copy require 'from'
-        if self.op in ("move", "copy") and self.from_ is None:
-            raise ValueError(f"RFC 6902 Violation: operation '{self.op}' requires a 'from' path.")
-
-        # Rule B: Add/Replace/Test require 'value'
-        # We check model_fields_set to allow explicit `value=None` (JSON null) while rejecting omission
-        if self.op in ("add", "replace", "test") and "value" not in self.model_fields_set:
-            raise ValueError(f"RFC 6902 Violation: operation '{self.op}' requires a 'value' field.")
-
-        return self
-
-
 # =========================================================================
 #  CHECKPOINTING ("Time Travel")
 # =========================================================================
@@ -97,7 +66,7 @@ class Checkpoint(CoreasonModel):
 
     thread_id: Annotated[str, Field(description="The unique identifier for the execution thread.")]
     node_id: Annotated[str, Field(description="The ID of the Node where this checkpoint was taken.")]
-    state_diff: Annotated[list[StateDiff], Field(description="The RFC 6902 JSON Patch representing the state delta.")]
+    state_diff: Annotated[list[JSONPatchOperation], Field(description="The RFC 6902 JSON Patch representing the state delta.")]
 
 
 # =========================================================================

--- a/src/coreason_manifest/core/telemetry/stream.py
+++ b/src/coreason_manifest/core/telemetry/stream.py
@@ -3,6 +3,7 @@ from typing import Annotated, Any, Literal
 from pydantic import BaseModel, ConfigDict, Field
 
 from coreason_manifest.core.common.presentation import AdaptiveUIContract
+from coreason_manifest.core.state.persistence import JSONPatchOperation
 
 
 class StreamError(BaseModel):
@@ -55,7 +56,7 @@ class StreamUIEnvelope(BaseEnvelope):
 
 class StreamStateDeltaEnvelope(BaseEnvelope):
     op: Literal["state_delta"]
-    p: list[dict[str, Any]]
+    p: list[JSONPatchOperation]
 
 
 # SOTA Python 3.12 Union syntax mapped to a Pydantic Discriminator

--- a/src/coreason_manifest/toolkit/diff_engine.py
+++ b/src/coreason_manifest/toolkit/diff_engine.py
@@ -305,7 +305,10 @@ def _apply_patch_in_place(state: Any, patch: JSONPatchOperation) -> None:
         if isinstance(parent, dict):
             parent[key] = deepcopy(patch.value)
         elif isinstance(parent, list):
-            parent.insert(int(key), deepcopy(patch.value))
+            if key == "-":
+                parent.append(deepcopy(patch.value))
+            else:
+                parent.insert(int(key), deepcopy(patch.value))
     elif patch.op == PatchOp.REMOVE:
         parent, key = _resolve_json_pointer(state, patch.path)
         if isinstance(parent, dict):
@@ -327,7 +330,10 @@ def _apply_patch_in_place(state: Any, patch: JSONPatchOperation) -> None:
         if isinstance(target_parent, dict):
             target_parent[target_key] = val
         else:
-            target_parent.insert(int(target_key), val)
+            if target_key == "-":
+                target_parent.append(val)
+            else:
+                target_parent.insert(int(target_key), val)
     elif patch.op == PatchOp.COPY:
         if patch.from_ is None:
             raise ValueError("copy requires from")
@@ -340,7 +346,10 @@ def _apply_patch_in_place(state: Any, patch: JSONPatchOperation) -> None:
         if isinstance(target_parent, dict):
             target_parent[target_key] = val
         else:
-            target_parent.insert(int(target_key), val)
+            if target_key == "-":
+                target_parent.append(val)
+            else:
+                target_parent.insert(int(target_key), val)
     elif patch.op == PatchOp.TEST:
         parent, key = _resolve_json_pointer(state, patch.path)
         current_val = parent.get(key) if isinstance(parent, dict) else parent[int(key)]

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -56,7 +56,7 @@ def test_genui_multiplexer_emission() -> None:
             p=AdaptiveUIContract(
                 layout=[{"type": "weather_widget", "props": {"location": "San Francisco", "user_id": "123-45-678"}}]
             ),
-            timestamp=2.0
+            timestamp=2.0,
         )
 
     # Simulate multiplexer reading the stream

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,8 @@ import pytest
 
 from coreason_manifest.adapters.observability.privacy import scrub_genui_payload
 from coreason_manifest.core.primitives.types import DataClassification
+from coreason_manifest.core.common.presentation import AdaptiveUIContract
+from coreason_manifest.core.telemetry.stream import StreamThoughtEnvelope, StreamUIEnvelope
 
 
 def test_import() -> None:
@@ -47,23 +49,14 @@ def test_genui_multiplexer_emission() -> None:
     successfully strips PII from the UI props.
     """
 
-    # Mocking the forward-looking imports from Epic 1 and Epic 2
-    class StreamThoughtEnvelope:
-        def __init__(self, content: str):
-            self.content = content
-            self.type = "thought"
-
-    class StreamUIEnvelope:
-        def __init__(self, ui_data: dict[str, Any]):
-            self.ui_data = ui_data
-            self.type = "genui"
-
     def mock_stream() -> Any:
-        yield StreamThoughtEnvelope(content="Generating dashboard...")
+        yield StreamThoughtEnvelope(op="thought", p="Generating dashboard...", timestamp=1.0)
         yield StreamUIEnvelope(
-            ui_data={
-                "layout": [{"type": "weather_widget", "props": {"location": "San Francisco", "user_id": "123-45-678"}}]
-            }
+            op="ui_mount",
+            p=AdaptiveUIContract(
+                layout=[{"type": "weather_widget", "props": {"location": "San Francisco", "user_id": "123-45-678"}}]
+            ),
+            timestamp=2.0
         )
 
     # Simulate multiplexer reading the stream
@@ -71,11 +64,11 @@ def test_genui_multiplexer_emission() -> None:
 
     # Assert non-blocking generation (all items yielded)
     assert len(stream_results) == 2
-    assert stream_results[0].type == "thought"
-    assert stream_results[1].type == "genui"
+    assert stream_results[0].op == "thought"
+    assert stream_results[1].op == "ui_mount"
 
     # Simulate processing the UI envelope and passing to logger/scrubber
-    raw_payload = stream_results[1].ui_data
+    raw_payload = stream_results[1].p.model_dump()
     scrubbed_payload = scrub_genui_payload(raw_payload)
 
     # The layout structure should be intact

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,8 +3,8 @@ from typing import Any
 import pytest
 
 from coreason_manifest.adapters.observability.privacy import scrub_genui_payload
-from coreason_manifest.core.primitives.types import DataClassification
 from coreason_manifest.core.common.presentation import AdaptiveUIContract
+from coreason_manifest.core.primitives.types import DataClassification
 from coreason_manifest.core.telemetry.stream import StreamThoughtEnvelope, StreamUIEnvelope
 
 


### PR DESCRIPTION
Completes the final reconciliation refactor, integrating 5 parallel epics and fixing known edge cases. Includes state model consolidation, fix for array appending in RFC 6902 patches, zero-trust MCP wiring, and telemetry test cleanup.

---
*PR created automatically by Jules for task [8469135502319818137](https://jules.google.com/task/8469135502319818137) started by @gowthamrao*