### PR TITLE
Update SOTA scientific illustration topology with new schemas and oversight nodes

### DIFF
--- a/src/coreason_manifest/core/workflow/topologies/sci_vis_flow.py
+++ b/src/coreason_manifest/core/workflow/topologies/sci_vis_flow.py
@@ -1,5 +1,7 @@
 from coreason_manifest.core.workflow.flow import Edge, FlowInterface, FlowMetadata, Graph, GraphFlow
-from coreason_manifest.core.workflow.nodes import AgentNode, CognitiveProfile, InspectorNode, PlannerNode, SwitchNode
+from coreason_manifest.core.workflow.nodes import AgentNode, CognitiveProfile, PlannerNode, SwitchNode
+from coreason_manifest.core.workflow.nodes.visual_oversight import VisBenchRubricConfig, VisualInspectorNode
+from coreason_manifest.spec.domains.scientific_vis import HierarchicalBlueprint
 
 
 def get_sota_scivis_topology() -> GraphFlow:
@@ -9,7 +11,7 @@ def get_sota_scivis_topology() -> GraphFlow:
     semantic_parser = PlannerNode(
         id="semantic_parser",
         goal="Parses text to hierarchical blueprint",
-        output_schema={"type": "object"},
+        output_schema=HierarchicalBlueprint.model_json_schema(),
     )
 
     # Node 2: layout_agent
@@ -23,11 +25,18 @@ def get_sota_scivis_topology() -> GraphFlow:
     )
 
     # Node 3: visual_critic
-    visual_critic = InspectorNode(
+    visual_critic = VisualInspectorNode(
         id="visual_critic",
         target_variable="layout",
         criteria="Applies VisBench rubrics to layout",
         output_variable="critique_result",
+        target_artifact_key="rendered_layout_svg",
+        rubrics=VisBenchRubricConfig(
+            check_alignment=True,
+            check_text_readability=True,
+            check_spatial_overlap=True,
+            check_hallucinations=True,
+        ),
     )
 
     # Node 4: critique_router

--- a/tests/core/workflow/topologies/test_sci_vis_flow.py
+++ b/tests/core/workflow/topologies/test_sci_vis_flow.py
@@ -1,4 +1,5 @@
 from coreason_manifest.core.workflow.nodes import SwitchNode
+from coreason_manifest.core.workflow.nodes.visual_oversight import VisualInspectorNode
 from coreason_manifest.core.workflow.topologies.sci_vis_flow import get_sota_scivis_topology
 
 
@@ -16,6 +17,11 @@ def test_sci_vis_flow_serialization_and_structure() -> None:
     assert "visual_critic" in flow.graph.nodes
     assert "critique_router" in flow.graph.nodes
     assert "final_renderer" in flow.graph.nodes
+
+    # Validate visual_critic node
+    visual_critic = flow.graph.nodes["visual_critic"]
+    assert isinstance(visual_critic, VisualInspectorNode)
+    assert visual_critic.target_artifact_key == "rendered_layout_svg"
 
     # Validate the default non-null constraint on router
     router = flow.graph.nodes["critique_router"]


### PR DESCRIPTION
This PR updates the SOTA scientific illustration topology by integrating the new schemas and oversight nodes introduced in the recent epics. It updates the `semantic_parser` node to use the `HierarchicalBlueprint` schema and replaces the generic `InspectorNode` with the specialized `VisualInspectorNode` for the `visual_critic` node. It also updates the topology tests to verify the updated properties.

---
*PR created automatically by Jules for task [6290219025913923521](https://jules.google.com/task/6290219025913923521) started by @gowthamrao*