### PR TITLE
feat: dx enhancements for scientific visualization schemas

### DIFF
--- a/src/coreason_manifest/cli/main.py
+++ b/src/coreason_manifest/cli/main.py
@@ -8,6 +8,7 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+import json
 import sys
 from importlib.metadata import PackageNotFoundError, version
 
@@ -15,9 +16,11 @@ import typer
 from rich import print as rprint
 
 from coreason_manifest.adapters.system.dynamic_loader import load_flow_from_file
+from coreason_manifest.core.workflow.topologies.sci_vis_flow import get_sota_scivis_topology
+from coreason_manifest.spec.domains.scientific_vis import HierarchicalBlueprint
 from coreason_manifest.toolkit.exporter import render_agent_card
 from coreason_manifest.toolkit.validator import validate_flow
-from coreason_manifest.toolkit.visualizer import to_mermaid
+from coreason_manifest.toolkit.visualizer import export_html_diagram, to_mermaid
 
 app = typer.Typer(help="CoReason Manifest CLI")
 
@@ -66,6 +69,39 @@ def create() -> None:
     """
     rprint("[yellow]Create command is not yet implemented.[/yellow]")
     raise typer.Exit(code=1)
+
+
+@app.command(name="export-schema")
+def export_schema(
+    model_name: str = typer.Argument(..., help="Model name (e.g. HierarchicalBlueprint)"),
+    out_file: str = typer.Argument(..., help="Output JSON file path"),
+) -> int:
+    """
+    Export Pydantic model JSON schema to a file
+    """
+    if model_name != "HierarchicalBlueprint":
+        rprint(f"[red]❌ Error: Model '{model_name}' not supported.[/red]", file=sys.stderr)
+        raise typer.Exit(code=1)
+
+    schema = HierarchicalBlueprint.model_json_schema()
+    with open(out_file, "w", encoding="utf-8") as f:
+        json.dump(schema, f, indent=2)
+
+    rprint(f"[green]✅ Schema exported to {out_file}[/green]")
+    return 0
+
+
+@app.command(name="export-diagram")
+def export_diagram(
+    out_file: str = typer.Argument(..., help="Output HTML file path"),
+) -> int:
+    """
+    Export SciVis Flow as HTML preview
+    """
+    flow = get_sota_scivis_topology()
+    export_html_diagram(flow, out_file)
+    rprint(f"[green]✅ Diagram exported to {out_file}[/green]")
+    return 0
 
 
 def _handle_validate(file_path: str) -> int:

--- a/src/coreason_manifest/spec/domains/scientific_vis.py
+++ b/src/coreason_manifest/spec/domains/scientific_vis.py
@@ -12,9 +12,14 @@ from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
+from pydantic_core import PydanticCustomError
 
 
 class VisInformationType(str, Enum):  # noqa: UP042
+    """
+    Taxonomy for scientific visualization types.
+    """
+
     QUALITATIVE_SCHEMATIC = "QUALITATIVE_SCHEMATIC"
     QUANTITATIVE_STATISTICAL = "QUANTITATIVE_STATISTICAL"
     SPATIAL_GEOMETRIC = "SPATIAL_GEOMETRIC"
@@ -22,7 +27,11 @@ class VisInformationType(str, Enum):  # noqa: UP042
 
 
 class SciVisIntent(BaseModel):
-    vis_type: VisInformationType
+    vis_type: VisInformationType = Field(
+        ...,
+        description="Classify the scientific visualization type based on the MECE taxonomy.",
+        examples=[VisInformationType.QUALITATIVE_SCHEMATIC, VisInformationType.QUANTITATIVE_STATISTICAL],
+    )
     requires_code_execution: bool = Field(
         description="Indicates if code execution is required for exact numerics (e.g., Matplotlib)."
     )
@@ -60,9 +69,17 @@ class HierarchicalBlueprint(BaseModel):
         module_ids = {module.module_id for module in self.modules}
         for connection in self.connections:
             if connection.source_module_id not in module_ids:
-                raise ValueError(f"source_module_id '{connection.source_module_id}' not found in modules.")
+                raise PydanticCustomError(
+                    "hallucinated_module_reference",
+                    'Module ID "{invalid_id}" does not exist in the declared modules list.',
+                    {"invalid_id": connection.source_module_id},
+                )
             if connection.target_module_id not in module_ids:
-                raise ValueError(f"target_module_id '{connection.target_module_id}' not found in modules.")
+                raise PydanticCustomError(
+                    "hallucinated_module_reference",
+                    'Module ID "{invalid_id}" does not exist in the declared modules list.',
+                    {"invalid_id": connection.target_module_id},
+                )
         return self
 
 

--- a/src/coreason_manifest/toolkit/visualizer.py
+++ b/src/coreason_manifest/toolkit/visualizer.py
@@ -299,3 +299,19 @@ def to_react_flow(flow: GraphFlow | LinearFlow, snapshot: ExecutionSnapshot | No
         rf_edges.append(edge_data)
 
     return {"nodes": rf_nodes, "edges": rf_edges}
+
+
+def export_html_diagram(flow: GraphFlow | LinearFlow, output_path: str = "graph.html") -> None:
+    """Exports a flow to an HTML file containing a Mermaid.js diagram."""
+    mermaid_str = to_mermaid(flow)
+    html_content = f"""<!DOCTYPE html>
+<html><body>
+    <script type="module">
+        import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs';
+        mermaid.initialize({{ startOnLoad: true }});
+    </script>
+    <div class="mermaid">{mermaid_str}</div>
+</body></html>
+"""
+    with open(output_path, "w", encoding="utf-8") as f:
+        f.write(html_content)

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,7 +1,7 @@
 import json
 import os
 import tempfile
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from typer.testing import CliRunner
 
@@ -37,8 +37,6 @@ def test_export_schema_unsupported() -> None:
     # Check stderr or stdout, typer prints red error to stderr
     # if runner doesn't capture stderr properly, we can just check exit_code
 
-
-from unittest.mock import MagicMock
 
 @patch("coreason_manifest.cli.main.export_html_diagram")
 @patch("coreason_manifest.cli.main.get_sota_scivis_topology")

--- a/tests/cli/test_main.py
+++ b/tests/cli/test_main.py
@@ -1,0 +1,61 @@
+import json
+import os
+import tempfile
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from coreason_manifest.cli.main import app
+
+runner = CliRunner()
+
+
+def test_export_schema() -> None:
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".json") as tmp:
+        tmp_path = tmp.name
+
+    try:
+        result = runner.invoke(app, ["export-schema", "HierarchicalBlueprint", tmp_path])
+        assert result.exit_code == 0
+        assert "Schema exported to" in result.stdout
+
+        with open(tmp_path, encoding="utf-8") as f:
+            data = json.load(f)
+
+        assert "title" in data
+        assert data["title"] == "HierarchicalBlueprint"
+        assert "properties" in data
+
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
+def test_export_schema_unsupported() -> None:
+    result = runner.invoke(app, ["export-schema", "UnknownModel", "out.json"])
+    assert result.exit_code == 1
+    # Check stderr or stdout, typer prints red error to stderr
+    # if runner doesn't capture stderr properly, we can just check exit_code
+
+
+from unittest.mock import MagicMock
+
+@patch("coreason_manifest.cli.main.export_html_diagram")
+@patch("coreason_manifest.cli.main.get_sota_scivis_topology")
+def test_export_diagram(mock_get_topology: MagicMock, mock_export_diagram: MagicMock) -> None:
+    mock_get_topology.return_value = "mock_flow"
+
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp:
+        tmp_path = tmp.name
+
+    try:
+        result = runner.invoke(app, ["export-diagram", tmp_path])
+        assert result.exit_code == 0
+        assert "Diagram exported to" in result.stdout
+
+        mock_get_topology.assert_called_once()
+        mock_export_diagram.assert_called_once_with("mock_flow", tmp_path)
+
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)

--- a/tests/spec/domains/test_scientific_vis.py
+++ b/tests/spec/domains/test_scientific_vis.py
@@ -82,7 +82,7 @@ def test_invalid_hierarchical_blueprint_source() -> None:
     with pytest.raises(ValidationError) as exc_info:
         HierarchicalBlueprint(modules=modules, connections=connections, aspect_ratio_preference="16:9")
 
-    assert "source_module_id 'invalid_mod' not found in modules" in str(exc_info.value)
+    assert 'Module ID "invalid_mod" does not exist in the declared modules list.' in str(exc_info.value)
 
 
 def test_invalid_hierarchical_blueprint_target() -> None:
@@ -101,7 +101,7 @@ def test_invalid_hierarchical_blueprint_target() -> None:
     with pytest.raises(ValidationError) as exc_info:
         HierarchicalBlueprint(modules=modules, connections=connections, aspect_ratio_preference="16:9")
 
-    assert "target_module_id 'invalid_target' not found in modules" in str(exc_info.value)
+    assert 'Module ID "invalid_target" does not exist in the declared modules list.' in str(exc_info.value)
 
 
 def test_scivis_intent() -> None:

--- a/tests/toolkit/test_sci_vis_visualizer.py
+++ b/tests/toolkit/test_sci_vis_visualizer.py
@@ -1,8 +1,10 @@
+import os
+import tempfile
 import unittest.mock
 from unittest.mock import MagicMock
 
 from coreason_manifest.core.workflow.flow import GraphFlow
-from coreason_manifest.toolkit.visualizer import to_mermaid
+from coreason_manifest.toolkit.visualizer import export_html_diagram, to_mermaid
 
 
 def test_visual_inspector_mermaid_styling() -> None:
@@ -31,3 +33,28 @@ def test_visual_inspector_mermaid_styling() -> None:
         # Verify the distinct styling class is injected in the output strings
         assert "classDef visual_inspector fill:#fdebd0,stroke:#d35400,stroke-width:2px;" in result
         assert "mock_visual_node:::visual_inspector" in result or "mock_visual_node" in result
+
+
+def test_export_html_diagram() -> None:
+    dummy_flow = MagicMock(spec=GraphFlow)
+
+    with unittest.mock.patch("coreason_manifest.toolkit.visualizer.to_mermaid") as mock_to_mermaid:
+        mock_to_mermaid.return_value = "graph TD\n    A-->B"
+
+        with tempfile.NamedTemporaryFile(delete=False, suffix=".html") as tmp:
+            tmp_path = tmp.name
+
+        try:
+            export_html_diagram(dummy_flow, tmp_path)
+
+            with open(tmp_path, encoding="utf-8") as f:
+                content = f.read()
+
+            assert "<!DOCTYPE html>" in content
+            assert "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs" in content
+            assert "graph TD\n    A-->B" in content
+            assert '<div class="mermaid">' in content
+
+        finally:
+            if os.path.exists(tmp_path):
+                os.remove(tmp_path)


### PR DESCRIPTION
This PR introduces Developer Experience (DX) enhancements to the 2026 SOTA Scientific Illustration capabilities in the `coreason-manifest` shared kernel. 

Key changes include:
1.  **Schema Enrichment:** Updated `VisInformationType` and `SciVisIntent` schemas with detailed descriptions and examples to optimize LLM prompt generation without extra downstream engineering.
2.  **LLM-Optimized Error Messages:** Replaced generic `ValueErrors` with structured `PydanticCustomError` in `HierarchicalBlueprint` connections validation, using the `hallucinated_module_reference` identifier for improved LLM self-correction feedback.
3.  **Auto-Generating Diagram Previews:** Added a pure function `export_html_diagram` in the toolkit visualizer that wraps Mermaid flow strings into a minimal, browser-ready HTML template.
4.  **Schema Export CLI:** Introduced `export-schema` and `export-diagram` Typer commands in `main.py` to expose the new tooling directly to developers.
5.  **Testing & QA:** Updated existing domains and toolkit tests to verify the new error formats and HTML generation. Created new CLI runner tests (`tests/cli/test_main.py`) to validate the new CLI subcommands.

All changes adhere strictly to the non-execution architectural laws defined in `AGENTS.md`. Local verifications (ruff, mypy, pytest) pass successfully.

---
*PR created automatically by Jules for task [15514784282600602214](https://jules.google.com/task/15514784282600602214) started by @gowthamrao*