### PR TITLE
Epic 5.1: Protocol-Bound Methodological Councils

### DIFF
--- a/src/coreason_manifest/core/compute/reasoning.py
+++ b/src/coreason_manifest/core/compute/reasoning.py
@@ -98,16 +98,15 @@ class MethodologyConfig(BaseModel):
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
     standard: Annotated[
-        MethodologyStandard,
-        Field(description="The scientific standard the council must mathematically follow.")
+        MethodologyStandard, Field(description="The scientific standard the council must mathematically follow.")
     ]
     require_flow_diagram_metadata: Annotated[
         bool,
-        Field(description="If True, the council must output metadata to generate a flow diagram (e.g., PRISMA flow).")
+        Field(description="If True, the council must output metadata to generate a flow diagram (e.g., PRISMA flow)."),
     ] = True
     step_validation: Annotated[
         Literal["strict", "advisory"],
-        Field(description="If 'strict', the runtime hard-fails if intermediate methodology artifacts are missed.")
+        Field(description="If 'strict', the runtime hard-fails if intermediate methodology artifacts are missed."),
     ] = "strict"
 
 
@@ -306,8 +305,7 @@ class CouncilReasoning(BaseReasoning):
 
     personas: list[str] = Field(..., description="List of system prompts.")
     methodology: Annotated[
-        MethodologyConfig | None,
-        Field(description="Strict methodological protocol the council is bound to.")
+        MethodologyConfig | None, Field(description="Strict methodological protocol the council is bound to.")
     ] = None
     proposal_count: int = 1
     voting_mode: Literal["unanimous", "majority", "weighted"] = "majority"

--- a/src/coreason_manifest/core/compute/reasoning.py
+++ b/src/coreason_manifest/core/compute/reasoning.py
@@ -97,9 +97,18 @@ class MethodologyConfig(BaseModel):
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    standard: Annotated[MethodologyStandard, Field(description="The scientific standard the council must mathematically follow.")]
-    require_flow_diagram_metadata: Annotated[bool, Field(description="If True, the council must output metadata to generate a flow diagram (e.g., PRISMA flow).")] = True
-    step_validation: Annotated[Literal["strict", "advisory"], Field(description="If 'strict', the runtime hard-fails if intermediate methodology artifacts are missed.")] = "strict"
+    standard: Annotated[
+        MethodologyStandard,
+        Field(description="The scientific standard the council must mathematically follow.")
+    ]
+    require_flow_diagram_metadata: Annotated[
+        bool,
+        Field(description="If True, the council must output metadata to generate a flow diagram (e.g., PRISMA flow).")
+    ] = True
+    step_validation: Annotated[
+        Literal["strict", "advisory"],
+        Field(description="If 'strict', the runtime hard-fails if intermediate methodology artifacts are missed.")
+    ] = "strict"
 
 
 class ReviewStrategy(StrEnum):
@@ -296,7 +305,10 @@ class CouncilReasoning(BaseReasoning):
     type: Literal["council"] = "council"
 
     personas: list[str] = Field(..., description="List of system prompts.")
-    methodology: Annotated[MethodologyConfig | None, Field(description="Strict methodological protocol the council is bound to.")] = None
+    methodology: Annotated[
+        MethodologyConfig | None,
+        Field(description="Strict methodological protocol the council is bound to.")
+    ] = None
     proposal_count: int = 1
     voting_mode: Literal["unanimous", "majority", "weighted"] = "majority"
     rounds: int = 1

--- a/src/coreason_manifest/core/compute/reasoning.py
+++ b/src/coreason_manifest/core/compute/reasoning.py
@@ -85,6 +85,23 @@ ModelRef = str | ModelCriteria
 # =========================================================================
 
 
+class MethodologyStandard(StrEnum):
+    PRISMA_2020 = "prisma_2020"
+    PRISMA_S = "prisma_s"
+    COCHRANE_MECIR = "cochrane_mecir"
+    GRADE = "grade"
+
+
+class MethodologyConfig(BaseModel):
+    """Configuration to bind an agent council to a strict clinical/scientific protocol."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    standard: Annotated[MethodologyStandard, Field(description="The scientific standard the council must mathematically follow.")]
+    require_flow_diagram_metadata: Annotated[bool, Field(description="If True, the council must output metadata to generate a flow diagram (e.g., PRISMA flow).")] = True
+    step_validation: Annotated[Literal["strict", "advisory"], Field(description="If 'strict', the runtime hard-fails if intermediate methodology artifacts are missed.")] = "strict"
+
+
 class ReviewStrategy(StrEnum):
     NONE = "none"
     BASIC = "basic"
@@ -274,11 +291,12 @@ class EvolutionaryReasoning(BaseReasoning):
 
 @register_engine
 class CouncilReasoning(BaseReasoning):
-    """Multi-Persona Consensus."""
+    """Multi-Persona Consensus, now supporting Protocol-Bound Methodological Execution."""
 
     type: Literal["council"] = "council"
 
     personas: list[str] = Field(..., description="List of system prompts.")
+    methodology: Annotated[MethodologyConfig | None, Field(description="Strict methodological protocol the council is bound to.")] = None
     proposal_count: int = 1
     voting_mode: Literal["unanimous", "majority", "weighted"] = "majority"
     rounds: int = 1
@@ -549,6 +567,8 @@ __all__ = [
     "FastPath",
     "GapScanConfig",
     "GraphReasoning",
+    "MethodologyConfig",
+    "MethodologyStandard",
     "ModelCriteria",
     "ModelRef",
     "Optimizer",


### PR DESCRIPTION
Added `MethodologyStandard` and `MethodologyConfig` to support clinical protocols in `CouncilReasoning` engine.

---
*PR created automatically by Jules for task [7558360731881517611](https://jules.google.com/task/7558360731881517611) started by @gowthamrao*