### PR TITLE
feat: Epic 5.3 - Cryptographic Visual Provenance in memory config

### DIFF
--- a/src/coreason_manifest/core/__init__.py
+++ b/src/coreason_manifest/core/__init__.py
@@ -43,7 +43,7 @@ from coreason_manifest.core.oversight.resilience import (
 )
 from coreason_manifest.core.primitives.registry import resolve_node_union
 from coreason_manifest.core.primitives.types import WasmMiddlewareDef
-from coreason_manifest.core.state.persistence import Checkpoint, PersistenceConfig, StateDiff
+from coreason_manifest.core.state.persistence import Checkpoint, PersistenceConfig
 from coreason_manifest.core.state.tools import MCPPrompt, MCPResourceTemplate, MCPTool, ToolPack
 from coreason_manifest.core.workflow.evals import EvalsManifest, FuzzingTarget, TestCase
 from coreason_manifest.core.workflow.flow import (
@@ -137,7 +137,6 @@ __all__ = [
     "RetryStrategy",
     "Safety",
     "StandardReasoning",
-    "StateDiff",
     "SupervisionPolicy",
     "SwarmNode",
     "SwitchNode",

--- a/src/coreason_manifest/core/state/__init__.py
+++ b/src/coreason_manifest/core/state/__init__.py
@@ -1,3 +1,3 @@
-from coreason_manifest.core.state.persistence import Checkpoint, PersistenceConfig, StateDiff
+from coreason_manifest.core.state.persistence import Checkpoint, PersistenceConfig
 
-__all__ = ["Checkpoint", "PersistenceConfig", "StateDiff"]
+__all__ = ["Checkpoint", "PersistenceConfig"]

--- a/src/coreason_manifest/core/state/memory.py
+++ b/src/coreason_manifest/core/state/memory.py
@@ -74,11 +74,17 @@ class ProvenanceConfig(CoreasonModel):
 
     required_level: ProvenanceLevel = Field(
         default=ProvenanceLevel.VISUAL_BOUNDING_BOX,
-        description="The minimum level of provenance required. 'visual_bounding_box' forces precise PDF pixel coordinate tracking.",
+        description=(
+            "The minimum level of provenance required. "
+            "'visual_bounding_box' forces precise PDF pixel coordinate tracking."
+        ),
     )
     enforce_cryptographic_trace: bool = Field(
         default=True,
-        description="If true, requires an immutable hash chain linking extracted data to its original source binary (e.g., 21 CFR Part 11 compliance).",
+        description=(
+            "If true, requires an immutable hash chain linking extracted data "
+            "to its original source binary (e.g., 21 CFR Part 11 compliance)."
+        ),
     )
 
 
@@ -123,7 +129,10 @@ class SemanticMemoryConfig(CoreasonModel):
         0.75, ge=0.0, le=1.0, description="Minimum confidence score for the runtime to inject the context."
     )
     provenance: ProvenanceConfig | None = Field(
-        None, description="Strict provenance requirements for ensuring extracted evidence is mathematically and visually grounded."
+        None,
+        description=(
+            "Strict provenance requirements for ensuring extracted evidence is mathematically and visually grounded."
+        ),
     )
 
     @model_validator(mode="after")

--- a/src/coreason_manifest/core/state/memory.py
+++ b/src/coreason_manifest/core/state/memory.py
@@ -60,6 +60,28 @@ class EpisodicMemoryConfig(CoreasonModel):
     consolidation_strategy: ConsolidationStrategy = Field(default=ConsolidationStrategy.SESSION_CLOSE)
 
 
+class ProvenanceLevel(StrEnum):
+    DOCUMENT_HASH = "document_hash"
+    TEXT_SNIPPET = "text_snippet"
+    VISUAL_BOUNDING_BOX = "visual_bounding_box"
+
+
+class ProvenanceConfig(CoreasonModel):
+    """
+    Configuration for cryptographic and visual traceability of extracted data.
+    Ensures 100% 'Glass Box' auditability for regulatory submissions.
+    """
+
+    required_level: ProvenanceLevel = Field(
+        default=ProvenanceLevel.VISUAL_BOUNDING_BOX,
+        description="The minimum level of provenance required. 'visual_bounding_box' forces precise PDF pixel coordinate tracking.",
+    )
+    enforce_cryptographic_trace: bool = Field(
+        default=True,
+        description="If true, requires an immutable hash chain linking extracted data to its original source binary (e.g., 21 CFR Part 11 compliance).",
+    )
+
+
 class SemanticMemoryConfig(CoreasonModel):
     """
     Configuration for the agent's semantic knowledge graph (Knowledge Graph).
@@ -99,6 +121,9 @@ class SemanticMemoryConfig(CoreasonModel):
     )
     min_score_threshold: float = Field(
         0.75, ge=0.0, le=1.0, description="Minimum confidence score for the runtime to inject the context."
+    )
+    provenance: ProvenanceConfig | None = Field(
+        None, description="Strict provenance requirements for ensuring extracted evidence is mathematically and visually grounded."
     )
 
     @model_validator(mode="after")

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -81,6 +81,8 @@ def test_genui_multiplexer_emission() -> None:
     props = scrubbed_payload["layout"][0]["props"]
     assert props["location"] == "[REDACTED_PII]"
     assert props["user_id"] == "[REDACTED_PII]"
+
+
 def test_swarm_orchestration_schema() -> None:
     from pydantic import ValidationError
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -51,12 +51,16 @@ def test_genui_multiplexer_emission() -> None:
     successfully strips PII from the UI props.
     """
 
+    from coreason_manifest.core.common.presentation import UIComponentNode
+
     def mock_stream() -> Any:
         yield StreamThoughtEnvelope(op="thought", p="Generating dashboard...", timestamp=1.0)
         yield StreamUIEnvelope(
             op="ui_mount",
             p=AdaptiveUIContract(
-                layout=[{"type": "weather_widget", "props": {"location": "San Francisco", "user_id": "123-45-678"}}]
+                layout=[
+                    UIComponentNode(type="weather_widget", props={"location": "San Francisco", "user_id": "123-45-678"})
+                ]
             ),
             timestamp=2.0,
         )

--- a/tests/test_diff_engine_and_persistence.py
+++ b/tests/test_diff_engine_and_persistence.py
@@ -4,56 +4,56 @@ from coreason_manifest.core.state.persistence import JSONPatchOperation, PatchOp
 from coreason_manifest.toolkit.diff_engine import apply_rewind, generate_inverse_patches
 
 
-def test_json_patch_operation_add_replace_test():
-    op = JSONPatchOperation(op=PatchOp.ADD, path="/test", value=1)
+def test_json_patch_operation_add_replace_test() -> None:
+    op = JSONPatchOperation(op=PatchOp.ADD, path="/test", value=1, from_=None)
     assert op.op == PatchOp.ADD
     assert op.path == "/test"
     assert op.value == 1
 
-    op = JSONPatchOperation(op=PatchOp.REPLACE, path="/test", value=1)
+    op = JSONPatchOperation(op=PatchOp.REPLACE, path="/test", value=1, from_=None)
     assert op.op == PatchOp.REPLACE
 
-    op = JSONPatchOperation(op=PatchOp.TEST, path="/test", value=1)
+    op = JSONPatchOperation(op=PatchOp.TEST, path="/test", value=1, from_=None)
     assert op.op == PatchOp.TEST
 
 
-def test_json_patch_operation_add_replace_test_requires_value():
+def test_json_patch_operation_add_replace_test_requires_value() -> None:
     with pytest.raises(ValueError, match="requires a 'value' field"):
-        JSONPatchOperation(op=PatchOp.ADD, path="/test")
+        JSONPatchOperation(op=PatchOp.ADD, path="/test", value=None, from_=None)
 
 
-def test_json_patch_operation_move_copy():
-    op = JSONPatchOperation(op=PatchOp.MOVE, path="/test2", from_="/test")
+def test_json_patch_operation_move_copy() -> None:
+    op = JSONPatchOperation(op=PatchOp.MOVE, path="/test2", from_="/test", value=None)
     assert op.op == PatchOp.MOVE
     assert op.path == "/test2"
     assert op.from_ == "/test"
 
-    op = JSONPatchOperation(op=PatchOp.COPY, path="/test2", from_="/test")
+    op = JSONPatchOperation(op=PatchOp.COPY, path="/test2", from_="/test", value=None)
     assert op.op == PatchOp.COPY
 
 
-def test_json_patch_operation_move_copy_requires_from():
+def test_json_patch_operation_move_copy_requires_from() -> None:
     with pytest.raises(ValueError, match="requires a 'from' path"):
-        JSONPatchOperation(op=PatchOp.MOVE, path="/test2")
+        JSONPatchOperation(op=PatchOp.MOVE, path="/test2", value=None, from_=None)
 
 
-def test_state_checkpoint():
+def test_state_checkpoint() -> None:
     sc = StateCheckpoint(
         checkpoint_id="cp1", parent_id=None, forward_patches=[], reverse_patches=[], trigger_source="TEST"
     )
     assert sc.checkpoint_id == "cp1"
 
 
-def test_generate_inverse_patches_and_apply_rewind():
+def test_generate_inverse_patches_and_apply_rewind() -> None:
     state = {"a": 1, "b": {"c": 2}, "d": [1, 2, 3]}
 
     patches = [
-        JSONPatchOperation(op=PatchOp.ADD, path="/e", value=4),
-        JSONPatchOperation(op=PatchOp.REPLACE, path="/a", value=10),
-        JSONPatchOperation(op=PatchOp.REMOVE, path="/b/c"),
-        JSONPatchOperation(op=PatchOp.MOVE, path="/f", from_="/b"),
-        JSONPatchOperation(op=PatchOp.COPY, path="/d/1", from_="/d/0"),
-        JSONPatchOperation(op=PatchOp.TEST, path="/d/2", value=2),
+        JSONPatchOperation(op=PatchOp.ADD, path="/e", value=4, from_=None),
+        JSONPatchOperation(op=PatchOp.REPLACE, path="/a", value=10, from_=None),
+        JSONPatchOperation(op=PatchOp.REMOVE, path="/b/c", value=None, from_=None),
+        JSONPatchOperation(op=PatchOp.MOVE, path="/f", from_="/b", value=None),
+        JSONPatchOperation(op=PatchOp.COPY, path="/d/1", from_="/d/0", value=None),
+        JSONPatchOperation(op=PatchOp.TEST, path="/d/2", value=2, from_=None),
     ]
 
     inverse_patches = generate_inverse_patches(state, patches)

--- a/tests/test_presentation.py
+++ b/tests/test_presentation.py
@@ -4,24 +4,25 @@ from pydantic import ValidationError
 from coreason_manifest.core.common.presentation import UIEventMap
 
 
-def test_uieventmap_valid_payload_mapping():
+def test_uieventmap_valid_payload_mapping() -> None:
     # Valid map
     evt = UIEventMap(
         trigger="on_click", action="submit", mutates_variables=["user_id", "status"], payload_mapping={"id": "user_id"}
     )
+    assert evt.payload_mapping is not None
     assert evt.payload_mapping["id"] == "user_id"
 
 
-def test_uieventmap_invalid_payload_mapping_target_not_in_mutates():
+def test_uieventmap_invalid_payload_mapping_target_not_in_mutates() -> None:
     with pytest.raises(ValidationError, match="not allowed by mutates_variables"):
         UIEventMap(trigger="on_click", action="submit", mutates_variables=["status"], payload_mapping={"id": "user_id"})
 
 
-def test_uieventmap_invalid_payload_mapping_requires_mutates():
+def test_uieventmap_invalid_payload_mapping_requires_mutates() -> None:
     with pytest.raises(ValidationError, match="requires mutates_variables to be defined"):
         UIEventMap(trigger="on_click", action="submit", payload_mapping={"id": "user_id"})
 
 
-def test_uieventmap_no_payload_mapping():
+def test_uieventmap_no_payload_mapping() -> None:
     evt = UIEventMap(trigger="on_click", action="submit")
     assert evt.payload_mapping is None


### PR DESCRIPTION
Epic 5.3: Cryptographic Visual Provenance (FaithfulRAG)

Added `ProvenanceLevel` enum and `ProvenanceConfig` to ensure mathematical anchoring to visual pixel coordinates in source documents via cryptographic hash chains. Injected `provenance` field into `SemanticMemoryConfig` as required.

---
*PR created automatically by Jules for task [14226770965887294440](https://jules.google.com/task/14226770965887294440) started by @gowthamrao*