### PR TITLE
Epic 6.5: Ephemeral Scratchpad State (Local Context)

### DIFF
--- a/src/coreason_manifest/core/__init__.py
+++ b/src/coreason_manifest/core/__init__.py
@@ -43,7 +43,7 @@ from coreason_manifest.core.oversight.resilience import (
 )
 from coreason_manifest.core.primitives.registry import resolve_node_union
 from coreason_manifest.core.primitives.types import WasmMiddlewareDef
-from coreason_manifest.core.state.persistence import Checkpoint, PersistenceConfig, StateDiff
+from coreason_manifest.core.state.persistence import Checkpoint, PersistenceConfig, StateCheckpoint
 from coreason_manifest.core.state.tools import MCPPrompt, MCPResourceTemplate, MCPTool, ToolPack
 from coreason_manifest.core.workflow.evals import EvalsManifest, FuzzingTarget, TestCase
 from coreason_manifest.core.workflow.flow import (
@@ -137,7 +137,7 @@ __all__ = [
     "RetryStrategy",
     "Safety",
     "StandardReasoning",
-    "StateDiff",
+    "StateCheckpoint",
     "SupervisionPolicy",
     "SwarmNode",
     "SwitchNode",

--- a/src/coreason_manifest/core/state/__init__.py
+++ b/src/coreason_manifest/core/state/__init__.py
@@ -1,3 +1,3 @@
-from coreason_manifest.core.state.persistence import Checkpoint, PersistenceConfig, StateDiff
+from coreason_manifest.core.state.persistence import Checkpoint, PersistenceConfig, StateCheckpoint
 
-__all__ = ["Checkpoint", "PersistenceConfig", "StateDiff"]
+__all__ = ["Checkpoint", "PersistenceConfig", "StateCheckpoint"]

--- a/src/coreason_manifest/core/state/ephemeral.py
+++ b/src/coreason_manifest/core/state/ephemeral.py
@@ -1,0 +1,46 @@
+from enum import StrEnum
+from typing import Any
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class LocalVariableType(StrEnum):
+    STRING = "string"
+    NUMBER = "number"
+    BOOLEAN = "boolean"
+    LIST = "list"
+    DICT = "dict"
+
+
+class LocalVariable(CoreasonModel):
+    type: LocalVariableType
+    default: Any | None = None
+    description: str | None = None
+
+    @model_validator(mode="after")
+    def validate_default_type(self) -> "LocalVariable":
+        if self.default is not None:
+            if self.type == LocalVariableType.STRING and not isinstance(self.default, str):
+                raise ValueError("Default value must be a string for STRING type.")
+            if self.type == LocalVariableType.NUMBER:
+                if not isinstance(self.default, (int, float)) or isinstance(self.default, bool):
+                    raise ValueError("Default value must be an int or float for NUMBER type.")
+            if self.type == LocalVariableType.BOOLEAN and not isinstance(self.default, bool):
+                raise ValueError("Default value must be a bool for BOOLEAN type.")
+            if self.type == LocalVariableType.LIST and not isinstance(self.default, list):
+                raise ValueError("Default value must be a list for LIST type.")
+            if self.type == LocalVariableType.DICT and not isinstance(self.default, dict):
+                raise ValueError("Default value must be a dict for DICT type.")
+        return self
+
+
+class LocalStateManifest(CoreasonModel):
+    """
+    Groups local variables together for the local state manifest.
+
+    These variables are accessed on the client using pointer syntax (e.g., $local.variable_name)
+    and do NOT trigger RFC 6902 state patches on the backend.
+    """
+    keys: dict[str, LocalVariable] = Field(default_factory=dict)

--- a/src/coreason_manifest/core/state/ephemeral.py
+++ b/src/coreason_manifest/core/state/ephemeral.py
@@ -24,9 +24,10 @@ class LocalVariable(CoreasonModel):
         if self.default is not None:
             if self.type == LocalVariableType.STRING and not isinstance(self.default, str):
                 raise ValueError("Default value must be a string for STRING type.")
-            if self.type == LocalVariableType.NUMBER:
-                if not isinstance(self.default, (int, float)) or isinstance(self.default, bool):
-                    raise ValueError("Default value must be an int or float for NUMBER type.")
+            if self.type == LocalVariableType.NUMBER and (
+                not isinstance(self.default, (int, float)) or isinstance(self.default, bool)
+            ):
+                raise ValueError("Default value must be an int or float for NUMBER type.")
             if self.type == LocalVariableType.BOOLEAN and not isinstance(self.default, bool):
                 raise ValueError("Default value must be a bool for BOOLEAN type.")
             if self.type == LocalVariableType.LIST and not isinstance(self.default, list):

--- a/src/coreason_manifest/core/state/ephemeral.py
+++ b/src/coreason_manifest/core/state/ephemeral.py
@@ -44,4 +44,5 @@ class LocalStateManifest(CoreasonModel):
     These variables are accessed on the client using pointer syntax (e.g., $local.variable_name)
     and do NOT trigger RFC 6902 state patches on the backend.
     """
+
     keys: dict[str, LocalVariable] = Field(default_factory=dict)

--- a/tests/core/state/test_ephemeral.py
+++ b/tests/core/state/test_ephemeral.py
@@ -1,0 +1,82 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.state.ephemeral import (
+    LocalStateManifest,
+    LocalVariable,
+    LocalVariableType,
+)
+
+
+def test_local_variable_string():
+    var = LocalVariable(type=LocalVariableType.STRING, default="hello", description="A string var")
+    assert var.type == LocalVariableType.STRING
+    assert var.default == "hello"
+    assert var.description == "A string var"
+
+    with pytest.raises(ValidationError):
+        LocalVariable(type=LocalVariableType.STRING, default=123)
+
+
+def test_local_variable_number():
+    var = LocalVariable(type=LocalVariableType.NUMBER, default=42)
+    assert var.default == 42
+
+    var_float = LocalVariable(type=LocalVariableType.NUMBER, default=3.14)
+    assert var_float.default == 3.14
+
+    with pytest.raises(ValidationError):
+        LocalVariable(type=LocalVariableType.NUMBER, default="42")
+
+    with pytest.raises(ValidationError):
+        LocalVariable(type=LocalVariableType.NUMBER, default=True)
+
+
+def test_local_variable_boolean():
+    var = LocalVariable(type=LocalVariableType.BOOLEAN, default=True)
+    assert var.default is True
+
+    with pytest.raises(ValidationError):
+        LocalVariable(type=LocalVariableType.BOOLEAN, default=1)
+
+    with pytest.raises(ValidationError):
+        LocalVariable(type=LocalVariableType.BOOLEAN, default="True")
+
+
+def test_local_variable_list():
+    var = LocalVariable(type=LocalVariableType.LIST, default=[1, 2, 3])
+    assert var.default == [1, 2, 3]
+
+    with pytest.raises(ValidationError):
+        LocalVariable(type=LocalVariableType.LIST, default="[1, 2, 3]")
+
+
+def test_local_variable_dict():
+    var = LocalVariable(type=LocalVariableType.DICT, default={"a": 1})
+    assert var.default == {"a": 1}
+
+    with pytest.raises(ValidationError):
+        LocalVariable(type=LocalVariableType.DICT, default=["a", 1])
+
+
+def test_local_variable_no_default():
+    var = LocalVariable(type=LocalVariableType.STRING)
+    assert var.default is None
+
+
+def test_local_state_manifest():
+    manifest = LocalStateManifest(
+        keys={
+            "search_query": LocalVariable(type=LocalVariableType.STRING, default=""),
+            "is_open": LocalVariable(type=LocalVariableType.BOOLEAN, default=False),
+        }
+    )
+    assert len(manifest.keys) == 2
+    assert "search_query" in manifest.keys
+    assert manifest.keys["search_query"].type == LocalVariableType.STRING
+    assert manifest.keys["is_open"].default is False
+
+
+def test_local_state_manifest_default():
+    manifest = LocalStateManifest()
+    assert manifest.keys == {}

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -81,6 +81,8 @@ def test_genui_multiplexer_emission() -> None:
     props = scrubbed_payload["layout"][0]["props"]
     assert props["location"] == "[REDACTED_PII]"
     assert props["user_id"] == "[REDACTED_PII]"
+
+
 def test_swarm_orchestration_schema() -> None:
     from pydantic import ValidationError
 


### PR DESCRIPTION
- Defined `LocalVariableType` Enum for typed registers (STRING, NUMBER, BOOLEAN, LIST, DICT).
- Built `LocalVariable` schema with Pydantic `@model_validator` to enforce strict matching between default values and their types.
- Implemented `LocalStateManifest` grouping variables appropriately.
- Thoroughly tested schemas in `test_ephemeral.py`.

---
*PR created automatically by Jules for task [12919591174008658035](https://jules.google.com/task/12919591174008658035) started by @gowthamrao*