### PR TITLE
feat: client-side declarative validation schema

### DIFF
--- a/src/coreason_manifest/core/common/validation.py
+++ b/src/coreason_manifest/core/common/validation.py
@@ -1,0 +1,105 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import StrEnum
+from typing import Annotated, Literal
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class ValidationRuleType(StrEnum):
+    REQUIRED = "required"
+    LENGTH = "length"
+    RANGE = "range"
+    REGEX = "regex"
+    MATCH_FIELD = "match_field"
+    CUSTOM_WEBHOOK = "custom_webhook"
+
+
+class RuleRequired(CoreasonModel):
+    rule_type: Literal[ValidationRuleType.REQUIRED] = ValidationRuleType.REQUIRED
+    message: str
+
+
+class RuleLength(CoreasonModel):
+    rule_type: Literal[ValidationRuleType.LENGTH] = ValidationRuleType.LENGTH
+    message: str
+    min: int | None = None
+    max: int | None = None
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> "RuleLength":
+        if self.min is None and self.max is None:
+            raise ValueError("At least one bound (min or max) must be provided.")
+        if self.min is not None and self.max is not None and self.min > self.max:
+            raise ValueError("min cannot be greater than max.")
+        return self
+
+
+class RuleRange(CoreasonModel):
+    rule_type: Literal[ValidationRuleType.RANGE] = ValidationRuleType.RANGE
+    message: str
+    min: float | None = None
+    max: float | None = None
+
+    @model_validator(mode="after")
+    def validate_bounds(self) -> "RuleRange":
+        if self.min is None and self.max is None:
+            raise ValueError("At least one bound (min or max) must be provided.")
+        if self.min is not None and self.max is not None and self.min > self.max:
+            raise ValueError("min cannot be greater than max.")
+        return self
+
+
+class RuleRegex(CoreasonModel):
+    rule_type: Literal[ValidationRuleType.REGEX] = ValidationRuleType.REGEX
+    message: str
+    pattern: str
+
+
+class RuleMatchField(CoreasonModel):
+    rule_type: Literal[ValidationRuleType.MATCH_FIELD] = ValidationRuleType.MATCH_FIELD
+    message: str
+    target_field_id: str
+
+
+class RuleWebhook(CoreasonModel):
+    rule_type: Literal[ValidationRuleType.CUSTOM_WEBHOOK] = ValidationRuleType.CUSTOM_WEBHOOK
+    message: str
+    url: str
+    debounce_ms: int
+
+
+ValidationRule = Annotated[
+    RuleRequired | RuleLength | RuleRange | RuleRegex | RuleMatchField | RuleWebhook,
+    Field(discriminator="rule_type"),
+]
+
+
+class UIValidationSchema(CoreasonModel):
+    rules: list[ValidationRule]
+    evaluate_on: Literal["change", "blur", "submit"] = "change"
+
+    @model_validator(mode="after")
+    def validate_rules(self) -> "UIValidationSchema":
+        rule_types_seen = set()
+        for rule in self.rules:
+            if rule.rule_type in (
+                ValidationRuleType.REQUIRED,
+                ValidationRuleType.LENGTH,
+                ValidationRuleType.RANGE,
+                ValidationRuleType.MATCH_FIELD,
+            ):
+                if rule.rule_type in rule_types_seen:
+                    raise ValueError(f"Duplicate rule type found: {rule.rule_type}. Only one allowed per schema.")
+                rule_types_seen.add(rule.rule_type)
+        return self

--- a/tests/core/common/test_validation.py
+++ b/tests/core/common/test_validation.py
@@ -1,0 +1,142 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.common.validation import (
+    RuleLength,
+    RuleMatchField,
+    RuleRange,
+    RuleRegex,
+    RuleRequired,
+    RuleWebhook,
+    UIValidationSchema,
+    ValidationRuleType,
+)
+
+
+def test_rule_required() -> None:
+    rule = RuleRequired(message="Field is required")
+    assert rule.rule_type == ValidationRuleType.REQUIRED
+    assert rule.message == "Field is required"
+
+
+def test_rule_length_valid() -> None:
+    rule1 = RuleLength(message="Min length 5", min=5)
+    assert rule1.min == 5
+    assert rule1.max is None
+
+    rule2 = RuleLength(message="Max length 10", max=10)
+    assert rule2.min is None
+    assert rule2.max == 10
+
+    rule3 = RuleLength(message="Length 5-10", min=5, max=10)
+    assert rule3.min == 5
+    assert rule3.max == 10
+
+
+def test_rule_length_invalid() -> None:
+    with pytest.raises(ValidationError, match="At least one bound"):
+        RuleLength(message="Invalid")
+
+    with pytest.raises(ValidationError, match="min cannot be greater than max"):
+        RuleLength(message="Invalid", min=10, max=5)
+
+
+def test_rule_range_valid() -> None:
+    rule1 = RuleRange(message="Min range 5.0", min=5.0)
+    assert rule1.min == 5.0
+    assert rule1.max is None
+
+    rule2 = RuleRange(message="Max range 10.0", max=10.0)
+    assert rule2.min is None
+    assert rule2.max == 10.0
+
+    rule3 = RuleRange(message="Range 5.0-10.0", min=5.0, max=10.0)
+    assert rule3.min == 5.0
+    assert rule3.max == 10.0
+
+
+def test_rule_range_invalid() -> None:
+    with pytest.raises(ValidationError, match="At least one bound"):
+        RuleRange(message="Invalid")
+
+    with pytest.raises(ValidationError, match="min cannot be greater than max"):
+        RuleRange(message="Invalid", min=10.0, max=5.0)
+
+
+def test_rule_regex() -> None:
+    rule = RuleRegex(message="Must be alphanumeric", pattern="^[a-zA-Z0-9]+$")
+    assert rule.rule_type == ValidationRuleType.REGEX
+    assert rule.pattern == "^[a-zA-Z0-9]+$"
+
+
+def test_rule_match_field() -> None:
+    rule = RuleMatchField(message="Passwords must match", target_field_id="password")
+    assert rule.rule_type == ValidationRuleType.MATCH_FIELD
+    assert rule.target_field_id == "password"
+
+
+def test_rule_webhook() -> None:
+    rule = RuleWebhook(message="Checking username...", url="https://api.example.com/check", debounce_ms=500)
+    assert rule.rule_type == ValidationRuleType.CUSTOM_WEBHOOK
+    assert rule.url == "https://api.example.com/check"
+    assert rule.debounce_ms == 500
+
+
+def test_ui_validation_schema_valid() -> None:
+    schema = UIValidationSchema(
+        rules=[
+            RuleRequired(message="Required"),
+            RuleLength(message="Length", min=5),
+            RuleRegex(message="Regex 1", pattern="^foo$"),
+            RuleRegex(message="Regex 2", pattern="^bar$"),
+            RuleWebhook(message="Webhook 1", url="http://1", debounce_ms=100),
+            RuleWebhook(message="Webhook 2", url="http://2", debounce_ms=100),
+        ],
+        evaluate_on="blur",
+    )
+    assert len(schema.rules) == 6
+    assert schema.evaluate_on == "blur"
+
+
+def test_ui_validation_schema_duplicate_type_contradiction() -> None:
+    with pytest.raises(ValidationError, match="Duplicate rule type found: length"):
+        UIValidationSchema(
+            rules=[
+                RuleLength(message="Length 1", min=5),
+                RuleLength(message="Length 2", max=10),
+            ]
+        )
+
+    with pytest.raises(ValidationError, match="Duplicate rule type found: range"):
+        UIValidationSchema(
+            rules=[
+                RuleRange(message="Range 1", min=5.0),
+                RuleRange(message="Range 2", max=10.0),
+            ]
+        )
+
+    with pytest.raises(ValidationError, match="Duplicate rule type found: required"):
+        UIValidationSchema(
+            rules=[
+                RuleRequired(message="Required 1"),
+                RuleRequired(message="Required 2"),
+            ]
+        )
+
+    with pytest.raises(ValidationError, match="Duplicate rule type found: match_field"):
+        UIValidationSchema(
+            rules=[
+                RuleMatchField(message="Match 1", target_field_id="field1"),
+                RuleMatchField(message="Match 2", target_field_id="field2"),
+            ]
+        )


### PR DESCRIPTION
Implements the zero-trust client-side validation schema constraints as outlined in Epic 6.3.

Provides a fully type-hinted and Pydantic v2 compliant declarative validation rule definitions that will later be bound to the AST UI components.

Changes:
* `src/coreason_manifest/core/common/validation.py` created with rules, discriminated union, and constraints.
* `tests/core/common/test_validation.py` implemented for comprehensive test coverage over constraints.

---
*PR created automatically by Jules for task [12789494148273982314](https://jules.google.com/task/12789494148273982314) started by @gowthamrao*