### PR TITLE
feat: implement MCP Operations Toolkit contracts

### DIFF
--- a/src/coreason_manifest/spec/domains/mcp_contracts.py
+++ b/src/coreason_manifest/spec/domains/mcp_contracts.py
@@ -1,0 +1,43 @@
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class MCPToolName(StrEnum):
+    """Names of the Universal Canvas API tools."""
+
+    CANVAS_ADD_ELEMENT = "CANVAS_ADD_ELEMENT"
+    CANVAS_UPDATE_ELEMENT = "CANVAS_UPDATE_ELEMENT"
+    CANVAS_REMOVE_ELEMENT = "CANVAS_REMOVE_ELEMENT"
+    CANVAS_GROUP_ELEMENTS = "CANVAS_GROUP_ELEMENTS"
+    CANVAS_ADD_CONNECTION = "CANVAS_ADD_CONNECTION"
+    CANVAS_APPLY_STYLE = "CANVAS_APPLY_STYLE"
+
+
+class MCPOperation(BaseModel):
+    """An atomic design action executed on a headless canvas."""
+
+    operation_id: str = Field(..., description="Unique ID for tracing and logging this specific action.")
+    tool_name: MCPToolName
+    target_element_id: str | None = Field(
+        default=None, description="The ID of the specific canvas object being mutated. Crucial for targeted edits."
+    )
+    parameters: dict[str, Any] = Field(
+        default_factory=dict, description="The kwargs payload for the tool (e.g., x, y, width, fill_color)."
+    )
+
+
+class MCPOperationSequence(BaseModel):
+    """An ordered, transactional sequence of atomic design actions."""
+
+    sequence_id: str
+    operations: list[MCPOperation]
+    transaction_mode: Literal["atomic_commit", "sequential_best_effort"] = Field(
+        default="atomic_commit",
+        description="If atomic, the downstream engine must snapshot the canvas and rollback if any operation fails.",
+    )
+    expected_canvas_state_hash: str | None = Field(
+        default=None,
+        description="Ensures the sequence is applied to the correct diagram version to prevent races.",
+    )

--- a/tests/spec/domains/test_mcp_contracts.py
+++ b/tests/spec/domains/test_mcp_contracts.py
@@ -1,0 +1,103 @@
+from typing import Any
+
+from hypothesis import given
+from hypothesis import strategies as st
+
+from coreason_manifest.spec.domains.mcp_contracts import MCPOperation, MCPOperationSequence, MCPToolName
+
+
+def test_mcp_tool_name_serialization() -> None:
+    """Validate JSON serialization of the MCPToolName enum."""
+
+    class DummyModel(MCPOperation):
+        pass
+
+    op = MCPOperation(
+        operation_id="123", tool_name=MCPToolName.CANVAS_ADD_ELEMENT, target_element_id="abc", parameters={"x": 10}
+    )
+
+    json_str = op.model_dump_json()
+    assert '"CANVAS_ADD_ELEMENT"' in json_str
+
+    deserialized = MCPOperation.model_validate_json(json_str)
+    assert deserialized.tool_name == MCPToolName.CANVAS_ADD_ELEMENT
+
+
+# Strategy to generate valid JSON-like parameters
+# The parameters must be a dictionary, so we wrap the recursive strategy in a dictionary.
+json_types = st.text() | st.integers() | st.floats(allow_nan=False, allow_infinity=False) | st.booleans() | st.none()
+json_recursive = st.recursive(
+    json_types,
+    lambda children: st.dictionaries(st.text(), children) | st.lists(children),
+    max_leaves=10,
+)
+json_dict_strategy = st.dictionaries(st.text(), json_recursive)
+
+
+@given(
+    operation_id=st.text(min_size=1),
+    tool_name=st.sampled_from(MCPToolName),
+    target_element_id=st.one_of(st.none(), st.text(min_size=1)),
+    parameters=json_dict_strategy,
+)
+def test_mcp_operation_fuzzing(
+    operation_id: str,
+    tool_name: MCPToolName,
+    target_element_id: str | None,
+    parameters: dict[str, Any],
+) -> None:
+    """Fuzz the generation of MCPOperation payloads."""
+    op = MCPOperation(
+        operation_id=operation_id,
+        tool_name=tool_name,
+        target_element_id=target_element_id,
+        parameters=parameters,
+    )
+
+    # Test serialization and deserialization
+    json_str = op.model_dump_json()
+    deserialized = MCPOperation.model_validate_json(json_str)
+
+    assert deserialized.operation_id == operation_id
+    assert deserialized.tool_name == tool_name
+    assert deserialized.target_element_id == target_element_id
+    assert deserialized.parameters == parameters
+
+
+@given(
+    sequence_id=st.text(min_size=1),
+    operations=st.lists(
+        st.builds(
+            MCPOperation,
+            operation_id=st.text(min_size=1),
+            tool_name=st.sampled_from(MCPToolName),
+            target_element_id=st.one_of(st.none(), st.text(min_size=1)),
+            parameters=json_dict_strategy,
+        ),
+        min_size=0,
+        max_size=5,
+    ),
+    transaction_mode=st.sampled_from(["atomic_commit", "sequential_best_effort"]),
+    expected_canvas_state_hash=st.one_of(st.none(), st.text(min_size=1)),
+)
+def test_mcp_operation_sequence_fuzzing(
+    sequence_id: str,
+    operations: list[MCPOperation],
+    transaction_mode: str,
+    expected_canvas_state_hash: str | None,
+) -> None:
+    """Fuzz the generation of MCPOperationSequence payloads."""
+    seq = MCPOperationSequence(
+        sequence_id=sequence_id,
+        operations=operations,
+        transaction_mode=transaction_mode,
+        expected_canvas_state_hash=expected_canvas_state_hash,
+    )
+
+    json_str = seq.model_dump_json()
+    deserialized = MCPOperationSequence.model_validate_json(json_str)
+
+    assert deserialized.sequence_id == sequence_id
+    assert len(deserialized.operations) == len(operations)
+    assert deserialized.transaction_mode == transaction_mode
+    assert deserialized.expected_canvas_state_hash == expected_canvas_state_hash


### PR DESCRIPTION
Implemented Universal Canvas API schema as per Epic 4 requirements:
- Created `MCPToolName` Enum.
- Created `MCPOperation` BaseModel.
- Created `MCPOperationSequence` BaseModel.
- Added comprehensive hypothesis fuzzing tests.

Strictly adhered to isolated file paths (`src/coreason_manifest/spec/domains/mcp_contracts.py` and `tests/spec/domains/test_mcp_contracts.py`) to prevent merge conflicts. 

Note: Test suite execution fails due to a pre-existing ImportError outside of this task's isolated scope. User approved submission ignoring test coverage requirements.

---
*PR created automatically by Jules for task [15456287412655177044](https://jules.google.com/task/15456287412655177044) started by @gowthamrao*