### PR TITLE
Refactor internal imports to use API Gateways (facades)

### DIFF
--- a/src/coreason_manifest/adapters/providers/mcp.py
+++ b/src/coreason_manifest/adapters/providers/mcp.py
@@ -4,7 +4,8 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from coreason_manifest.core.common.presentation import UIEventMap
-from coreason_manifest.core.state.tools import MCPTool, ToolPack
+from coreason_manifest.core.state import ToolPack
+from coreason_manifest.core.state.tools import MCPTool
 
 
 class MCPRequestMethod(StrEnum):

--- a/src/coreason_manifest/adapters/providers/openai.py
+++ b/src/coreason_manifest/adapters/providers/openai.py
@@ -3,8 +3,8 @@ from typing import Any, override
 from coreason_manifest.adapters.system.config import AdapterConfig
 from coreason_manifest.core.common.exceptions import ManifestError, ManifestErrorCode
 from coreason_manifest.core.security.compliance import RemediationAction
-from coreason_manifest.core.state.tools import ToolPack
-from coreason_manifest.core.workflow.nodes import AgentNode, CognitiveProfile
+from coreason_manifest.core.state import ToolPack
+from coreason_manifest.core.workflow import AgentNode, CognitiveProfile
 from coreason_manifest.ports.llm_provider import GenerativeAdapter
 
 

--- a/src/coreason_manifest/cli/main.py
+++ b/src/coreason_manifest/cli/main.py
@@ -18,9 +18,7 @@ from rich import print as rprint
 from coreason_manifest.adapters.system.dynamic_loader import load_flow_from_file
 from coreason_manifest.core.domains.scientific_vis import HierarchicalBlueprint
 from coreason_manifest.core.workflow.topologies.sci_vis_flow import get_sota_scivis_topology
-from coreason_manifest.toolkit.exporter import render_agent_card
-from coreason_manifest.toolkit.validator import validate_flow
-from coreason_manifest.toolkit.visualizer import export_html_diagram, to_mermaid
+from coreason_manifest.toolkit import export_html_diagram, render_agent_card, to_mermaid, validate_flow
 
 app = typer.Typer(help="CoReason Manifest CLI")
 

--- a/src/coreason_manifest/ports/llm_provider.py
+++ b/src/coreason_manifest/ports/llm_provider.py
@@ -1,7 +1,7 @@
 from typing import Any, Protocol
 
-from coreason_manifest.core.state.tools import ToolPack
-from coreason_manifest.core.workflow.nodes import AgentNode
+from coreason_manifest.core.state import ToolPack
+from coreason_manifest.core.workflow import AgentNode
 
 
 class GenerativeAdapter(Protocol):

--- a/src/coreason_manifest/toolkit/__init__.py
+++ b/src/coreason_manifest/toolkit/__init__.py
@@ -1,6 +1,8 @@
 from coreason_manifest.toolkit.builder import AgentBuilder, NewGraphFlow, NewLinearFlow, PlannerBuilder
 from coreason_manifest.toolkit.diff_engine import SemanticPatchReport, apply_rewind, compare_flows
+from coreason_manifest.toolkit.exporter import render_agent_card
 from coreason_manifest.toolkit.validator import validate_flow
+from coreason_manifest.toolkit.visualizer import export_html_diagram, to_mermaid
 
 __all__ = [
     "AgentBuilder",
@@ -10,5 +12,8 @@ __all__ = [
     "SemanticPatchReport",
     "apply_rewind",
     "compare_flows",
+    "export_html_diagram",
+    "render_agent_card",
+    "to_mermaid",
     "validate_flow",
 ]

--- a/src/coreason_manifest/toolkit/builder.py
+++ b/src/coreason_manifest/toolkit/builder.py
@@ -47,40 +47,43 @@ from coreason_manifest.core.oversight.resilience import (
     SupervisionPolicy,
 )
 from coreason_manifest.core.primitives.types import RiskLevel
-from coreason_manifest.core.state.memory import (
-    ConsolidationStrategy,
+from coreason_manifest.core.state import (
     EpisodicMemoryConfig,
-    KnowledgeScope,
     MemorySubsystem,
     ProceduralMemoryConfig,
     SemanticMemoryConfig,
     WorkingMemoryConfig,
 )
+from coreason_manifest.core.state.memory import ConsolidationStrategy, KnowledgeScope
 from coreason_manifest.core.system.rebuild import rebuild_manifest
 
 if TYPE_CHECKING:
-    from coreason_manifest.core.state.tools import ToolPack
+    from coreason_manifest.core.state import ToolPack
+    from coreason_manifest.core.workflow import AnyNode
     from coreason_manifest.core.workflow.evals import EvalsManifest
-    from coreason_manifest.core.workflow.flow import AnyNode
 
-from coreason_manifest.core.workflow.flow import (
+from coreason_manifest.core.workflow import (
+    AgentNode,
     Blackboard,
-    DataSchema,
+    CognitiveProfile,
     Edge,
+    Graph,
+    GraphFlow,
+    HumanNode,
+    InspectorNode,
+    LinearFlow,
+    PlannerNode,
+)
+from coreason_manifest.core.workflow.flow import (
+    DataSchema,
     FlowDefinitions,
     FlowInterface,
     FlowMetadata,
-    Graph,
-    GraphFlow,
-    LinearFlow,
     ProvenanceData,
     ProvenanceType,
 )
-from coreason_manifest.core.workflow.nodes.agent import AgentNode, CognitiveProfile
 from coreason_manifest.core.workflow.nodes.base import Constraint, ConstraintOperator
-from coreason_manifest.core.workflow.nodes.human import CollaborationMode, HumanNode
-from coreason_manifest.core.workflow.nodes.oversight import InspectorNode
-from coreason_manifest.core.workflow.nodes.planner import PlannerNode
+from coreason_manifest.core.workflow.nodes.human import CollaborationMode
 from coreason_manifest.toolkit.validator import validate_flow
 
 

--- a/src/coreason_manifest/toolkit/diff_engine.py
+++ b/src/coreason_manifest/toolkit/diff_engine.py
@@ -5,8 +5,8 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field
 
-from coreason_manifest.core.state.persistence import JSONPatchOperation, PatchOp
-from coreason_manifest.core.workflow.flow import GraphFlow, LinearFlow
+from coreason_manifest.core.state import JSONPatchOperation, PatchOp
+from coreason_manifest.core.workflow import GraphFlow, LinearFlow
 
 type DomainType = Literal["resource", "topology", "governance", "evals"]
 type MutationOp = Literal["add", "remove", "replace", "move", "copy", "test"]

--- a/src/coreason_manifest/toolkit/exporter.py
+++ b/src/coreason_manifest/toolkit/exporter.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from coreason_manifest.core.workflow.flow import GraphFlow, LinearFlow
+from coreason_manifest.core.workflow import GraphFlow, LinearFlow
 from coreason_manifest.toolkit.visualizer import to_mermaid
 
 

--- a/src/coreason_manifest/toolkit/gatekeeper.py
+++ b/src/coreason_manifest/toolkit/gatekeeper.py
@@ -11,10 +11,16 @@ from coreason_manifest.core.security.compliance import (
     ErrorCatalog,
     RemediationAction,
 )
-from coreason_manifest.core.workflow.flow import GraphFlow, LinearFlow
-from coreason_manifest.core.workflow.nodes import AgentNode, AnyNode, HumanNode, SwarmNode
+from coreason_manifest.core.workflow import (
+    AgentNode,
+    AnyNode,
+    GraphFlow,
+    HumanNode,
+    InspectorNode,
+    LinearFlow,
+)
+from coreason_manifest.core.workflow.nodes import SwarmNode
 from coreason_manifest.core.workflow.nodes.human import CollaborationMode
-from coreason_manifest.core.workflow.nodes.oversight import InspectorNode
 from coreason_manifest.core.workflow.topology import (
     get_reachable_nodes,
     get_strongly_connected_components,
@@ -22,7 +28,7 @@ from coreason_manifest.core.workflow.topology import (
 )
 
 if TYPE_CHECKING:
-    from coreason_manifest.core.state.tools import AnyTool
+    from coreason_manifest.core.state import AnyTool
 
 
 def _get_capabilities(node: AnyNode, flow: LinearFlow | GraphFlow) -> list[str]:

--- a/src/coreason_manifest/toolkit/validator.py
+++ b/src/coreason_manifest/toolkit/validator.py
@@ -16,23 +16,20 @@ from coreason_manifest.core.oversight.resilience import (
 )
 from coreason_manifest.core.primitives.types import RiskLevel
 from coreason_manifest.core.security.compliance import ComplianceReport, ErrorCatalog, RemediationAction
-from coreason_manifest.core.state.tools import ToolCapability, ToolPack
-from coreason_manifest.core.workflow.flow import (
-    AnyNode,
-    FlowDefinitions,
-    GraphFlow,
-    LinearFlow,
-)
-from coreason_manifest.core.workflow.nodes import (
+from coreason_manifest.core.state import ToolPack
+from coreason_manifest.core.state.tools import ToolCapability
+from coreason_manifest.core.workflow import (
     AgentNode,
+    AnyNode,
     CognitiveProfile,
-    EmergenceInspectorNode,
+    GraphFlow,
     HumanNode,
     InspectorNode,
+    LinearFlow,
     PlannerNode,
-    SwarmNode,
-    SwitchNode,
 )
+from coreason_manifest.core.workflow.flow import FlowDefinitions
+from coreason_manifest.core.workflow.nodes import EmergenceInspectorNode, SwarmNode, SwitchNode
 from coreason_manifest.core.workflow.topology import get_unified_topology
 
 


### PR DESCRIPTION
Refactored imports across `toolkit/`, `adapters/`, and `cli/` to use the defined facades for `core.state`, `core.workflow`, and `toolkit`.

Maintained specific deep imports when items were not exposed through facades (such as `MCPTool` and `ToolCapability`). Reverted `to_mermaid` in `toolkit/exporter.py` back to its deep import to resolve a runtime circular import. Verified the absence of `CircularImportError` through mypy and runtime testing.