### PR TITLE
feat: implement PICO AST representations for precise search

### DIFF
--- a/src/coreason_manifest/core/common/semantic.py
+++ b/src/coreason_manifest/core/common/semantic.py
@@ -1,5 +1,8 @@
 # Prosperity-3.0
-from typing import Any
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import Annotated, Any, Literal
 
 from pydantic import ConfigDict, Field
 
@@ -56,3 +59,74 @@ class SemanticRef(CoreasonModel):
         default_factory=list,
         description="Stores AI-driven catalog search results (candidates) before final resolution.",
     )
+
+
+class PICOClass(StrEnum):
+    POPULATION = "population"
+    INTERVENTION = "intervention"
+    COMPARISON = "comparison"
+    OUTCOME = "outcome"
+    STUDY_DESIGN = "study_design"
+
+
+class SearchTermType(StrEnum):
+    CONTROLLED_VOCAB = "controlled_vocab"
+    FREE_TEXT = "free_text"
+
+
+class PICOOperator(StrEnum):
+    AND = "AND"
+    OR = "OR"
+    NOT = "NOT"
+    PROXIMITY = "PROXIMITY"
+
+
+class PICOLeafNode(CoreasonModel):
+    """An atomic search term decoupled from database-specific syntax."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    type: Literal["leaf"] = "leaf"
+    pico_class: Annotated[PICOClass | None, Field(description="The PICO category this term belongs to.")] = None
+    term: Annotated[str, Field(description="The exact search string or ontology ID (e.g., 'D006339' or 'Heart Failure').")]
+    term_type: Annotated[SearchTermType, Field(description="Whether this is a controlled term (e.g. MeSH) or free text.")]
+    explode: Annotated[bool, Field(description="If True, search all narrower terms in the ontology tree.")] = False
+    truncate: Annotated[bool, Field(description="If True, apply wildcard truncation to the term.")] = False
+    field_restrictions: Annotated[list[str] | None, Field(description="Specific fields to search (e.g., ['tiab', 'tw']).")] = None
+
+
+class PICOOperatorNode(CoreasonModel):
+    """A recursive boolean or proximity combinator."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    type: Literal["operator"] = "operator"
+    operator: Annotated[PICOOperator, Field(description="The logic operator applied to the children.")]
+    proximity_distance: Annotated[int | None, Field(description="Distance 'n' required if operator is PROXIMITY.")] = None
+    children: Annotated[list['PICONode'], Field(description="Child nodes connected by this operator.")]
+
+
+# Discriminated Union for recursive tree walking
+PICONode = Annotated[PICOLeafNode | PICOOperatorNode, Field(discriminator="type")]
+
+
+class PICOASTConfig(CoreasonModel):
+    """Contract enforcing that an agent outputs a structured PICO AST rather than raw text."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    enforce_pico_ast: Annotated[bool, Field(description="If True, the agent must output a valid PICONode JSON tree.")] = True
+    default_operator: Annotated[PICOOperator, Field(description="The default operator to combine disjoint PICO classes at the root.")] = PICOOperator.AND
+
+
+__all__ = [
+    "OptimizationIntent",
+    "SemanticRef",
+    "PICOClass",
+    "SearchTermType",
+    "PICOOperator",
+    "PICOLeafNode",
+    "PICOOperatorNode",
+    "PICONode",
+    "PICOASTConfig",
+]


### PR DESCRIPTION
Implemented "Epic 6.1: Precision Search Representation (The PICO AST)" to support 2026+ "Regulatory-Grade" systematic literature reviews. Added an Abstract Syntax Tree (AST) mapped to the PICO framework to guarantee flawless query compilation downstream.

Key changes:
- Included necessary type imports for recursive typing support (`from __future__ import annotations`, `StrEnum`, `Annotated`, `Literal`).
- Added PICO Primitive Enums: `PICOClass`, `SearchTermType`, `PICOOperator`.
- Added Recursive Pydantic AST Models: `PICOLeafNode`, `PICOOperatorNode`, `PICONode` (discriminated union), and `PICOASTConfig`.
- Updated `__all__` export list to cleanly expose the new classes while maintaining existing exports.

Note: Strictly adhered to parallel execution constraints by limiting modifications to `src/coreason_manifest/core/common/semantic.py` only and did not write or modify test files. Tested locally.

---
*PR created automatically by Jules for task [5417282802521083110](https://jules.google.com/task/5417282802521083110) started by @gowthamrao*