### PR TITLE
feat: Implement DataTransformSchema AST for Edge-Computed Filtering

### DIFF
--- a/src/coreason_manifest/core/common/transform.py
+++ b/src/coreason_manifest/core/common/transform.py
@@ -1,0 +1,91 @@
+from enum import StrEnum
+from typing import Any, Union
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class TransformOperator(StrEnum):
+    EQUALS = "EQUALS"
+    NOT_EQUALS = "NOT_EQUALS"
+    GREATER_THAN = "GREATER_THAN"
+    LESS_THAN = "LESS_THAN"
+    GREATER_THAN_OR_EQUAL = "GREATER_THAN_OR_EQUAL"
+    LESS_THAN_OR_EQUAL = "LESS_THAN_OR_EQUAL"
+    CONTAINS = "CONTAINS"
+    STARTS_WITH = "STARTS_WITH"
+    ENDS_WITH = "ENDS_WITH"
+    REGEX_MATCH = "REGEX_MATCH"
+    IN_LIST = "IN_LIST"
+    NOT_IN_LIST = "NOT_IN_LIST"
+
+
+class LogicalOperator(StrEnum):
+    AND = "AND"
+    OR = "OR"
+    NOT = "NOT"
+
+
+class SortDirection(StrEnum):
+    ASC = "ASC"
+    DESC = "DESC"
+
+
+class FilterRule(CoreasonModel):
+    field_pointer: str = Field(description="The JSON Pointer to the data key being evaluated, e.g., `/item/price`.")
+    operator: TransformOperator
+    value: Any | None = None
+    value_pointer: str | None = None
+
+    @model_validator(mode="after")
+    def validate_pointers_and_values(self) -> "FilterRule":
+        if not self.field_pointer.startswith("/"):
+            raise ValueError("field_pointer must be a valid RFC 6901 JSON pointer starting with '/'")
+
+        if self.value_pointer is not None and not self.value_pointer.startswith("$local."):
+            raise ValueError("value_pointer MUST start with '$local.'")
+
+        if (self.value is not None and self.value_pointer is not None) or (
+            self.value is None and self.value_pointer is None
+        ):
+            raise ValueError("Exactly one of value or value_pointer must be provided")
+
+        return self
+
+
+class FilterGroup(CoreasonModel):
+    logic: LogicalOperator
+    conditions: list[Union["FilterRule", "FilterGroup"]]
+
+    @model_validator(mode="after")
+    def validate_recursion_depth(self) -> "FilterGroup":
+        def _get_depth(group: "FilterGroup") -> int:
+            max_depth = 1
+            for condition in group.conditions:
+                if isinstance(condition, FilterGroup):
+                    max_depth = max(max_depth, 1 + _get_depth(condition))
+            return max_depth
+
+        depth = _get_depth(self)
+        if depth > 3:
+            raise ValueError("FilterGroup recursion depth cannot exceed 3 levels")
+
+        return self
+
+
+class DataSortRule(CoreasonModel):
+    field_pointer: str
+    direction: SortDirection
+
+    @model_validator(mode="after")
+    def validate_pointer(self) -> "DataSortRule":
+        if not self.field_pointer.startswith("/"):
+            raise ValueError("field_pointer must be a valid RFC 6901 JSON pointer starting with '/'")
+        return self
+
+
+class DataTransformSchema(CoreasonModel):
+    filter: FilterGroup | FilterRule | None = Field(default=None, description="The AST defining edge-filtering logic.")
+    sort: list[DataSortRule] = Field(default_factory=list, description="Ordered array of sorting instructions.")
+    limit: int | None = Field(default=None, description="Optional integer for client-side truncation/pagination.")

--- a/tests/core/common/test_transform.py
+++ b/tests/core/common/test_transform.py
@@ -1,0 +1,98 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.common.transform import (
+    DataSortRule,
+    DataTransformSchema,
+    FilterGroup,
+    FilterRule,
+    LogicalOperator,
+    SortDirection,
+    TransformOperator,
+)
+
+
+def test_valid_data_transform_schema_instantiation() -> None:
+    """Test valid DataTransformSchema with nested FilterGroup"""
+    filter_rule_1 = FilterRule(
+        field_pointer="/item/price",
+        operator=TransformOperator.GREATER_THAN,
+        value=10.0,
+    )
+
+    filter_rule_2 = FilterRule(
+        field_pointer="/item/category",
+        operator=TransformOperator.EQUALS,
+        value_pointer="$local.selected_category",
+    )
+
+    filter_group = FilterGroup(logic=LogicalOperator.AND, conditions=[filter_rule_1, filter_rule_2])
+
+    sort_rule = DataSortRule(
+        field_pointer="/item/price",
+        direction=SortDirection.DESC,
+    )
+
+    schema = DataTransformSchema(
+        filter=filter_group,
+        sort=[sort_rule],
+        limit=50,
+    )
+
+    assert schema.filter is not None
+    assert len(schema.sort) == 1
+    assert schema.limit == 50
+
+
+def test_filter_rule_missing_slash_rejection() -> None:
+    """Test FilterRule validator rejects missing '/' on field_pointer"""
+    with pytest.raises(ValidationError, match="field_pointer must be a valid RFC 6901 JSON pointer starting with '/'"):
+        FilterRule(
+            field_pointer="item/price",  # Missing leading slash
+            operator=TransformOperator.EQUALS,
+            value=10,
+        )
+
+
+def test_filter_rule_mutual_exclusivity() -> None:
+    """Test FilterRule enforces mutual exclusivity of value vs value_pointer"""
+    with pytest.raises(ValidationError, match="Exactly one of value or value_pointer must be provided"):
+        FilterRule(
+            field_pointer="/item/price",
+            operator=TransformOperator.EQUALS,
+            value=10,
+            value_pointer="$local.price",
+        )
+
+    with pytest.raises(ValidationError, match="Exactly one of value or value_pointer must be provided"):
+        FilterRule(
+            field_pointer="/item/price",
+            operator=TransformOperator.EQUALS,
+            # Neither value nor value_pointer provided
+        )
+
+
+def test_filter_rule_value_pointer_format() -> None:
+    """Test FilterRule blocks value_pointers that do not start with $local."""
+    with pytest.raises(ValidationError, match=r"value_pointer MUST start with '\$local.'"):
+        FilterRule(
+            field_pointer="/item/price",
+            operator=TransformOperator.EQUALS,
+            value_pointer="global.price",  # Missing $local.
+        )
+
+
+def test_filter_group_recursion_depth_limit() -> None:
+    """Test FilterGroup raises ValueError if nesting depth exceeds 3"""
+    rule = FilterRule(
+        field_pointer="/item/price",
+        operator=TransformOperator.EQUALS,
+        value=10,
+    )
+
+    group_level_4 = FilterGroup(logic=LogicalOperator.OR, conditions=[rule])
+    group_level_3 = FilterGroup(logic=LogicalOperator.AND, conditions=[group_level_4])
+    group_level_2 = FilterGroup(logic=LogicalOperator.OR, conditions=[group_level_3])
+
+    with pytest.raises(ValidationError, match="FilterGroup recursion depth cannot exceed 3 levels"):
+        FilterGroup(logic=LogicalOperator.AND, conditions=[group_level_2])


### PR DESCRIPTION
Adds the `DataTransformSchema` and supporting models to provide a universal Abstract Syntax Tree (AST) for the SOTA Server-Driven UI architecture.

This enables zero-latency filtering, sorting, and slicing natively on the client device without sending network requests for data already in memory. Features strict Pydantic v2 validation rules, including recursion depth limiting for `FilterGroup` to prevent client stack overflows, and RFC 6901 pointer syntax enforcement.

---
*PR created automatically by Jules for task [4278157170731726537](https://jules.google.com/task/4278157170731726537) started by @gowthamrao*