### PR TITLE
Epic 7.3: State-Bound URI Templating (ParameterizedDataRef)

### DIFF
--- a/src/coreason_manifest/core/common/templating.py
+++ b/src/coreason_manifest/core/common/templating.py
@@ -24,9 +24,7 @@ class ArrayEncodingStyle(StrEnum):
 
 
 class TemplateVariable(CoreasonModel):
-    pointer: str = Field(
-        ..., description="The ephemeral state pointer, e.g., '$local.selected_brands'."
-    )
+    pointer: str = Field(..., description="The ephemeral state pointer, e.g., '$local.selected_brands'.")
     array_encoding: ArrayEncodingStyle = Field(default=ArrayEncodingStyle.COMMA)
     fallback_value: Any | None = Field(
         default=None, description="Value to use if the local variable is currently null."
@@ -40,9 +38,7 @@ class TemplateVariable(CoreasonModel):
 
 
 class TemplateString(CoreasonModel):
-    template: str = Field(
-        ..., description="The parameterized URI, e.g., '/api/search?q={query}&b={brands}'."
-    )
+    template: str = Field(..., description="The parameterized URI, e.g., '/api/search?q={query}&b={brands}'.")
     variables: dict[str, TemplateVariable] = Field(
         ..., description="Maps template placeholders to variable definitions."
     )
@@ -52,9 +48,7 @@ class TemplateString(CoreasonModel):
         placeholders = set(re.findall(r"\{([a-zA-Z0-9_]+)\}", self.template))
         for p in placeholders:
             if p not in self.variables:
-                raise ValueError(
-                    f"Placeholder '{p}' extracted from template is missing from variables dictionary."
-                )
+                raise ValueError(f"Placeholder '{p}' extracted from template is missing from variables dictionary.")
         return self
 
 
@@ -63,9 +57,7 @@ class StateDependencyConfig(CoreasonModel):
         ...,
         description="List of $local pointers that should trigger a network re-fetch when mutated.",
     )
-    debounce_ms: int = Field(
-        default=300, description="Network throttling delay after the last state mutation."
-    )
+    debounce_ms: int = Field(default=300, description="Network throttling delay after the last state mutation.")
     auto_suspend: bool = Field(
         default=True,
         description="If true, the widget automatically drops into its Suspense skeleton while the new fetch resolves.",

--- a/src/coreason_manifest/core/common/templating.py
+++ b/src/coreason_manifest/core/common/templating.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import re
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class ArrayEncodingStyle(StrEnum):
+    COMMA = "COMMA"
+    REPEAT = "REPEAT"
+    BRACKET = "BRACKET"
+
+
+class TemplateVariable(CoreasonModel):
+    pointer: str = Field(
+        ..., description="The ephemeral state pointer, e.g., '$local.selected_brands'."
+    )
+    array_encoding: ArrayEncodingStyle = Field(default=ArrayEncodingStyle.COMMA)
+    fallback_value: Any | None = Field(
+        default=None, description="Value to use if the local variable is currently null."
+    )
+
+    @model_validator(mode="after")
+    def validate_pointer(self) -> "TemplateVariable":
+        if not self.pointer.startswith("$local."):
+            raise ValueError("pointer must strictly start with '$local.'")
+        return self
+
+
+class TemplateString(CoreasonModel):
+    template: str = Field(
+        ..., description="The parameterized URI, e.g., '/api/search?q={query}&b={brands}'."
+    )
+    variables: dict[str, TemplateVariable] = Field(
+        ..., description="Maps template placeholders to variable definitions."
+    )
+
+    @model_validator(mode="after")
+    def validate_placeholders(self) -> "TemplateString":
+        placeholders = set(re.findall(r"\{([a-zA-Z0-9_]+)\}", self.template))
+        for p in placeholders:
+            if p not in self.variables:
+                raise ValueError(
+                    f"Placeholder '{p}' extracted from template is missing from variables dictionary."
+                )
+        return self
+
+
+class StateDependencyConfig(CoreasonModel):
+    trigger_pointers: list[str] = Field(
+        ...,
+        description="List of $local pointers that should trigger a network re-fetch when mutated.",
+    )
+    debounce_ms: int = Field(
+        default=300, description="Network throttling delay after the last state mutation."
+    )
+    auto_suspend: bool = Field(
+        default=True,
+        description="If true, the widget automatically drops into its Suspense skeleton while the new fetch resolves.",
+    )
+
+    @model_validator(mode="after")
+    def validate_config(self) -> "StateDependencyConfig":
+        if self.debounce_ms < 50:
+            raise ValueError("debounce_ms must be strictly >= 50.")
+        for pointer in self.trigger_pointers:
+            if not pointer.startswith("$local."):
+                raise ValueError(f"trigger_pointer '{pointer}' must strictly start with '$local.'")
+        return self
+
+
+class ParameterizedDataRef(CoreasonModel):
+    uri_template: TemplateString
+    method: Literal["GET", "POST"] = Field(default="GET")
+    headers: dict[str, str] | None = Field(default=None)
+    dependency_config: StateDependencyConfig

--- a/tests/core/common/test_templating.py
+++ b/tests/core/common/test_templating.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.common.templating import (
+    ArrayEncodingStyle,
+    ParameterizedDataRef,
+    StateDependencyConfig,
+    TemplateString,
+    TemplateVariable,
+)
+
+
+def test_template_variable_valid():
+    var = TemplateVariable(pointer="$local.selected_brands")
+    assert var.pointer == "$local.selected_brands"
+    assert var.array_encoding == ArrayEncodingStyle.COMMA
+    assert var.fallback_value is None
+
+
+def test_template_variable_invalid_pointer():
+    with pytest.raises(ValidationError) as exc_info:
+        TemplateVariable(pointer="selected_brands")
+    assert "pointer must strictly start with '$local.'" in str(exc_info.value)
+
+
+def test_template_string_valid():
+    ts = TemplateString(
+        template="/api/search?q={query}&b={brands}",
+        variables={
+            "query": TemplateVariable(pointer="$local.query"),
+            "brands": TemplateVariable(pointer="$local.brands", array_encoding=ArrayEncodingStyle.BRACKET),
+        },
+    )
+    assert ts.template == "/api/search?q={query}&b={brands}"
+    assert "query" in ts.variables
+    assert "brands" in ts.variables
+
+
+def test_template_string_missing_variable():
+    with pytest.raises(ValidationError) as exc_info:
+        TemplateString(
+            template="/api/search?q={query}&b={brands}",
+            variables={
+                "query": TemplateVariable(pointer="$local.query"),
+                # Missing 'brands'
+            },
+        )
+    assert "Placeholder 'brands' extracted from template is missing from variables dictionary." in str(
+        exc_info.value
+    )
+
+
+def test_state_dependency_config_valid():
+    config = StateDependencyConfig(
+        trigger_pointers=["$local.selected_brands", "$local.query"],
+        debounce_ms=300,
+        auto_suspend=True,
+    )
+    assert config.debounce_ms == 300
+    assert config.trigger_pointers == ["$local.selected_brands", "$local.query"]
+
+
+def test_state_dependency_config_invalid_debounce():
+    with pytest.raises(ValidationError) as exc_info:
+        StateDependencyConfig(
+            trigger_pointers=["$local.selected_brands"],
+            debounce_ms=49,
+        )
+    assert "debounce_ms must be strictly >= 50." in str(exc_info.value)
+
+
+def test_state_dependency_config_invalid_pointer():
+    with pytest.raises(ValidationError) as exc_info:
+        StateDependencyConfig(
+            trigger_pointers=["$local.selected_brands", "query"],
+        )
+    assert "trigger_pointer 'query' must strictly start with '$local.'" in str(exc_info.value)
+
+
+def test_parameterized_data_ref_valid():
+    ref = ParameterizedDataRef(
+        uri_template=TemplateString(
+            template="/api/search?q={query}",
+            variables={"query": TemplateVariable(pointer="$local.query")},
+        ),
+        method="GET",
+        headers={"Authorization": "Bearer token"},
+        dependency_config=StateDependencyConfig(
+            trigger_pointers=["$local.query"],
+            debounce_ms=100,
+        ),
+    )
+    assert ref.method == "GET"
+    assert ref.headers == {"Authorization": "Bearer token"}
+    assert ref.uri_template.template == "/api/search?q={query}"
+    assert ref.dependency_config.debounce_ms == 100

--- a/tests/core/common/test_templating.py
+++ b/tests/core/common/test_templating.py
@@ -55,9 +55,7 @@ def test_template_string_missing_variable():
                 # Missing 'brands'
             },
         )
-    assert "Placeholder 'brands' extracted from template is missing from variables dictionary." in str(
-        exc_info.value
-    )
+    assert "Placeholder 'brands' extracted from template is missing from variables dictionary." in str(exc_info.value)
 
 
 def test_state_dependency_config_valid():


### PR DESCRIPTION
Implemented Epic 7.3: State-Bound URI Templating (`ParameterizedDataRef`) by creating a Reactive Network Protocol AST. This schema allows the LLM to emit a parameterized URI mapped to the client's ephemeral memory, bypassing the AI orchestrator for facet updates.

---
*PR created automatically by Jules for task [8722976993694903250](https://jules.google.com/task/8722976993694903250) started by @gowthamrao*