### PR TITLE
Epic 7.5: Implement Hybrid Search Layout and Test Suite

### DIFF
--- a/src/coreason_manifest/core/common/search_layout.py
+++ b/src/coreason_manifest/core/common/search_layout.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from enum import StrEnum
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.common.base import CoreasonModel
+from coreason_manifest.core.common.highlighting import HighlightConfig
+from coreason_manifest.core.common.templating import ParameterizedDataRef
+from coreason_manifest.core.common.transform import DataTransformSchema
+from coreason_manifest.core.common.typeahead import TypeaheadConfig
+
+
+class PartitionType(StrEnum):
+    SEMANTIC_THOUGHT = "SEMANTIC_THOUGHT"
+    GENERATIVE_ANSWER = "GENERATIVE_ANSWER"
+    LEXICAL_RESULTS = "LEXICAL_RESULTS"
+    CITATION_CARDS = "CITATION_CARDS"
+
+
+class LayoutPartitionConfig(CoreasonModel):
+    flex_ratio: int = Field(default=1, description="The CSS flex-grow ratio for desktop side-by-side rendering.")
+    mobile_stack_order: int = Field(default=1, description="The vertical rendering order on small screens.")
+
+    @model_validator(mode="after")
+    def validate_layout(self) -> "LayoutPartitionConfig":
+        if self.flex_ratio < 1:
+            raise ValueError("flex_ratio must be strictly >= 1")
+        if self.mobile_stack_order < 0:
+            raise ValueError("mobile_stack_order must be >= 0")
+        return self
+
+
+class SearchPartitionNode(CoreasonModel):
+    target_node_id: str = Field(
+        ..., description="The unique DOM/Widget ID. Essential for SSE multiplexing to target this specific zone."
+    )
+    partition_type: PartitionType
+    layout: LayoutPartitionConfig = Field(default_factory=LayoutPartitionConfig)
+    data_ref: ParameterizedDataRef | None = Field(
+        default=None, description="Reactive data source for this partition (e.g., for Lexical Results)."
+    )
+    transform: DataTransformSchema | None = Field(
+        default=None, description="Edge-computed filtering/sorting rules for this partition's data."
+    )
+    highlighting: HighlightConfig | None = Field(
+        default=None, description="Client-side highlighting rules (e.g., highlighting search terms in Citation Cards)."
+    )
+
+
+class HybridSearchLayout(CoreasonModel):
+    search_bar_typeahead: TypeaheadConfig | None = Field(
+        default=None, description="Fast-path autocomplete configuration for the global search input."
+    )
+    partitions: list[SearchPartitionNode] = Field(
+        ..., description="The UI zones that make up the hybrid search interface."
+    )
+
+    @model_validator(mode="after")
+    def validate_unique_node_ids(self) -> "HybridSearchLayout":
+        node_ids = set()
+        for partition in self.partitions:
+            if partition.target_node_id in node_ids:
+                raise ValueError(f"Duplicate target_node_id found: '{partition.target_node_id}'")
+            node_ids.add(partition.target_node_id)
+        return self

--- a/tests/core/common/test_search_layout.py
+++ b/tests/core/common/test_search_layout.py
@@ -1,0 +1,110 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.common.highlighting import HighlightConfig, HighlightRule, HighlightStyle, MatchType
+from coreason_manifest.core.common.search_layout import (
+    HybridSearchLayout,
+    LayoutPartitionConfig,
+    PartitionType,
+    SearchPartitionNode,
+)
+from coreason_manifest.core.common.templating import (
+    ParameterizedDataRef,
+    StateDependencyConfig,
+    TemplateString,
+    TemplateVariable,
+)
+from coreason_manifest.core.common.transform import DataSortRule, DataTransformSchema, SortDirection
+from coreason_manifest.core.common.typeahead import SuggestionMapper, TypeaheadConfig, TypeaheadEndpoint
+
+
+def test_layout_partition_config_valid() -> None:
+    config = LayoutPartitionConfig(flex_ratio=2, mobile_stack_order=0)
+    assert config.flex_ratio == 2
+    assert config.mobile_stack_order == 0
+
+
+def test_layout_partition_config_invalid_flex_ratio() -> None:
+    with pytest.raises(ValidationError, match="flex_ratio must be strictly >= 1"):
+        LayoutPartitionConfig(flex_ratio=0)
+
+
+def test_layout_partition_config_invalid_mobile_stack_order() -> None:
+    with pytest.raises(ValidationError, match="mobile_stack_order must be >= 0"):
+        LayoutPartitionConfig(mobile_stack_order=-1)
+
+
+def test_search_partition_node_initialization() -> None:
+    transform = DataTransformSchema(sort=[DataSortRule(field_pointer="/title", direction=SortDirection.ASC)])
+
+    data_ref = ParameterizedDataRef(
+        uri_template=TemplateString(
+            template="/api/search?q={query}", variables={"query": TemplateVariable(pointer="$local.q")}
+        ),
+        dependency_config=StateDependencyConfig(trigger_pointers=["$local.q"]),
+    )
+
+    highlighting = HighlightConfig(
+        rules=[HighlightRule(pattern="query", match_type=MatchType.LITERAL, style=HighlightStyle.MARKER_YELLOW)]
+    )
+
+    node = SearchPartitionNode(
+        target_node_id="test_node_1",
+        partition_type=PartitionType.LEXICAL_RESULTS,
+        layout=LayoutPartitionConfig(flex_ratio=2, mobile_stack_order=1),
+        data_ref=data_ref,
+        transform=transform,
+        highlighting=highlighting,
+    )
+
+    assert node.target_node_id == "test_node_1"
+    assert node.partition_type == PartitionType.LEXICAL_RESULTS
+    assert node.layout.flex_ratio == 2
+    assert node.layout.mobile_stack_order == 1
+    assert node.data_ref is not None
+    assert node.transform is not None
+    assert node.highlighting is not None
+
+
+def test_hybrid_search_layout_valid() -> None:
+    node1 = SearchPartitionNode(target_node_id="results_panel", partition_type=PartitionType.LEXICAL_RESULTS)
+    node2 = SearchPartitionNode(target_node_id="ai_overview", partition_type=PartitionType.GENERATIVE_ANSWER)
+
+    layout = HybridSearchLayout(partitions=[node1, node2])
+
+    assert len(layout.partitions) == 2
+    assert layout.partitions[0].target_node_id == "results_panel"
+    assert layout.partitions[1].target_node_id == "ai_overview"
+
+
+def test_hybrid_search_layout_duplicate_target_node_id() -> None:
+    node1 = SearchPartitionNode(target_node_id="results_panel", partition_type=PartitionType.LEXICAL_RESULTS)
+    node2 = SearchPartitionNode(target_node_id="results_panel", partition_type=PartitionType.GENERATIVE_ANSWER)
+
+    with pytest.raises(ValidationError, match="Duplicate target_node_id found: 'results_panel'"):
+        HybridSearchLayout(partitions=[node1, node2])
+
+
+def test_hybrid_search_layout_with_typeahead() -> None:
+    typeahead = TypeaheadConfig(
+        endpoint=TypeaheadEndpoint(uri="/api/suggest"),
+        mapper=SuggestionMapper(results_path="/data", title_pointer="/title", value_pointer="/value"),
+    )
+
+    node = SearchPartitionNode(target_node_id="main_panel", partition_type=PartitionType.LEXICAL_RESULTS)
+
+    layout = HybridSearchLayout(search_bar_typeahead=typeahead, partitions=[node])
+
+    assert layout.search_bar_typeahead is not None
+    assert layout.search_bar_typeahead.endpoint.uri == "/api/suggest"
+    assert len(layout.partitions) == 1


### PR DESCRIPTION
Closes Epic 7.5: The Hybrid Search Layout. Modern AI search bipartite interfaces (Lexical database results and Semantic AI streams side-by-side) are now structurally defined via Pydantic AST models (`PartitionType`, `LayoutPartitionConfig`, `SearchPartitionNode`, `HybridSearchLayout`), properly utilizing edge-computation schemas (Transforms, Typeahead, Templating, Highlighting) defined earlier in Epic 7.

Tested thoroughly and verified zero-trust validations for duplicate node IDs.

---
*PR created automatically by Jules for task [2106971447585917890](https://jules.google.com/task/2106971447585917890) started by @gowthamrao*