### PR TITLE
feat: Epic 7.6 Final Reconciliation Refactor

### DIFF
--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -7,7 +7,12 @@ from coreason_manifest.core.common.base import CoreasonModel
 from coreason_manifest.core.state.ephemeral import LocalStateManifest
 
 from .client_actions import ClientActionMap
+from .highlighting import HighlightConfig
+from .search_layout import HybridSearchLayout
 from .suspense import SuspenseConfig
+from .templating import ParameterizedDataRef
+from .transform import DataTransformSchema
+from .typeahead import TypeaheadConfig
 from .validation import UIValidationSchema
 
 
@@ -66,6 +71,14 @@ class UIComponentNode(CoreasonModel):
     local_state: LocalStateManifest | None = Field(
         default=None, description="Ephemeral Scratchpad memory for this component."
     )
+    data_ref: ParameterizedDataRef | None = Field(
+        default=None, description="Reactive data source for out-of-band fetching."
+    )
+    data_transform: DataTransformSchema | None = Field(
+        default=None, description="Edge-computed filtering/sorting rules."
+    )
+    typeahead: TypeaheadConfig | None = Field(default=None, description="Fast-path autocomplete configuration.")
+    highlighting: HighlightConfig | None = Field(default=None, description="Client-side text highlighting rules.")
 
 
 class AdaptiveUIContract(CoreasonModel):
@@ -88,6 +101,9 @@ class AdaptiveUIContract(CoreasonModel):
     mcp_ui_resource_uri: str | None = Field(
         default=None,
         description="The ui:// scheme URI pointing to the bundled HTML/JS for sandboxed execution (SEP-1865).",
+    )
+    hybrid_search: HybridSearchLayout | None = Field(
+        default=None, description="Bipartite search layout for side-by-side Lexical/Semantic results."
     )
 
     @model_validator(mode="before")

--- a/src/coreason_manifest/core/common/semantic.py
+++ b/src/coreason_manifest/core/common/semantic.py
@@ -88,11 +88,17 @@ class PICOLeafNode(CoreasonModel):
 
     type: Literal["leaf"] = "leaf"
     pico_class: Annotated[PICOClass | None, Field(description="The PICO category this term belongs to.")] = None
-    term: Annotated[str, Field(description="The exact search string or ontology ID (e.g., 'D006339' or 'Heart Failure').")]
-    term_type: Annotated[SearchTermType, Field(description="Whether this is a controlled term (e.g. MeSH) or free text.")]
+    term: Annotated[
+        str, Field(description="The exact search string or ontology ID (e.g., 'D006339' or 'Heart Failure').")
+    ]
+    term_type: Annotated[
+        SearchTermType, Field(description="Whether this is a controlled term (e.g. MeSH) or free text.")
+    ]
     explode: Annotated[bool, Field(description="If True, search all narrower terms in the ontology tree.")] = False
     truncate: Annotated[bool, Field(description="If True, apply wildcard truncation to the term.")] = False
-    field_restrictions: Annotated[list[str] | None, Field(description="Specific fields to search (e.g., ['tiab', 'tw']).")] = None
+    field_restrictions: Annotated[
+        list[str] | None, Field(description="Specific fields to search (e.g., ['tiab', 'tw']).")
+    ] = None
 
 
 class PICOOperatorNode(CoreasonModel):
@@ -102,8 +108,10 @@ class PICOOperatorNode(CoreasonModel):
 
     type: Literal["operator"] = "operator"
     operator: Annotated[PICOOperator, Field(description="The logic operator applied to the children.")]
-    proximity_distance: Annotated[int | None, Field(description="Distance 'n' required if operator is PROXIMITY.")] = None
-    children: Annotated[list['PICONode'], Field(description="Child nodes connected by this operator.")]
+    proximity_distance: Annotated[int | None, Field(description="Distance 'n' required if operator is PROXIMITY.")] = (
+        None
+    )
+    children: Annotated[list[PICONode], Field(description="Child nodes connected by this operator.")]
 
 
 # Discriminated Union for recursive tree walking
@@ -115,18 +123,22 @@ class PICOASTConfig(CoreasonModel):
 
     model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
 
-    enforce_pico_ast: Annotated[bool, Field(description="If True, the agent must output a valid PICONode JSON tree.")] = True
-    default_operator: Annotated[PICOOperator, Field(description="The default operator to combine disjoint PICO classes at the root.")] = PICOOperator.AND
+    enforce_pico_ast: Annotated[
+        bool, Field(description="If True, the agent must output a valid PICONode JSON tree.")
+    ] = True
+    default_operator: Annotated[
+        PICOOperator, Field(description="The default operator to combine disjoint PICO classes at the root.")
+    ] = PICOOperator.AND
 
 
 __all__ = [
     "OptimizationIntent",
-    "SemanticRef",
-    "PICOClass",
-    "SearchTermType",
-    "PICOOperator",
-    "PICOLeafNode",
-    "PICOOperatorNode",
-    "PICONode",
     "PICOASTConfig",
+    "PICOClass",
+    "PICOLeafNode",
+    "PICONode",
+    "PICOOperator",
+    "PICOOperatorNode",
+    "SearchTermType",
+    "SemanticRef",
 ]

--- a/src/coreason_manifest/core/common/templating.py
+++ b/src/coreason_manifest/core/common/templating.py
@@ -29,6 +29,10 @@ class TemplateVariable(CoreasonModel):
     fallback_value: Any | None = Field(
         default=None, description="Value to use if the local variable is currently null."
     )
+    required: bool = Field(
+        default=False,
+        description="If true and the local variable is null with no fallback, the client aborts the network fetch.",
+    )
 
     @model_validator(mode="after")
     def validate_pointer(self) -> "TemplateVariable":

--- a/src/coreason_manifest/core/common/transform.py
+++ b/src/coreason_manifest/core/common/transform.py
@@ -19,6 +19,8 @@ class TransformOperator(StrEnum):
     REGEX_MATCH = "REGEX_MATCH"
     IN_LIST = "IN_LIST"
     NOT_IN_LIST = "NOT_IN_LIST"
+    IS_NULL = "IS_NULL"
+    IS_NOT_NULL = "IS_NOT_NULL"
 
 
 class LogicalOperator(StrEnum):
@@ -46,8 +48,9 @@ class FilterRule(CoreasonModel):
         if self.value_pointer is not None and not self.value_pointer.startswith("$local."):
             raise ValueError("value_pointer MUST start with '$local.'")
 
-        if (self.value is not None and self.value_pointer is not None) or (
-            self.value is None and self.value_pointer is None
+        if self.operator not in (TransformOperator.IS_NULL, TransformOperator.IS_NOT_NULL) and (
+            (self.value is not None and self.value_pointer is not None)
+            or (self.value is None and self.value_pointer is None)
         ):
             raise ValueError("Exactly one of value or value_pointer must be provided")
 

--- a/src/coreason_manifest/core/common/typeahead.py
+++ b/src/coreason_manifest/core/common/typeahead.py
@@ -31,12 +31,14 @@ class SuggestionMapper(CoreasonModel):
     @model_validator(mode="after")
     def validate_pointers(self) -> "SuggestionMapper":
         pointers = [
-            self.results_path,
             self.title_pointer,
             self.subtitle_pointer,
             self.icon_pointer,
             self.value_pointer,
         ]
+
+        if self.results_path is not None and self.results_path != "" and not self.results_path.startswith("/"):
+            raise ValueError(f"JSON pointer '{self.results_path}' must start with '/' or be an empty string")
 
         for pointer in pointers:
             if pointer is not None and not pointer.startswith("/"):

--- a/tests/core/common/test_templating.py
+++ b/tests/core/common/test_templating.py
@@ -20,20 +20,20 @@ from coreason_manifest.core.common.templating import (
 )
 
 
-def test_template_variable_valid():
+def test_template_variable_valid() -> None:
     var = TemplateVariable(pointer="$local.selected_brands")
     assert var.pointer == "$local.selected_brands"
     assert var.array_encoding == ArrayEncodingStyle.COMMA
     assert var.fallback_value is None
 
 
-def test_template_variable_invalid_pointer():
+def test_template_variable_invalid_pointer() -> None:
     with pytest.raises(ValidationError) as exc_info:
         TemplateVariable(pointer="selected_brands")
     assert "pointer must strictly start with '$local.'" in str(exc_info.value)
 
 
-def test_template_string_valid():
+def test_template_string_valid() -> None:
     ts = TemplateString(
         template="/api/search?q={query}&b={brands}",
         variables={
@@ -46,7 +46,7 @@ def test_template_string_valid():
     assert "brands" in ts.variables
 
 
-def test_template_string_missing_variable():
+def test_template_string_missing_variable() -> None:
     with pytest.raises(ValidationError) as exc_info:
         TemplateString(
             template="/api/search?q={query}&b={brands}",
@@ -58,7 +58,7 @@ def test_template_string_missing_variable():
     assert "Placeholder 'brands' extracted from template is missing from variables dictionary." in str(exc_info.value)
 
 
-def test_state_dependency_config_valid():
+def test_state_dependency_config_valid() -> None:
     config = StateDependencyConfig(
         trigger_pointers=["$local.selected_brands", "$local.query"],
         debounce_ms=300,
@@ -68,7 +68,7 @@ def test_state_dependency_config_valid():
     assert config.trigger_pointers == ["$local.selected_brands", "$local.query"]
 
 
-def test_state_dependency_config_invalid_debounce():
+def test_state_dependency_config_invalid_debounce() -> None:
     with pytest.raises(ValidationError) as exc_info:
         StateDependencyConfig(
             trigger_pointers=["$local.selected_brands"],
@@ -77,7 +77,7 @@ def test_state_dependency_config_invalid_debounce():
     assert "debounce_ms must be strictly >= 50." in str(exc_info.value)
 
 
-def test_state_dependency_config_invalid_pointer():
+def test_state_dependency_config_invalid_pointer() -> None:
     with pytest.raises(ValidationError) as exc_info:
         StateDependencyConfig(
             trigger_pointers=["$local.selected_brands", "query"],
@@ -85,7 +85,7 @@ def test_state_dependency_config_invalid_pointer():
     assert "trigger_pointer 'query' must strictly start with '$local.'" in str(exc_info.value)
 
 
-def test_parameterized_data_ref_valid():
+def test_parameterized_data_ref_valid() -> None:
     ref = ParameterizedDataRef(
         uri_template=TemplateString(
             template="/api/search?q={query}",
@@ -102,3 +102,8 @@ def test_parameterized_data_ref_valid():
     assert ref.headers == {"Authorization": "Bearer token"}
     assert ref.uri_template.template == "/api/search?q={query}"
     assert ref.dependency_config.debounce_ms == 100
+
+
+def test_template_variable_required() -> None:
+    var = TemplateVariable(pointer="$local.selected_brands", required=True)
+    assert var.required is True

--- a/tests/core/common/test_transform.py
+++ b/tests/core/common/test_transform.py
@@ -96,3 +96,19 @@ def test_filter_group_recursion_depth_limit() -> None:
 
     with pytest.raises(ValidationError, match="FilterGroup recursion depth cannot exceed 3 levels"):
         FilterGroup(logic=LogicalOperator.AND, conditions=[group_level_2])
+
+
+def test_filter_rule_is_null_operators() -> None:
+    """Test FilterRule allows IS_NULL and IS_NOT_NULL without value/value_pointer"""
+    # Should not raise validation error
+    rule1 = FilterRule(
+        field_pointer="/item/price",
+        operator=TransformOperator.IS_NULL,
+    )
+    assert rule1.operator == TransformOperator.IS_NULL
+
+    rule2 = FilterRule(
+        field_pointer="/item/price",
+        operator=TransformOperator.IS_NOT_NULL,
+    )
+    assert rule2.operator == TransformOperator.IS_NOT_NULL

--- a/tests/core/common/test_typeahead.py
+++ b/tests/core/common/test_typeahead.py
@@ -42,7 +42,7 @@ def test_suggestion_mapper_invalid_pointer() -> None:
             title_pointer="/name",
             value_pointer="/id",
         )
-    assert "must start with '/'" in str(exc_info.value)
+    assert "must start with '/' or be an empty string" in str(exc_info.value)
 
     with pytest.raises(ValidationError) as exc_info:
         SuggestionMapper(
@@ -134,3 +134,13 @@ def test_typeahead_config_min_chars_too_low() -> None:
             min_chars_to_trigger=0,
         )
     assert "min_chars_to_trigger must be strictly >= 1" in str(exc_info.value)
+
+
+def test_suggestion_mapper_empty_results_path() -> None:
+    """Test SuggestionMapper allows empty string for results_path."""
+    mapper = SuggestionMapper(
+        results_path="",
+        title_pointer="/name",
+        value_pointer="/id",
+    )
+    assert mapper.results_path == ""


### PR DESCRIPTION
This pull request finalizes the Epic 7.6 Final Reconciliation Refactor by integrating the Agentic Search UX schemas (Transforms, Typeahead, Templating, Highlighting, and Hybrid Layouts) into the core `presentation.py` AST and applying critical patches to those schemas.

Tasks completed:
1. Updated `presentation.py` to attach new Epic 7 capabilities to the Generative UI components.
2. Updated `transform.py` to fix the "Null-Value Trap" by adding `IS_NULL` and `IS_NOT_NULL` operators.
3. Updated `typeahead.py` to allow `results_path` to map root-level JSON arrays.
4. Updated `templating.py` to prevent 404 errors when a URL path parameter resolves to null.
5. Added unit tests for all patches.

---
*PR created automatically by Jules for task [7203160154475084953](https://jules.google.com/task/7203160154475084953) started by @gowthamrao*