### PR TITLE
feat(oversight): add semantic drift policy and resilience strategies

### DIFF
--- a/src/coreason_manifest/core/oversight/governance.py
+++ b/src/coreason_manifest/core/oversight/governance.py
@@ -1,8 +1,8 @@
 import time
-from enum import IntEnum
+from enum import IntEnum, StrEnum
 from typing import Any, Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import ConfigDict, Field, field_validator, model_validator
 
 from coreason_manifest.core.common.base import CoreasonModel
 from coreason_manifest.core.common.exceptions import FaultSeverity, ManifestError, RecoveryAction, SemanticFault
@@ -158,6 +158,26 @@ class ComputeLimits(CoreasonModel):
     )
 
 
+class DriftMeasurementMethod(StrEnum):
+    COSINE_DISTANCE = "cosine_distance"
+    JACCARD_INDEX = "jaccard_index"
+    EPISTEMIC_FALSIFICATION = "epistemic_falsification"
+
+
+class DriftPolicy(CoreasonModel):
+    """Declarative bounds for semantic stability."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    input_drift_threshold: float = Field(..., ge=0.0, le=1.0, description="Threshold for input drift.")
+    output_drift_threshold: float = Field(..., ge=0.0, le=1.0, description="Threshold for output drift.")
+    trajectory_divergence_limit: float = Field(
+        ..., ge=0.0, le=1.0, description="Max allowed cosine distance between Step 1 and Step N."
+    )
+    baseline_dataset_id: str | None = Field(None, description="Dataset ID for epistemic falsification checks.")
+    measurement_method: DriftMeasurementMethod = Field(..., description="Method for drift measurement.")
+
+
 class OperationalPolicy(CoreasonModel):
     financial: FinancialLimits | None = Field(None, description="Financial limits configuration.")
     data: DataLimits | None = Field(None, description="Data usage limits configuration.")
@@ -218,6 +238,7 @@ class Governance(CoreasonModel):
         description="References to .rego files or inline Open Policy Agent definitions for custom enterprise rules.",
     )
     mixed_initiative: MixedInitiativePolicy | None = Field(None)
+    drift: DriftPolicy | None = Field(None, description="Semantic drift and stability policy.")
 
     @field_validator("active_middlewares")
     @classmethod

--- a/src/coreason_manifest/core/oversight/resilience.py
+++ b/src/coreason_manifest/core/oversight/resilience.py
@@ -20,6 +20,8 @@ class ErrorDomain(StrEnum):
     TIMEOUT = "timeout"
     FINANCIAL = "financial"
     IDENTITY = "identity"
+    DRIFT = "drift"
+    ALIGNMENT = "alignment"
 
 
 class ResilienceStrategy(BaseModel):
@@ -198,6 +200,32 @@ class HumanHandoffStrategy(ResilienceStrategy):
     )
 
 
+class ContextPruningStrategy(ResilienceStrategy):
+    """Strategy to shrink the agent's context window when drift occurs."""
+
+    type: Literal["context_pruning"] = Field(
+        "context_pruning", description="The strategy type.", examples=["context_pruning"]
+    )
+
+    eviction_target: Literal["oldest_messages", "lowest_salience"] = Field(
+        ..., description="What part of the context to evict.", examples=["oldest_messages"]
+    )
+    prune_percentage: float = Field(..., gt=0.0, le=1.0, description="Percentage of context to prune.", examples=[0.2])
+
+
+class TutorAlignmentStrategy(ResilienceStrategy):
+    """Strategy to issue a harsh correction to an agent."""
+
+    type: Literal["tutor_alignment"] = Field(
+        "tutor_alignment", description="The strategy type.", examples=["tutor_alignment"]
+    )
+
+    system_prompt_override: str = Field(
+        ..., description="The overriding correction instruction.", examples=["You must follow the baseline dataset."]
+    )
+    reset_trajectory: bool = Field(..., description="Whether to reset the trajectory to step 1.", examples=[True])
+
+
 # Polymorphic Union
 RecoveryStrategy = Annotated[
     RetryStrategy
@@ -205,7 +233,9 @@ RecoveryStrategy = Annotated[
     | ReflexionStrategy
     | EscalationStrategy
     | DiagnosisReasoning
-    | HumanHandoffStrategy,
+    | HumanHandoffStrategy
+    | ContextPruningStrategy
+    | TutorAlignmentStrategy,
     Field(discriminator="type"),
 ]
 

--- a/tests/oversight/test_drift_governance.py
+++ b/tests/oversight/test_drift_governance.py
@@ -1,0 +1,141 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.oversight.governance import (
+    DriftMeasurementMethod,
+    DriftPolicy,
+    Governance,
+)
+from coreason_manifest.core.oversight.resilience import (
+    ContextPruningStrategy,
+    ErrorDomain,
+    ErrorHandler,
+    TutorAlignmentStrategy,
+)
+
+
+def test_drift_policy_instantiation() -> None:
+    """Test standard instantiation of DriftPolicy."""
+    policy = DriftPolicy(
+        input_drift_threshold=0.1,
+        output_drift_threshold=0.2,
+        trajectory_divergence_limit=0.15,
+        baseline_dataset_id="golden_set_v1",
+        measurement_method=DriftMeasurementMethod.COSINE_DISTANCE,
+    )
+    assert policy.input_drift_threshold == 0.1
+    assert policy.output_drift_threshold == 0.2
+    assert policy.trajectory_divergence_limit == 0.15
+    assert policy.baseline_dataset_id == "golden_set_v1"
+    assert policy.measurement_method == DriftMeasurementMethod.COSINE_DISTANCE
+
+
+def test_drift_policy_constraints() -> None:
+    """Test bound checks for drift threshold fields."""
+    with pytest.raises(ValidationError):
+        DriftPolicy(
+            input_drift_threshold=-0.1,
+            output_drift_threshold=0.2,
+            trajectory_divergence_limit=0.15,
+            baseline_dataset_id="golden_set_v1",
+            measurement_method=DriftMeasurementMethod.JACCARD_INDEX,
+        )
+
+    with pytest.raises(ValidationError):
+        DriftPolicy(
+            input_drift_threshold=0.1,
+            output_drift_threshold=1.1,
+            trajectory_divergence_limit=0.15,
+            baseline_dataset_id="golden_set_v1",
+            measurement_method=DriftMeasurementMethod.JACCARD_INDEX,
+        )
+
+    with pytest.raises(ValidationError):
+        DriftPolicy(
+            input_drift_threshold=0.1,
+            output_drift_threshold=0.2,
+            trajectory_divergence_limit=-0.05,
+            baseline_dataset_id="golden_set_v1",
+            measurement_method=DriftMeasurementMethod.EPISTEMIC_FALSIFICATION,
+        )
+
+
+def test_governance_with_drift_policy() -> None:
+    """Test Governance model accepts the new DriftPolicy."""
+    drift_policy = DriftPolicy(
+        input_drift_threshold=0.05,
+        output_drift_threshold=0.1,
+        trajectory_divergence_limit=0.3,
+        measurement_method=DriftMeasurementMethod.EPISTEMIC_FALSIFICATION,
+    )
+
+    governance = Governance(
+        active_middlewares=[],
+        drift=drift_policy,
+    )
+
+    assert governance.drift is not None
+    assert governance.drift.input_drift_threshold == 0.05
+    assert governance.drift.measurement_method == DriftMeasurementMethod.EPISTEMIC_FALSIFICATION
+
+
+def test_context_pruning_strategy_instantiation() -> None:
+    """Test standard instantiation of ContextPruningStrategy."""
+    strategy = ContextPruningStrategy(
+        eviction_target="oldest_messages",
+        prune_percentage=0.25,
+    )
+    assert strategy.type == "context_pruning"
+    assert strategy.eviction_target == "oldest_messages"
+    assert strategy.prune_percentage == 0.25
+
+
+def test_context_pruning_strategy_constraints() -> None:
+    """Test constraint checks on prune_percentage."""
+    with pytest.raises(ValidationError):
+        ContextPruningStrategy(
+            eviction_target="oldest_messages",
+            prune_percentage=0.0,
+        )
+    with pytest.raises(ValidationError):
+        ContextPruningStrategy(
+            eviction_target="lowest_salience",
+            prune_percentage=1.1,
+        )
+
+
+def test_tutor_alignment_strategy_instantiation() -> None:
+    """Test standard instantiation of TutorAlignmentStrategy."""
+    strategy = TutorAlignmentStrategy(
+        system_prompt_override="Do better.",
+        reset_trajectory=True,
+    )
+    assert strategy.type == "tutor_alignment"
+    assert strategy.system_prompt_override == "Do better."
+    assert strategy.reset_trajectory is True
+
+
+def test_mapping_strategies_to_error_domain() -> None:
+    """Test mapping strategies to ErrorDomain.DRIFT within an ErrorHandler."""
+    context_pruning = ContextPruningStrategy(eviction_target="lowest_salience", prune_percentage=0.5)
+    tutor_alignment = TutorAlignmentStrategy(system_prompt_override="Align strictly.", reset_trajectory=False)
+
+    handler1 = ErrorHandler(
+        match_domain=[ErrorDomain.DRIFT],
+        strategy=context_pruning,
+    )
+
+    handler2 = ErrorHandler(
+        match_domain=[ErrorDomain.ALIGNMENT],
+        strategy=tutor_alignment,
+    )
+
+    assert handler1.match_domain == [ErrorDomain.DRIFT]
+    assert handler1.strategy.type == "context_pruning"
+    assert isinstance(handler1.strategy, ContextPruningStrategy)
+    assert handler1.strategy.eviction_target == "lowest_salience"
+
+    assert handler2.match_domain == [ErrorDomain.ALIGNMENT]
+    assert handler2.strategy.type == "tutor_alignment"
+    assert isinstance(handler2.strategy, TutorAlignmentStrategy)
+    assert handler2.strategy.reset_trajectory is False


### PR DESCRIPTION
This PR introduces declarative semantic drift configuration and agentic healing strategies, expanding the passive guardrails framework.
    - Defines mathematical bounds for semantic drift (`input_drift_threshold`, `output_drift_threshold`, `trajectory_divergence_limit`) inside `DriftPolicy`.
    - Expands resilience mechanics (`ContextPruningStrategy`, `TutorAlignmentStrategy`) to allow orchestrators to recover an agent from sycophancy or hallucination.
    - Comprehensive unit tests enforcing constraint boundaries and correct typing.

---
*PR created automatically by Jules for task [822340080664354383](https://jules.google.com/task/822340080664354383) started by @gowthamrao*