### PR TITLE
Refactor evals.py and diff.py for strict typing and immutability

### DIFF
--- a/src/coreason_manifest/core/workflow/evals.py
+++ b/src/coreason_manifest/core/workflow/evals.py
@@ -31,7 +31,7 @@ class AdversaryProfile(CoreasonModel, frozen=True):
     attack_model: str | None = Field(default=None, description="Model to use for executing the attack.")
 
 
-class SimulationScenario(CoreasonModel):
+class SimulationScenario(CoreasonModel, frozen=True, extra="forbid"):
     """
     A deterministic test case for an agent graph.
     """
@@ -52,7 +52,7 @@ class SimulationScenario(CoreasonModel):
     adversary: AdversaryProfile | None = Field(default=None, description="Red-team configuration for semantic fuzzing.")
 
 
-class FuzzingTarget(CoreasonModel):
+class FuzzingTarget(CoreasonModel, frozen=True, extra="forbid"):
     """
     Definition of a fuzzing target for automated adversarial probing.
     """
@@ -70,7 +70,7 @@ class FuzzingTarget(CoreasonModel):
     )
 
 
-class EvalsManifest(CoreasonModel):
+class EvalsManifest(CoreasonModel, frozen=True, extra="forbid"):
     """
     Manifest defining how an agent graph is deterministically tested.
     """
@@ -79,4 +79,7 @@ class EvalsManifest(CoreasonModel):
     fuzzing_targets: list[FuzzingTarget] = Field(default_factory=list, description="List of fuzzing targets.")
 
 
-TestCase = SimulationScenario
+class TestCase(SimulationScenario):
+    """Alias for SimulationScenario used in standard test runs."""
+
+    pass

--- a/src/coreason_manifest/toolkit/diff.py
+++ b/src/coreason_manifest/toolkit/diff.py
@@ -9,6 +9,7 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 import difflib
+import json
 from enum import StrEnum
 from typing import Any
 
@@ -25,10 +26,16 @@ class ChangeCategory(StrEnum):
     PATCH = "PATCH"
 
 
+class ChangeType(StrEnum):
+    ADD = "add"
+    REMOVE = "remove"
+    MODIFY = "modify"
+
+
 class DiffChange(CoreasonModel):
     path: str
     category: ChangeCategory
-    change_type: str = Field(..., description="'add', 'remove', or 'modify'")
+    change_type: ChangeType = Field(..., description="'add', 'remove', or 'modify'")
     old_value: Any | None = None
     new_value: Any | None = None
 
@@ -83,8 +90,6 @@ def _compare_lists(path_prefix: str, old_list: list[Any], new_list: list[Any]) -
             return item
         # Fallback for complex objects without 'id', hash their string representation
         # It's not perfect but works for simple diffing
-        import json
-
         try:
             return json.dumps(item, sort_keys=True)
         except Exception:
@@ -106,8 +111,8 @@ def _compare_lists(path_prefix: str, old_list: list[Any], new_list: list[Any]) -
                     changes.append(
                         DiffChange(
                             path=current_path,
-                            category=_categorize_path(current_path, "modify"),
-                            change_type="modify",
+                            category=_categorize_path(current_path, ChangeType.MODIFY),
+                            change_type=ChangeType.MODIFY,
                             old_value=old_list[i],
                             new_value=new_list[j],
                         )
@@ -119,8 +124,8 @@ def _compare_lists(path_prefix: str, old_list: list[Any], new_list: list[Any]) -
                     changes.append(
                         DiffChange(
                             path=current_path,
-                            category=_categorize_path(current_path, "remove"),
-                            change_type="remove",
+                            category=_categorize_path(current_path, ChangeType.REMOVE),
+                            change_type=ChangeType.REMOVE,
                             old_value=old_list[i],
                             new_value=None,
                         )
@@ -131,8 +136,8 @@ def _compare_lists(path_prefix: str, old_list: list[Any], new_list: list[Any]) -
                     changes.append(
                         DiffChange(
                             path=current_path,
-                            category=_categorize_path(current_path, "add"),
-                            change_type="add",
+                            category=_categorize_path(current_path, ChangeType.ADD),
+                            change_type=ChangeType.ADD,
                             old_value=None,
                             new_value=new_list[j],
                         )
@@ -143,8 +148,8 @@ def _compare_lists(path_prefix: str, old_list: list[Any], new_list: list[Any]) -
                 changes.append(
                     DiffChange(
                         path=current_path,
-                        category=_categorize_path(current_path, "remove"),
-                        change_type="remove",
+                        category=_categorize_path(current_path, ChangeType.REMOVE),
+                        change_type=ChangeType.REMOVE,
                         old_value=old_list[i],
                         new_value=None,
                     )
@@ -155,8 +160,8 @@ def _compare_lists(path_prefix: str, old_list: list[Any], new_list: list[Any]) -
                 changes.append(
                     DiffChange(
                         path=current_path,
-                        category=_categorize_path(current_path, "add"),
-                        change_type="add",
+                        category=_categorize_path(current_path, ChangeType.ADD),
+                        change_type=ChangeType.ADD,
                         old_value=None,
                         new_value=new_list[j],
                     )
@@ -178,8 +183,8 @@ def _compare_dicts(path_prefix: str, old_dict: dict[str, Any], new_dict: dict[st
             changes.append(
                 DiffChange(
                     path=current_path,
-                    category=_categorize_path(current_path, "add"),
-                    change_type="add",
+                    category=_categorize_path(current_path, ChangeType.ADD),
+                    change_type=ChangeType.ADD,
                     old_value=None,
                     new_value=new_dict[key],
                 )
@@ -188,8 +193,8 @@ def _compare_dicts(path_prefix: str, old_dict: dict[str, Any], new_dict: dict[st
             changes.append(
                 DiffChange(
                     path=current_path,
-                    category=_categorize_path(current_path, "remove"),
-                    change_type="remove",
+                    category=_categorize_path(current_path, ChangeType.REMOVE),
+                    change_type=ChangeType.REMOVE,
                     old_value=old_dict[key],
                     new_value=None,
                 )
@@ -206,8 +211,8 @@ def _compare_dicts(path_prefix: str, old_dict: dict[str, Any], new_dict: dict[st
                 changes.append(
                     DiffChange(
                         path=current_path,
-                        category=_categorize_path(current_path, "modify"),
-                        change_type="modify",
+                        category=_categorize_path(current_path, ChangeType.MODIFY),
+                        change_type=ChangeType.MODIFY,
                         old_value=old_val,
                         new_value=new_val,
                     )

--- a/tests/toolkit/test_diff.py
+++ b/tests/toolkit/test_diff.py
@@ -11,7 +11,7 @@
 from coreason_manifest.core.oversight.resilience import RetryStrategy
 from coreason_manifest.core.workflow.flow import Edge, FlowInterface, FlowMetadata, Graph, GraphFlow, LinearFlow
 from coreason_manifest.core.workflow.nodes.agent import AgentNode, CognitiveProfile
-from coreason_manifest.toolkit.diff import ChangeCategory, compare_flows
+from coreason_manifest.toolkit.diff import ChangeCategory, ChangeType, compare_flows
 
 
 def test_compare_flows_add_tool() -> None:
@@ -39,7 +39,7 @@ def test_compare_flows_add_tool() -> None:
     tool_changes = [c for c in report.changes if "tools" in c.path]
     assert len(tool_changes) > 0
     assert any(c.category == ChangeCategory.FEATURE for c in tool_changes)
-    assert any(c.change_type == "add" and c.new_value == "tool_b" for c in tool_changes)
+    assert any(c.change_type == ChangeType.ADD and c.new_value == "tool_b" for c in tool_changes)
 
 
 def test_compare_flows_change_governance() -> None:
@@ -102,7 +102,7 @@ def test_compare_flows_remove_edge() -> None:
     edge_changes = [c for c in report.changes if "edges" in c.path]
     assert len(edge_changes) > 0
     assert any(c.category == ChangeCategory.BREAKING for c in edge_changes)
-    assert any(c.change_type == "remove" for c in edge_changes)
+    assert any(c.change_type == ChangeType.REMOVE for c in edge_changes)
 
 
 def test_compare_flows_change_description() -> None:
@@ -182,7 +182,7 @@ def test_compare_flows_list_different_lengths() -> None:
 
     report = compare_flows(old_flow, new_flow)
 
-    tool_changes = [c for c in report.changes if "tools" in c.path and c.change_type == "add"]
+    tool_changes = [c for c in report.changes if "tools" in c.path and c.change_type == ChangeType.ADD]
     assert len(tool_changes) == 2  # Added tool_3 and tool_4
 
 
@@ -245,10 +245,10 @@ def test_compare_flows_linear_list_complex() -> None:
     report = compare_flows(old_flow, new_flow)
 
     # Check that steps were removed
-    step_removals = [c for c in report.changes if "steps" in c.path and c.change_type == "remove"]
+    step_removals = [c for c in report.changes if "steps" in c.path and c.change_type == ChangeType.REMOVE]
     assert len(step_removals) == 2
 
     # Now test the reverse (1 step -> 3 steps)
     report2 = compare_flows(new_flow, old_flow)
-    step_additions = [c for c in report2.changes if "steps" in c.path and c.change_type == "add"]
+    step_additions = [c for c in report2.changes if "steps" in c.path and c.change_type == ChangeType.ADD]
     assert len(step_additions) == 2


### PR DESCRIPTION
Refactored the codebase to resolve mutability leaks and typing inconsistencies introduced during recent Epics parallel merge.
- `src/coreason_manifest/core/workflow/evals.py`: Enforced immutability and strict schema validation on top-level evaluation schemas by making `SimulationScenario`, `FuzzingTarget`, and `EvalsManifest` strictly inherit frozen properties and forbid extra fields. Changed `TestCase` from an alias to a subclass for better IDE support.
- `src/coreason_manifest/toolkit/diff.py`: Migrated structural diff change types from string literals to a strongly-typed `ChangeType` StrEnum for safety. Optimized imports by moving `import json` out of a nested loop in the diff traversal logic.
- `tests/toolkit/test_diff.py`: Adjusted relevant test assertions to use the new Enum instead of raw strings.

---
*PR created automatically by Jules for task [17174789367692472483](https://jules.google.com/task/17174789367692472483) started by @gowthamrao*