### PR TITLE
feat: Epic 4 Native MCP Integration

### DIFF
--- a/src/coreason_manifest/adapters/providers/mcp.py
+++ b/src/coreason_manifest/adapters/providers/mcp.py
@@ -1,0 +1,24 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class MCPClientMessage(BaseModel):
+    """Strict JSON-RPC 2.0 structure for MCP client messages."""
+
+    jsonrpc: Literal["2.0"] = Field(default="2.0", description="JSON-RPC version.")
+    method: Literal["mcp.ui.emit_intent"] = Field(..., description="Method for intent bubbling.")
+    params: dict[str, Any] = Field(default_factory=dict, description="Payload parameters.")
+    id: str | int = Field(..., description="Unique request identifier.")
+
+
+class MCPUIBroker:
+    """Broker for handling MCP UI JSON-RPC messages."""
+
+    def validate_iframe_payload(self, payload: dict[str, Any]) -> MCPClientMessage:
+        """Parses and validates the raw dictionary from the Flutter WebView."""
+        return MCPClientMessage.model_validate(payload)
+
+    def translate_intent_to_action(self, message: MCPClientMessage) -> dict[str, Any]:
+        """Safely unpacks the `params` (the user's intent) so the execution engine can route it."""
+        return message.params

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -210,5 +210,10 @@ class PresentationHints(CoreasonModel):
         Field(description="Preferred metadata detail level."),
     ] = "basic"
 
+    mcp_ui_resource_uri: Annotated[
+        str | None,
+        Field(description="The ui:// scheme URI pointing to the bundled HTML/JS for sandboxed execution (SEP-1865)."),
+    ] = None
+
 
 UIComponentNode.model_rebuild()

--- a/src/coreason_manifest/ports/mcp.py
+++ b/src/coreason_manifest/ports/mcp.py
@@ -1,8 +1,9 @@
 from enum import StrEnum
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field, model_validator
 
+from coreason_manifest.core.common.base import CoreasonModel
 from coreason_manifest.spec.domains.scivis_provenance import ActorIdentity
 
 
@@ -20,7 +21,7 @@ class MCPToolName(StrEnum):
     CANVAS_UPDATE_MATH_NODE = "CANVAS_UPDATE_MATH_NODE"
 
 
-class MCPOperation(BaseModel):
+class MCPOperation(CoreasonModel):
     """An atomic design action executed on a headless canvas."""
 
     operation_id: str = Field(..., description="Unique ID for tracing and logging this specific action.")
@@ -35,8 +36,19 @@ class MCPOperation(BaseModel):
         default=None, description="Cryptographically tags the specific agent/human issuing this canvas command."
     )
 
+    @model_validator(mode="after")
+    def validate_target_element_id(self) -> "MCPOperation":
+        requires_id = {
+            MCPToolName.CANVAS_UPDATE_ELEMENT,
+            MCPToolName.CANVAS_REMOVE_ELEMENT,
+            MCPToolName.CANVAS_UPDATE_MATH_NODE,
+        }
+        if self.tool_name in requires_id and self.target_element_id is None:
+            raise ValueError(f"target_element_id cannot be None when tool_name is {self.tool_name}")
+        return self
 
-class MCPOperationSequence(BaseModel):
+
+class MCPOperationSequence(CoreasonModel):
     """An ordered, transactional sequence of atomic design actions."""
 
     sequence_id: str

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,5 +1,8 @@
+import pytest
+
 from coreason_manifest.adapters.providers.mcp import MCPClientMessage, MCPUIBroker
 from coreason_manifest.core.common.presentation import PresentationHints
+from coreason_manifest.ports.mcp import MCPOperation, MCPToolName
 
 
 def test_mcp_client_message() -> None:
@@ -24,3 +27,27 @@ def test_mcp_ui_broker() -> None:
 def test_presentation_hints_mcp_uri() -> None:
     hints = PresentationHints(mcp_ui_resource_uri="ui://my-custom-app")
     assert hints.mcp_ui_resource_uri == "ui://my-custom-app"
+
+
+def test_mcp_operation_validation() -> None:
+    # This should pass because we provide a target_element_id
+    op1 = MCPOperation(
+        operation_id="123",
+        tool_name=MCPToolName.CANVAS_UPDATE_ELEMENT,
+        target_element_id="elem-1",
+    )
+    assert op1.target_element_id == "elem-1"
+
+    # This should pass because CANVAS_ADD_ELEMENT does not require a target_element_id
+    op2 = MCPOperation(
+        operation_id="124",
+        tool_name=MCPToolName.CANVAS_ADD_ELEMENT,
+    )
+    assert op2.target_element_id is None
+
+    # This should fail because CANVAS_REMOVE_ELEMENT requires a target_element_id
+    with pytest.raises(ValueError, match="target_element_id cannot be None"):
+        MCPOperation(
+            operation_id="125",
+            tool_name=MCPToolName.CANVAS_REMOVE_ELEMENT,
+        )

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,26 @@
+from coreason_manifest.adapters.providers.mcp import MCPClientMessage, MCPUIBroker
+from coreason_manifest.core.common.presentation import PresentationHints
+
+
+def test_mcp_client_message() -> None:
+    data = {"jsonrpc": "2.0", "method": "mcp.ui.emit_intent", "params": {"action": "checkout"}, "id": 1}
+    msg = MCPClientMessage(**data)
+    assert msg.jsonrpc == "2.0"
+    assert msg.method == "mcp.ui.emit_intent"
+    assert msg.params == {"action": "checkout"}
+    assert msg.id == 1
+
+
+def test_mcp_ui_broker() -> None:
+    broker = MCPUIBroker()
+    data = {"jsonrpc": "2.0", "method": "mcp.ui.emit_intent", "params": {"action": "save_draft"}, "id": "abc"}
+    msg = broker.validate_iframe_payload(data)
+    assert isinstance(msg, MCPClientMessage)
+
+    intent = broker.translate_intent_to_action(msg)
+    assert intent == {"action": "save_draft"}
+
+
+def test_presentation_hints_mcp_uri() -> None:
+    hints = PresentationHints(mcp_ui_resource_uri="ui://my-custom-app")
+    assert hints.mcp_ui_resource_uri == "ui://my-custom-app"


### PR DESCRIPTION
Implement Epic 4: Native Model Context Protocol (MCP) Integration based on SEP-1865. Added the necessary presentation layer hints and implemented the JSON-RPC broker for validating and translating intent from sandboxed applications. Tested code using pydantic 2.0.

---
*PR created automatically by Jules for task [13413817226215421250](https://jules.google.com/task/13413817226215421250) started by @gowthamrao*