### PR TITLE
feat: upgrade AdaptiveUIContract to support recursive UIComponentNode layout

### DIFF
--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -82,16 +82,7 @@ class UIComponentNode(CoreasonModel):
 
 
 class AdaptiveUIContract(CoreasonModel):
-    layout: list[UIComponentNode] = Field(default_factory=list, description="The root elements of the generated UI.")
-    widget_id: str | None = Field(
-        None, description="[DEPRECATED] The abstract identifier for the frontend component registry."
-    )
-    props_schema: dict[str, Any] | None = Field(
-        None, description="[DEPRECATED] JSON Schema defining the data required to render the widget."
-    )
-    props_mapping: dict[str, str] = Field(
-        default_factory=dict, description="[DEPRECATED] Maps Blackboard variables (values) to widget props (keys)."
-    )
+    layout: list[UIComponentNode] = Field(..., description="The root elements of the generated UI.")
     events: list[UIEventMap] = Field(
         default_factory=list, description="Maps widget interactions to orchestrator commands."
     )
@@ -105,21 +96,6 @@ class AdaptiveUIContract(CoreasonModel):
     hybrid_search: HybridSearchLayout | None = Field(
         default=None, description="Bipartite search layout for side-by-side Lexical/Semantic results."
     )
-
-    @model_validator(mode="before")
-    @classmethod
-    def migrate_legacy_widget(cls, data: Any) -> Any:
-        """Migrate legacy widget dictionary structure to layout nodes."""
-        if isinstance(data, dict):
-            layout = data.get("layout")
-            widget_id = data.get("widget_id")
-
-            # If layout is empty/missing but widget_id is provided, auto-migrate to the new structure
-            if not layout and widget_id:
-                props = data.get("props_mapping", {})
-                node = {"type": widget_id, "props": props, "children": []}
-                data["layout"] = [node]
-        return data
 
 
 class NotificationRouting(CoreasonModel):


### PR DESCRIPTION
# Objective
Execute Epic 2: Dynamic Agent-Driven UIs & Composability by upgrading the UI engine from static single widgets to a dynamic, recursively composable Generative UI system.

# Changes
- **Task 1: Recursive Composability (`presentation.py`)**
  - Updated `AdaptiveUIContract` to rely on `layout: list[UIComponentNode]` instead of deprecated singleton UI widget definitions.
  - Removed deprecated `widget_id`, `props_schema`, and `props_mapping` from `AdaptiveUIContract` to enforce a pure recursive DOM-like AST for UI structure generation.
  - Deleted the legacy model validator `migrate_legacy_widget` since legacy components are no longer supported.

- **Task 2: Agent UI Registry Binding (`agent.py`)**
  - Confirmed `ui_capabilities` already exists as an optional parameter within `CognitiveProfile` allowing components registry IDs.

- **Task 3: Fluent API Integration (`builder.py`)**
  - **SKIPPED**: According to updated user directions, modifying `builder.py` is skipped completely. Builders have been removed intentionally from the `coreason-manifest` architecture.

# Verification
- Verified fields and changes.
- Tested changes by running `pytest`.
- Avoided all concurrent files like `stream.py`, `persistence.py`, `mcp.py` as strictly specified in the instruction prompt to prevent any merge conflicts.

---
*PR created automatically by Jules for task [7165035694350050945](https://jules.google.com/task/7165035694350050945) started by @gowthamrao*