### PR TITLE
feat: Epic 9.3 Ambient Literature Binding (The MCP Copilot)

### DIFF
--- a/src/coreason_manifest/core/common/ambient.py
+++ b/src/coreason_manifest/core/common/ambient.py
@@ -1,0 +1,41 @@
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class AmbientTriggerRule(CoreasonModel):
+    trigger_events: list[str] = Field(
+        ...,
+        description="List of headless tool names to listen for (e.g., ['CANVAS_ADD_CONNECTION']).",
+    )
+    debounce_ms: int = Field(default=800, description="Wait for state to settle before firing.")
+    extract_triplets: bool = Field(
+        default=True,
+        description="If True, the client extracts geometric relationships into Semantic Triplets before firing.",
+    )
+
+    @model_validator(mode="after")
+    def validate_debounce_ms(self) -> "AmbientTriggerRule":
+        if self.debounce_ms < 100 or self.debounce_ms > 5000:
+            raise ValueError("debounce_ms must be mathematically sane (>= 100 and <= 5000).")
+        return self
+
+
+class AmbientListenerConfig(CoreasonModel):
+    listener_id: str
+    target_canvas_id: str = Field(..., description="The ID of the specific MCP UI widget to monitor.")
+    trigger_rules: list[AmbientTriggerRule]
+    action_route: str = Field(
+        ...,
+        description="The LangGraph node or agent ID to asynchronously dispatch the extracted intent to.",
+    )
+    ui_target_pointer: str = Field(
+        ...,
+        description="The local state pointer where the search results should stream into.",
+    )
+
+    @model_validator(mode="after")
+    def validate_ui_target_pointer(self) -> "AmbientListenerConfig":
+        if not self.ui_target_pointer.startswith("$local."):
+            raise ValueError("ui_target_pointer strictly must start with '$local.'")
+        return self

--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -11,6 +11,7 @@ from coreason_manifest.core.presentation.transform import DataTransformSchema
 from coreason_manifest.core.presentation.typeahead import TypeaheadConfig
 from coreason_manifest.core.state.ephemeral import LocalStateManifest
 
+from .ambient import AmbientListenerConfig
 from .client_actions import ClientActionMap
 from .suspense import SuspenseConfig
 from .validation import UIValidationSchema
@@ -95,6 +96,9 @@ class AdaptiveUIContract(CoreasonModel):
     )
     hybrid_search: HybridSearchLayout | None = Field(
         default=None, description="Bipartite search layout for side-by-side Lexical/Semantic results."
+    )
+    ambient_listeners: list[AmbientListenerConfig] | None = Field(
+        default=None, description="Silent background observers that trigger out-of-band AI workflows based on user interactions."
     )
 
 
@@ -193,3 +197,4 @@ class PresentationHints(CoreasonModel):
 
 
 UIComponentNode.model_rebuild()
+AdaptiveUIContract.model_rebuild()


### PR DESCRIPTION
This commit introduces the `AmbientTriggerRule` and `AmbientListenerConfig` schemas in `core.common.ambient`, fulfilling Epic 9.3: Ambient Literature Binding. These models allow for the asynchronous, headless monitoring of UI events (such as geometric canvas changes) to trigger background workflows like scientific search agents without blocking the main UI thread.

The models leverage Pydantic V2 `model_validator` to enforce boundary rules, such as zero-trust restrictions on `ui_target_pointer` (requiring a `$local.` prefix) and mathematically sane bounds on `debounce_ms` (100 to 5000ms). The `AdaptiveUIContract` model in `core.common.presentation` has been extended to support `ambient_listeners` as a list of background observer definitions. 

Tests were explicitly skipped per user instructions.

---
*PR created automatically by Jules for task [14694597964581807390](https://jules.google.com/task/14694597964581807390) started by @gowthamrao*