### PR TITLE
test: Fix pytest.raises in compute routing tests

### DIFF
--- a/src/coreason_manifest/core/compute/__init__.py
+++ b/src/coreason_manifest/core/compute/__init__.py
@@ -1,0 +1,21 @@
+"""
+Compute provisioning and resource routing structures.
+"""
+
+from .resources import (
+    IntentRouter,
+    provision_compute,
+)
+from .velocity import (
+    ComputeIntent,
+    VelocityAConfig,
+    VelocityBConfig,
+)
+
+__all__ = [
+    "ComputeIntent",
+    "IntentRouter",
+    "VelocityAConfig",
+    "VelocityBConfig",
+    "provision_compute",
+]

--- a/src/coreason_manifest/core/compute/resources.py
+++ b/src/coreason_manifest/core/compute/resources.py
@@ -1,8 +1,14 @@
 from enum import StrEnum
+from typing import Any
 
 from pydantic import Field
 
 from coreason_manifest.core.common.base import CoreasonModel
+from coreason_manifest.core.compute.velocity import (
+    ComputeIntent,
+    VelocityAConfig,
+    VelocityBConfig,
+)
 
 
 class Currency(StrEnum):
@@ -35,3 +41,39 @@ class ModelProfile(CoreasonModel):
     provider: str = Field(..., description="The provider of the model.", examples=["openai", "anthropic"])
     model_id: str = Field(..., description="The unique identifier of the model.", examples=["o1-preview", "gpt-4o"])
     pricing: RateCard | None = Field(None, description="The rate card associated with the model's pricing.")
+
+
+class IntentRouter:
+    """
+    Dynamically slices workloads into distinct SLA profiles based on intent.
+    Routes tasks to appropriate compute hardware tiers (Velocity A vs B).
+    """
+
+    def route(self, task_def: Any, intent: ComputeIntent) -> VelocityAConfig | VelocityBConfig:  # noqa: ARG002
+        """
+        Evaluate task intent and generate the strict SLA configuration.
+        """
+        if intent == ComputeIntent.REALTIME_SYNC:
+            # Velocity A: User-facing, latency matters, bursting mode.
+            return VelocityAConfig(
+                max_latency_seconds=60,
+                allow_model_downgrade=True,
+                target_compute_tier="serverless_burst",
+            )
+        if intent == ComputeIntent.BATCH_BACKGROUND:
+            # Velocity B: Data-lake, throughput matters, preemptible node.
+            return VelocityBConfig(
+                max_retries=-1,
+                preemption_safe=True,
+                target_compute_tier="spot_fleet",
+            )
+        raise ValueError(f"Unknown compute intent: {intent}")
+
+
+async def provision_compute(intent: ComputeIntent, task_def: Any = None) -> VelocityAConfig | VelocityBConfig:
+    """
+    Mock method to simulate requesting hardware from the orchestrator.
+    Evaluates routing and returns the provisioned velocity configuration profile.
+    """
+    router = IntentRouter()
+    return router.route(task_def, intent)

--- a/src/coreason_manifest/core/compute/velocity.py
+++ b/src/coreason_manifest/core/compute/velocity.py
@@ -1,0 +1,54 @@
+from enum import StrEnum
+
+from pydantic import Field
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class ComputeIntent(StrEnum):
+    """Execution intent profiles that drive hardware routing decisions."""
+
+    REALTIME_SYNC = "REALTIME_SYNC"
+    BATCH_BACKGROUND = "BATCH_BACKGROUND"
+
+
+class VelocityAConfig(CoreasonModel):
+    """
+    Velocity A: Real-Time execution profile.
+    Optimized for low-latency, user-facing interactions. Enables serverless burst and allows fallback
+    to smaller models (graceful epistemic degradation) to preserve SLAs.
+    """
+
+    max_latency_seconds: int = Field(
+        default=60,
+        description="Strict latency budget. Exceeding this triggers a LatencySLAExceededError.",
+    )
+    allow_model_downgrade: bool = Field(
+        ...,
+        description="Whether to permit Graceful Epistemic Degradation to preserve SLA.",
+    )
+    target_compute_tier: str = Field(
+        ...,
+        description="Expected compute tier, e.g., 'serverless_burst'.",
+    )
+
+
+class VelocityBConfig(CoreasonModel):
+    """
+    Velocity B: Background/Batch execution profile.
+    Optimized for throughput over latency. Uses spot/preemptible fleets to maximize cost efficiency.
+    Fault-tolerant design ensures preemption interrupts do not break data lineage.
+    """
+
+    max_retries: int = Field(
+        default=-1,
+        description="Number of retries for interrupted executions. -1 indicates infinite retries.",
+    )
+    preemption_safe: bool = Field(
+        ...,
+        description="Must be True to explicitly acknowledge fault-tolerance requirements.",
+    )
+    target_compute_tier: str = Field(
+        ...,
+        description="Expected compute tier, e.g., 'spot_fleet'.",
+    )

--- a/src/coreason_manifest/core/workflow/exceptions.py
+++ b/src/coreason_manifest/core/workflow/exceptions.py
@@ -22,3 +22,39 @@ class LineageIntegrityError(ManifestError):
                 recovery_action=RecoveryAction.HALT,
             )
         )
+
+
+class LatencySLAExceededError(ManifestError):
+    """
+    Raised when a Real-Time task exceeds its SLA.
+    This signals the swarm to trigger Graceful Epistemic Degradation.
+    """
+
+    def __init__(self, message: str) -> None:
+        """Initialize LatencySLAExceededError."""
+        super().__init__(
+            SemanticFault(
+                error_code="SLA-LATENCY-001",
+                message=message,
+                severity=FaultSeverity.RECOVERABLE,
+                recovery_action=RecoveryAction.RETRY,
+            )
+        )
+
+
+class HardwarePreemptionInterrupt(ManifestError):  # noqa: N818
+    """
+    Raised when a cloud provider sends a preemption warning.
+    This signals the pipeline to flush telemetry and checkpoint the Ledger.
+    """
+
+    def __init__(self, message: str) -> None:
+        """Initialize HardwarePreemptionInterrupt."""
+        super().__init__(
+            SemanticFault(
+                error_code="HW-PREEMPTION-001",
+                message=message,
+                severity=FaultSeverity.CRITICAL,
+                recovery_action=RecoveryAction.HALT,
+            )
+        )

--- a/tests/core/compute/test_velocity_routing.py
+++ b/tests/core/compute/test_velocity_routing.py
@@ -1,0 +1,52 @@
+import pytest
+
+from coreason_manifest.core.compute.resources import IntentRouter, provision_compute
+from coreason_manifest.core.compute.velocity import (
+    ComputeIntent,
+    VelocityAConfig,
+    VelocityBConfig,
+)
+from coreason_manifest.core.workflow.exceptions import LatencySLAExceededError
+
+
+@pytest.mark.asyncio
+async def test_realtime_sync_routing() -> None:
+    """Test 1: Prove that REALTIME_SYNC correctly returns VelocityAConfig."""
+    config = await provision_compute(intent=ComputeIntent.REALTIME_SYNC, task_def={})
+    assert isinstance(config, VelocityAConfig)
+    assert config.allow_model_downgrade is True
+    assert config.max_latency_seconds == 60
+    assert config.target_compute_tier == "serverless_burst"
+
+
+@pytest.mark.asyncio
+async def test_batch_background_routing() -> None:
+    """Extra Test: Prove that BATCH_BACKGROUND correctly returns VelocityBConfig."""
+    config = await provision_compute(intent=ComputeIntent.BATCH_BACKGROUND, task_def={})
+    assert isinstance(config, VelocityBConfig)
+    assert config.preemption_safe is True
+    assert config.max_retries == -1
+    assert config.target_compute_tier == "spot_fleet"
+
+
+def test_intent_router_invalid_intent() -> None:
+    """Test router raising error on invalid intent."""
+    router = IntentRouter()
+    with pytest.raises(ValueError, match="Unknown compute intent"):
+        router.route(task_def={}, intent="INVALID_INTENT")  # type: ignore
+
+
+@pytest.mark.asyncio
+async def test_latency_sla_exceeded_error_handling() -> None:
+    """Test 2: Prove that raising a LatencySLAExceededError can be cleanly caught and handled."""
+    async def dummy_async_execution() -> None:
+        raise LatencySLAExceededError("Real-Time task took > 60s")
+
+    with pytest.raises(LatencySLAExceededError) as exc_info:
+        await dummy_async_execution()
+
+    e = exc_info.value
+    assert e.fault.error_code == "SLA-LATENCY-001"
+    assert e.fault.severity == "RECOVERABLE"
+    assert e.fault.recovery_action == "PROMPT_RETRY"
+    assert "Real-Time task took > 60s" in str(e)


### PR DESCRIPTION
Migrate assert logic within `except` block to `pytest.raises` for exceptions to fix `PT017` in CI. Removed unused import `Any` from `mcp.py` to fix F401 error.