### PR TITLE
feat(workflow): Add protocol harmonization schemas to SwarmNode

### DIFF
--- a/src/coreason_manifest/core/common/presentation.py
+++ b/src/coreason_manifest/core/common/presentation.py
@@ -98,7 +98,8 @@ class AdaptiveUIContract(CoreasonModel):
         default=None, description="Bipartite search layout for side-by-side Lexical/Semantic results."
     )
     ambient_listeners: list[AmbientListenerConfig] | None = Field(
-        default=None, description="Silent background observers that trigger out-of-band AI workflows based on user interactions."
+        default=None,
+        description="Silent background observers that trigger out-of-band AI workflows based on user interactions.",
     )
 
 

--- a/src/coreason_manifest/core/workflow/evals.py
+++ b/src/coreason_manifest/core/workflow/evals.py
@@ -81,5 +81,3 @@ class EvalsManifest(CoreasonModel, frozen=True, extra="forbid"):
 
 class TestCase(SimulationScenario):
     """Alias for SimulationScenario used in standard test runs."""
-
-    pass

--- a/src/coreason_manifest/core/workflow/nodes/swarm.py
+++ b/src/coreason_manifest/core/workflow/nodes/swarm.py
@@ -69,6 +69,29 @@ class TournamentConfig(BaseModel):
     )
 
 
+class HarmonizationStrategy(StrEnum):
+    NLI_ENTAILMENT = "nli_entailment"
+    PICO_AST_ALIGNMENT = "pico_ast_alignment"
+
+
+class HarmonizationConfig(BaseModel):
+    """Configuration for cross-document Risk of Bias (RoB 2.0) triangulation."""
+
+    model_config = ConfigDict(extra="forbid", strict=True, frozen=True)
+
+    strategy: Annotated[
+        HarmonizationStrategy, Field(description="The algorithmic approach to detecting reporting contradictions.")
+    ]
+    flag_swapped_endpoints: Annotated[
+        bool,
+        Field(description="If True, strictly checks if primary/secondary hierarchies were altered from the registry."),
+    ] = True
+    enforce_rob2_domain5: Annotated[
+        bool,
+        Field(description="If True, mathematically forces the output to include a formal Risk of Bias Domain 5 grade."),
+    ] = True
+
+
 class SwarmNode(Node):
     """Dynamic Swarm Spawning. Spins up N ephemeral worker agents to process a dataset/workload in parallel."""
 
@@ -114,6 +137,7 @@ class SwarmNode(Node):
             "tabular_join",
             "meta_analysis_matrix",
             "epistemic_deduplication",
+            "protocol_harmonization",
         ]
         | None
     ) = Field(..., description="How to combine results.", examples=["concat"])
@@ -126,6 +150,10 @@ class SwarmNode(Node):
 
     deduplication_config: DeduplicationConfig | None = Field(
         None, description="Required if reducer_function is set to 'epistemic_deduplication'."
+    )
+
+    harmonization_config: HarmonizationConfig | None = Field(
+        None, description="Required if reducer_function is set to 'protocol_harmonization'."
     )
 
     sub_swarm_count: Annotated[
@@ -178,6 +206,11 @@ class SwarmNode(Node):
         if self.reducer_function == "epistemic_deduplication" and self.deduplication_config is None:
             raise ValueError(
                 "SwarmNode with reducer_function='epistemic_deduplication' requires a 'deduplication_config'."
+            )
+
+        if self.reducer_function == "protocol_harmonization" and self.harmonization_config is None:
+            raise ValueError(
+                "SwarmNode with reducer_function='protocol_harmonization' requires a 'harmonization_config'."
             )
 
         if self.reducer_function == "tournament" and self.tournament_config is None:

--- a/src/coreason_manifest/ports/mcp.py
+++ b/src/coreason_manifest/ports/mcp.py
@@ -6,14 +6,19 @@ Epistemic Ledger, our strict Neuro-Symbolic Data Contracts, and dynamic prompts.
 """
 
 from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Literal
 from uuid import uuid4
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import Field, model_validator
 
+from coreason_manifest.core.common.base import CoreasonModel
 from coreason_manifest.core.domains.epistemic import ClinicalProposition
 from coreason_manifest.core.state.events import EpistemicAnchor, EpistemicEvent, EventType
 from coreason_manifest.core.state.ledger import EpistemicLedger
 from coreason_manifest.core.telemetry.telemetry_schemas import AgentSignature, HardwareFingerprint
+from coreason_manifest.spec.domains.scivis_provenance import ActorIdentity
 
 
 def create_mcp_server(ledger: EpistemicLedger) -> FastMCP:
@@ -90,13 +95,6 @@ def create_mcp_server(ledger: EpistemicLedger) -> FastMCP:
         )
 
     return mcp
-from enum import StrEnum
-from typing import Any, Literal
-
-from pydantic import Field, model_validator
-
-from coreason_manifest.core.common.base import CoreasonModel
-from coreason_manifest.spec.domains.scivis_provenance import ActorIdentity
 
 
 class MCPToolName(StrEnum):

--- a/src/coreason_manifest/ports/mcp.py
+++ b/src/coreason_manifest/ports/mcp.py
@@ -14,7 +14,7 @@ from mcp.server.fastmcp import FastMCP
 from pydantic import Field, model_validator
 
 from coreason_manifest.core.common.base import CoreasonModel
-from coreason_manifest.core.domains.epistemic import ClinicalProposition
+from coreason_manifest.core.compute.epistemic import ClinicalProposition
 from coreason_manifest.core.state.events import EpistemicAnchor, EpistemicEvent, EventType
 from coreason_manifest.core.state.ledger import EpistemicLedger
 from coreason_manifest.core.telemetry.telemetry_schemas import AgentSignature, HardwareFingerprint

--- a/tests/core/compute/test_velocity_routing.py
+++ b/tests/core/compute/test_velocity_routing.py
@@ -39,6 +39,7 @@ def test_intent_router_invalid_intent() -> None:
 @pytest.mark.asyncio
 async def test_latency_sla_exceeded_error_handling() -> None:
     """Test 2: Prove that raising a LatencySLAExceededError can be cleanly caught and handled."""
+
     async def dummy_async_execution() -> None:
         raise LatencySLAExceededError("Real-Time task took > 60s")
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -7,4 +7,3 @@ def test_schema_import() -> None:
     import coreason_manifest
 
     assert coreason_manifest is not None
-


### PR DESCRIPTION
Implement "Epic 7.4: Grey Literature Harmonization (Risk of Bias Swarms)"
by adding `HarmonizationStrategy` and `HarmonizationConfig` to
`swarm.py`.

Changes:
- Defined `HarmonizationStrategy` and `HarmonizationConfig` with strict
  Pydantic constraints.
- Expanded `reducer_function` literal to include
  `protocol_harmonization`.
- Added `harmonization_config` to `SwarmNode`.
- Enforced required config via `validate_reducer_requirements`.

---
*PR created automatically by Jules for task [5682170123111097871](https://jules.google.com/task/5682170123111097871) started by @gowthamrao*