### PR TITLE
Refactor FastMCP server to enforce Zero-Trust architecture

### DIFF
--- a/src/coreason_manifest/ports/mcp.py
+++ b/src/coreason_manifest/ports/mcp.py
@@ -10,8 +10,8 @@ from enum import StrEnum
 from typing import Any, Literal
 from uuid import uuid4
 
-from mcp.server.fastmcp import FastMCP
-from pydantic import Field, model_validator
+from mcp.server.fastmcp import Context, FastMCP
+from pydantic import Field, ValidationError, model_validator
 
 from coreason_manifest.core.common.base import CoreasonModel
 from coreason_manifest.core.compute.epistemic import ClinicalProposition
@@ -49,17 +49,39 @@ def create_mcp_server(ledger: EpistemicLedger) -> FastMCP:
         raise ValueError(f"Event {event_id} not found in ledger")
 
     @mcp.tool()
-    async def append_clinical_proposition(
-        proposition: ClinicalProposition, agent_sig: AgentSignature, hardware_fingerprint: HardwareFingerprint
-    ) -> str:
+    async def append_clinical_proposition(proposition: ClinicalProposition, ctx: Context[Any, Any, Any]) -> str:
         """
         Intercept a call to append a ClinicalProposition, run strict Pydantic validation natively,
         wrap it in an EpistemicEvent, and append it to the Ledger.
         """
-        if agent_sig is None:
-            raise ValueError("SecurityException: agent_sig is required for Zero-Trust validation")
-        if hardware_fingerprint is None:
-            raise ValueError("SecurityException: hardware_fingerprint is required for Zero-Trust validation")
+        if ctx.request_context is None or ctx.request_context.meta is None:
+            raise ValueError("SecurityException: Context metadata is missing.")
+
+        # The prompt instructed to use `ctx.request_context.meta.get("x-agent-signature")`,
+        # but mypy complains because meta is typed as RequestParams.Meta which doesn't have get.
+        # However, at runtime it might be a dict, or a Pydantic model with extra fields.
+        meta_obj = ctx.request_context.meta
+        if isinstance(meta_obj, dict):
+            meta_get = meta_obj.get
+        else:
+            meta_dict = getattr(meta_obj, "model_extra", None) or getattr(meta_obj, "__dict__", {})
+            meta_get = getattr(meta_obj, "get", meta_dict.get)
+
+        agent_sig_raw = meta_get("x-agent-signature")
+        if agent_sig_raw is None or not isinstance(agent_sig_raw, dict):
+            raise ValueError("SecurityException: x-agent-signature header is missing or invalid in Context metadata")
+
+        hw_fingerprint_raw = meta_get("x-hardware-fingerprint")
+        if hw_fingerprint_raw is None or not isinstance(hw_fingerprint_raw, dict):
+            raise ValueError(
+                "SecurityException: x-hardware-fingerprint header is missing or invalid in Context metadata"
+            )
+
+        try:
+            agent_sig = AgentSignature.model_validate(agent_sig_raw)
+            hardware_fingerprint = HardwareFingerprint.model_validate(hw_fingerprint_raw)
+        except ValidationError as e:
+            raise ValueError(f"SecurityException: Validation failed for Zero-Trust credentials: {e}") from e
 
         event = EpistemicEvent(
             event_id=str(uuid4()),

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,88 @@
+import pytest
+from typing import Any, cast
+from mcp.server.fastmcp import Context
+from mcp.shared.context import RequestContext
+
+from coreason_manifest.core.compute.epistemic import ClinicalProposition, ReifiedEntity, ProvenanceSpan
+from coreason_manifest.core.state.ledger import EpistemicLedger
+from coreason_manifest.ports.mcp import create_mcp_server
+
+class MockRequestContext:
+    def __init__(self, meta_kwargs: dict[str, Any]):
+        self.meta = meta_kwargs
+
+class MockContext(Context[Any, Any, Any]):
+    def __init__(self, request_context: MockRequestContext):
+        self._request_context = cast(RequestContext[Any, Any, Any], request_context)
+
+    @property
+    def request_context(self) -> RequestContext[Any, Any, Any]:
+        assert self._request_context is not None
+        return self._request_context
+
+def create_mock_proposition() -> ClinicalProposition:
+    def dummy_validator(gid: str) -> bool:
+        return True
+
+    ctx = {"ontology_validator": dummy_validator, "document_hash_validator": dummy_validator}
+
+    subject = ReifiedEntity.model_validate({"entity_string": "sub1", "global_id": "Patient"}, context=ctx)
+    obj = ReifiedEntity.model_validate({"entity_string": "obj1", "global_id": "Condition"}, context=ctx)
+    provenance = ProvenanceSpan.model_validate({"source_document_hash": "doc1", "page_number": 1, "bounding_box": (0.0, 0.0, 1.0, 1.0), "raw_text_crop": "doc1"}, context=ctx)
+
+    return ClinicalProposition.model_validate({
+        "subject": subject.model_dump(),
+        "relation": "has",
+        "object": obj.model_dump(),
+        "provenance": provenance.model_dump()
+    }, context=ctx)
+
+@pytest.mark.asyncio
+async def test_append_clinical_proposition_success() -> None:
+    ledger = EpistemicLedger()
+    mcp_server = create_mcp_server(ledger)
+
+    proposition = create_mock_proposition()
+
+    agent_sig = {
+        "model_weights_hash": "hash123",
+        "prompt_commit_hash": "commit123",
+        "temperature": 0.7,
+        "seed": 42,
+        "inference_engine": "vLLM"
+    }
+
+    hardware_fingerprint = {
+        "architecture": "Hopper",
+        "compute_precision": "fp16",
+        "vram_allocated": 16000
+    }
+
+    req_ctx = MockRequestContext({
+        "x-agent-signature": agent_sig,
+        "x-hardware-fingerprint": hardware_fingerprint
+    })
+    ctx = MockContext(request_context=req_ctx)
+
+    tool = mcp_server._tool_manager.get_tool("append_clinical_proposition")
+
+    assert tool is not None
+    result = await tool.fn(proposition=proposition, ctx=ctx)
+    assert "Successfully appended event" in result
+
+@pytest.mark.asyncio
+async def test_append_clinical_proposition_missing_headers() -> None:
+    ledger = EpistemicLedger()
+    mcp_server = create_mcp_server(ledger)
+
+    proposition = create_mock_proposition()
+
+    req_ctx = MockRequestContext({})
+    ctx = MockContext(request_context=req_ctx)
+
+    tool = mcp_server._tool_manager.get_tool("append_clinical_proposition")
+
+    assert tool is not None
+
+    with pytest.raises(ValueError, match="x-agent-signature header is missing or invalid"):
+        await tool.fn(proposition=proposition, ctx=ctx)


### PR DESCRIPTION
Refactored `append_clinical_proposition` in `src/coreason_manifest/ports/mcp.py` to remove security credentials from the LLM-facing tool schema. Instead, these credentials (`x-agent-signature` and `x-hardware-fingerprint`) are now securely extracted from the transport/session context via FastMCP `Context`.

Also created a new test file `tests/test_mcp.py` to test this refactored behavior directly by mocking the FastMCP context metadata, ensuring appropriate exceptions are raised if validation fails. All static type checks and tests pass successfully.

---
*PR created automatically by Jules for task [8674454273610682251](https://jules.google.com/task/8674454273610682251) started by @gowthamrao*