### PR TITLE
fix: restrict JSON patch state mutations strictly to protected namespaces

### DIFF
--- a/src/coreason_manifest/core/state/persistence.py
+++ b/src/coreason_manifest/core/state/persistence.py
@@ -24,13 +24,18 @@ class JSONPatchOperation(CoreasonModel):
     path: Annotated[str, Field(description="A JSON Pointer path pointing to the target location.")]
     value: Annotated[Any | None, Field(default=None, description="The value to add, replace, or test.")]
 
-    @field_validator("path", mode="after")
+    @field_validator("path", "from_", mode="after")
     @classmethod
-    def validate_restricted_paths(cls, v: str) -> str:
+    def validate_restricted_paths(cls, v: str | None) -> str | None:
         """Reject paths that start with restricted namespaces."""
+        if v is None:
+            return v
         restricted_namespaces = ("/system", "/_internal", "/auth", "/governance")
-        if v.startswith(restricted_namespaces):
-            raise ValueError(f"Security Violation: Mutation of restricted namespace '{v}' is forbidden.")
+        for namespace in restricted_namespaces:
+            if v == namespace or v.startswith(f"{namespace}/"):
+                raise ValueError(
+                    f"Security Violation: Access or mutation of restricted namespace '{namespace}' is forbidden."
+                )
         return v
 
     from_: Annotated[

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,11 +1,13 @@
-import pytest
 from typing import Any, cast
+
+import pytest
 from mcp.server.fastmcp import Context
 from mcp.shared.context import RequestContext
 
-from coreason_manifest.core.compute.epistemic import ClinicalProposition, ReifiedEntity, ProvenanceSpan
+from coreason_manifest.core.compute.epistemic import ClinicalProposition, ProvenanceSpan, ReifiedEntity
 from coreason_manifest.core.state.ledger import EpistemicLedger
 from coreason_manifest.ports.mcp import create_mcp_server
+
 
 class MockRequestContext:
     def __init__(self, meta_kwargs: dict[str, Any]):
@@ -13,7 +15,7 @@ class MockRequestContext:
 
 class MockContext(Context[Any, Any, Any]):
     def __init__(self, request_context: MockRequestContext):
-        self._request_context = cast(RequestContext[Any, Any, Any], request_context)
+        self._request_context = cast("RequestContext[Any, Any, Any]", request_context)
 
     @property
     def request_context(self) -> RequestContext[Any, Any, Any]:

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,29 @@
+import pytest
+from coreason_manifest.core.state.persistence import JSONPatchOperation, PatchOp
+
+
+def test_validate_restricted_paths_valid():
+    op = JSONPatchOperation(op=PatchOp.ADD, path="/valid/path", value="test")
+    assert op.path == "/valid/path"
+
+def test_validate_restricted_paths_invalid_exact():
+    with pytest.raises(ValueError, match="Security Violation: Access or mutation of restricted namespace '/system' is forbidden."):
+        JSONPatchOperation(op=PatchOp.ADD, path="/system", value="test")
+
+def test_validate_restricted_paths_invalid_subpath():
+    with pytest.raises(ValueError, match="Security Violation: Access or mutation of restricted namespace '/auth' is forbidden."):
+        JSONPatchOperation(op=PatchOp.ADD, path="/auth/token", value="test")
+
+def test_validate_restricted_paths_from_valid():
+    op = JSONPatchOperation(op=PatchOp.COPY, path="/valid/path", from_="/valid/source")
+    assert op.path == "/valid/path"
+    assert op.from_ == "/valid/source"
+
+def test_validate_restricted_paths_from_invalid():
+    with pytest.raises(ValueError, match="Security Violation: Access or mutation of restricted namespace '/_internal' is forbidden."):
+        JSONPatchOperation(op=PatchOp.COPY, path="/valid/path", from_="/_internal/data")
+
+def test_validate_restricted_paths_prefix_false_positive():
+    # Should not raise ValueError because it's not exactly /system and not a subpath
+    op = JSONPatchOperation(op=PatchOp.ADD, path="/systematic_review", value="test")
+    assert op.path == "/systematic_review"


### PR DESCRIPTION
Refactored the `JSONPatchOperation.validate_restricted_paths` validator to correctly restrict operations on exact matches and subpaths of restricted namespaces, eliminating false positives for paths starting with similar prefixes (e.g., `/systematic_review`). Additionally applied the validator to the `from_` field to prevent restricted data exfiltration. Tests have been added to verify these changes.

---
*PR created automatically by Jules for task [4842571864268350108](https://jules.google.com/task/4842571864268350108) started by @gowthamrao*