### PR TITLE
Refactor Epic 2: Telemetry Hardening in multiplexer (#794)

### DIFF
--- a/src/coreason_manifest/core/telemetry/multiplexer.py
+++ b/src/coreason_manifest/core/telemetry/multiplexer.py
@@ -1,6 +1,7 @@
 import asyncio
-import logging
 from collections.abc import AsyncGenerator, Awaitable, Callable
+
+from loguru import logger
 
 from coreason_manifest.core.telemetry.custody import EpistemicEnvelope
 from coreason_manifest.core.telemetry.stream import (
@@ -10,7 +11,7 @@ from coreason_manifest.core.telemetry.stream import (
     StreamUIEnvelope,
 )
 
-logger = logging.getLogger(__name__)
+logger.disable("coreason_manifest")
 
 
 class AsyncSSEMultiplexer:
@@ -40,13 +41,15 @@ class AsyncSSEMultiplexer:
                 try:
                     await observer(packet)
                 except Exception as e:
-                    logger.error(f"UI Observer {getattr(observer, '__name__', str(observer))} failed: {e}")
+                    logger.error(
+                        "ui_observer_failed", observer=getattr(observer, "__name__", str(observer)), error=str(e)
+                    )
 
         queue = await self._get_queue()
         try:
             await asyncio.wait_for(queue.put(packet), timeout=1.0)
         except TimeoutError:
-            logger.warning("Telemetry queue full. Dropped stream packet to prevent LLM stalling.")
+            logger.warning("telemetry_queue_full", action="dropped_stream_packet", reason="prevent_llm_stalling")
 
     async def broadcast_envelope(self, envelope: EpistemicEnvelope) -> None:
         """
@@ -70,7 +73,21 @@ class AsyncSSEMultiplexer:
         before a spot-instance shutdown.
         """
         if self._background_tasks:
-            await asyncio.gather(*self._background_tasks, return_exceptions=True)
+            results = await asyncio.gather(*self._background_tasks, return_exceptions=True)
+            exceptions = [r for r in results if isinstance(r, Exception)]
+
+            if exceptions:
+                eg = ExceptionGroup("Telemetry flush failures", exceptions)
+                try:
+                    raise eg
+                except* asyncio.CancelledError:
+                    pass
+                except* (TimeoutError, ConnectionError) as eg_network:
+                    for e_net in eg_network.exceptions:
+                        logger.error("flush_network_error", error=str(e_net))
+                except* Exception as eg_generic:
+                    for e_gen in eg_generic.exceptions:
+                        logger.error("flush_generic_error", error=str(e_gen))
 
     async def stream_sse(self) -> AsyncGenerator[str, None]:
         """

--- a/src/coreason_manifest/core/telemetry/simulation.py
+++ b/src/coreason_manifest/core/telemetry/simulation.py
@@ -48,7 +48,9 @@ class SimulationStep(CoreasonModel, frozen=True, extra="forbid"):
     traceparent: str = Field(..., description="W3C traceparent string.")
     tracestate: str = Field(..., description="W3C tracestate string.")
     state_mutations: list[JSONPatchOperation] = Field(default_factory=list, description="RFC 6902 state mutations.")
-    execution_hash: str = Field(..., description="Cryptographic lineage hash to prevent post-execution tampering or metric manipulation.")
+    execution_hash: str = Field(
+        ..., description="Cryptographic lineage hash to prevent post-execution tampering or metric manipulation."
+    )
     thought: str | dict[str, Any] | None = Field(default=None, description="Multimodal thought payload.")
 
 

--- a/src/coreason_manifest/core/workflow/nodes/__init__.py
+++ b/src/coreason_manifest/core/workflow/nodes/__init__.py
@@ -1,6 +1,7 @@
 # Prosperity-3.0
 from typing import Annotated
 
+import pydantic
 from pydantic import Field
 
 from .agent import AgentNode, CognitiveProfile
@@ -13,8 +14,6 @@ from .routing import SwitchNode
 from .swarm import SwarmNode
 from .system import PlaceholderNode
 from .visual_oversight import MultimodalConstraint, VisualInspectorNode
-
-import pydantic
 
 AnyNode = Annotated[
     AgentNode

--- a/src/coreason_manifest/core/workflow/nodes/oversight.py
+++ b/src/coreason_manifest/core/workflow/nodes/oversight.py
@@ -1,7 +1,7 @@
 # Prosperity-3.0
 from typing import Annotated, Any, Literal
 
-from pydantic import AliasChoices, Field, model_validator
+from pydantic import Field, model_validator
 
 from coreason_manifest.core.compute.reasoning import ModelRef, Optimizer
 from coreason_manifest.core.primitives.types import VariableID


### PR DESCRIPTION
* refactor: telemetry hardening and multiplexer exception handling (Epic 2)

- Removed active standard library logging from telemetry `multiplexer.py`.
- Replaced with loguru structured logging (`logger.error("key", ...)`).
- Disabled `coreason_manifest` logger at the module level to enforce the "Passive by Design" and library constraints.
- Refactored `asyncio.gather` error handling in the `flush()` method.
- Implemented Python 3.11+ `ExceptionGroup` and `try...except*` routing to distinctly handle network/timeout exceptions, ignored teardown cancellations (`asyncio.CancelledError`), and generic exceptions.
- Passed `ruff` formatting, linting fixes, and strict `mypy` type checking.