### PR TITLE
fix: Use Pydantic by_alias in JSON Patch structural pattern matching

### DIFF
--- a/src/coreason_manifest/core/state/state_rewind.py
+++ b/src/coreason_manifest/core/state/state_rewind.py
@@ -63,7 +63,7 @@ def generate_inverse_patches(
     inverses: list[JSONPatchOperation] = []
 
     for patch in patches:
-        match patch.model_dump(exclude_unset=True):
+        match patch.model_dump(exclude_unset=True, by_alias=True):
             case {"op": "test"}:
                 continue
             case {"op": "add", "path": path, "value": val}:
@@ -173,7 +173,7 @@ def apply_rewind(current_state: dict[str, Any], reverse_patches: list[JSONPatchO
     """
     state: dict[str, Any] | list[Any] = current_state
     for patch in reverse_patches:
-        match patch.model_dump(exclude_unset=True):
+        match patch.model_dump(exclude_unset=True, by_alias=True):
             case {"op": "test"}:
                 continue
             case {"op": "add", "path": path, "value": val}:


### PR DESCRIPTION
Fix JSON Patch `move` and `copy` state-rewind operations when performing structural pattern matching with Pydantic V2 models.

---
*PR created automatically by Jules for task [8333101626913225855](https://jules.google.com/task/8333101626913225855) started by @gowthamrao*