### PR TITLE
Refactor: Resolve technical debt, legacy shim, and professionalize comments

### DIFF
--- a/src/coreason_manifest/core/presentation/visualizer.py
+++ b/src/coreason_manifest/core/presentation/visualizer.py
@@ -225,7 +225,7 @@ def _compute_layout(nodes: Sequence[AnyNode], edges: list[tuple[str, str, str | 
     if not queue and nodes:
         first_node = next(iter(nodes)).id
         queue.append(first_node)
-        in_degree[first_node] = 0  # Force it
+        in_degree[first_node] = 0  # Explicitly reset in_degree to 0 to artificially break the cycle.
 
     for n_id in queue:
         ranks[n_id] = 0

--- a/src/coreason_manifest/core/state/ledger.py
+++ b/src/coreason_manifest/core/state/ledger.py
@@ -22,12 +22,6 @@ class EpistemicLedger:
         if event.event_id not in self._events:
             self._events[event.event_id] = event
 
-    async def aappend(self, event: EpistemicEvent) -> None:
-        """
-        Asynchronous out-of-order event appending.
-        """
-        self.append(event)
-
     def get_event_by_id(self, event_id: str) -> EpistemicEvent | None:
         """
         Returns a specific event by its ID in O(1) time.

--- a/src/coreason_manifest/core/telemetry/request.py
+++ b/src/coreason_manifest/core/telemetry/request.py
@@ -42,9 +42,8 @@ class AgentRequest(BaseModel):
     manifest: GraphFlow | LinearFlow = Field(..., description="The AOT-compiled execution graph.")
 
     # V2 Standard: The Zero-Trust Identity Envelope.
-    # Strictly bound to IdentityPassport post-merge.
-    passport: IdentityPassport | None = Field(
-        None, description="The cryptographic Zero-Trust Identity Passport for this request."
+    passport: IdentityPassport = Field(
+        ..., description="The cryptographic Zero-Trust Identity Passport for this request."
     )
 
     @model_validator(mode="before")

--- a/src/coreason_manifest/ports/mcp.py
+++ b/src/coreason_manifest/ports/mcp.py
@@ -91,7 +91,7 @@ def create_mcp_server(ledger: EpistemicLedger) -> FastMCP:
             payload=proposition.model_dump(mode="json"),
             epistemic_anchor=EpistemicAnchor(),
         )
-        await ledger.aappend(event)
+        ledger.append(event)
         return f"Successfully appended event {event.event_id}"
 
     @mcp.prompt("auditor_recovery_prompt")

--- a/src/coreason_manifest/utils/logger.py
+++ b/src/coreason_manifest/utils/logger.py
@@ -1,6 +1,6 @@
 from loguru import logger
 
-# THE SUPREME LAW (AGENTS.md): Disable the logger by default so the library is 100% passive.
+# Architectural Constraint (per AGENTS.md): Disable the logger by default to ensure the library remains strictly passive.
 # Only the consuming Builder/Engine application will attach sinks and enable it.
 logger.disable("coreason_manifest")
 


### PR DESCRIPTION
This commit implements the required technical debt resolutions across the `coreason-manifest` package:

1. **Strict Typing (`request.py`)**: The `passport` field is now strictly typed to `IdentityPassport` and the associated developer comment is removed.
2. **Legacy Shim Removal (`ledger.py`, `mcp.py`)**: The `aappend` method is completely removed from `EpistemicLedger`. The caller in `mcp.py` is successfully updated to use the standard synchronous `append` method, with the `await` keyword cleanly removed.
3. **Professionalize Comments (`logger.py`, `visualizer.py`)**: Replaced the melodramatic "THE SUPREME LAW" comment with a professional architectural constraint description. Similarly, updated the informal "# Force it" annotation to a descriptive summary of the state mutation.

All tests have been run and verified to pass successfully.

---
*PR created automatically by Jules for task [5306041879355540418](https://jules.google.com/task/5306041879355540418) started by @gowthamrao*