### PR TITLE
feat(security): add deep reconciliation guards for epic 7

### DIFF
--- a/src/coreason_manifest/core/security/gatekeeper.py
+++ b/src/coreason_manifest/core/security/gatekeeper.py
@@ -1032,7 +1032,10 @@ def _check_visual_extraction_inspector_guard(flow) -> list:
             for next_node_id in outgoing_edges.get(node.id, []):
                 target = node_map.get(next_node_id)
                 # Avoid circular imports by checking type name
-                if type(target).__name__ == "VisualInspectorNode" and getattr(target, "spatial_validation", None) is not None:
+                if (
+                    type(target).__name__ == "VisualInspectorNode"
+                    and getattr(target, "spatial_validation", None) is not None
+                ):
                     is_guarded = True
                     break
 

--- a/src/coreason_manifest/core/security/gatekeeper.py
+++ b/src/coreason_manifest/core/security/gatekeeper.py
@@ -933,8 +933,8 @@ def _check_prisma_ledger_mandate(flow) -> list:
 
     for node in nodes:
         if type(node).__name__ == "SwarmNode" and (
-            getattr(node, "cal_config", None) is not None or
-            getattr(node, "reducer_function", None) == "epistemic_deduplication"
+            getattr(node, "cal_config", None) is not None
+            or getattr(node, "reducer_function", None) == "epistemic_deduplication"
         ):
             has_ledger = False
             if flow.definitions and getattr(node, "worker_profile", None) in flow.definitions.profiles:

--- a/src/coreason_manifest/core/security/gatekeeper.py
+++ b/src/coreason_manifest/core/security/gatekeeper.py
@@ -923,16 +923,16 @@ def _check_cal_deduplication_guard(flow: LinearFlow | GraphFlow) -> list[Complia
     return reports
 
 
-def _check_prisma_ledger_mandate(flow) -> list:
+def _check_prisma_ledger_mandate(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
     """Epic 7 Cohesion: Document-dropping swarms MUST have a PRISMA Attrition Ledger."""
     from coreason_manifest.core.security.compliance import ComplianceReport, RemediationAction
     from coreason_manifest.workflow.topology import get_unified_topology
 
-    reports = []
+    reports: list[ComplianceReport] = []
     nodes, _ = get_unified_topology(flow)
 
     for node in nodes:
-        if type(node).__name__ == "SwarmNode" and (
+        if isinstance(node, SwarmNode) and (
             getattr(node, "cal_config", None) is not None
             or getattr(node, "reducer_function", None) == "epistemic_deduplication"
         ):
@@ -946,7 +946,7 @@ def _check_prisma_ledger_mandate(flow) -> list:
             if not has_ledger:
                 reports.append(
                     ComplianceReport(
-                        code="ERR_PRISMA_LEDGER_MISSING_011",
+                        code=cast("ErrorCatalog", "ERR_PRISMA_LEDGER_MISSING_011"),
                         severity="violation",
                         message=(
                             f"SwarmNode '{node.id}' performs document exclusion (CAL or Deduplication) "
@@ -964,16 +964,16 @@ def _check_prisma_ledger_mandate(flow) -> list:
     return reports
 
 
-def _check_harmonization_vision_guard(flow) -> list:
+def _check_harmonization_vision_guard(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
     """Epic 7 Cohesion: Harmonization Swarms MUST use Multimodal Vision RAG."""
     from coreason_manifest.core.security.compliance import ComplianceReport, RemediationAction
     from coreason_manifest.workflow.topology import get_unified_topology
 
-    reports = []
+    reports: list[ComplianceReport] = []
     nodes, _ = get_unified_topology(flow)
 
     for node in nodes:
-        if type(node).__name__ == "SwarmNode" and getattr(node, "reducer_function", None) == "protocol_harmonization":
+        if isinstance(node, SwarmNode) and getattr(node, "reducer_function", None) == "protocol_harmonization":
             is_vision = False
             if flow.definitions and getattr(node, "worker_profile", None) in flow.definitions.profiles:
                 profile = flow.definitions.profiles[node.worker_profile]
@@ -984,7 +984,7 @@ def _check_harmonization_vision_guard(flow) -> list:
             if not is_vision:
                 reports.append(
                     ComplianceReport(
-                        code="ERR_HARMONIZATION_REQUIRES_VISION_012",
+                        code=cast("ErrorCatalog", "ERR_HARMONIZATION_REQUIRES_VISION_012"),
                         severity="violation",
                         message=(
                             f"SwarmNode '{node.id}' performs protocol_harmonization but its worker_profile "
@@ -1002,12 +1002,12 @@ def _check_harmonization_vision_guard(flow) -> list:
     return reports
 
 
-def _check_visual_extraction_inspector_guard(flow) -> list:
+def _check_visual_extraction_inspector_guard(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
     """Epic 7 Cohesion: Visual Extraction MUST be topologically verified by a Spatial Inspector."""
     from coreason_manifest.core.security.compliance import ComplianceReport, RemediationAction
     from coreason_manifest.workflow.topology import get_unified_topology
 
-    reports = []
+    reports: list[ComplianceReport] = []
     if type(flow).__name__ != "GraphFlow":
         return reports
 
@@ -1042,7 +1042,7 @@ def _check_visual_extraction_inspector_guard(flow) -> list:
             if not is_guarded:
                 reports.append(
                     ComplianceReport(
-                        code="ERR_VISUAL_EXTRACTION_UNGUARDED_013",
+                        code=cast("ErrorCatalog", "ERR_VISUAL_EXTRACTION_UNGUARDED_013"),
                         severity="violation",
                         message=(
                             f"Node '{node.id}' uses VisualExtractionReasoning but its output is not "
@@ -1050,7 +1050,7 @@ def _check_visual_extraction_inspector_guard(flow) -> list:
                         ),
                         node_id=node.id,
                         remediation=RemediationAction(
-                            type="add_inspector_guard",
+                            type="add_guard_node",
                             target_node_id=node.id,
                             patch_data=[],
                             description="Route this node's output to a VisualInspectorNode verifying bounding boxes.",

--- a/src/coreason_manifest/core/security/gatekeeper.py
+++ b/src/coreason_manifest/core/security/gatekeeper.py
@@ -923,6 +923,140 @@ def _check_cal_deduplication_guard(flow: LinearFlow | GraphFlow) -> list[Complia
     return reports
 
 
+def _check_prisma_ledger_mandate(flow) -> list:
+    """Epic 7 Cohesion: Document-dropping swarms MUST have a PRISMA Attrition Ledger."""
+    from coreason_manifest.core.security.compliance import ComplianceReport, RemediationAction
+    from coreason_manifest.workflow.topology import get_unified_topology
+
+    reports = []
+    nodes, _ = get_unified_topology(flow)
+
+    for node in nodes:
+        if type(node).__name__ == "SwarmNode" and (
+            getattr(node, "cal_config", None) is not None or
+            getattr(node, "reducer_function", None) == "epistemic_deduplication"
+        ):
+            has_ledger = False
+            if flow.definitions and getattr(node, "worker_profile", None) in flow.definitions.profiles:
+                profile = flow.definitions.profiles[node.worker_profile]
+                memory = getattr(profile, "memory", None)
+                if memory and getattr(memory, "prisma_ledger", None) is not None:
+                    has_ledger = True
+
+            if not has_ledger:
+                reports.append(
+                    ComplianceReport(
+                        code="ERR_PRISMA_LEDGER_MISSING_011",
+                        severity="violation",
+                        message=(
+                            f"SwarmNode '{node.id}' performs document exclusion (CAL or Deduplication) "
+                            "but its worker_profile lacks a 'prisma_ledger'. PRISMA compliance is broken."
+                        ),
+                        node_id=node.id,
+                        remediation=RemediationAction(
+                            type="update_field",
+                            target_node_id=node.id,
+                            patch_data=[],
+                            description="Initialize a PRISMAAttritionLedger in the worker profile's MemorySubsystem.",
+                        ),
+                    )
+                )
+    return reports
+
+
+def _check_harmonization_vision_guard(flow) -> list:
+    """Epic 7 Cohesion: Harmonization Swarms MUST use Multimodal Vision RAG."""
+    from coreason_manifest.core.security.compliance import ComplianceReport, RemediationAction
+    from coreason_manifest.workflow.topology import get_unified_topology
+
+    reports = []
+    nodes, _ = get_unified_topology(flow)
+
+    for node in nodes:
+        if type(node).__name__ == "SwarmNode" and getattr(node, "reducer_function", None) == "protocol_harmonization":
+            is_vision = False
+            if flow.definitions and getattr(node, "worker_profile", None) in flow.definitions.profiles:
+                profile = flow.definitions.profiles[node.worker_profile]
+                reasoning = getattr(profile, "reasoning", None)
+                if getattr(reasoning, "type", "") == "visual_extraction":
+                    is_vision = True
+
+            if not is_vision:
+                reports.append(
+                    ComplianceReport(
+                        code="ERR_HARMONIZATION_REQUIRES_VISION_012",
+                        severity="violation",
+                        message=(
+                            f"SwarmNode '{node.id}' performs protocol_harmonization but its worker_profile "
+                            "does not use VisualExtractionReasoning. Text-chunking destroys trial table structures."
+                        ),
+                        node_id=node.id,
+                        remediation=RemediationAction(
+                            type="update_field",
+                            target_node_id=node.id,
+                            patch_data=[],
+                            description="Change the worker_profile's reasoning to VisualExtractionReasoning.",
+                        ),
+                    )
+                )
+    return reports
+
+
+def _check_visual_extraction_inspector_guard(flow) -> list:
+    """Epic 7 Cohesion: Visual Extraction MUST be topologically verified by a Spatial Inspector."""
+    from coreason_manifest.core.security.compliance import ComplianceReport, RemediationAction
+    from coreason_manifest.workflow.topology import get_unified_topology
+
+    reports = []
+    if type(flow).__name__ != "GraphFlow":
+        return reports
+
+    nodes, edges = get_unified_topology(flow)
+    node_map = {n.id: n for n in nodes}
+
+    outgoing_edges: dict[str, list[str]] = {n.id: [] for n in nodes}
+    for edge in edges:
+        outgoing_edges[edge.from_node].append(edge.to_node)
+
+    for node in nodes:
+        is_visual_extraction = False
+        if type(node).__name__ in ("AgentNode", "SwarmNode"):
+            profile_ref = getattr(node, "profile", None) or getattr(node, "worker_profile", None)
+            if isinstance(profile_ref, str) and flow.definitions and profile_ref in flow.definitions.profiles:
+                reasoning = flow.definitions.profiles[profile_ref].reasoning
+                if getattr(reasoning, "type", "") == "visual_extraction":
+                    is_visual_extraction = True
+
+        if is_visual_extraction:
+            is_guarded = False
+            for next_node_id in outgoing_edges.get(node.id, []):
+                target = node_map.get(next_node_id)
+                # Avoid circular imports by checking type name
+                if type(target).__name__ == "VisualInspectorNode" and getattr(target, "spatial_validation", None) is not None:
+                    is_guarded = True
+                    break
+
+            if not is_guarded:
+                reports.append(
+                    ComplianceReport(
+                        code="ERR_VISUAL_EXTRACTION_UNGUARDED_013",
+                        severity="violation",
+                        message=(
+                            f"Node '{node.id}' uses VisualExtractionReasoning but its output is not "
+                            "topologically guarded by a VisualInspectorNode with spatial_validation enabled."
+                        ),
+                        node_id=node.id,
+                        remediation=RemediationAction(
+                            type="add_inspector_guard",
+                            target_node_id=node.id,
+                            patch_data=[],
+                            description="Route this node's output to a VisualInspectorNode verifying bounding boxes.",
+                        ),
+                    )
+                )
+    return reports
+
+
 def validate_policy(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
     """Execute overarching structural verification encompassing critical authorization and orchestration parameters.
 
@@ -991,6 +1125,11 @@ def validate_policy(flow: LinearFlow | GraphFlow) -> list[ComplianceReport]:
 
     # 13. Zero-Trust GenUI Fencing
     reports.extend(_check_genui_rbac(flow))
+
+    # Epic 7: SOTA Regulatory Extraction & Provenance Hooks
+    reports.extend(_check_prisma_ledger_mandate(flow))
+    reports.extend(_check_harmonization_vision_guard(flow))
+    reports.extend(_check_visual_extraction_inspector_guard(flow))
 
     return reports
 


### PR DESCRIPTION
Added new cross-domain topological invariants to Gatekeeper:
- _check_prisma_ledger_mandate: Ensures document-dropping swarms have PRISMA ledgers.
- _check_harmonization_vision_guard: Enforces visual reasoning for harmonization swarms.
- _check_visual_extraction_inspector_guard: Topologically verifies visual extraction.
Hooked these into the master `validate_policy` runner.

---
*PR created automatically by Jules for task [7846925543008214324](https://jules.google.com/task/7846925543008214324) started by @gowthamrao*