### PR TITLE
feat: Agentic Bounded DCGs & Visualization

### DIFF
--- a/src/coreason_manifest/workflow/flow.py
+++ b/src/coreason_manifest/workflow/flow.py
@@ -106,6 +106,7 @@ class Edge(CoreasonModel):
     condition: str | None = None
     cost_weight: float = Field(0.0, ge=0.0, description="Estimated financial cost (USD) to traverse this edge.")
     latency_weight_ms: float = Field(0.0, ge=0.0, description="Estimated latency in milliseconds.")
+    is_feedback: bool = Field(default=False, description="Marks an edge as a backward loop for UI visualization and circuit-breaker routing.")
 
     @field_validator("condition", mode="before")
     @classmethod
@@ -138,6 +139,7 @@ class Graph(CoreasonModel):
     nodes: dict[str, AnyNode]
     edges: list[Edge]
     entry_point: NodeID | None = None
+    allow_cycles: bool = Field(default=False, description="If true, bypasses strict DAG validation to allow agentic feedback loops.")
 
     @model_validator(mode="after")
     def validate_graph_structure(self) -> "Graph":
@@ -234,7 +236,7 @@ class Graph(CoreasonModel):
                 if in_degree[neighbor] == 0:
                     queue.append(neighbor)
 
-        if processed_nodes != len(valid_ids):
+        if processed_nodes != len(valid_ids) and not self.allow_cycles:
             raise ManifestError.critical_halt(
                 code=ManifestErrorCode.VAL_TOPOLOGY_CYCLE,
                 message="Execution graphs must be strict Directed Acyclic Graphs (DAGs). Cycle detected.",
@@ -282,7 +284,17 @@ class GraphFlow(CoreasonModel):
     blackboard: Blackboard | None = Field(default_factory=Blackboard)
     definitions: FlowDefinitions | None = None
     graph: Graph
+    max_iterations: int | None = Field(default=None, description="Circuit breaker for cyclic graphs to prevent infinite token burn.")
     evals: EvalsManifest | None = Field(None, description="Embedded executable specifications and test scenarios.")
+
+    @model_validator(mode="after")
+    def enforce_circuit_breaker(self) -> "GraphFlow":
+        """Enforce that cyclic graphs have a strictly positive max_iterations circuit breaker."""
+        if self.graph.allow_cycles and (self.max_iterations is None or self.max_iterations < 1):
+            raise ValueError(
+                "A GraphFlow with 'allow_cycles=True' must define a valid 'max_iterations' circuit breaker."
+            )
+        return self
 
     @model_validator(mode="after")
     def validate_middleware_integrity(self) -> "GraphFlow":

--- a/src/coreason_manifest/workflow/flow.py
+++ b/src/coreason_manifest/workflow/flow.py
@@ -106,7 +106,10 @@ class Edge(CoreasonModel):
     condition: str | None = None
     cost_weight: float = Field(0.0, ge=0.0, description="Estimated financial cost (USD) to traverse this edge.")
     latency_weight_ms: float = Field(0.0, ge=0.0, description="Estimated latency in milliseconds.")
-    is_feedback: bool = Field(default=False, description="Marks an edge as a backward loop for UI visualization and circuit-breaker routing.")
+    is_feedback: bool = Field(
+        default=False,
+        description="Marks an edge as a backward loop for UI visualization and circuit-breaker routing.",
+    )
 
     @field_validator("condition", mode="before")
     @classmethod
@@ -139,7 +142,9 @@ class Graph(CoreasonModel):
     nodes: dict[str, AnyNode]
     edges: list[Edge]
     entry_point: NodeID | None = None
-    allow_cycles: bool = Field(default=False, description="If true, bypasses strict DAG validation to allow agentic feedback loops.")
+    allow_cycles: bool = Field(
+        default=False, description="If true, bypasses strict DAG validation to allow agentic feedback loops."
+    )
 
     @model_validator(mode="after")
     def validate_graph_structure(self) -> "Graph":
@@ -284,7 +289,9 @@ class GraphFlow(CoreasonModel):
     blackboard: Blackboard | None = Field(default_factory=Blackboard)
     definitions: FlowDefinitions | None = None
     graph: Graph
-    max_iterations: int | None = Field(default=None, description="Circuit breaker for cyclic graphs to prevent infinite token burn.")
+    max_iterations: int | None = Field(
+        default=None, description="Circuit breaker for cyclic graphs to prevent infinite token burn."
+    )
     evals: EvalsManifest | None = Field(None, description="Embedded executable specifications and test scenarios.")
 
     @model_validator(mode="after")

--- a/tests/core/workflow/test_flow.py
+++ b/tests/core/workflow/test_flow.py
@@ -1,0 +1,97 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.core.common.exceptions import ManifestError, ManifestErrorCode
+from coreason_manifest.workflow.flow import Edge, FlowInterface, FlowMetadata, Graph, GraphFlow
+from coreason_manifest.workflow.nodes.system import PlaceholderNode
+
+
+def create_mock_agent_node(node_id: str) -> PlaceholderNode:
+    return PlaceholderNode(id=node_id, required_capabilities=["dummy_cap"])
+
+
+def test_edge_is_feedback_retained() -> None:
+    """Test 4: Visualization Metadata"""
+    edge = Edge(from_node="A", to_node="B", is_feedback=True)
+    assert edge.is_feedback is True
+
+    edge_default = Edge(from_node="A", to_node="B")
+    assert edge_default.is_feedback is False
+
+
+def test_default_dag_enforced() -> None:
+    """Test 1: Default DAG Enforced"""
+    node_a = create_mock_agent_node("A")
+    node_b = create_mock_agent_node("B")
+
+    # Creating a cycle: A -> B -> A
+    edges = [
+        Edge(from_node="A", to_node="B"),
+        Edge(from_node="B", to_node="A", is_feedback=True),
+    ]
+
+    with pytest.raises(ManifestError) as exc_info:
+        Graph(nodes={"A": node_a, "B": node_b}, edges=edges, allow_cycles=False)
+
+    assert exc_info.value.fault.error_code == ManifestErrorCode.VAL_TOPOLOGY_CYCLE
+
+
+def test_unsafe_dcg_blocked() -> None:
+    """Test 2: Unsafe DCG Blocked"""
+    node_a = create_mock_agent_node("A")
+    node_b = create_mock_agent_node("B")
+
+    # Cycle allowed at graph level
+    graph = Graph(
+        nodes={"A": node_a, "B": node_b},
+        edges=[
+            Edge(from_node="A", to_node="B"),
+            Edge(from_node="B", to_node="A", is_feedback=True),
+        ],
+        allow_cycles=True,
+    )
+
+    metadata = FlowMetadata(name="Test Flow", version="1.0.0")
+
+    # Missing max_iterations
+    with pytest.raises(ValidationError) as exc_info:
+        GraphFlow(metadata=metadata, interface=FlowInterface(), graph=graph)
+
+    assert "A GraphFlow with 'allow_cycles=True' must define a valid 'max_iterations' circuit breaker." in str(
+        exc_info.value
+    )
+
+    # max_iterations = 0
+    with pytest.raises(ValidationError) as exc_info_zero:
+        GraphFlow(metadata=metadata, interface=FlowInterface(), graph=graph, max_iterations=0)
+
+    assert "A GraphFlow with 'allow_cycles=True' must define a valid 'max_iterations' circuit breaker." in str(
+        exc_info_zero.value
+    )
+
+
+def test_bounded_dcg_allowed() -> None:
+    """Test 3: Bounded DCG Allowed"""
+    node_a = create_mock_agent_node("A")
+    node_b = create_mock_agent_node("B")
+
+    graph = Graph(
+        nodes={"A": node_a, "B": node_b},
+        edges=[
+            Edge(from_node="A", to_node="B"),
+            Edge(from_node="B", to_node="A", is_feedback=True),
+        ],
+        allow_cycles=True,
+    )
+
+    metadata = FlowMetadata(name="Test Flow", version="1.0.0")
+
+    flow = GraphFlow(
+        metadata=metadata,
+        interface=FlowInterface(),
+        graph=graph,
+        max_iterations=5,
+    )
+
+    assert flow.max_iterations == 5
+    assert flow.graph.allow_cycles is True


### PR DESCRIPTION
Implements Epic 11: Agentic Bounded DCGs & Visualization by augmenting the Coreason Manifest Shared Kernel data schemas to support Bounded Directed Cyclic Graphs (DCGs). It allows graph topologies with explicit back-edges (`is_feedback=True`) and introduces a strict `max_iterations` circuit breaker to ensure loops are always bounded, preventing infinite execution token burn while maintaining zero runtime side-effects.

---
*PR created automatically by Jules for task [5928021536003468784](https://jules.google.com/task/5928021536003468784) started by @gowthamrao*