### PR TITLE
feat: Implement Zero-Trust Wasm/WASI Sandboxing data models

### DIFF
--- a/src/coreason_manifest/adapters/mcp/server.py
+++ b/src/coreason_manifest/adapters/mcp/server.py
@@ -79,6 +79,8 @@ def create_mcp_server(ledger: EpistemicLedger) -> FastMCP:
         except ValidationError as e:
             raise ValueError(f"SecurityException: Validation failed for Zero-Trust credentials: {e}") from e
 
+        from coreason_manifest.state.events import LegacyPayload
+
         event = EpistemicEvent(
             event_id=str(uuid4()),
             timestamp=datetime.now(UTC),
@@ -88,7 +90,7 @@ def create_mcp_server(ledger: EpistemicLedger) -> FastMCP:
                 "prompt_version": "1.0",
             },
             event_type=EventType.SEMANTIC_EXTRACTED,
-            payload=proposition.model_dump(mode="json"),
+            payload=LegacyPayload.model_validate(proposition.model_dump(mode="json")),
             epistemic_anchor=EpistemicAnchor(),
         )
         ledger.append(event)

--- a/src/coreason_manifest/core/primitives/wasm_types.py
+++ b/src/coreason_manifest/core/primitives/wasm_types.py
@@ -1,0 +1,43 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Literal
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+# A discriminated union or literal-typed model representing specific sandbox permissions
+type WasiCapability = Literal[
+    "DirectoryReadCapability",
+    "DirectoryWriteCapability",
+    "NetworkFetchCapability",
+    "SystemClockCapability",
+    "RandomEntropyCapability",
+]
+
+
+class WasmResourceLimits(CoreasonModel):
+    """
+    Strict integers for `memory_limit_mb` and `instruction_fuel_limit`.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    memory_limit_mb: int = Field(
+        ...,
+        gt=0,
+        description="The maximum amount of memory (in megabytes) the Wasm module is allowed to allocate.",
+    )
+    instruction_fuel_limit: int = Field(
+        ...,
+        gt=0,
+        description="The maximum number of instructions (fuel) the Wasm module is allowed to execute.",
+    )

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -1,6 +1,6 @@
 from datetime import UTC, datetime
 from enum import StrEnum
-from typing import Any, Protocol, runtime_checkable
+from typing import Annotated, Any, Literal, Protocol, runtime_checkable
 
 from pydantic import ConfigDict, Field, model_validator
 
@@ -38,6 +38,7 @@ class WasmExecutionTrace(CoreasonModel):
 
     model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
 
+    trace_type: Literal["wasm_execution"] = Field("wasm_execution", description="Tagged union discriminator.")
     executed_module_hash: str = Field(
         ...,
         pattern=r"^[a-fA-F0-9]{64}$",
@@ -57,6 +58,15 @@ class WasmExecutionTrace(CoreasonModel):
         pattern=r"^[a-fA-F0-9]{64}$",
         description="The exact SHA-256 hash of the output payload generated.",
     )
+
+
+class LegacyPayload(CoreasonModel):
+    """
+    Fallback payload for legacy un-discriminated events.
+    """
+
+    model_config = ConfigDict(extra="allow", frozen=True)
+    trace_type: Literal["legacy_payload"] = Field("legacy_payload", description="Tagged union discriminator.")
 
 
 class EpistemicAnchor(CoreasonModel):
@@ -83,7 +93,9 @@ class EpistemicEvent(CoreasonModel):
         ..., description="A generic dict or Protocol representing hardware, prompt version, agent signature."
     )
     event_type: EventType = Field(..., description="The type of the event.")
-    payload: dict[str, Any] | WasmExecutionTrace = Field(..., description="The actual data mutation.")
+    payload: Annotated[
+        WasmExecutionTrace | LegacyPayload, Field(discriminator="trace_type", description="The actual data mutation.")
+    ]
     epistemic_anchor: EpistemicAnchor = Field(
         ..., description="A reference to the parent event and spatial coordinates."
     )

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -2,9 +2,10 @@ from datetime import UTC, datetime
 from enum import StrEnum
 from typing import Any, Protocol, runtime_checkable
 
-from pydantic import Field, model_validator
+from pydantic import ConfigDict, Field, model_validator
 
 from coreason_manifest.core.common.base import CoreasonModel
+from coreason_manifest.core.primitives.wasm_types import WasiCapability
 
 
 @runtime_checkable
@@ -26,7 +27,36 @@ class EventType(StrEnum):
 
     STRUCTURAL_PARSED = "STRUCTURAL_PARSED"
     SEMANTIC_EXTRACTED = "SEMANTIC_EXTRACTED"
+    WASM_EXECUTION_TRACE_RECORDED = "WASM_EXECUTION_TRACE_RECORDED"
     # Other event types can be added here
+
+
+class WasmExecutionTrace(CoreasonModel):
+    """
+    Records the exact deterministic outcome of the external execution of a Wasm module.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    executed_module_hash: str = Field(
+        ...,
+        pattern=r"^[a-fA-F0-9]{64}$",
+        description="The exact SHA-256 hash of the target Wasm module executed.",
+    )
+    granted_capabilities: list[WasiCapability] = Field(
+        ...,
+        description="The strictly typed list of WASI capabilities the runner actually allowed.",
+    )
+    fuel_consumed: int = Field(
+        ...,
+        ge=0,
+        description="The number of instructions (fuel) consumed during execution.",
+    )
+    output_payload_hash: str = Field(
+        ...,
+        pattern=r"^[a-fA-F0-9]{64}$",
+        description="The exact SHA-256 hash of the output payload generated.",
+    )
 
 
 class EpistemicAnchor(CoreasonModel):
@@ -53,7 +83,7 @@ class EpistemicEvent(CoreasonModel):
         ..., description="A generic dict or Protocol representing hardware, prompt version, agent signature."
     )
     event_type: EventType = Field(..., description="The type of the event.")
-    payload: dict[str, Any] = Field(..., description="The actual data mutation.")
+    payload: dict[str, Any] | WasmExecutionTrace = Field(..., description="The actual data mutation.")
     epistemic_anchor: EpistemicAnchor = Field(
         ..., description="A reference to the parent event and spatial coordinates."
     )

--- a/src/coreason_manifest/state/projections.py
+++ b/src/coreason_manifest/state/projections.py
@@ -40,7 +40,7 @@ class DocumentTextProjection(BaseProjection):
         blocks_processed = 0
 
         for event in events:
-            if event.event_type == EventType.STRUCTURAL_PARSED:
+            if event.event_type == EventType.STRUCTURAL_PARSED and isinstance(event.payload, dict):
                 text_block = event.payload.get("text_block")
                 if text_block is not None:
                     # Append text with a newline separator if needed

--- a/src/coreason_manifest/state/projections.py
+++ b/src/coreason_manifest/state/projections.py
@@ -40,8 +40,11 @@ class DocumentTextProjection(BaseProjection):
         blocks_processed = 0
 
         for event in events:
-            if event.event_type == EventType.STRUCTURAL_PARSED and isinstance(event.payload, dict):
-                text_block = event.payload.get("text_block")
+            if (
+                event.event_type == EventType.STRUCTURAL_PARSED
+                and getattr(event.payload, "trace_type", "") == "legacy_payload"
+            ):
+                text_block = getattr(event.payload, "text_block", None)
                 if text_block is not None:
                     # Append text with a newline separator if needed
                     if aggregated_text:

--- a/src/coreason_manifest/workflow/nodes/wasm.py
+++ b/src/coreason_manifest/workflow/nodes/wasm.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Annotated, Literal
+
+from pydantic import ConfigDict, Field
+
+from coreason_manifest.core.primitives.wasm_types import WasiCapability, WasmResourceLimits
+from coreason_manifest.workflow.nodes.base import Node
+
+
+class WasmExecutionNode(Node):
+    """
+    A strictly declarative node defining a Zero-Trust Wasm/WASI Execution Sandboxing request.
+    This does NOT execute Wasm. It only records the capabilities and limits requested.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    type: Literal["wasm_execution"] = Field(
+        default="wasm_execution",
+        description="Discriminator for Wasm execution nodes.",
+    )
+
+    wasm_module_hash: Annotated[
+        str,
+        Field(
+            pattern=r"^[a-fA-F0-9]{64}$",
+            description="The exact SHA-256 hash of the target Wasm module to execute.",
+        ),
+    ]
+
+    resource_limits: WasmResourceLimits = Field(
+        ...,
+        description="Strict upper bounds on execution resources.",
+    )
+
+    capabilities: list[WasiCapability] = Field(
+        default_factory=list,
+        description="The strictly typed list of WASI capabilities requested by this node.",
+    )

--- a/tests/spec/topologies/test_scivis_drafting.py
+++ b/tests/spec/topologies/test_scivis_drafting.py
@@ -7,7 +7,7 @@ from coreason_manifest.spec.topologies.scivis_drafting import (
 )
 
 
-def test_scivis_drafting_flow_initialization():
+def test_scivis_drafting_flow_initialization() -> None:
     flow = SciVisDraftingFlow()
 
     assert "metadata" in flow.model_dump()
@@ -41,7 +41,7 @@ def test_scivis_drafting_flow_initialization():
     assert drafter_critic_edge is not None
 
 
-def test_scivis_drafting_blackboard_initialization():
+def test_scivis_drafting_blackboard_initialization() -> None:
     from coreason_manifest.presentation.scivis.scientific_vis import SciVisIntent, VisInformationType
 
     intent = SciVisIntent(

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -1,0 +1,32 @@
+from coreason_manifest.core.primitives.wasm_types import WasmResourceLimits, WasiCapability
+from coreason_manifest.workflow.nodes.wasm import WasmExecutionNode
+from coreason_manifest.state.events import WasmExecutionTrace
+
+def test_wasm_execution_node() -> None:
+    node = WasmExecutionNode(
+        id="wasm_node",
+        wasm_module_hash="a" * 64,
+        resource_limits=WasmResourceLimits(
+            memory_limit_mb=128,
+            instruction_fuel_limit=1000000
+        ),
+        capabilities=["DirectoryReadCapability", "NetworkFetchCapability"]
+    )
+    assert node.type == "wasm_execution"
+    assert node.wasm_module_hash == "a" * 64
+    assert node.resource_limits.memory_limit_mb == 128
+    assert node.resource_limits.instruction_fuel_limit == 1000000
+    assert len(node.capabilities) == 2
+
+
+def test_wasm_execution_trace() -> None:
+    trace = WasmExecutionTrace(
+        executed_module_hash="a" * 64,
+        granted_capabilities=["DirectoryReadCapability"],
+        fuel_consumed=50000,
+        output_payload_hash="b" * 64
+    )
+    assert trace.executed_module_hash == "a" * 64
+    assert trace.fuel_consumed == 50000
+    assert trace.output_payload_hash == "b" * 64
+    assert len(trace.granted_capabilities) == 1

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -7,11 +7,8 @@ def test_wasm_execution_node() -> None:
     node = WasmExecutionNode(
         id="wasm_node",
         wasm_module_hash="a" * 64,
-        resource_limits=WasmResourceLimits(
-            memory_limit_mb=128,
-            instruction_fuel_limit=1000000
-        ),
-        capabilities=["DirectoryReadCapability", "NetworkFetchCapability"]
+        resource_limits=WasmResourceLimits(memory_limit_mb=128, instruction_fuel_limit=1000000),
+        capabilities=["DirectoryReadCapability", "NetworkFetchCapability"],
     )
     assert node.type == "wasm_execution"
     assert node.wasm_module_hash == "a" * 64
@@ -25,7 +22,7 @@ def test_wasm_execution_trace() -> None:
         executed_module_hash="a" * 64,
         granted_capabilities=["DirectoryReadCapability"],
         fuel_consumed=50000,
-        output_payload_hash="b" * 64
+        output_payload_hash="b" * 64,
     )
     assert trace.executed_module_hash == "a" * 64
     assert trace.fuel_consumed == 50000

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -19,11 +19,13 @@ def test_wasm_execution_node() -> None:
 
 def test_wasm_execution_trace() -> None:
     trace = WasmExecutionTrace(
+        trace_type="wasm_execution",
         executed_module_hash="a" * 64,
         granted_capabilities=["DirectoryReadCapability"],
         fuel_consumed=50000,
         output_payload_hash="b" * 64,
     )
+    assert trace.trace_type == "wasm_execution"
     assert trace.executed_module_hash == "a" * 64
     assert trace.fuel_consumed == 50000
     assert trace.output_payload_hash == "b" * 64

--- a/tests/test_wasm.py
+++ b/tests/test_wasm.py
@@ -1,6 +1,7 @@
-from coreason_manifest.core.primitives.wasm_types import WasmResourceLimits, WasiCapability
-from coreason_manifest.workflow.nodes.wasm import WasmExecutionNode
+from coreason_manifest.core.primitives.wasm_types import WasmResourceLimits
 from coreason_manifest.state.events import WasmExecutionTrace
+from coreason_manifest.workflow.nodes.wasm import WasmExecutionNode
+
 
 def test_wasm_execution_node() -> None:
     node = WasmExecutionNode(


### PR DESCRIPTION
This PR introduces the strictly typed, declarative data structures required to record Zero-Trust Wasm/WASI Execution Sandboxing requests and their execution traces.

Key changes:
- `src/coreason_manifest/core/primitives/wasm_types.py`: `WasiCapability` strict types, `WasmResourceLimits` integer boundaries.
- `src/coreason_manifest/workflow/nodes/wasm.py`: `WasmExecutionNode` containing the declarative request metadata (hash, limits, caps).
- `src/coreason_manifest/state/events.py`: `WasmExecutionTrace` to append to the ledger reflecting the state-changing action. Updates `EpistemicEvent` payload typing.
- Updates existing projection logic in `src/coreason_manifest/state/projections.py` to prevent regression.

No active execution code (`subprocess`, `extism`, `wasmtime`) was introduced.

---
*PR created automatically by Jules for task [2645045951136527623](https://jules.google.com/task/2645045951136527623) started by @gowthamrao*