### PR TITLE
chore: reconcile architectural epics and tighten typing boundaries

### DIFF
--- a/src/coreason_manifest/core/security/gatekeeper.py
+++ b/src/coreason_manifest/core/security/gatekeeper.py
@@ -150,27 +150,13 @@ def _check_domain_whitelist(flow: WorkflowEnvelope, tool_map: dict[str, AnyTool]
                 )
 
     # EPIC 4: Zero-Trust MCP Egress Validation
-    mcp_clients = getattr(flow, "mcp_clients", [])
-    if isinstance(mcp_clients, dict):
-        mcp_clients = list(mcp_clients.values())
-
-    for client in mcp_clients:
-        transport = getattr(client, "transport", None)
-        if not transport:
+    for idx, client in enumerate(flow.mcp_clients):
+        if not client.transport:
             continue
 
-        t_type = getattr(transport, "type", "")
-        if t_type == "sse":
-            uri = getattr(transport, "uri", None)
-            if uri:
-                # uri could be a Pydantic HttpUrl or a string
-                host = getattr(uri, "host", None)
-                if not host:
-                    from urllib.parse import urlparse
-
-                    parsed = urlparse(str(uri))
-                    host = parsed.hostname
-
+        if client.transport.type == "sse":
+            if client.transport.uri:
+                host = client.transport.uri.host
                 if host:
                     domain = canonicalize_domain(str(host))
                     allowed = False
@@ -198,8 +184,8 @@ def _check_domain_whitelist(flow: WorkflowEnvelope, tool_map: dict[str, AnyTool]
                                 ),
                             )
                         )
-        elif t_type == "stdio":
-            command = getattr(transport, "command", "")
+        elif client.transport.type == "stdio":
+            command = client.transport.command
             if command in ["bash", "sh", "cmd", "powershell"]:
                 client_name = getattr(client, "name", "unknown_mcp_client")
                 logger.warning("mcp_stdio_unsafe", client_name=client_name, command=command)
@@ -212,7 +198,7 @@ def _check_domain_whitelist(flow: WorkflowEnvelope, tool_map: dict[str, AnyTool]
                         remediation=RemediationAction(
                             type="prune_mcp_client",
                             format="json_patch",
-                            patch_data=[{"op": "remove", "path": f"/mcp_clients/{client_name}"}],
+                            patch_data=[{"op": "remove", "path": f"/mcp_clients/{idx}"}],
                             description=f"Remove unsafe MCP client '{client_name}'",
                         ),
                     )
@@ -1154,12 +1140,7 @@ def _enforce_red_button_rule(flow: WorkflowEnvelope) -> list[ComplianceReport]:
     """
     reports: list[ComplianceReport] = []
 
-    mcp_export = getattr(flow, "mcp_export", None)
-    if not mcp_export:
-        return reports
-
-    is_exported = getattr(mcp_export, "expose_as_tool", False)
-    if not is_exported:
+    if not flow.mcp_export or not flow.mcp_export.expose_as_tool:
         return reports
 
     nodes, _ = get_unified_topology(flow)

--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -1,7 +1,7 @@
 from coreason_manifest.workflow.bidding import Bid, yield_to_suspense
 from coreason_manifest.workflow.blackboard import BlackboardBrokerConfig
 from coreason_manifest.workflow.exceptions import LineageIntegrityError
-from coreason_manifest.workflow.flow import Blackboard, Edge, WorkflowEnvelope
+from coreason_manifest.workflow.flow import Blackboard, Edge, MCPServerExport, WorkflowEnvelope
 from coreason_manifest.workflow.nodes import (
     AgentNode,
     AnyNode,
@@ -35,6 +35,7 @@ __all__ = [
     "InspectorNode",
     "InspectorNodeBase",
     "LineageIntegrityError",
+    "MCPServerExport",
     "Node",
     "PlaceholderNode",
     "PlannerNode",

--- a/src/coreason_manifest/workflow/flow.py
+++ b/src/coreason_manifest/workflow/flow.py
@@ -77,6 +77,7 @@ __all__ = [
     "FlowInterface",
     "FlowMetadata",
     "HierarchicalTopology",
+    "MCPServerExport",
     "MapReduceTopology",
     "SwarmTopology",
     "VariableDef",

--- a/src/coreason_manifest/workflow/nodes/agent.py
+++ b/src/coreason_manifest/workflow/nodes/agent.py
@@ -4,6 +4,7 @@ from typing import Annotated, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from coreason_manifest.adapters.mcp.server import MCPPromptRef
 from coreason_manifest.compute.reasoning import FastPath, ReasoningConfig
 from coreason_manifest.core.common.base import CoreasonModel
 from coreason_manifest.core.common.semantic import SemanticRef
@@ -13,20 +14,6 @@ from coreason_manifest.oversight.intervention import EscalationCriteria
 from coreason_manifest.state.memory import MemorySubsystem
 
 from .base import Node
-
-
-class MCPPromptRef(CoreasonModel):
-    """Reference to a remote prompt via the Model Context Protocol (MCP)."""
-
-    server_id: str = Field(..., description="The ID of the MCP server to connect to.")
-    prompt_name: str = Field(..., description="The exact semantic identifier on the remote server.")
-    arguments: dict[str, Any] = Field(
-        default_factory=dict, description="Variables to inject into the remote prompt template."
-    )
-    fallback_persona: str | None = Field(None, description="Optional static fallback string if the server times out.")
-    prompt_hash: str | None = Field(
-        None, description="Optional SHA-256 hash to cryptographically pin the remote prompt."
-    )
 
 
 class CognitiveProfile(CoreasonModel):


### PR DESCRIPTION
- Removed `MCPPromptRef` local duplication from `agent.py` and sourced it from the newly defined `mcp/server.py`.
- Substituted dynamic `getattr` approaches with statically typed object access (`transport.type`, `uri.host`, etc.) across `gatekeeper.py`.
- Addressed a JSON Patch index pathing bug for `mcp_clients` resolution in `gatekeeper.py`.
- Re-exposed `MCPServerExport` through the module `__all__` mappings in `flow.py` and `__init__.py`.

---
*PR created automatically by Jules for task [6450408934464909759](https://jules.google.com/task/6450408934464909759) started by @gowthamrao*