### PR TITLE
feat: Add MCP primitive schemas for health informatics

### DIFF
--- a/src/coreason_manifest/adapters/mcp/clinical.py
+++ b/src/coreason_manifest/adapters/mcp/clinical.py
@@ -1,0 +1,129 @@
+"""
+Model Context Protocol (MCP) Primitives for Health Informatics and Observational Research.
+
+This module defines state-of-the-art MCP primitives acting as the definitive schema
+contracts for external execution environments interacting with the OMOP Common Data
+Model and the OHDSI open-science collaborative ecosystem.
+
+These structures are pure, passive contracts. An external MCP server uses them to
+securely expose OMOP standard constructs to an AI agent, wrap open-source execution
+software (like CohortDiagnostics), and treat prompt engineering as a reproducible
+scientific artifact.
+"""
+
+import re
+from enum import StrEnum
+from typing import Any
+
+from pydantic import Field, field_validator
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class OMOPDomain(StrEnum):
+    """
+    Standard OMOP domains for resource types.
+    """
+
+    CONCEPT = "CONCEPT"
+    COHORT_DEFINITION = "COHORT_DEFINITION"
+    CONCEPT_ANCESTOR = "CONCEPT_ANCESTOR"
+    PHENOTYPE_EVALUATION = "PHENOTYPE_EVALUATION"
+
+
+class OMOPResourceTemplate(CoreasonModel):
+    """
+    Represents an MCP Resource Template exposing OMOP standard constructs to an AI agent securely.
+
+    An external MCP server will utilize this contract to advertise available epidemiological
+    data resources. The AI agent populates the template variables to request specific OMOP
+    concepts, cohorts, or other supported analytical constructs.
+    """
+
+    uri_template: str = Field(
+        ...,
+        description="The URI template for the resource, matching an omop:// protocol pattern.",
+    )
+    resource_type: OMOPDomain = Field(
+        ...,
+        description="The standard OMOP domain for the resource.",
+    )
+    description: str = Field(
+        ...,
+        description="Documents exactly what epidemiological data this resource yields.",
+    )
+
+    @field_validator("uri_template")
+    @classmethod
+    def validate_uri_template(cls, v: str) -> str:
+        """Ensure the URI template strictly matches the omop:// protocol pattern."""
+        if not re.match(r"^omop://[a-zA-Z0-9_/-]+(?:/\{[a-zA-Z0-9_]+\})?[a-zA-Z0-9_/-]*$", v):
+            raise ValueError("uri_template must follow the 'omop://' protocol pattern")
+        return v
+
+
+class CohortDiagnosticsRequest(CoreasonModel):
+    """
+    Declarative input contract for an MCP Tool wrapping OHDSI CohortDiagnostics software.
+
+    The AI agent populates this schema with the necessary analytical parameters. A separate
+    execution server reads this passive contract and maps it directly to the underlying
+    R package function arguments to execute OHDSI CohortDiagnostics.
+    """
+
+    inclusion_rules: list[str | dict[str, Any]] = Field(
+        ...,
+        description="Array of heavily typed JSON-logic or criteria string representations.",
+    )
+    target_cohort_ids: list[int] = Field(
+        ...,
+        description="List of target cohort IDs.",
+    )
+    comparator_cohort_ids: list[int] | None = Field(
+        default=None,
+        description="Optional list of comparator cohort IDs.",
+    )
+    evaluation_windows: list[int] = Field(
+        ...,
+        description="List of integers representing days (e.g., [0, 30, 365]).",
+    )
+    diagnostic_flags: dict[str, bool] = Field(
+        ...,
+        description="Mapping of string flags to booleans, matching the R package's execution parameters.",
+    )
+
+
+class EpistemicPromptManifest(CoreasonModel):
+    """
+    MCP Prompt specifically bounded for phenotype development and clinical reasoning.
+
+    Treats prompt engineering as a reproducible scientific artifact. An external MCP server
+    uses this contract to supply the AI agent with a rigorously defined prompt structure
+    for health informatics tasks, ensuring that outputs strictly adhere to required guidelines
+    and scientific rigor.
+    """
+
+    prompt_id: str = Field(
+        ...,
+        description="The unique identifier for the prompt.",
+    )
+    version: str = Field(
+        ...,
+        description="The version string of the prompt.",
+    )
+    instruction_template: str = Field(
+        ...,
+        description="The core LLM directive.",
+    )
+    required_guideline_citations: bool = Field(
+        ...,
+        description="Indicates if the LLM must provide W3C PROV-O structured citations in its output.",
+    )
+    expected_output_schema: str = Field(
+        ...,
+        description="Reference to the Pydantic model the LLM must return.",
+    )
+    reproducibility_hash: str = Field(
+        ...,
+        description="Cryptographically locks the exact phrasing of the prompt for peer-reviewed publication tracking.",
+    )

--- a/src/coreason_manifest/adapters/mcp/clinical.py
+++ b/src/coreason_manifest/adapters/mcp/clinical.py
@@ -12,6 +12,7 @@ scientific artifact.
 """
 
 import re
+from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any
 
@@ -57,7 +58,7 @@ class OMOPResourceTemplate(CoreasonModel):
     @classmethod
     def validate_uri_template(cls, v: str) -> str:
         """Ensure the URI template strictly matches the omop:// protocol pattern."""
-        if not re.match(r"^omop://[a-zA-Z0-9_/-]+(?:/\{[a-zA-Z0-9_]+\})?[a-zA-Z0-9_/-]*$", v):
+        if not re.match(r"^omop://(?:[a-zA-Z0-9_/-]+|/\{[a-zA-Z0-9_]+\})+$", v):
             raise ValueError("uri_template must follow the 'omop://' protocol pattern")
         return v
 
@@ -71,23 +72,23 @@ class CohortDiagnosticsRequest(CoreasonModel):
     R package function arguments to execute OHDSI CohortDiagnostics.
     """
 
-    inclusion_rules: list[str | dict[str, Any]] = Field(
+    inclusion_rules: tuple[str | Mapping[str, Any], ...] = Field(
         ...,
         description="Array of heavily typed JSON-logic or criteria string representations.",
     )
-    target_cohort_ids: list[int] = Field(
+    target_cohort_ids: tuple[int, ...] = Field(
         ...,
         description="List of target cohort IDs.",
     )
-    comparator_cohort_ids: list[int] | None = Field(
+    comparator_cohort_ids: tuple[int, ...] | None = Field(
         default=None,
         description="Optional list of comparator cohort IDs.",
     )
-    evaluation_windows: list[int] = Field(
+    evaluation_windows: tuple[int, ...] = Field(
         ...,
         description="List of integers representing days (e.g., [0, 30, 365]).",
     )
-    diagnostic_flags: dict[str, bool] = Field(
+    diagnostic_flags: Mapping[str, bool] = Field(
         ...,
         description="Mapping of string flags to booleans, matching the R package's execution parameters.",
     )

--- a/tests/adapters/mcp/test_clinical.py
+++ b/tests/adapters/mcp/test_clinical.py
@@ -1,0 +1,54 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.adapters.mcp.clinical import (
+    CohortDiagnosticsRequest,
+    EpistemicPromptManifest,
+    OMOPDomain,
+    OMOPResourceTemplate,
+)
+
+
+def test_omop_resource_template_valid() -> None:
+    template = OMOPResourceTemplate(
+        uri_template="omop://vocab/concept/{concept_id}",
+        resource_type=OMOPDomain.CONCEPT,
+        description="A concept resource.",
+    )
+    assert template.uri_template == "omop://vocab/concept/{concept_id}"
+    assert template.resource_type == OMOPDomain.CONCEPT
+
+
+def test_omop_resource_template_invalid_uri() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        OMOPResourceTemplate(
+            uri_template="http://vocab/concept/{concept_id}",
+            resource_type=OMOPDomain.CONCEPT,
+            description="Invalid URI protocol.",
+        )
+    assert "uri_template must follow the 'omop://' protocol pattern" in str(exc_info.value)
+
+
+def test_cohort_diagnostics_request_valid() -> None:
+    request = CohortDiagnosticsRequest(
+        inclusion_rules=["rule1", {"type": "json_logic"}],
+        target_cohort_ids=[1, 2],
+        comparator_cohort_ids=[3],
+        evaluation_windows=[0, 30, 365],
+        diagnostic_flags={"runInclusionStatistics": True},
+    )
+    assert request.target_cohort_ids == [1, 2]
+    assert request.comparator_cohort_ids == [3]
+
+
+def test_epistemic_prompt_manifest_valid() -> None:
+    manifest = EpistemicPromptManifest(
+        prompt_id="test_prompt",
+        version="1.0.0",
+        instruction_template="You are a helpful assistant.",
+        required_guideline_citations=True,
+        expected_output_schema="TestSchema",
+        reproducibility_hash="hash123",
+    )
+    assert manifest.prompt_id == "test_prompt"
+    assert manifest.required_guideline_citations is True

--- a/tests/adapters/mcp/test_clinical.py
+++ b/tests/adapters/mcp/test_clinical.py
@@ -19,6 +19,16 @@ def test_omop_resource_template_valid() -> None:
     assert template.resource_type == OMOPDomain.CONCEPT
 
 
+def test_omop_resource_template_valid_multiple_vars() -> None:
+    template = OMOPResourceTemplate(
+        uri_template="omop://cohort/{cohort_id}/concept/{concept_id}",
+        resource_type=OMOPDomain.CONCEPT,
+        description="A concept resource with multiple vars.",
+    )
+    assert template.uri_template == "omop://cohort/{cohort_id}/concept/{concept_id}"
+    assert template.resource_type == OMOPDomain.CONCEPT
+
+
 def test_omop_resource_template_invalid_uri() -> None:
     with pytest.raises(ValidationError) as exc_info:
         OMOPResourceTemplate(
@@ -31,14 +41,14 @@ def test_omop_resource_template_invalid_uri() -> None:
 
 def test_cohort_diagnostics_request_valid() -> None:
     request = CohortDiagnosticsRequest(
-        inclusion_rules=["rule1", {"type": "json_logic"}],
-        target_cohort_ids=[1, 2],
-        comparator_cohort_ids=[3],
-        evaluation_windows=[0, 30, 365],
+        inclusion_rules=("rule1", {"type": "json_logic"}),
+        target_cohort_ids=(1, 2),
+        comparator_cohort_ids=(3,),
+        evaluation_windows=(0, 30, 365),
         diagnostic_flags={"runInclusionStatistics": True},
     )
-    assert request.target_cohort_ids == [1, 2]
-    assert request.comparator_cohort_ids == [3]
+    assert request.target_cohort_ids == (1, 2)
+    assert request.comparator_cohort_ids == (3,)
 
 
 def test_epistemic_prompt_manifest_valid() -> None:


### PR DESCRIPTION
Introduces three SOTA Model Context Protocol (MCP) primitives to `coreason_manifest` for advanced health informatics interoperability. The structures (`OMOPResourceTemplate`, `CohortDiagnosticsRequest`, and `EpistemicPromptManifest`) strictly enforce Pydantic type hinting, inherit from `CoreasonModel`, and act entirely as passive schema contracts without runtime logic. Also includes accompanying unit tests.

---
*PR created automatically by Jules for task [18008031605579798601](https://jules.google.com/task/18008031605579798601) started by @gowthamrao*