### PR TITLE
feat(epic-1): Add intent protocols and liquid topologies

### DIFF
--- a/src/coreason_manifest/spec/intent_protocols.py
+++ b/src/coreason_manifest/spec/intent_protocols.py
@@ -49,7 +49,9 @@ class GracefulDegradationPolicy(CoreasonModel):
     )
     allow_synthetic_bootstrapping: bool = Field(
         ...,
-        description="If True, the orchestrator is allowed to synthetically generate a less optimal swarm to fulfill the intent.",
+        description=(
+            "If True, the orchestrator is allowed to synthetically generate a less optimal swarm to fulfill the intent."
+        ),
         examples=[False],
     )
 
@@ -68,7 +70,10 @@ class UniversalIntentURI(CoreasonModel):
     )
     ecosystem_target: str = Field(
         ...,
-        description="The target registry, catalog, or provider where the intent should be resolved (e.g., 'huggingface', 'internal-registry').",
+        description=(
+            "The target registry, catalog, or provider where the intent should be resolved "
+            "(e.g., 'huggingface', 'internal-registry')."
+        ),
         examples=["internal-registry"],
     )
     semantic_payload: str = Field(

--- a/src/coreason_manifest/spec/intent_protocols.py
+++ b/src/coreason_manifest/spec/intent_protocols.py
@@ -1,0 +1,86 @@
+# Prosperity-3.0
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class ConstraintConfig(CoreasonModel):
+    """
+    Defines hard execution boundaries for a routed intent.
+    This establishes the 2026 SOTA compliance and performance limits
+    before an intent is allowed to instantiate in a given environment.
+    """
+
+    max_latency_ms: int = Field(
+        ...,
+        description="The maximum allowed execution time in milliseconds before the intent is considered failed.",
+        examples=[5000],
+    )
+    requires_hipaa_compliance: bool = Field(
+        ...,
+        description="Whether the target ecosystem must be certified for handling Protected Health Information (PHI).",
+        examples=[True],
+    )
+    allowed_compute_regions: list[str] = Field(
+        ...,
+        description="A list of approved geographical or logical regions where compute can be allocated.",
+        examples=[["us-east-1", "eu-west-1"]],
+    )
+
+
+class GracefulDegradationPolicy(CoreasonModel):
+    """
+    Dictates how an intent degrades if a strict catalog match fails.
+    This enables resilient intent routing by falling back to relaxed constraints
+    or alternative bootstrapping mechanisms under load.
+    """
+
+    droppable_constraints: list[str] = Field(
+        ...,
+        description="A list of field names in ConstraintConfig that can be safely ignored during a fallback scenario.",
+        examples=[["max_latency_ms"]],
+    )
+    fallback_timeout_ms: int = Field(
+        ...,
+        description="The maximum time to wait in milliseconds while attempting to find a fallback routing solution.",
+        examples=[10000],
+    )
+    allow_synthetic_bootstrapping: bool = Field(
+        ...,
+        description="If True, the orchestrator is allowed to synthetically generate a less optimal swarm to fulfill the intent.",
+        examples=[False],
+    )
+
+
+class UniversalIntentURI(CoreasonModel):
+    """
+    The core SOTA routing protocol for Universal Intent.
+    Standardizes how macroscopic goals are mapped to isolated AI ecosystems
+    (like local models or enterprise registries via MCP).
+    """
+
+    scheme: Literal["ibo", "mcp", "local"] = Field(
+        ...,
+        description="The routing scheme protocol to use for dispatching the intent.",
+        examples=["ibo"],
+    )
+    ecosystem_target: str = Field(
+        ...,
+        description="The target registry, catalog, or provider where the intent should be resolved (e.g., 'huggingface', 'internal-registry').",
+        examples=["internal-registry"],
+    )
+    semantic_payload: str = Field(
+        ...,
+        description="The dense natural language intent or macroscopic goal to be executed.",
+        examples=["Extract temporal clinical relationships"],
+    )
+    constraints: ConstraintConfig = Field(
+        ...,
+        description="Hard execution boundaries ensuring compliance, latency, and regional data residency.",
+    )
+    degradation_policy: GracefulDegradationPolicy | None = Field(
+        None,
+        description="Optional policy detailing how the intent should degrade if the strict constraints cannot be met.",
+    )

--- a/src/coreason_manifest/workflow/nodes/liquid.py
+++ b/src/coreason_manifest/workflow/nodes/liquid.py
@@ -27,7 +27,10 @@ class DecompositionStrategy(CoreasonModel):
     )
     require_human_oversight_on_synthesis: bool = Field(
         ...,
-        description="Whether a human-in-the-loop confirmation is required before the swarm collapses and synthesizes its final result.",
+        description=(
+            "Whether a human-in-the-loop confirmation is required before the swarm collapses "
+            "and synthesizes its final result."
+        ),
         examples=[True],
     )
 
@@ -45,7 +48,9 @@ class LiquidTopologyNode(Node):
     )
     macro_intent: str | UniversalIntentURI = Field(
         ...,
-        description="The high-level goal that this topology aims to satisfy, represented either as a string or a strict URI.",
+        description=(
+            "The high-level goal that this topology aims to satisfy, represented either as a string or a strict URI."
+        ),
         examples=["Migrate all user data to the new schema"],
     )
     decomposition: DecompositionStrategy = Field(
@@ -55,6 +60,8 @@ class LiquidTopologyNode(Node):
     ephemeral_ttl_seconds: int = Field(
         ...,
         gt=0,
-        description="The time-to-live for the dynamically generated swarm before it dissolves to free up compute resources.",
+        description=(
+            "The time-to-live for the dynamically generated swarm before it dissolves to free up compute resources."
+        ),
         examples=[3600],
     )

--- a/src/coreason_manifest/workflow/nodes/liquid.py
+++ b/src/coreason_manifest/workflow/nodes/liquid.py
@@ -1,7 +1,7 @@
 # Prosperity-3.0
-from typing import Union
+from typing import Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field
 
 from coreason_manifest.core.common.base import CoreasonModel
 from coreason_manifest.spec.intent_protocols import UniversalIntentURI
@@ -39,7 +39,11 @@ class LiquidTopologyNode(Node):
     that autonomously spawns and dissolves a swarm of micro-agents at runtime.
     """
 
-    macro_intent: Union[str, UniversalIntentURI] = Field(
+    type: Literal["liquid"] = Field(
+        default="liquid",
+        description="The type of the node, used for polymorphic deserialization.",
+    )
+    macro_intent: str | UniversalIntentURI = Field(
         ...,
         description="The high-level goal that this topology aims to satisfy, represented either as a string or a strict URI.",
         examples=["Migrate all user data to the new schema"],
@@ -50,14 +54,7 @@ class LiquidTopologyNode(Node):
     )
     ephemeral_ttl_seconds: int = Field(
         ...,
+        gt=0,
         description="The time-to-live for the dynamically generated swarm before it dissolves to free up compute resources.",
         examples=[3600],
     )
-
-    @field_validator("ephemeral_ttl_seconds")
-    @classmethod
-    def validate_positive_ttl(cls, v: int) -> int:
-        """Ensure TTL is strictly positive."""
-        if v <= 0:
-            raise ValueError("ephemeral_ttl_seconds must be a positive integer strictly greater than 0.")
-        return v

--- a/src/coreason_manifest/workflow/nodes/liquid.py
+++ b/src/coreason_manifest/workflow/nodes/liquid.py
@@ -1,0 +1,63 @@
+# Prosperity-3.0
+from typing import Union
+
+from pydantic import Field, field_validator
+
+from coreason_manifest.core.common.base import CoreasonModel
+from coreason_manifest.spec.intent_protocols import UniversalIntentURI
+from coreason_manifest.workflow.nodes.base import Node
+
+
+class DecompositionStrategy(CoreasonModel):
+    """
+    Defines how a macro-intent is broken down at runtime.
+    This establishes limits on the dynamic instantiation of swarms under the SOTA 2026 Liquid Topology orchestration.
+    """
+
+    max_micro_agents: int = Field(
+        ...,
+        gt=0,
+        description="The strict upper bound on the number of micro-agents that can be dynamically spawned.",
+        examples=[5],
+    )
+    allowed_sub_intents: list[str] = Field(
+        ...,
+        description="A predefined whitelist of sub-intents or capabilities the swarm is permitted to decompose into.",
+        examples=[["fetch_data", "summarize"]],
+    )
+    require_human_oversight_on_synthesis: bool = Field(
+        ...,
+        description="Whether a human-in-the-loop confirmation is required before the swarm collapses and synthesizes its final result.",
+        examples=[True],
+    )
+
+
+class LiquidTopologyNode(Node):
+    """
+    Represents an ephemeral, liquid topology node in the orchestration graph.
+    Instead of mapping to a single explicit agent, this node maps to a macro-intent
+    that autonomously spawns and dissolves a swarm of micro-agents at runtime.
+    """
+
+    macro_intent: Union[str, UniversalIntentURI] = Field(
+        ...,
+        description="The high-level goal that this topology aims to satisfy, represented either as a string or a strict URI.",
+        examples=["Migrate all user data to the new schema"],
+    )
+    decomposition: DecompositionStrategy = Field(
+        ...,
+        description="The policy dictating how the orchestrator divides the macro_intent into granular micro-agents.",
+    )
+    ephemeral_ttl_seconds: int = Field(
+        ...,
+        description="The time-to-live for the dynamically generated swarm before it dissolves to free up compute resources.",
+        examples=[3600],
+    )
+
+    @field_validator("ephemeral_ttl_seconds")
+    @classmethod
+    def validate_positive_ttl(cls, v: int) -> int:
+        """Ensure TTL is strictly positive."""
+        if v <= 0:
+            raise ValueError("ephemeral_ttl_seconds must be a positive integer strictly greater than 0.")
+        return v

--- a/tests/spec/test_intent_protocols.py
+++ b/tests/spec/test_intent_protocols.py
@@ -1,0 +1,75 @@
+# Prosperity-3.0
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.intent_protocols import (
+    ConstraintConfig,
+    GracefulDegradationPolicy,
+    UniversalIntentURI,
+)
+
+
+def test_constraint_config() -> None:
+    config = ConstraintConfig(
+        max_latency_ms=1000,
+        requires_hipaa_compliance=True,
+        allowed_compute_regions=["us-east-1"],
+    )
+    assert config.max_latency_ms == 1000
+    assert config.requires_hipaa_compliance is True
+    assert config.allowed_compute_regions == ["us-east-1"]
+
+
+def test_graceful_degradation_policy() -> None:
+    policy = GracefulDegradationPolicy(
+        droppable_constraints=["max_latency_ms"],
+        fallback_timeout_ms=5000,
+        allow_synthetic_bootstrapping=True,
+    )
+    assert policy.droppable_constraints == ["max_latency_ms"]
+    assert policy.fallback_timeout_ms == 5000
+    assert policy.allow_synthetic_bootstrapping is True
+
+
+def test_universal_intent_uri_valid() -> None:
+    config = ConstraintConfig(
+        max_latency_ms=500,
+        requires_hipaa_compliance=False,
+        allowed_compute_regions=["eu-central-1"],
+    )
+    policy = GracefulDegradationPolicy(
+        droppable_constraints=["max_latency_ms"],
+        fallback_timeout_ms=10000,
+        allow_synthetic_bootstrapping=False,
+    )
+
+    uri = UniversalIntentURI(
+        scheme="ibo",
+        ecosystem_target="huggingface",
+        semantic_payload="Identify relevant text snippets",
+        constraints=config,
+        degradation_policy=policy,
+    )
+
+    assert uri.scheme == "ibo"
+    assert uri.ecosystem_target == "huggingface"
+    assert uri.semantic_payload == "Identify relevant text snippets"
+    assert uri.constraints == config
+    assert uri.degradation_policy == policy
+
+
+def test_universal_intent_uri_invalid_scheme() -> None:
+    config = ConstraintConfig(
+        max_latency_ms=500,
+        requires_hipaa_compliance=False,
+        allowed_compute_regions=["eu-central-1"],
+    )
+
+    with pytest.raises(ValidationError):
+        UniversalIntentURI(
+            scheme="invalid_scheme",  # type: ignore
+            ecosystem_target="huggingface",
+            semantic_payload="Identify relevant text snippets",
+            constraints=config,
+            degradation_policy=None,
+        )

--- a/tests/workflow/nodes/test_liquid_nodes.py
+++ b/tests/workflow/nodes/test_liquid_nodes.py
@@ -1,0 +1,89 @@
+# Prosperity-3.0
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.intent_protocols import (
+    ConstraintConfig,
+    GracefulDegradationPolicy,
+    UniversalIntentURI,
+)
+from coreason_manifest.workflow.nodes.liquid import (
+    DecompositionStrategy,
+    LiquidTopologyNode,
+)
+
+
+def test_liquid_topology_node_inheritance() -> None:
+    config = ConstraintConfig(
+        max_latency_ms=1000,
+        requires_hipaa_compliance=False,
+        allowed_compute_regions=["us-west-2"],
+    )
+    policy = GracefulDegradationPolicy(
+        droppable_constraints=["max_latency_ms"],
+        fallback_timeout_ms=5000,
+        allow_synthetic_bootstrapping=True,
+    )
+
+    uri = UniversalIntentURI(
+        scheme="ibo",
+        ecosystem_target="registry-alpha",
+        semantic_payload="Parse these logs",
+        constraints=config,
+        degradation_policy=policy,
+    )
+    decomp = DecompositionStrategy(
+        max_micro_agents=3,
+        allowed_sub_intents=["read", "parse"],
+        require_human_oversight_on_synthesis=True,
+    )
+
+    node = LiquidTopologyNode(
+        id="liquid-node-1",
+        type="liquid",
+        macro_intent=uri,
+        decomposition=decomp,
+        ephemeral_ttl_seconds=3600,
+    )
+    assert node.id == "liquid-node-1"
+    assert node.type == "liquid"
+    assert node.macro_intent == uri
+    assert node.decomposition == decomp
+    assert node.ephemeral_ttl_seconds == 3600
+
+
+def test_liquid_topology_negative_ttl_validation() -> None:
+    config = ConstraintConfig(
+        max_latency_ms=1000,
+        requires_hipaa_compliance=False,
+        allowed_compute_regions=["us-west-2"],
+    )
+    uri = UniversalIntentURI(
+        scheme="local",
+        ecosystem_target="local",
+        semantic_payload="Test",
+        constraints=config,
+    )
+    decomp = DecompositionStrategy(
+        max_micro_agents=2,
+        allowed_sub_intents=["test"],
+        require_human_oversight_on_synthesis=False,
+    )
+
+    with pytest.raises(ValidationError, match="ephemeral_ttl_seconds must be a positive integer"):
+        LiquidTopologyNode(
+            id="liquid-node-2",
+            type="liquid",
+            macro_intent=uri,
+            decomposition=decomp,
+            ephemeral_ttl_seconds=-5,
+        )
+
+
+def test_decomposition_strategy_max_agents_validation() -> None:
+    with pytest.raises(ValidationError):
+        DecompositionStrategy(
+            max_micro_agents=0,  # Invalid, must be > 0
+            allowed_sub_intents=["test"],
+            require_human_oversight_on_synthesis=True,
+        )

--- a/tests/workflow/nodes/test_liquid_nodes.py
+++ b/tests/workflow/nodes/test_liquid_nodes.py
@@ -40,7 +40,6 @@ def test_liquid_topology_node_inheritance() -> None:
 
     node = LiquidTopologyNode(
         id="liquid-node-1",
-        type="liquid",
         macro_intent=uri,
         decomposition=decomp,
         ephemeral_ttl_seconds=3600,
@@ -70,10 +69,9 @@ def test_liquid_topology_negative_ttl_validation() -> None:
         require_human_oversight_on_synthesis=False,
     )
 
-    with pytest.raises(ValidationError, match="ephemeral_ttl_seconds must be a positive integer"):
+    with pytest.raises(ValidationError):
         LiquidTopologyNode(
             id="liquid-node-2",
-            type="liquid",
             macro_intent=uri,
             decomposition=decomp,
             ephemeral_ttl_seconds=-5,


### PR DESCRIPTION
This PR implements the initial data models for "EPIC 1: Liquid Topologies & Universal Intent".

It introduces:
- `UniversalIntentURI` and related constraints to standardize intent routing.
- `LiquidTopologyNode` to define ephemeral swarms in the orchestration graph.
- Corresponding test coverage for Pydantic validation and inheritance.

All changes adhere to the Passive Shared Kernel guidelines.

---
*PR created automatically by Jules for task [18188012417473095603](https://jules.google.com/task/18188012417473095603) started by @gowthamrao*