### PR TITLE
feat: add Toolchain schemas for dynamic Tool-RAG and JIT Synthesis

### DIFF
--- a/src/coreason_manifest/state/toolchains.py
+++ b/src/coreason_manifest/state/toolchains.py
@@ -8,10 +8,12 @@ dynamic discovery, semantic compression, and on-the-fly synthesis capabilities.
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import Field
+
+from coreason_manifest.core.common.base import CoreasonModel
 
 
-class CognitiveLoadTrimmer(BaseModel):
+class CognitiveLoadTrimmer(CoreasonModel):
     """
     Defines the orchestrator's strategy for managing the LLM context window.
 
@@ -20,7 +22,9 @@ class CognitiveLoadTrimmer(BaseModel):
     """
 
     max_tool_tokens: int = Field(
-        ..., description="The absolute maximum number of tokens allowed for tool descriptions in the prompt."
+        ...,
+        gt=0,
+        description="The absolute maximum number of tokens allowed for tool descriptions in the prompt.",
     )
 
     auto_provision_subagent: bool = Field(
@@ -36,7 +40,7 @@ class CognitiveLoadTrimmer(BaseModel):
     )
 
 
-class JITToolSynthesisConfig(BaseModel):
+class JITToolSynthesisConfig(CoreasonModel):
     """
     Declares the algorithmic process for generating a net-new tool on the fly.
 
@@ -56,11 +60,13 @@ class JITToolSynthesisConfig(BaseModel):
     )
 
     max_synthesis_time_ms: int = Field(
-        ..., description="Timeout (in milliseconds) for the generation and testing loop."
+        ...,
+        gt=0,
+        description="Timeout (in milliseconds) for the generation and testing loop.",
     )
 
 
-class SemanticToolchain(BaseModel):
+class SemanticToolchain(CoreasonModel):
     """
     Represents a DAG of micro-tools linked by vector similarity rather than hardcoded edges.
 

--- a/src/coreason_manifest/state/toolchains.py
+++ b/src/coreason_manifest/state/toolchains.py
@@ -1,0 +1,90 @@
+"""
+Toolchain definitions for dynamic Tool-RAG and JIT Synthesis architectures.
+
+This module provides the schema contracts required to support the 2026
+Dynamic Tool-RAG architecture, ensuring precise management of the orchestrator's
+dynamic discovery, semantic compression, and on-the-fly synthesis capabilities.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class CognitiveLoadTrimmer(BaseModel):
+    """
+    Defines the orchestrator's strategy for managing the LLM context window.
+
+    In a dynamic Tool-RAG architecture, too many tool descriptions can overwhelm
+    the model's effective context. This trimmer prevents context collapse.
+    """
+
+    max_tool_tokens: int = Field(
+        ..., description="The absolute maximum number of tokens allowed for tool descriptions in the prompt."
+    )
+
+    auto_provision_subagent: bool = Field(
+        ...,
+        description="If True, orchestrator spawns a sub-agent when max_tool_tokens is exceeded rather than truncating.",
+    )
+
+    context_compression_ratio: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Threshold (0.0 to 1.0) indicating when semantic compression of tool descriptions triggers.",
+    )
+
+
+class JITToolSynthesisConfig(BaseModel):
+    """
+    Declares the algorithmic process for generating a net-new tool on the fly.
+
+    If the semantic search catalog returns no matches, this configuration defines
+    how a fallback generation and verification process occurs.
+    """
+
+    generation_model_uri: str = Field(..., description="The identifier of the model tasked with writing the tool code.")
+
+    wasm_sandbox_profile: Literal["strict", "network-enabled", "fs-read-only"] = Field(
+        ..., description="The required security boundary to safely test the generated tool."
+    )
+
+    verification_assertion: str = Field(
+        ...,
+        description="Natural language or code-based assertion the generated tool must pass before being registered.",
+    )
+
+    max_synthesis_time_ms: int = Field(
+        ..., description="Timeout (in milliseconds) for the generation and testing loop."
+    )
+
+
+class SemanticToolchain(BaseModel):
+    """
+    Represents a DAG of micro-tools linked by vector similarity rather than hardcoded edges.
+
+    Allows tools to be dynamically assembled and chained during an orchestrator run.
+    """
+
+    macro_intent_hash: str = Field(..., description="The hash of the high-level goal this toolchain serves.")
+
+    discovered_tool_uris: list[str] = Field(
+        ..., description="URIs pointing to tools pulled from an MCP registry or local vector database."
+    )
+
+    similarity_threshold: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Minimum cosine similarity score (0.0 to 1.0) required for a tool to be included in this chain.",
+    )
+
+    load_strategy: Literal["lazy_eval", "eager_mount", "ephemeral"] = Field(
+        ..., description="How the runtime should provision these tools."
+    )
+
+    jit_synthesis_fallback: JITToolSynthesisConfig | None = Field(
+        default=None,
+        description="Fallback mechanism for JIT synthesis if semantic search fails to yield sufficient tools.",
+    )

--- a/tests/state/test_toolchains.py
+++ b/tests/state/test_toolchains.py
@@ -22,18 +22,34 @@ def test_cognitive_load_trimmer_valid() -> None:
 
 def test_cognitive_load_trimmer_invalid_bounds() -> None:
     """Test that context_compression_ratio validates its bounds."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"Input should be greater than or equal to 0"):
         CognitiveLoadTrimmer(
             max_tool_tokens=1024,
             auto_provision_subagent=False,
             context_compression_ratio=-0.1,  # Below 0.0
         )
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"Input should be less than or equal to 1"):
         CognitiveLoadTrimmer(
             max_tool_tokens=1024,
             auto_provision_subagent=False,
             context_compression_ratio=1.1,  # Above 1.0
+        )
+
+
+def test_cognitive_load_trimmer_invalid_tokens() -> None:
+    """Test that max_tool_tokens must be strictly positive."""
+    with pytest.raises(ValidationError, match=r"Input should be greater than 0"):
+        CognitiveLoadTrimmer(
+            max_tool_tokens=0,
+            auto_provision_subagent=False,
+            context_compression_ratio=0.5,
+        )
+    with pytest.raises(ValidationError, match=r"Input should be greater than 0"):
+        CognitiveLoadTrimmer(
+            max_tool_tokens=-10,
+            auto_provision_subagent=False,
+            context_compression_ratio=0.5,
         )
 
 
@@ -53,12 +69,23 @@ def test_jit_tool_synthesis_config_valid() -> None:
 
 def test_jit_tool_synthesis_config_invalid_profile() -> None:
     """Test that wasm_sandbox_profile must be a valid Literal."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"Input should be 'strict', 'network-enabled' or 'fs-read-only'"):
         JITToolSynthesisConfig(
             generation_model_uri="model://sota/2026",
-            wasm_sandbox_profile="invalid_profile",
+            wasm_sandbox_profile="invalid_profile",  # type: ignore[arg-type]
             verification_assertion="assert tool.execute() is not None",
             max_synthesis_time_ms=5000,
+        )
+
+
+def test_jit_tool_synthesis_config_invalid_time() -> None:
+    """Test that max_synthesis_time_ms must be strictly positive."""
+    with pytest.raises(ValidationError, match=r"Input should be greater than 0"):
+        JITToolSynthesisConfig(
+            generation_model_uri="model://sota/2026",
+            wasm_sandbox_profile="strict",
+            verification_assertion="assert tool.execute() is not None",
+            max_synthesis_time_ms=0,
         )
 
 
@@ -101,7 +128,7 @@ def test_semantic_toolchain_valid_with_fallback() -> None:
 
 def test_semantic_toolchain_invalid_bounds() -> None:
     """Test that similarity_threshold validates its bounds."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"Input should be greater than or equal to 0"):
         SemanticToolchain(
             macro_intent_hash="0x1111",
             discovered_tool_uris=[],
@@ -109,7 +136,7 @@ def test_semantic_toolchain_invalid_bounds() -> None:
             load_strategy="ephemeral",
         )
 
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"Input should be less than or equal to 1"):
         SemanticToolchain(
             macro_intent_hash="0x1111",
             discovered_tool_uris=[],
@@ -120,10 +147,10 @@ def test_semantic_toolchain_invalid_bounds() -> None:
 
 def test_semantic_toolchain_invalid_strategy() -> None:
     """Test that load_strategy must be a valid Literal."""
-    with pytest.raises(ValidationError):
+    with pytest.raises(ValidationError, match=r"Input should be 'lazy_eval', 'eager_mount' or 'ephemeral'"):
         SemanticToolchain(
             macro_intent_hash="0x1111",
             discovered_tool_uris=[],
             similarity_threshold=0.5,
-            load_strategy="invalid_strategy",
+            load_strategy="invalid_strategy",  # type: ignore[arg-type]
         )

--- a/tests/state/test_toolchains.py
+++ b/tests/state/test_toolchains.py
@@ -1,0 +1,129 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.state.toolchains import (
+    CognitiveLoadTrimmer,
+    JITToolSynthesisConfig,
+    SemanticToolchain,
+)
+
+
+def test_cognitive_load_trimmer_valid() -> None:
+    """Test successful instantiation of CognitiveLoadTrimmer."""
+    trimmer = CognitiveLoadTrimmer(
+        max_tool_tokens=2048,
+        auto_provision_subagent=True,
+        context_compression_ratio=0.75,
+    )
+    assert trimmer.max_tool_tokens == 2048
+    assert trimmer.auto_provision_subagent is True
+    assert trimmer.context_compression_ratio == 0.75
+
+
+def test_cognitive_load_trimmer_invalid_bounds() -> None:
+    """Test that context_compression_ratio validates its bounds."""
+    with pytest.raises(ValidationError):
+        CognitiveLoadTrimmer(
+            max_tool_tokens=1024,
+            auto_provision_subagent=False,
+            context_compression_ratio=-0.1,  # Below 0.0
+        )
+
+    with pytest.raises(ValidationError):
+        CognitiveLoadTrimmer(
+            max_tool_tokens=1024,
+            auto_provision_subagent=False,
+            context_compression_ratio=1.1,  # Above 1.0
+        )
+
+
+def test_jit_tool_synthesis_config_valid() -> None:
+    """Test successful instantiation of JITToolSynthesisConfig."""
+    config = JITToolSynthesisConfig(
+        generation_model_uri="model://sota/2026",
+        wasm_sandbox_profile="strict",
+        verification_assertion="assert tool.execute() is not None",
+        max_synthesis_time_ms=5000,
+    )
+    assert config.generation_model_uri == "model://sota/2026"
+    assert config.wasm_sandbox_profile == "strict"
+    assert config.verification_assertion == "assert tool.execute() is not None"
+    assert config.max_synthesis_time_ms == 5000
+
+
+def test_jit_tool_synthesis_config_invalid_profile() -> None:
+    """Test that wasm_sandbox_profile must be a valid Literal."""
+    with pytest.raises(ValidationError):
+        JITToolSynthesisConfig(
+            generation_model_uri="model://sota/2026",
+            wasm_sandbox_profile="invalid_profile",
+            verification_assertion="assert tool.execute() is not None",
+            max_synthesis_time_ms=5000,
+        )
+
+
+def test_semantic_toolchain_valid_without_fallback() -> None:
+    """Test successful instantiation of SemanticToolchain without fallback."""
+    toolchain = SemanticToolchain(
+        macro_intent_hash="0xabcd1234",
+        discovered_tool_uris=["tool://math/add", "tool://math/subtract"],
+        similarity_threshold=0.85,
+        load_strategy="lazy_eval",
+    )
+    assert toolchain.macro_intent_hash == "0xabcd1234"
+    assert toolchain.discovered_tool_uris == ["tool://math/add", "tool://math/subtract"]
+    assert toolchain.similarity_threshold == 0.85
+    assert toolchain.load_strategy == "lazy_eval"
+    assert toolchain.jit_synthesis_fallback is None
+
+
+def test_semantic_toolchain_valid_with_fallback() -> None:
+    """Test successful instantiation of a complex SemanticToolchain with a JIT fallback."""
+    fallback = JITToolSynthesisConfig(
+        generation_model_uri="model://sota/2026",
+        wasm_sandbox_profile="network-enabled",
+        verification_assertion="return True",
+        max_synthesis_time_ms=10000,
+    )
+
+    toolchain = SemanticToolchain(
+        macro_intent_hash="0xdeadbeef",
+        discovered_tool_uris=[],
+        similarity_threshold=0.9,
+        load_strategy="eager_mount",
+        jit_synthesis_fallback=fallback,
+    )
+    assert toolchain.similarity_threshold == 0.9
+    assert toolchain.load_strategy == "eager_mount"
+    assert toolchain.jit_synthesis_fallback is not None
+    assert toolchain.jit_synthesis_fallback.generation_model_uri == "model://sota/2026"
+
+
+def test_semantic_toolchain_invalid_bounds() -> None:
+    """Test that similarity_threshold validates its bounds."""
+    with pytest.raises(ValidationError):
+        SemanticToolchain(
+            macro_intent_hash="0x1111",
+            discovered_tool_uris=[],
+            similarity_threshold=-0.5,  # Below 0.0
+            load_strategy="ephemeral",
+        )
+
+    with pytest.raises(ValidationError):
+        SemanticToolchain(
+            macro_intent_hash="0x1111",
+            discovered_tool_uris=[],
+            similarity_threshold=1.01,  # Above 1.0
+            load_strategy="ephemeral",
+        )
+
+
+def test_semantic_toolchain_invalid_strategy() -> None:
+    """Test that load_strategy must be a valid Literal."""
+    with pytest.raises(ValidationError):
+        SemanticToolchain(
+            macro_intent_hash="0x1111",
+            discovered_tool_uris=[],
+            similarity_threshold=0.5,
+            load_strategy="invalid_strategy",
+        )


### PR DESCRIPTION
Implements dynamic Tool-RAG capabilities by defining the Pydantic schemas `CognitiveLoadTrimmer`, `JITToolSynthesisConfig`, and `SemanticToolchain`. This correctly models how an orchestrator can dynamically discover, chain, and synthesize tools. Tests are added and pass with 100% statement coverage. Code conforms to the Shared Kernel architectural directive by avoiding any execution logic.

---
*PR created automatically by Jules for task [1999752829549107513](https://jules.google.com/task/1999752829549107513) started by @gowthamrao*