### PR TITLE
feat: Add SCIVIS and oversight adjudication contracts

### DIFF
--- a/src/coreason_manifest/oversight/adjudication.py
+++ b/src/coreason_manifest/oversight/adjudication.py
@@ -8,11 +8,21 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
+from collections.abc import Sequence
 from typing import Literal
 
 from pydantic import Field
 
 from coreason_manifest.core.common.base import CoreasonModel
+
+
+class AdjudicationOption(CoreasonModel):
+    """
+    Represents a specific choice in an adjudication form.
+    """
+
+    option_id: str = Field(..., description="The unique identifier for the option.")
+    clinical_justification: str = Field(..., description="The clinical justification for the option.")
 
 
 class AdjudicationFormContract(CoreasonModel):
@@ -30,15 +40,12 @@ class AdjudicationFormContract(CoreasonModel):
     epistemic_context: str = Field(
         ..., description="String explaining exactly *why* the AI is uncertain and requires human input."
     )
-    uncertain_concepts: list[str] = Field(
-        ..., description="List of strings representing the ambiguous clinical terms or OMOP concept IDs."
+    uncertain_concepts: Sequence[str] = Field(
+        ..., description="Sequence of strings representing the ambiguous clinical terms or OMOP concept IDs."
     )
-    proposed_options: list[dict[str, str]] = Field(
+    proposed_options: Sequence[AdjudicationOption] = Field(
         ...,
-        description=(
-            "List of dictionaries representing the multi-choice options the human can select, "
-            "expected to include an `option_id` and `clinical_justification`."
-        ),
+        description=("Sequence of AdjudicationOption representing the multi-choice options the human can select."),
     )
     requires_consensus: bool = Field(
         ..., description="Boolean indicating if multiple humans must respond before the workflow resumes."

--- a/src/coreason_manifest/oversight/adjudication.py
+++ b/src/coreason_manifest/oversight/adjudication.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class AdjudicationFormContract(CoreasonModel):
+    """
+    Represents a structured "Interrupt" where the AI pauses execution and asks a human expert
+    for guidance (e.g., via an MS Teams Adaptive Card). It specifies why it is uncertain
+    and the available multiple-choice options for the human to select from.
+    External applications interpret this declarative contract to render interactive forms.
+    """
+
+    adjudication_id: str = Field(..., description="A unique UUID string identifying this adjudication contract.")
+    urgency_level: Literal["LOW", "MEDIUM", "HIGH", "BLOCKING"] = Field(
+        ..., description="The urgency level for the requested human intervention."
+    )
+    epistemic_context: str = Field(
+        ..., description="String explaining exactly *why* the AI is uncertain and requires human input."
+    )
+    uncertain_concepts: list[str] = Field(
+        ..., description="List of strings representing the ambiguous clinical terms or OMOP concept IDs."
+    )
+    proposed_options: list[dict[str, str]] = Field(
+        ...,
+        description=(
+            "List of dictionaries representing the multi-choice options the human can select, "
+            "expected to include an `option_id` and `clinical_justification`."
+        ),
+    )
+    requires_consensus: bool = Field(
+        ..., description="Boolean indicating if multiple humans must respond before the workflow resumes."
+    )
+
+
+class AmbientInsightContract(CoreasonModel):
+    """
+    Represents a passive, non-blocking notification (e.g., an Excel cell highlight or subtle sidebar alert).
+    It defines an alert that does not pause AI execution, but highlights an anomaly or suggested action.
+    """
+
+    insight_id: str = Field(..., description="A unique UUID string identifying this ambient insight.")
+    target_ui_element: str = Field(..., description="String reference to what the external app should anchor this to.")
+    anomaly_type: Literal["STATISTICAL_DEVIATION", "BIAS_DETECTED", "LITERATURE_CONFLICT"] = Field(
+        ..., description="The classification of the detected anomaly."
+    )
+    mathematical_deviation: float = Field(..., description="Float representing the magnitude of the anomaly.")
+    suggested_review_action: str = Field(..., description="Suggested action for the user to review the finding.")

--- a/src/coreason_manifest/presentation/scivis/grammar.py
+++ b/src/coreason_manifest/presentation/scivis/grammar.py
@@ -8,11 +8,22 @@
 #
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
-from typing import Any, Literal
+from collections.abc import Mapping, Sequence
+from typing import Literal
 
 from pydantic import Field
 
 from coreason_manifest.core.common.base import CoreasonModel
+
+
+class TimelineEvent(CoreasonModel):
+    """
+    Represents a specific event in a timeline or patient trajectory.
+    """
+
+    event_name: str = Field(..., description="The name of the event.")
+    days_from_index: int = Field(..., description="The number of days from the index date.")
+    event_domain: str = Field(..., description="The clinical domain of the event (e.g., Condition, Drug).")
 
 
 class GrammarOfGraphicsSpecification(CoreasonModel):
@@ -31,10 +42,10 @@ class GrammarOfGraphicsSpecification(CoreasonModel):
     mark_type: Literal["LINE", "BAR", "POINT", "AREA", "TICK"] = Field(
         ..., description="The visual mark type to use (e.g. LINE, BAR, POINT, AREA, TICK)."
     )
-    data_bindings: dict[str, str] = Field(
+    data_bindings: Mapping[str, str] = Field(
         ..., description="Dictionary mapping string keys to expected data structures or OMOP column names."
     )
-    encoding: dict[str, str] = Field(
+    encoding: Mapping[str, str] = Field(
         ..., description="Dictionary mapping visual channels like `x`, `y`, `color`, `tooltip` to data fields."
     )
 
@@ -47,12 +58,9 @@ class TimelineVisContract(CoreasonModel):
 
     trajectory_id: str = Field(..., description="Identifier for the trajectory.")
     time_zero_event: str = Field(..., description="Description of the index date (time zero) event.")
-    events: list[dict[str, Any]] = Field(
+    events: Sequence[TimelineEvent] = Field(
         ...,
-        description=(
-            "A list of dictionaries representing events in the timeline, expected to "
-            "contain `event_name`, `days_from_index`, and `event_domain`."
-        ),
+        description=("A sequence of TimelineEvent objects representing events in the timeline."),
     )
     base_specification: GrammarOfGraphicsSpecification = Field(
         ..., description="Reference to a GrammarOfGraphicsSpecification base contract."

--- a/src/coreason_manifest/presentation/scivis/grammar.py
+++ b/src/coreason_manifest/presentation/scivis/grammar.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Any, Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class GrammarOfGraphicsSpecification(CoreasonModel):
+    """
+    Represents a Vega-Lite or Apache ECharts inspired declarative visualization contract.
+    This pure data schema dictates the visual mappings for data arrays provided externally.
+    External executing environments (like an MS Teams Adaptive Card or Excel native chart)
+    must interpret this contract to generate the UI components.
+    """
+
+    vis_id: str = Field(..., description="A unique UUID string identifying this visualization.")
+    title: str = Field(..., description="The title of the visualization.")
+    description: str = Field(
+        ..., description="Description explaining the epidemiological insight of the visualization."
+    )
+    mark_type: Literal["LINE", "BAR", "POINT", "AREA", "TICK"] = Field(
+        ..., description="The visual mark type to use (e.g. LINE, BAR, POINT, AREA, TICK)."
+    )
+    data_bindings: dict[str, str] = Field(
+        ..., description="Dictionary mapping string keys to expected data structures or OMOP column names."
+    )
+    encoding: dict[str, str] = Field(
+        ..., description="Dictionary mapping visual channels like `x`, `y`, `color`, `tooltip` to data fields."
+    )
+
+
+class TimelineVisContract(CoreasonModel):
+    """
+    A specialized schema for rendering OMOP patient trajectories or cohort attrition timelines.
+    This structure embeds a base GrammarOfGraphicsSpecification.
+    """
+
+    trajectory_id: str = Field(..., description="Identifier for the trajectory.")
+    time_zero_event: str = Field(..., description="Description of the index date (time zero) event.")
+    events: list[dict[str, Any]] = Field(
+        ...,
+        description=(
+            "A list of dictionaries representing events in the timeline, expected to "
+            "contain `event_name`, `days_from_index`, and `event_domain`."
+        ),
+    )
+    base_specification: GrammarOfGraphicsSpecification = Field(
+        ..., description="Reference to a GrammarOfGraphicsSpecification base contract."
+    )


### PR DESCRIPTION
Add SCIVIS presentation and oversight adjudication data schemas

This PR introduces pure-data, zero-execution Python Pydantic schemas to support declarative UI representations. It creates `src/coreason_manifest/presentation/scivis/grammar.py` to define `GrammarOfGraphicsSpecification` and `TimelineVisContract` for Vega-Lite inspired visualizations. It also creates `src/coreason_manifest/oversight/adjudication.py` to define `AdjudicationFormContract` and `AmbientInsightContract` for structured human-in-the-loop suspense and ambient telemetry. 

The implementations strictly inherit from `CoreasonModel` and enforce immutability, strong typing, and precise type constraints (using `Literal`), ensuring perfect compliance with the coreason_manifest domain standard for 2026+.

---
*PR created automatically by Jules for task [709242819683120654](https://jules.google.com/task/709242819683120654) started by @gowthamrao*