### PR TITLE
Epic 5: Add Ambient Edge Telemetry and Presentation Schemas

### DIFF
--- a/src/coreason_manifest/presentation/ambient_edge.py
+++ b/src/coreason_manifest/presentation/ambient_edge.py
@@ -10,13 +10,14 @@
 
 from typing import Literal
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field
 
+from coreason_manifest.core.common.base import CoreasonModel
 from coreason_manifest.presentation.ambient import AmbientListenerConfig
 from coreason_manifest.telemetry.ambient_schemas import MultimodalTelemetryStream
 
 
-class EdgeSLMProcessor(BaseModel):
+class EdgeSLMProcessor(CoreasonModel):
     """
     A schema configuring the local Small Language Model (running on the user's device).
 
@@ -31,6 +32,7 @@ class EdgeSLMProcessor(BaseModel):
     )
     max_latency_ms: int = Field(
         ...,
+        lt=250,
         description="Hard constraint for edge processing. Must be < 250ms to guarantee zero UI blocking.",
     )
     local_feature_extraction_only: bool = Field(
@@ -41,14 +43,8 @@ class EdgeSLMProcessor(BaseModel):
         ),
     )
 
-    @model_validator(mode="after")
-    def validate_max_latency_ms(self) -> "EdgeSLMProcessor":
-        if self.max_latency_ms >= 250:
-            raise ValueError("max_latency_ms must be < 250ms to guarantee zero UI blocking.")
-        return self
 
-
-class AutonomousPrecomputeIntent(BaseModel):
+class AutonomousPrecomputeIntent(CoreasonModel):
     """
     A schema representing a 'shadow task' in the 2026 Zero-UI architecture.
 
@@ -63,10 +59,13 @@ class AutonomousPrecomputeIntent(BaseModel):
     )
     confidence_score: float = Field(
         ...,
+        ge=0.0,
+        le=1.0,
         description="Prediction confidence from 0.0 to 1.0.",
     )
     background_resource_allocation_mb: int = Field(
         ...,
+        gt=0,
         description="Max memory the shadow task can consume in megabytes.",
     )
     auto_inject_ui_target: str | None = Field(
@@ -74,14 +73,8 @@ class AutonomousPrecomputeIntent(BaseModel):
         description="A DOM or application pointer where the results should be streamed if prediction is correct.",
     )
 
-    @model_validator(mode="after")
-    def validate_confidence_score(self) -> "AutonomousPrecomputeIntent":
-        if self.confidence_score < 0.0 or self.confidence_score > 1.0:
-            raise ValueError("confidence_score must be between 0.0 and 1.0.")
-        return self
 
-
-class EdgeNativeAmbientListener(BaseModel):
+class EdgeNativeAmbientListener(CoreasonModel):
     """
     The composite schema that an application mounts on startup for Edge-Native ambient observation.
 
@@ -103,5 +96,7 @@ class EdgeNativeAmbientListener(BaseModel):
     )
     precompute_threshold: float = Field(
         ...,
+        ge=0.0,
+        le=1.0,
         description="The minimum confidence_score required to trigger an AutonomousPrecomputeIntent.",
     )

--- a/src/coreason_manifest/presentation/ambient_edge.py
+++ b/src/coreason_manifest/presentation/ambient_edge.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+from typing import Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+from coreason_manifest.presentation.ambient import AmbientListenerConfig
+from coreason_manifest.telemetry.ambient_schemas import MultimodalTelemetryStream
+
+
+class EdgeSLMProcessor(BaseModel):
+    """
+    A schema configuring the local Small Language Model (running on the user's device).
+
+    This processor is responsible for extracting semantic triplets from the raw
+    `MultimodalTelemetryStream` locally to preserve privacy and reduce latency
+    in our 2026 Zero-UI architecture.
+    """
+
+    model_quantization: Literal["int4", "int8", "fp16"] = Field(
+        ...,
+        description="The quantization level of the SLM deployed on the edge device.",
+    )
+    max_latency_ms: int = Field(
+        ...,
+        description="Hard constraint for edge processing. Must be < 250ms to guarantee zero UI blocking.",
+    )
+    local_feature_extraction_only: bool = Field(
+        ...,
+        description=(
+            "If true, prevents raw telemetry from *ever* leaving the local device, "
+            "only transmitting the extracted semantic embeddings to the cloud."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_max_latency_ms(self) -> "EdgeSLMProcessor":
+        if self.max_latency_ms >= 250:
+            raise ValueError("max_latency_ms must be < 250ms to guarantee zero UI blocking.")
+        return self
+
+
+class AutonomousPrecomputeIntent(BaseModel):
+    """
+    A schema representing a 'shadow task' in the 2026 Zero-UI architecture.
+
+    When the `EdgeSLMProcessor` predicts what the user is about to do, it emits
+    this intent to pre-warm the cache or run heavy database queries silently
+    in the background.
+    """
+
+    predicted_query_hash: str = Field(
+        ...,
+        description="Unique identifier for the anticipated task to pre-compute.",
+    )
+    confidence_score: float = Field(
+        ...,
+        description="Prediction confidence from 0.0 to 1.0.",
+    )
+    background_resource_allocation_mb: int = Field(
+        ...,
+        description="Max memory the shadow task can consume in megabytes.",
+    )
+    auto_inject_ui_target: str | None = Field(
+        default=None,
+        description="A DOM or application pointer where the results should be streamed if prediction is correct.",
+    )
+
+    @model_validator(mode="after")
+    def validate_confidence_score(self) -> "AutonomousPrecomputeIntent":
+        if self.confidence_score < 0.0 or self.confidence_score > 1.0:
+            raise ValueError("confidence_score must be between 0.0 and 1.0.")
+        return self
+
+
+class EdgeNativeAmbientListener(BaseModel):
+    """
+    The composite schema that an application mounts on startup for Edge-Native ambient observation.
+
+    It binds the base listener config, telemetry stream, local SLM config,
+    and thresholds to orchestrate the next-generation Zero-UI experience.
+    """
+
+    base_config: AmbientListenerConfig = Field(
+        ...,
+        description="Base configuration for ambient listening triggers.",
+    )
+    telemetry_stream: MultimodalTelemetryStream = Field(
+        ...,
+        description="Configuration for the multimodal passive environmental exhaust.",
+    )
+    edge_processor: EdgeSLMProcessor = Field(
+        ...,
+        description="Local Small Language Model configuration.",
+    )
+    precompute_threshold: float = Field(
+        ...,
+        description="The minimum confidence_score required to trigger an AutonomousPrecomputeIntent.",
+    )

--- a/src/coreason_manifest/telemetry/ambient_schemas.py
+++ b/src/coreason_manifest/telemetry/ambient_schemas.py
@@ -1,0 +1,68 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class PrivacyMaskingZone(BaseModel):
+    """
+    A schema defining application bounds or coordinate boxes that the ambient listener must completely ignore.
+
+    This forms a crucial part of the 2026 Zero-UI and Edge Privacy architecture, ensuring that
+    sensitive contexts (e.g., password managers, messaging apps) are strictly excluded from
+    environmental exhaust telemetry.
+    """
+
+    app_name_regex: str | None = Field(
+        default=None,
+        description="Optional regex to match application names that should be masked.",
+    )
+    bounding_box_coordinates: list[int] | None = Field(
+        default=None,
+        description="Optional list of integers representing the [x, y, width, height] of the masking zone.",
+    )
+    is_strict_enforce: bool = Field(
+        ...,
+        description="If true, enforcement of the mask is mandatory and failure to mask will drop the telemetry frame.",
+    )
+
+
+class MultimodalTelemetryStream(BaseModel):
+    """
+    A schema extending standard text-based telemetry to include passive environmental exhaust.
+
+    In the 2026 Zero-UI architecture, this contract allows external clients to stream
+    multimodal (audio/screen) context to the orchestrator while adhering to strict
+    privacy and performance constraints.
+    """
+
+    audio_exhaust_enabled: bool = Field(
+        ...,
+        description="Whether background speech-to-text environmental exhaust is active.",
+    )
+    screen_capture_framerate: float = Field(
+        ...,
+        description="The FPS of semantic screen extraction. Must be strictly <= 1.0 FPS to prevent battery drain.",
+    )
+    privacy_masking_zones: list[PrivacyMaskingZone] = Field(
+        default_factory=list,
+        description="List of zones that must be masked out of the screen capture before processing.",
+    )
+
+    @model_validator(mode="after")
+    def validate_screen_capture_framerate(self) -> "MultimodalTelemetryStream":
+        """
+        Ensures the screen capture framerate is highly constrained (<= 1.0 FPS)
+        to prevent battery drain and excessive compute overhead.
+        """
+        if self.screen_capture_framerate > 1.0:
+            raise ValueError("screen_capture_framerate must be <= 1.0 FPS to prevent battery drain and overhead.")
+        return self

--- a/src/coreason_manifest/telemetry/ambient_schemas.py
+++ b/src/coreason_manifest/telemetry/ambient_schemas.py
@@ -9,10 +9,12 @@
 # Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field
+
+from coreason_manifest.core.common.base import CoreasonModel
 
 
-class PrivacyMaskingZone(BaseModel):
+class PrivacyMaskingZone(CoreasonModel):
     """
     A schema defining application bounds or coordinate boxes that the ambient listener must completely ignore.
 
@@ -35,7 +37,7 @@ class PrivacyMaskingZone(BaseModel):
     )
 
 
-class MultimodalTelemetryStream(BaseModel):
+class MultimodalTelemetryStream(CoreasonModel):
     """
     A schema extending standard text-based telemetry to include passive environmental exhaust.
 
@@ -50,19 +52,10 @@ class MultimodalTelemetryStream(BaseModel):
     )
     screen_capture_framerate: float = Field(
         ...,
+        le=1.0,
         description="The FPS of semantic screen extraction. Must be strictly <= 1.0 FPS to prevent battery drain.",
     )
     privacy_masking_zones: list[PrivacyMaskingZone] = Field(
         default_factory=list,
         description="List of zones that must be masked out of the screen capture before processing.",
     )
-
-    @model_validator(mode="after")
-    def validate_screen_capture_framerate(self) -> "MultimodalTelemetryStream":
-        """
-        Ensures the screen capture framerate is highly constrained (<= 1.0 FPS)
-        to prevent battery drain and excessive compute overhead.
-        """
-        if self.screen_capture_framerate > 1.0:
-            raise ValueError("screen_capture_framerate must be <= 1.0 FPS to prevent battery drain and overhead.")
-        return self

--- a/tests/presentation/test_ambient_edge.py
+++ b/tests/presentation/test_ambient_edge.py
@@ -1,0 +1,114 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.presentation.ambient import AmbientListenerConfig, AmbientTriggerRule
+from coreason_manifest.presentation.ambient_edge import (
+    AutonomousPrecomputeIntent,
+    EdgeNativeAmbientListener,
+    EdgeSLMProcessor,
+)
+from coreason_manifest.telemetry.ambient_schemas import MultimodalTelemetryStream
+
+
+def test_edge_slm_processor_valid() -> None:
+    """Test valid instantiation of EdgeSLMProcessor."""
+    processor = EdgeSLMProcessor(
+        model_quantization="int8",
+        max_latency_ms=150,
+        local_feature_extraction_only=True,
+    )
+    assert processor.model_quantization == "int8"
+    assert processor.max_latency_ms == 150
+    assert processor.local_feature_extraction_only is True
+
+
+def test_edge_slm_processor_invalid_latency() -> None:
+    """Test that max_latency_ms >= 250 raises a ValidationError."""
+    with pytest.raises(ValidationError) as excinfo:
+        EdgeSLMProcessor(
+            model_quantization="int4",
+            max_latency_ms=300,
+            local_feature_extraction_only=False,
+        )
+
+    assert "max_latency_ms must be < 250ms" in str(excinfo.value)
+
+    with pytest.raises(ValidationError) as excinfo2:
+        EdgeSLMProcessor(
+            model_quantization="int4",
+            max_latency_ms=250,
+            local_feature_extraction_only=False,
+        )
+
+    assert "max_latency_ms must be < 250ms" in str(excinfo2.value)
+
+
+def test_autonomous_precompute_intent_valid() -> None:
+    """Test valid instantiation of AutonomousPrecomputeIntent."""
+    intent = AutonomousPrecomputeIntent(
+        predicted_query_hash="1234abcd",
+        confidence_score=0.85,
+        background_resource_allocation_mb=512,
+        auto_inject_ui_target="$local.search_results",
+    )
+    assert intent.predicted_query_hash == "1234abcd"
+    assert intent.confidence_score == 0.85
+    assert intent.background_resource_allocation_mb == 512
+    assert intent.auto_inject_ui_target == "$local.search_results"
+
+
+def test_autonomous_precompute_intent_invalid_confidence() -> None:
+    """Test that confidence_score < 0.0 or > 1.0 raises a ValidationError."""
+    with pytest.raises(ValidationError) as excinfo_low:
+        AutonomousPrecomputeIntent(
+            predicted_query_hash="1234abcd",
+            confidence_score=-0.1,
+            background_resource_allocation_mb=512,
+        )
+    assert "confidence_score must be between 0.0 and 1.0" in str(excinfo_low.value)
+
+    with pytest.raises(ValidationError) as excinfo_high:
+        AutonomousPrecomputeIntent(
+            predicted_query_hash="1234abcd",
+            confidence_score=1.1,
+            background_resource_allocation_mb=512,
+        )
+    assert "confidence_score must be between 0.0 and 1.0" in str(excinfo_high.value)
+
+
+def test_edge_native_ambient_listener_valid() -> None:
+    """Test valid instantiation of EdgeNativeAmbientListener."""
+    trigger_rule = AmbientTriggerRule(
+        trigger_events=["CANVAS_ADD_CONNECTION"],
+        debounce_ms=800,
+        extract_triplets=True,
+    )
+    base_config = AmbientListenerConfig(
+        listener_id="listener_001",
+        target_canvas_id="canvas_001",
+        trigger_rules=[trigger_rule],
+        action_route="node_001",
+        ui_target_pointer="$local.results",
+    )
+    telemetry_stream = MultimodalTelemetryStream(
+        audio_exhaust_enabled=False,
+        screen_capture_framerate=1.0,
+        privacy_masking_zones=[],
+    )
+    processor = EdgeSLMProcessor(
+        model_quantization="int4",
+        max_latency_ms=200,
+        local_feature_extraction_only=True,
+    )
+
+    listener = EdgeNativeAmbientListener(
+        base_config=base_config,
+        telemetry_stream=telemetry_stream,
+        edge_processor=processor,
+        precompute_threshold=0.9,
+    )
+
+    assert listener.precompute_threshold == 0.9
+    assert listener.base_config.listener_id == "listener_001"
+    assert listener.telemetry_stream.screen_capture_framerate == 1.0
+    assert listener.edge_processor.max_latency_ms == 200

--- a/tests/presentation/test_ambient_edge.py
+++ b/tests/presentation/test_ambient_edge.py
@@ -31,7 +31,7 @@ def test_edge_slm_processor_invalid_latency() -> None:
             local_feature_extraction_only=False,
         )
 
-    assert "max_latency_ms must be < 250ms" in str(excinfo.value)
+    assert "Input should be less than 250" in str(excinfo.value)
 
     with pytest.raises(ValidationError) as excinfo2:
         EdgeSLMProcessor(
@@ -40,7 +40,7 @@ def test_edge_slm_processor_invalid_latency() -> None:
             local_feature_extraction_only=False,
         )
 
-    assert "max_latency_ms must be < 250ms" in str(excinfo2.value)
+    assert "Input should be less than 250" in str(excinfo2.value)
 
 
 def test_autonomous_precompute_intent_valid() -> None:
@@ -65,7 +65,7 @@ def test_autonomous_precompute_intent_invalid_confidence() -> None:
             confidence_score=-0.1,
             background_resource_allocation_mb=512,
         )
-    assert "confidence_score must be between 0.0 and 1.0" in str(excinfo_low.value)
+    assert "Input should be greater than or equal to 0" in str(excinfo_low.value)
 
     with pytest.raises(ValidationError) as excinfo_high:
         AutonomousPrecomputeIntent(
@@ -73,7 +73,18 @@ def test_autonomous_precompute_intent_invalid_confidence() -> None:
             confidence_score=1.1,
             background_resource_allocation_mb=512,
         )
-    assert "confidence_score must be between 0.0 and 1.0" in str(excinfo_high.value)
+    assert "Input should be less than or equal to 1" in str(excinfo_high.value)
+
+
+def test_autonomous_precompute_intent_invalid_allocation() -> None:
+    """Test that background_resource_allocation_mb <= 0 raises a ValidationError."""
+    with pytest.raises(ValidationError) as excinfo_low:
+        AutonomousPrecomputeIntent(
+            predicted_query_hash="1234abcd",
+            confidence_score=0.5,
+            background_resource_allocation_mb=0,
+        )
+    assert "Input should be greater than 0" in str(excinfo_low.value)
 
 
 def test_edge_native_ambient_listener_valid() -> None:
@@ -112,3 +123,47 @@ def test_edge_native_ambient_listener_valid() -> None:
     assert listener.base_config.listener_id == "listener_001"
     assert listener.telemetry_stream.screen_capture_framerate == 1.0
     assert listener.edge_processor.max_latency_ms == 200
+
+
+def test_edge_native_ambient_listener_invalid_threshold() -> None:
+    """Test that precompute_threshold < 0.0 or > 1.0 raises a ValidationError."""
+    trigger_rule = AmbientTriggerRule(
+        trigger_events=["CANVAS_ADD_CONNECTION"],
+        debounce_ms=800,
+        extract_triplets=True,
+    )
+    base_config = AmbientListenerConfig(
+        listener_id="listener_001",
+        target_canvas_id="canvas_001",
+        trigger_rules=[trigger_rule],
+        action_route="node_001",
+        ui_target_pointer="$local.results",
+    )
+    telemetry_stream = MultimodalTelemetryStream(
+        audio_exhaust_enabled=False,
+        screen_capture_framerate=1.0,
+        privacy_masking_zones=[],
+    )
+    processor = EdgeSLMProcessor(
+        model_quantization="int4",
+        max_latency_ms=200,
+        local_feature_extraction_only=True,
+    )
+
+    with pytest.raises(ValidationError) as excinfo_low:
+        EdgeNativeAmbientListener(
+            base_config=base_config,
+            telemetry_stream=telemetry_stream,
+            edge_processor=processor,
+            precompute_threshold=-0.1,
+        )
+    assert "Input should be greater than or equal to 0" in str(excinfo_low.value)
+
+    with pytest.raises(ValidationError) as excinfo_high:
+        EdgeNativeAmbientListener(
+            base_config=base_config,
+            telemetry_stream=telemetry_stream,
+            edge_processor=processor,
+            precompute_threshold=1.1,
+        )
+    assert "Input should be less than or equal to 1" in str(excinfo_high.value)

--- a/tests/telemetry/test_ambient_schemas.py
+++ b/tests/telemetry/test_ambient_schemas.py
@@ -1,0 +1,49 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.telemetry.ambient_schemas import (
+    MultimodalTelemetryStream,
+    PrivacyMaskingZone,
+)
+
+
+def test_privacy_masking_zone_valid() -> None:
+    """Test valid instantiation of PrivacyMaskingZone."""
+    zone = PrivacyMaskingZone(
+        app_name_regex="^1Password$",
+        bounding_box_coordinates=[0, 0, 100, 100],
+        is_strict_enforce=True,
+    )
+    assert zone.app_name_regex == "^1Password$"
+    assert zone.bounding_box_coordinates == [0, 0, 100, 100]
+    assert zone.is_strict_enforce is True
+
+
+def test_multimodal_telemetry_stream_valid() -> None:
+    """Test valid instantiation of MultimodalTelemetryStream."""
+    zone = PrivacyMaskingZone(
+        app_name_regex="^1Password$",
+        bounding_box_coordinates=None,
+        is_strict_enforce=True,
+    )
+    stream = MultimodalTelemetryStream(
+        audio_exhaust_enabled=True,
+        screen_capture_framerate=0.5,
+        privacy_masking_zones=[zone],
+    )
+    assert stream.audio_exhaust_enabled is True
+    assert stream.screen_capture_framerate == 0.5
+    assert len(stream.privacy_masking_zones) == 1
+    assert stream.privacy_masking_zones[0].app_name_regex == "^1Password$"
+
+
+def test_multimodal_telemetry_stream_invalid_framerate() -> None:
+    """Test that a screen capture framerate higher than 1.0 raises a ValidationError."""
+    with pytest.raises(ValidationError) as excinfo:
+        MultimodalTelemetryStream(
+            audio_exhaust_enabled=False,
+            screen_capture_framerate=1.5,
+            privacy_masking_zones=[],
+        )
+
+    assert "screen_capture_framerate must be <= 1.0 FPS" in str(excinfo.value)

--- a/tests/telemetry/test_ambient_schemas.py
+++ b/tests/telemetry/test_ambient_schemas.py
@@ -46,4 +46,4 @@ def test_multimodal_telemetry_stream_invalid_framerate() -> None:
             privacy_masking_zones=[],
         )
 
-    assert "screen_capture_framerate must be <= 1.0 FPS" in str(excinfo.value)
+    assert "Input should be less than or equal to 1" in str(excinfo.value)


### PR DESCRIPTION
This PR introduces the required Pydantic schema files and test coverage for the **Epic 5: Edge-Native Ambient Observation & Zero-UI** objective.

### Key Features:
- **`src/coreason_manifest/telemetry/ambient_schemas.py`**:
  - `PrivacyMaskingZone`: defines masking for specific apps/regions.
  - `MultimodalTelemetryStream`: extends telemetry with fields like `screen_capture_framerate` (strictly constrained to `<= 1.0` via Pydantic validator).
- **`src/coreason_manifest/presentation/ambient_edge.py`**:
  - `EdgeSLMProcessor`: enforces processing max latency `< 250ms`.
  - `AutonomousPrecomputeIntent`: enforces prediction confidence between 0.0 and 1.0.
  - `EdgeNativeAmbientListener`: binds config, stream, and SLM processor into a unified definition.
- **Test coverage**:
  - Added pure Pydantic validation tests covering constraints, catching standard validation exceptions across boundary cases. 
  - Meets strict `>= 95%` coverage constraint.

Files are completely isolated in net-new scripts to guarantee zero conflict risk and enforce the strict Passive Shared Kernel architectural boundary.

---
*PR created automatically by Jules for task [10441112471117203252](https://jules.google.com/task/10441112471117203252) started by @gowthamrao*