### PR TITLE
feat: Add epistemic uncertainty and defeasible logic schemas

### DIFF
--- a/src/coreason_manifest/compute/argumentation.py
+++ b/src/coreason_manifest/compute/argumentation.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+"""
+Schemas for formal multi-agent Defeasible Logic representation.
+
+These models allow storing multi-agent debates over phenotype definitions
+as rigorous mathematical state graphs (Argumentation DAGs) and capture the
+complex interaction between proposals and their critiques.
+"""
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.compute.uncertainty import SyntaxTreeCitationAnchor
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class DefeasibleClaim(CoreasonModel):
+    """
+    Represents a single node in a multi-agent debate regarding a clinical rule.
+
+    Captures individual proposals, rebuttals, or undercutting arguments
+    and grounds them in empirical evidence mapping.
+    """
+
+    claim_id: str = Field(..., description="Unique UUID string identifying this particular claim node.")
+    agent_id: str = Field(..., description="Identifier for the AI or Human submitting the claim.")
+    claim_type: Literal["PROPOSAL", "REBUTTAL", "UNDERCUT"] = Field(
+        ..., description="The type of the claim in relation to the debate graph."
+    )
+    target_claim_id: str | None = Field(
+        default=None,
+        description="UUID string pointing to a parent claim, required if this claim is a Rebuttal or Undercut.",
+    )
+    semantic_reasoning: str = Field(..., description="The clinical argument explaining the logic of the claim.")
+    citation_anchors: list[SyntaxTreeCitationAnchor] = Field(
+        ..., description="List of source-level anchors proving provenance for this claim."
+    )
+
+    @model_validator(mode="after")
+    def validate_target_claim(self) -> "DefeasibleClaim":
+        """Enforce that Rebuttals and Undercuts must point to a target claim."""
+        if self.claim_type in {"REBUTTAL", "UNDERCUT"} and not self.target_claim_id:
+            raise ValueError(
+                f"Validation Error: A claim of type '{self.claim_type}' MUST have a target_claim_id."
+            )
+        return self
+
+
+class ArgumentationDAG(CoreasonModel):
+    """
+    Represents the holistic state of a clinical disagreement.
+
+    A Directed Acyclic Graph connecting DefeasibleClaims mapped to an overarching
+    phenotype resolution path.
+    """
+
+    graph_id: str = Field(..., description="Unique UUID string identifying the full DAG state.")
+    target_phenotype_id: str = Field(..., description="Target overarching phenotype this graph seeks to define.")
+    claims: dict[str, DefeasibleClaim] = Field(
+        ..., description="Map of `claim_id` strings to nodes, forming the debate network."
+    )
+    resolution_status: Literal["UNRESOLVED", "CONSENSUS_REACHED", "OVERRIDDEN_BY_HUMAN"] = Field(
+        ..., description="The final consensus state of this multi-agent argumentation process."
+    )

--- a/src/coreason_manifest/compute/argumentation.py
+++ b/src/coreason_manifest/compute/argumentation.py
@@ -48,9 +48,11 @@ class DefeasibleClaim(CoreasonModel):
 
     @model_validator(mode="after")
     def validate_target_claim(self) -> "DefeasibleClaim":
-        """Enforce that Rebuttals and Undercuts must point to a target claim."""
+        """Enforce that Rebuttals and Undercuts must point to a target claim, and Proposals must not."""
         if self.claim_type in {"REBUTTAL", "UNDERCUT"} and not self.target_claim_id:
             raise ValueError(f"Validation Error: A claim of type '{self.claim_type}' MUST have a target_claim_id.")
+        if self.claim_type == "PROPOSAL" and self.target_claim_id is not None:
+            raise ValueError(f"Validation Error: A claim of type '{self.claim_type}' MUST NOT have a target_claim_id.")
         return self
 
 
@@ -70,3 +72,13 @@ class ArgumentationDAG(CoreasonModel):
     resolution_status: Literal["UNRESOLVED", "CONSENSUS_REACHED", "OVERRIDDEN_BY_HUMAN"] = Field(
         ..., description="The final consensus state of this multi-agent argumentation process."
     )
+
+    @model_validator(mode="after")
+    def validate_graph_edges(self) -> "ArgumentationDAG":
+        """Enforce that every target_claim_id in the graph resolves to a valid key within self.claims."""
+        for claim in self.claims.values():
+            if claim.target_claim_id and claim.target_claim_id not in self.claims:
+                raise ValueError(
+                    f"Validation Error: target_claim_id '{claim.target_claim_id}' is missing from the DAG."
+                )
+        return self

--- a/src/coreason_manifest/compute/argumentation.py
+++ b/src/coreason_manifest/compute/argumentation.py
@@ -50,9 +50,7 @@ class DefeasibleClaim(CoreasonModel):
     def validate_target_claim(self) -> "DefeasibleClaim":
         """Enforce that Rebuttals and Undercuts must point to a target claim."""
         if self.claim_type in {"REBUTTAL", "UNDERCUT"} and not self.target_claim_id:
-            raise ValueError(
-                f"Validation Error: A claim of type '{self.claim_type}' MUST have a target_claim_id."
-            )
+            raise ValueError(f"Validation Error: A claim of type '{self.claim_type}' MUST have a target_claim_id.")
         return self
 
 

--- a/src/coreason_manifest/compute/uncertainty.py
+++ b/src/coreason_manifest/compute/uncertainty.py
@@ -1,0 +1,80 @@
+# Copyright (c) 2025 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+"""
+Schemas for state-of-the-art Epistemic Uncertainty tracking.
+
+These models define rigorous structural representations for evidence-based
+confidence, source attribution, and counterfactual decision justification
+to support high-stakes clinical AI processing.
+"""
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.common.base import CoreasonModel
+
+
+class SyntaxTreeCitationAnchor(CoreasonModel):
+    """
+    Represents a W3C PROV-O aligned citation bound to a specific abstract syntax tree node.
+
+    Provides strict provenance mapping back to literature sources.
+    """
+
+    pmcid: str | None = Field(default=None, description="The PubMed Central ID of the source document.")
+    source_text_tokens: list[str] = Field(..., description="The exact quoted text tokens from the source.")
+    retrieval_timestamp: datetime = Field(..., description="The datetime the source text was retrieved.")
+    guideline_version: str = Field(..., description="The version of the guideline this citation belongs to.")
+
+
+class EpistemicWeight(CoreasonModel):
+    """
+    Represents a Conformal Prediction structured confidence vector.
+
+    Captures varying sources of doubt in AI reasoning, including random noise
+    (aleatoric) and lack of knowledge (epistemic).
+    """
+
+    aleatoric_doubt: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Data noise doubt level, represented as a float between 0.0 and 1.0.",
+    )
+    epistemic_doubt: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Lack of knowledge or consensus doubt level, represented as a float between 0.0 and 1.0.",
+    )
+    evidence_category: Literal[
+        "DIRECT_LEXICAL_MATCH", "SEMANTIC_INFERENCE", "GUIDELINE_EXTRAPOLATION", "EXPERT_CONSENSUS"
+    ] = Field(..., description="The category of clinical evidence supporting this weight.")
+
+
+class CounterfactualJustification(CoreasonModel):
+    """
+    Represents the mandatory tracking of rejected alternatives.
+
+    Essential for AI alignment in healthcare, providing transparency into
+    why a particular path or conclusion was chosen over others.
+    """
+
+    accepted_logic_node_id: str = Field(..., description="The identifier of the accepted logic node.")
+    rejected_alternatives: list[str] = Field(
+        ..., description="List of OMOP Concept IDs or logic rules that were considered but discarded."
+    )
+    rejection_reason: str = Field(..., description="Explanation of the epistemic deficit of the alternatives.")
+    epistemic_weight: EpistemicWeight = Field(
+        ..., description="The EpistemicWeight object justifying the final decision."
+    )

--- a/tests/test_argumentation.py
+++ b/tests/test_argumentation.py
@@ -11,32 +11,33 @@ def test_defeasible_claim() -> None:
         pmcid="PMC12345",
         source_text_tokens=["patient", "has", "hypertension"],
         retrieval_timestamp=datetime.now(UTC),
-        guideline_version="1.0"
+        guideline_version="1.0",
     )
     claim = DefeasibleClaim(
         claim_id="claim_1",
         agent_id="agent_a",
         claim_type="PROPOSAL",
         semantic_reasoning="The patient exhibits symptoms.",
-        citation_anchors=[anchor]
+        citation_anchors=[anchor],
     )
     assert claim.claim_id == "claim_1"
     assert claim.claim_type == "PROPOSAL"
     assert len(claim.citation_anchors) == 1
+
 
 def test_argumentation_dag() -> None:
     anchor = SyntaxTreeCitationAnchor(
         pmcid="PMC12345",
         source_text_tokens=["patient", "has", "hypertension"],
         retrieval_timestamp=datetime.now(UTC),
-        guideline_version="1.0"
+        guideline_version="1.0",
     )
     claim1 = DefeasibleClaim(
         claim_id="claim_1",
         agent_id="agent_a",
         claim_type="PROPOSAL",
         semantic_reasoning="The patient exhibits symptoms.",
-        citation_anchors=[anchor]
+        citation_anchors=[anchor],
     )
     claim2 = DefeasibleClaim(
         claim_id="claim_2",
@@ -44,14 +45,14 @@ def test_argumentation_dag() -> None:
         claim_type="REBUTTAL",
         target_claim_id="claim_1",
         semantic_reasoning="Symptoms are non-specific.",
-        citation_anchors=[]
+        citation_anchors=[],
     )
 
     dag = ArgumentationDAG(
         graph_id="dag_1",
         target_phenotype_id="phenotype_X",
         claims={"claim_1": claim1, "claim_2": claim2},
-        resolution_status="UNRESOLVED"
+        resolution_status="UNRESOLVED",
     )
     assert dag.graph_id == "dag_1"
     assert dag.resolution_status == "UNRESOLVED"
@@ -63,15 +64,16 @@ def test_argumentation_dag() -> None:
             graph_id="dag_1",
             target_phenotype_id="phenotype_X",
             claims={"claim_1": claim1},
-            resolution_status="INVALID_STATUS"  # type: ignore
+            resolution_status="INVALID_STATUS",  # type: ignore
         )
+
 
 def test_defeasible_claim_validation() -> None:
     anchor = SyntaxTreeCitationAnchor(
         pmcid="PMC12345",
         source_text_tokens=["patient", "has", "hypertension"],
         retrieval_timestamp=datetime.now(UTC),
-        guideline_version="1.0"
+        guideline_version="1.0",
     )
     with pytest.raises(ValueError, match="MUST have a target_claim_id"):
         DefeasibleClaim(
@@ -80,7 +82,7 @@ def test_defeasible_claim_validation() -> None:
             claim_type="REBUTTAL",
             target_claim_id=None,
             semantic_reasoning="Symptoms are non-specific.",
-            citation_anchors=[anchor]
+            citation_anchors=[anchor],
         )
 
     with pytest.raises(ValueError, match="MUST have a target_claim_id"):
@@ -89,5 +91,5 @@ def test_defeasible_claim_validation() -> None:
             agent_id="agent_a",
             claim_type="UNDERCUT",
             semantic_reasoning="Methodology was flawed.",
-            citation_anchors=[anchor]
+            citation_anchors=[anchor],
         )

--- a/tests/test_argumentation.py
+++ b/tests/test_argumentation.py
@@ -1,0 +1,93 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from coreason_manifest.compute.argumentation import ArgumentationDAG, DefeasibleClaim
+from coreason_manifest.compute.uncertainty import SyntaxTreeCitationAnchor
+
+
+def test_defeasible_claim() -> None:
+    anchor = SyntaxTreeCitationAnchor(
+        pmcid="PMC12345",
+        source_text_tokens=["patient", "has", "hypertension"],
+        retrieval_timestamp=datetime.now(UTC),
+        guideline_version="1.0"
+    )
+    claim = DefeasibleClaim(
+        claim_id="claim_1",
+        agent_id="agent_a",
+        claim_type="PROPOSAL",
+        semantic_reasoning="The patient exhibits symptoms.",
+        citation_anchors=[anchor]
+    )
+    assert claim.claim_id == "claim_1"
+    assert claim.claim_type == "PROPOSAL"
+    assert len(claim.citation_anchors) == 1
+
+def test_argumentation_dag() -> None:
+    anchor = SyntaxTreeCitationAnchor(
+        pmcid="PMC12345",
+        source_text_tokens=["patient", "has", "hypertension"],
+        retrieval_timestamp=datetime.now(UTC),
+        guideline_version="1.0"
+    )
+    claim1 = DefeasibleClaim(
+        claim_id="claim_1",
+        agent_id="agent_a",
+        claim_type="PROPOSAL",
+        semantic_reasoning="The patient exhibits symptoms.",
+        citation_anchors=[anchor]
+    )
+    claim2 = DefeasibleClaim(
+        claim_id="claim_2",
+        agent_id="agent_b",
+        claim_type="REBUTTAL",
+        target_claim_id="claim_1",
+        semantic_reasoning="Symptoms are non-specific.",
+        citation_anchors=[]
+    )
+
+    dag = ArgumentationDAG(
+        graph_id="dag_1",
+        target_phenotype_id="phenotype_X",
+        claims={"claim_1": claim1, "claim_2": claim2},
+        resolution_status="UNRESOLVED"
+    )
+    assert dag.graph_id == "dag_1"
+    assert dag.resolution_status == "UNRESOLVED"
+    assert len(dag.claims) == 2
+    assert dag.claims["claim_2"].target_claim_id == "claim_1"
+
+    with pytest.raises(ValueError, match="1 validation error for"):
+        ArgumentationDAG(
+            graph_id="dag_1",
+            target_phenotype_id="phenotype_X",
+            claims={"claim_1": claim1},
+            resolution_status="INVALID_STATUS"  # type: ignore
+        )
+
+def test_defeasible_claim_validation() -> None:
+    anchor = SyntaxTreeCitationAnchor(
+        pmcid="PMC12345",
+        source_text_tokens=["patient", "has", "hypertension"],
+        retrieval_timestamp=datetime.now(UTC),
+        guideline_version="1.0"
+    )
+    with pytest.raises(ValueError, match="MUST have a target_claim_id"):
+        DefeasibleClaim(
+            claim_id="claim_1",
+            agent_id="agent_a",
+            claim_type="REBUTTAL",
+            target_claim_id=None,
+            semantic_reasoning="Symptoms are non-specific.",
+            citation_anchors=[anchor]
+        )
+
+    with pytest.raises(ValueError, match="MUST have a target_claim_id"):
+        DefeasibleClaim(
+            claim_id="claim_2",
+            agent_id="agent_a",
+            claim_type="UNDERCUT",
+            semantic_reasoning="Methodology was flawed.",
+            citation_anchors=[anchor]
+        )

--- a/tests/test_argumentation.py
+++ b/tests/test_argumentation.py
@@ -93,3 +93,51 @@ def test_defeasible_claim_validation() -> None:
             semantic_reasoning="Methodology was flawed.",
             citation_anchors=[anchor],
         )
+
+def test_defeasible_claim_proposal_validation() -> None:
+    anchor = SyntaxTreeCitationAnchor(
+        pmcid="PMC12345",
+        source_text_tokens=["patient", "has", "hypertension"],
+        retrieval_timestamp=datetime.now(UTC),
+        guideline_version="1.0"
+    )
+    with pytest.raises(ValueError, match="1 validation error for"):
+        DefeasibleClaim(
+            claim_id="claim_1",
+            agent_id="agent_a",
+            claim_type="PROPOSAL",
+            target_claim_id="some_other_claim",
+            semantic_reasoning="The patient exhibits symptoms.",
+            citation_anchors=[anchor]
+        )
+
+def test_argumentation_dag_validation() -> None:
+    anchor = SyntaxTreeCitationAnchor(
+        pmcid="PMC12345",
+        source_text_tokens=["patient", "has", "hypertension"],
+        retrieval_timestamp=datetime.now(UTC),
+        guideline_version="1.0"
+    )
+    claim1 = DefeasibleClaim(
+        claim_id="claim_1",
+        agent_id="agent_a",
+        claim_type="PROPOSAL",
+        semantic_reasoning="The patient exhibits symptoms.",
+        citation_anchors=[anchor]
+    )
+    claim2 = DefeasibleClaim(
+        claim_id="claim_2",
+        agent_id="agent_b",
+        claim_type="REBUTTAL",
+        target_claim_id="non_existent_claim",
+        semantic_reasoning="Symptoms are non-specific.",
+        citation_anchors=[]
+    )
+
+    with pytest.raises(ValueError, match="1 validation error for"):
+        ArgumentationDAG(
+            graph_id="dag_1",
+            target_phenotype_id="phenotype_X",
+            claims={"claim_1": claim1, "claim_2": claim2},
+            resolution_status="UNRESOLVED"
+        )

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -10,45 +10,35 @@ def test_syntax_tree_citation_anchor() -> None:
         pmcid="PMC12345",
         source_text_tokens=["patient", "has", "hypertension"],
         retrieval_timestamp=datetime.now(UTC),
-        guideline_version="1.0"
+        guideline_version="1.0",
     )
     assert anchor.pmcid == "PMC12345"
     assert len(anchor.source_text_tokens) == 3
 
+
 def test_epistemic_weight() -> None:
-    weight = EpistemicWeight(
-        aleatoric_doubt=0.1,
-        epistemic_doubt=0.2,
-        evidence_category="DIRECT_LEXICAL_MATCH"
-    )
+    weight = EpistemicWeight(aleatoric_doubt=0.1, epistemic_doubt=0.2, evidence_category="DIRECT_LEXICAL_MATCH")
     assert weight.aleatoric_doubt == 0.1
     assert weight.epistemic_doubt == 0.2
 
     with pytest.raises(ValueError, match="1 validation error for"):
-        EpistemicWeight(
-            aleatoric_doubt=1.5,
-            epistemic_doubt=0.2,
-            evidence_category="DIRECT_LEXICAL_MATCH"
-        )
+        EpistemicWeight(aleatoric_doubt=1.5, epistemic_doubt=0.2, evidence_category="DIRECT_LEXICAL_MATCH")
 
     with pytest.raises(ValueError, match="1 validation error for"):
         EpistemicWeight(
             aleatoric_doubt=0.1,
             epistemic_doubt=0.2,
-            evidence_category="INVALID_CATEGORY"  # type: ignore
+            evidence_category="INVALID_CATEGORY",  # type: ignore
         )
 
+
 def test_counterfactual_justification() -> None:
-    weight = EpistemicWeight(
-        aleatoric_doubt=0.1,
-        epistemic_doubt=0.2,
-        evidence_category="EXPERT_CONSENSUS"
-    )
+    weight = EpistemicWeight(aleatoric_doubt=0.1, epistemic_doubt=0.2, evidence_category="EXPERT_CONSENSUS")
     justification = CounterfactualJustification(
         accepted_logic_node_id="node_1",
         rejected_alternatives=["node_2", "node_3"],
         rejection_reason="Lack of clinical evidence.",
-        epistemic_weight=weight
+        epistemic_weight=weight,
     )
     assert justification.accepted_logic_node_id == "node_1"
     assert justification.epistemic_weight.evidence_category == "EXPERT_CONSENSUS"

--- a/tests/test_uncertainty.py
+++ b/tests/test_uncertainty.py
@@ -1,0 +1,54 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from coreason_manifest.compute.uncertainty import CounterfactualJustification, EpistemicWeight, SyntaxTreeCitationAnchor
+
+
+def test_syntax_tree_citation_anchor() -> None:
+    anchor = SyntaxTreeCitationAnchor(
+        pmcid="PMC12345",
+        source_text_tokens=["patient", "has", "hypertension"],
+        retrieval_timestamp=datetime.now(UTC),
+        guideline_version="1.0"
+    )
+    assert anchor.pmcid == "PMC12345"
+    assert len(anchor.source_text_tokens) == 3
+
+def test_epistemic_weight() -> None:
+    weight = EpistemicWeight(
+        aleatoric_doubt=0.1,
+        epistemic_doubt=0.2,
+        evidence_category="DIRECT_LEXICAL_MATCH"
+    )
+    assert weight.aleatoric_doubt == 0.1
+    assert weight.epistemic_doubt == 0.2
+
+    with pytest.raises(ValueError, match="1 validation error for"):
+        EpistemicWeight(
+            aleatoric_doubt=1.5,
+            epistemic_doubt=0.2,
+            evidence_category="DIRECT_LEXICAL_MATCH"
+        )
+
+    with pytest.raises(ValueError, match="1 validation error for"):
+        EpistemicWeight(
+            aleatoric_doubt=0.1,
+            epistemic_doubt=0.2,
+            evidence_category="INVALID_CATEGORY"  # type: ignore
+        )
+
+def test_counterfactual_justification() -> None:
+    weight = EpistemicWeight(
+        aleatoric_doubt=0.1,
+        epistemic_doubt=0.2,
+        evidence_category="EXPERT_CONSENSUS"
+    )
+    justification = CounterfactualJustification(
+        accepted_logic_node_id="node_1",
+        rejected_alternatives=["node_2", "node_3"],
+        rejection_reason="Lack of clinical evidence.",
+        epistemic_weight=weight
+    )
+    assert justification.accepted_logic_node_id == "node_1"
+    assert justification.epistemic_weight.evidence_category == "EXPERT_CONSENSUS"


### PR DESCRIPTION
Implement state-of-the-art structural provenance, epistemic uncertainty tracking, and defeasible logic contracts. 

The implementation respects the repository's rules: pure data library without side effects, immutable Pydantic schemas inheriting from `CoreasonModel`, and comprehensive validation.

---
*PR created automatically by Jules for task [12607186137373087663](https://jules.google.com/task/12607186137373087663) started by @gowthamrao*