### PR TITLE
Epic 10: Cognitive Constraints & Interface Boundaries

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ select = [
     "E", "F", "B", "I", "UP", "SIM", "RUF", "ARG", "C4", "PT", "TCH", "FA", "PIE", "RET",
     "PERF", "FURB", "LOG", "N", "A", "S"
 ]
-ignore = ["S101"]
+ignore = ["S101", "TC001", "TC002", "TC003"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["coreason_manifest"]

--- a/src/coreason_manifest/adapters/mcp/schemas.py
+++ b/src/coreason_manifest/adapters/mcp/schemas.py
@@ -5,7 +5,7 @@ This module defines the core MCP connection primitives and pure, passive contrac
 """
 
 import re
-from collections.abc import Mapping  # noqa: TC003
+from collections.abc import Mapping
 from enum import StrEnum
 from typing import Any, Literal
 

--- a/src/coreason_manifest/oversight/__init__.py
+++ b/src/coreason_manifest/oversight/__init__.py
@@ -1,6 +1,12 @@
 from .adjudication import AdjudicationRubric, AdjudicationVerdict, GradingCriteria
 from .governance import ConstitutionalRule, GovernancePolicy
-from .intervention import AnyInterventionPayload, InterventionRequest, InterventionVerdict
+from .intervention import (
+    AnyInterventionPayload,
+    BoundedInterventionScope,
+    FallbackSLA,
+    InterventionRequest,
+    InterventionVerdict,
+)
 from .resilience import AnyResiliencePayload, CircuitBreakerTrip, FallbackTrigger, QuarantineOrder
 
 __all__ = [
@@ -8,8 +14,10 @@ __all__ = [
     "AdjudicationVerdict",
     "AnyInterventionPayload",
     "AnyResiliencePayload",
+    "BoundedInterventionScope",
     "CircuitBreakerTrip",
     "ConstitutionalRule",
+    "FallbackSLA",
     "FallbackTrigger",
     "GovernancePolicy",
     "GradingCriteria",

--- a/src/coreason_manifest/oversight/adjudication.py
+++ b/src/coreason_manifest/oversight/adjudication.py
@@ -1,3 +1,4 @@
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/oversight/intervention.py
+++ b/src/coreason_manifest/oversight/intervention.py
@@ -1,9 +1,31 @@
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
+
+
+class BoundedInterventionScope(CoreasonBaseModel):
+    """
+    Constraints bounding human interaction for interventions.
+    """
+
+    allowed_fields: list[str] = Field(description="List of specific fields the human is permitted to mutate.")
+    json_schema_whitelist: dict[str, str | int | float | bool | None | list[Any] | dict[str, Any]] = Field(
+        description="Strict JSON Schema constraints for the human's input."
+    )
+
+
+class FallbackSLA(CoreasonBaseModel):
+    """
+    SLA defining bounds on human intervention delays.
+    """
+
+    timeout_seconds: int = Field(description="The maximum allowed delay for a human intervention.")
+    timeout_action: Literal["fail_safe", "proceed_with_defaults", "escalate"] = Field(
+        description="The action to take when the timeout expires."
+    )
 
 
 class InterventionRequest(CoreasonBaseModel):
@@ -12,6 +34,10 @@ class InterventionRequest(CoreasonBaseModel):
     """
 
     type: Literal["request"] = Field(default="request", description="The type of the intervention payload.")
+    intervention_scope: BoundedInterventionScope | None = Field(
+        default=None, description="The scope constraints bounding the intervention."
+    )
+    fallback_sla: FallbackSLA | None = Field(default=None, description="The SLA constraints on the intervention delay.")
     target_node_id: NodeID = Field(description="The ID of the target node.")
     context_summary: str = Field(description="A summary of the context requiring intervention.")
     proposed_action: dict[str, str | int | float | bool | None] = Field(

--- a/src/coreason_manifest/presentation/intents.py
+++ b/src/coreason_manifest/presentation/intents.py
@@ -3,7 +3,7 @@ from typing import Annotated, Literal
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
-from coreason_manifest.presentation.scivis import MacroGrid  # noqa: TC001
+from coreason_manifest.presentation.scivis import MacroGrid
 
 
 class BaseIntent(CoreasonBaseModel):

--- a/src/coreason_manifest/state/memory.py
+++ b/src/coreason_manifest/state/memory.py
@@ -1,7 +1,7 @@
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
-from coreason_manifest.state.events import AnyStateEvent  # noqa: TC001
+from coreason_manifest.state.events import AnyStateEvent
 
 
 class EpistemicLedger(CoreasonBaseModel):

--- a/src/coreason_manifest/telemetry/custody.py
+++ b/src/coreason_manifest/telemetry/custody.py
@@ -1,3 +1,4 @@
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -1,5 +1,13 @@
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
-from coreason_manifest.workflow.nodes import AgentNode, AnyNode, HumanNode, SystemNode
+from coreason_manifest.workflow.nodes import (
+    AgentNode,
+    AnyNode,
+    EpistemicScanner,
+    HumanNode,
+    SelfCorrectionPolicy,
+    System1Reflex,
+    SystemNode,
+)
 from coreason_manifest.workflow.topologies import (
     AnyTopology,
     CouncilTopology,
@@ -13,8 +21,11 @@ __all__ = [
     "AnyTopology",
     "CouncilTopology",
     "DAGTopology",
+    "EpistemicScanner",
     "HumanNode",
+    "SelfCorrectionPolicy",
     "SwarmTopology",
+    "System1Reflex",
     "SystemNode",
     "WorkflowEnvelope",
 ]

--- a/src/coreason_manifest/workflow/envelope.py
+++ b/src/coreason_manifest/workflow/envelope.py
@@ -1,8 +1,8 @@
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
-from coreason_manifest.core.primitives import SemanticVersion  # noqa: TC001
-from coreason_manifest.workflow.topologies import AnyTopology  # noqa: TC001
+from coreason_manifest.core.primitives import SemanticVersion
+from coreason_manifest.workflow.topologies import AnyTopology
 
 
 class WorkflowEnvelope(CoreasonBaseModel):

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -13,12 +13,53 @@ class BaseNode(CoreasonBaseModel):
     description: str = Field(description="A description of the node's function.")
 
 
+class System1Reflex(CoreasonBaseModel):
+    """
+    Policy for fast, intuitive system 1 thinking.
+    """
+
+    confidence_threshold: float = Field(description="The confidence threshold required to execute a reflex action.")
+    allowed_read_only_tools: list[str] = Field(description="List of read-only tools allowed during a reflex action.")
+
+
+class EpistemicScanner(CoreasonBaseModel):
+    """
+    Policy for epistemic scanning and gap detection.
+    """
+
+    active: bool = Field(description="Whether the epistemic scanner is active.")
+    dissonance_threshold: float = Field(
+        description="The threshold for cognitive dissonance before triggering an action."
+    )
+    action_on_gap: Literal["fail", "probe", "clarify"] = Field(
+        description="The action to take when an epistemic gap is detected."
+    )
+
+
+class SelfCorrectionPolicy(CoreasonBaseModel):
+    """
+    Policy for self-correction and iterative refinement.
+    """
+
+    max_loops: int = Field(description="The maximum number of self-correction loops allowed.")
+    rollback_on_failure: bool = Field(description="Whether to rollback to the previous state on failure.")
+
+
 class AgentNode(BaseNode):
     """
     A node representing an autonomous agent.
     """
 
     type: Literal["agent"] = Field(default="agent", description="Discriminator for an Agent node.")
+    reflex_policy: System1Reflex | None = Field(
+        default=None, description="The policy governing System 1 reflex actions."
+    )
+    epistemic_policy: EpistemicScanner | None = Field(
+        default=None, description="The policy governing epistemic scanning."
+    )
+    correction_policy: SelfCorrectionPolicy | None = Field(
+        default=None, description="The policy governing self-correction loops."
+    )
 
 
 class HumanNode(BaseNode):

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -3,8 +3,8 @@ from typing import Annotated, Literal
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
-from coreason_manifest.core.primitives import NodeID  # noqa: TC001
-from coreason_manifest.workflow.nodes import AnyNode  # noqa: TC001
+from coreason_manifest.core.primitives import NodeID
+from coreason_manifest.workflow.nodes import AnyNode
 
 
 class BaseTopology(CoreasonBaseModel):

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -15,15 +15,60 @@ from coreason_manifest.presentation.scivis import AnyPanel, CohortAttritionGrid,
 from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, ObservationEvent, SystemFaultEvent
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, HumanNode, SystemNode
 
-node_adapter = TypeAdapter(AnyNode)
-event_adapter = TypeAdapter(AnyStateEvent)
-panel_adapter = TypeAdapter(AnyPanel)
-resilience_adapter = TypeAdapter(AnyResiliencePayload)
+node_adapter: TypeAdapter[AnyNode] = TypeAdapter(AnyNode)
+event_adapter: TypeAdapter[AnyStateEvent] = TypeAdapter(AnyStateEvent)
+panel_adapter: TypeAdapter[AnyPanel] = TypeAdapter(AnyPanel)
+resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResiliencePayload)
 
 
-@given(st.sampled_from(["agent", "human", "system"]), st.text())
-def test_anynode_routing(node_type: str, description: str) -> None:
-    payload = {"type": node_type, "description": description}
+@given(
+    st.sampled_from(["agent", "human", "system"]),
+    st.text(),
+    st.one_of(
+        st.none(),
+        st.fixed_dictionaries(
+            {
+                "confidence_threshold": st.floats(allow_nan=False, allow_infinity=False),
+                "allowed_read_only_tools": st.lists(st.text()),
+            }
+        ),
+    ),
+    st.one_of(
+        st.none(),
+        st.fixed_dictionaries(
+            {
+                "active": st.booleans(),
+                "dissonance_threshold": st.floats(allow_nan=False, allow_infinity=False),
+                "action_on_gap": st.sampled_from(["fail", "probe", "clarify"]),
+            }
+        ),
+    ),
+    st.one_of(
+        st.none(),
+        st.fixed_dictionaries(
+            {
+                "max_loops": st.integers(),
+                "rollback_on_failure": st.booleans(),
+            }
+        ),
+    ),
+)
+def test_anynode_routing(
+    node_type: str,
+    description: str,
+    reflex_policy: dict[str, Any] | None,
+    epistemic_policy: dict[str, Any] | None,
+    correction_policy: dict[str, Any] | None,
+) -> None:
+    payload: dict[str, Any] = {"type": node_type, "description": description}
+    if node_type == "agent":
+        if reflex_policy is not None:
+            payload["reflex_policy"] = reflex_policy
+        if epistemic_policy is not None:
+            payload["epistemic_policy"] = epistemic_policy
+        if correction_policy is not None:
+            payload["correction_policy"] = correction_policy
+
     parsed = node_adapter.validate_python(payload)
     if node_type == "agent":
         assert isinstance(parsed, AgentNode)


### PR DESCRIPTION
This submission resolves **Epic 10: Cognitive Constraints & Interface Boundaries** for the `coreason-manifest` architecture.

Key changes:
1. **Cognitive Policies**: Added `System1Reflex`, `EpistemicScanner`, and `SelfCorrectionPolicy` schemas to `src/coreason_manifest/workflow/nodes.py`.
2. **AgentNode Update**: Added optional fields `reflex_policy`, `epistemic_policy`, and `correction_policy` to `AgentNode`.
3. **HITL Contracts**: Added `BoundedInterventionScope` and `FallbackSLA` to `src/coreason_manifest/oversight/intervention.py`.
4. **InterventionRequest Update**: Added optional fields `intervention_scope` and `fallback_sla` to `InterventionRequest`.
5. **Testing**: Updated the hypothesis strategies in `tests/test_fuzzing.py` to generate optional dictionaries for `reflex_policy`, `epistemic_policy`, and `correction_policy` when testing `AgentNode`.
6. **Tooling Configurations**: Updated `pyproject.toml` to ignore `ruff` `TC001`, `TC002`, and `TC003` to prevent the auto-fixer from moving runtime type hints into `if TYPE_CHECKING:` blocks, conforming to the "No `__future__` annotations" mandate.
7. **Exports**: Made all new schemas available in their respective module `__init__.py` files.

All schemas strictly use Python 3.14 native typings, `CoreasonBaseModel` inheritance, and Pydantic `Field` definitions. All tests pass successfully.

---
*PR created automatically by Jules for task [158962155816801808](https://jules.google.com/task/158962155816801808) started by @gowthamrao*