### PR TITLE
feat: Epic 12 - Declarative Chaos & Red Teaming

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -9,15 +9,23 @@ from coreason_manifest.oversight import (
 )
 from coreason_manifest.state import EpistemicLedger, WorkingMemorySnapshot
 from coreason_manifest.telemetry import LogEnvelope, SpanTrace
+from coreason_manifest.testing.chaos import ChaosExperiment, FaultInjectionProfile, FaultType, SteadyStateHypothesis
+from coreason_manifest.testing.red_team import AdversaryProfile, AiTMStrategy, AttackVector
 from coreason_manifest.workflow import WorkflowEnvelope
 
 __all__ = [
     "AdjudicationRubric",
+    "AdversaryProfile",
+    "AiTMStrategy",
     "AnyInterventionPayload",
     "AnyResiliencePayload",
+    "AttackVector",
+    "ChaosExperiment",
     "ConstitutionalRule",
     "CoreasonBaseModel",
     "EpistemicLedger",
+    "FaultInjectionProfile",
+    "FaultType",
     "GovernancePolicy",
     "LogEnvelope",
     "ModelProfile",
@@ -25,6 +33,7 @@ __all__ = [
     "RateCard",
     "SemanticVersion",
     "SpanTrace",
+    "SteadyStateHypothesis",
     "WorkflowEnvelope",
     "WorkingMemorySnapshot",
 ]

--- a/src/coreason_manifest/testing/__init__.py
+++ b/src/coreason_manifest/testing/__init__.py
@@ -1,0 +1,12 @@
+from .chaos import ChaosExperiment, FaultInjectionProfile, FaultType, SteadyStateHypothesis
+from .red_team import AdversaryProfile, AiTMStrategy, AttackVector
+
+__all__ = [
+    "AdversaryProfile",
+    "AiTMStrategy",
+    "AttackVector",
+    "ChaosExperiment",
+    "FaultInjectionProfile",
+    "FaultType",
+    "SteadyStateHypothesis",
+]

--- a/src/coreason_manifest/testing/chaos.py
+++ b/src/coreason_manifest/testing/chaos.py
@@ -1,0 +1,35 @@
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+type FaultType = Literal[
+    "context_overload",
+    "incorrect_context",
+    "format_corruption",
+    "latency_spike",
+    "token_throttle",
+]
+
+
+class FaultInjectionProfile(CoreasonBaseModel):
+    fault_type: FaultType = Field(description="The specific type of fault to inject.")
+    target_node_id: str | None = Field(default=None, description="The specific node to attack, or None for swarm-wide.")
+    intensity: float = Field(description="The severity of the fault, represented from 0.0 to 1.0.")
+
+
+class SteadyStateHypothesis(CoreasonBaseModel):
+    expected_max_latency: float = Field(description="The expected maximum latency under normal conditions.")
+    max_loops_allowed: int = Field(description="The maximum allowed loops for the swarm to reach a conclusion.")
+    required_tool_usage: list[str] | None = Field(
+        default=None, description="A list of required tools that must be utilized."
+    )
+
+
+class ChaosExperiment(CoreasonBaseModel):
+    experiment_id: str = Field(description="The unique identifier for the chaos experiment.")
+    hypothesis: SteadyStateHypothesis = Field(description="The baseline steady state hypothesis being tested.")
+    faults: list[FaultInjectionProfile] = Field(
+        description="The list of fault injection profiles defining the chaotic elements."
+    )

--- a/src/coreason_manifest/testing/red_team.py
+++ b/src/coreason_manifest/testing/red_team.py
@@ -1,0 +1,28 @@
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+type AttackVector = Literal[
+    "semantic_hijacking",
+    "system_prompt_extraction",
+    "sabotage",
+    "deception",
+    "data_exfiltration",
+]
+
+
+class AdversaryProfile(CoreasonBaseModel):
+    persona: str = Field(description="The assigned persona or character the attacker agent must adopt.")
+    attack_vector: AttackVector = Field(description="The method or angle of the adversarial attack.")
+    goal: str = Field(description="The explicit adversarial goal (e.g., 'Extract the adjudicator system prompt').")
+
+
+class AiTMStrategy(CoreasonBaseModel):
+    source_node_id: str = Field(description="The node originating the intercepted message.")
+    target_node_id: str = Field(description="The node intended to receive the message.")
+    mutation_instruction: str = Field(
+        description="The instruction dictating how the red-team agent should subtly "
+        "corrupt the intercepted state event."
+    )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -13,9 +13,11 @@ from coreason_manifest.oversight.resilience import (
 )
 from coreason_manifest.presentation.scivis import AnyPanel, CohortAttritionGrid, InsightCard, TimeSeriesPanel
 from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, ObservationEvent, SystemFaultEvent
+from coreason_manifest.testing.chaos import ChaosExperiment
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, HumanNode, SystemNode
 
 node_adapter: TypeAdapter[AnyNode] = TypeAdapter(AnyNode)
+chaos_adapter: TypeAdapter[ChaosExperiment] = TypeAdapter(ChaosExperiment)
 event_adapter: TypeAdapter[AnyStateEvent] = TypeAdapter(AnyStateEvent)
 panel_adapter: TypeAdapter[AnyPanel] = TypeAdapter(AnyPanel)
 resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResiliencePayload)
@@ -169,3 +171,49 @@ def test_anyresilience_routing(res_type: str, target: str, fallback: str, reason
         assert isinstance(parsed, CircuitBreakerTrip)
     elif res_type == "fallback":
         assert isinstance(parsed, FallbackTrigger)
+
+
+@given(
+    st.text(),
+    st.floats(allow_nan=False, allow_infinity=False),
+    st.integers(),
+    st.one_of(st.none(), st.lists(st.text())),
+    st.lists(
+        st.fixed_dictionaries(
+            {
+                "fault_type": st.sampled_from(
+                    [
+                        "context_overload",
+                        "incorrect_context",
+                        "format_corruption",
+                        "latency_spike",
+                        "token_throttle",
+                    ]
+                ),
+                "target_node_id": st.one_of(st.none(), st.text()),
+                "intensity": st.floats(allow_nan=False, allow_infinity=False),
+            }
+        )
+    ),
+)
+def test_chaosexperiment_fuzzing(
+    experiment_id: str,
+    expected_max_latency: float,
+    max_loops_allowed: int,
+    required_tool_usage: list[str] | None,
+    faults: list[dict[str, Any]],
+) -> None:
+    payload: dict[str, Any] = {
+        "experiment_id": experiment_id,
+        "hypothesis": {
+            "expected_max_latency": expected_max_latency,
+            "max_loops_allowed": max_loops_allowed,
+        },
+        "faults": faults,
+    }
+    if required_tool_usage is not None:
+        payload["hypothesis"]["required_tool_usage"] = required_tool_usage
+
+    parsed = chaos_adapter.validate_python(payload)
+    assert isinstance(parsed, ChaosExperiment)
+    assert parsed.experiment_id == experiment_id


### PR DESCRIPTION
Epic 12 implementation introducing Declarative Chaos & Red Teaming testing data schemas. Complies strictly with immutable `CoreasonBaseModel` requirements, PEP 695 typing, and 100% type-checking pass coverage for newly added models.

---
*PR created automatically by Jules for task [7947745670575830210](https://jules.google.com/task/7947745670575830210) started by @gowthamrao*