### PR TITLE
Add standard copyright and license notices to .py files

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from coreason_manifest.compute import ModelProfile, RateCard
 from coreason_manifest.core import CoreasonBaseModel, NodeID, SemanticVersion
 from coreason_manifest.oversight import (

--- a/src/coreason_manifest/adapters/mcp/__init__.py
+++ b/src/coreason_manifest/adapters/mcp/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from coreason_manifest.adapters.mcp.server import (
     MCPPromptRef,
     MCPResourceList,

--- a/src/coreason_manifest/adapters/mcp/schemas.py
+++ b/src/coreason_manifest/adapters/mcp/schemas.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 """
 Native Model Context Protocol (MCP) Integration for the CoReason Manifest.
 

--- a/src/coreason_manifest/cli/__init__.py
+++ b/src/coreason_manifest/cli/__init__.py
@@ -1,0 +1,6 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 import importlib
 import json
 import sys

--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP

--- a/src/coreason_manifest/compute/__init__.py
+++ b/src/coreason_manifest/compute/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from coreason_manifest.compute.profiles import (
     ComputeProvisioningRequest,
     ModelProfile,

--- a/src/coreason_manifest/compute/profiles.py
+++ b/src/coreason_manifest/compute/profiles.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/core/__init__.py
+++ b/src/coreason_manifest/core/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from .base import CoreasonBaseModel
 from .primitives import (
     DataClassification,

--- a/src/coreason_manifest/core/base.py
+++ b/src/coreason_manifest/core/base.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 import json
 from typing import Any
 

--- a/src/coreason_manifest/core/primitives.py
+++ b/src/coreason_manifest/core/primitives.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from enum import StrEnum
 from typing import Annotated
 

--- a/src/coreason_manifest/oversight/__init__.py
+++ b/src/coreason_manifest/oversight/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from .adjudication import AdjudicationRubric, AdjudicationVerdict, GradingCriteria
 from .governance import ConstitutionalRule, GovernancePolicy
 from .intervention import (

--- a/src/coreason_manifest/oversight/adjudication.py
+++ b/src/coreason_manifest/oversight/adjudication.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/oversight/governance.py
+++ b/src/coreason_manifest/oversight/governance.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/oversight/intervention.py
+++ b/src/coreason_manifest/oversight/intervention.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Annotated, Any, Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/oversight/resilience.py
+++ b/src/coreason_manifest/oversight/resilience.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Annotated, Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/presentation/__init__.py
+++ b/src/coreason_manifest/presentation/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from .intents import (
     AdjudicationIntent,
     AnyIntent,

--- a/src/coreason_manifest/presentation/intents.py
+++ b/src/coreason_manifest/presentation/intents.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Annotated, Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/presentation/scivis.py
+++ b/src/coreason_manifest/presentation/scivis.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Annotated, Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/presentation/templates.py
+++ b/src/coreason_manifest/presentation/templates.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/spec/__init__.py
+++ b/src/coreason_manifest/spec/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from .clinical import CohortDefinition, ConceptSet, ObservationRecord
 
 __all__ = [

--- a/src/coreason_manifest/spec/clinical.py
+++ b/src/coreason_manifest/spec/clinical.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/state/__init__.py
+++ b/src/coreason_manifest/state/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from coreason_manifest.state.events import (
     AnyStateEvent,
     BaseStateEvent,

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Annotated, Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/state/memory.py
+++ b/src/coreason_manifest/state/memory.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/state/toolchains.py
+++ b/src/coreason_manifest/state/toolchains.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/telemetry/__init__.py
+++ b/src/coreason_manifest/telemetry/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from coreason_manifest.telemetry.custody import CustodyRecord
 from coreason_manifest.telemetry.schemas import LogEnvelope, SpanTrace
 from coreason_manifest.telemetry.ux import AmbientSignal, SuspenseEnvelope

--- a/src/coreason_manifest/telemetry/custody.py
+++ b/src/coreason_manifest/telemetry/custody.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/telemetry/schemas.py
+++ b/src/coreason_manifest/telemetry/schemas.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/telemetry/ux.py
+++ b/src/coreason_manifest/telemetry/ux.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/testing/__init__.py
+++ b/src/coreason_manifest/testing/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from .chaos import ChaosExperiment, FaultInjectionProfile, FaultType, SteadyStateHypothesis
 from .red_team import AdversaryProfile, AiTMStrategy, AttackVector
 

--- a/src/coreason_manifest/testing/chaos.py
+++ b/src/coreason_manifest/testing/chaos.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/testing/red_team.py
+++ b/src/coreason_manifest/testing/red_team.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import (
     AgentNode,

--- a/src/coreason_manifest/workflow/envelope.py
+++ b/src/coreason_manifest/workflow/envelope.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Annotated, Literal
 
 from pydantic import Field

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Annotated, Literal
 
 from pydantic import Field

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 import concurrent.futures
 from typing import Any
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from coreason_manifest.presentation.intents import DraftingIntent, PresentationEnvelope
 from coreason_manifest.presentation.scivis import InsightCard, MacroGrid
 from coreason_manifest.state.events import ObservationEvent

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from typing import Any
 
 import pytest

--- a/tests/test_semantics.py
+++ b/tests/test_semantics.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 import ast
 from pathlib import Path
 


### PR DESCRIPTION
Added the standard copyright and license notice to all `.py` files in the repository as requested. This adds a block comment containing the copyright information at the very top of each file, before any imports or module docstrings, and leaves a blank line before the code begins.

---
*PR created automatically by Jules for task [17361578735321709866](https://jules.google.com/task/17361578735321709866) started by @gowthamrao*