### PR TITLE
Fix workflow topology Pydantic schemas and add SOTA BDD tests

### DIFF
--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -25,7 +25,9 @@ class System1Reflex(CoreasonBaseModel):
     Policy for fast, intuitive system 1 thinking.
     """
 
-    confidence_threshold: float = Field(description="The confidence threshold required to execute a reflex action.")
+    confidence_threshold: float = Field(
+        ge=0.0, le=1.0, description="The confidence threshold required to execute a reflex action."
+    )
     allowed_read_only_tools: list[str] = Field(description="List of read-only tools allowed during a reflex action.")
 
 
@@ -36,7 +38,7 @@ class EpistemicScanner(CoreasonBaseModel):
 
     active: bool = Field(description="Whether the epistemic scanner is active.")
     dissonance_threshold: float = Field(
-        description="The threshold for cognitive dissonance before triggering an action."
+        ge=0.0, le=1.0, description="The threshold for cognitive dissonance before triggering an action."
     )
     action_on_gap: Literal["fail", "probe", "clarify"] = Field(
         description="The action to take when an epistemic gap is detected."
@@ -48,7 +50,7 @@ class SelfCorrectionPolicy(CoreasonBaseModel):
     Policy for self-correction and iterative refinement.
     """
 
-    max_loops: int = Field(description="The maximum number of self-correction loops allowed.")
+    max_loops: int = Field(ge=0, le=50, description="The maximum number of self-correction loops allowed.")
     rollback_on_failure: bool = Field(description="Whether to rollback to the previous state on failure.")
 
 

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -7,7 +7,7 @@
 
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
@@ -58,6 +58,7 @@ class DAGTopology(BaseTopology):
     """
 
     type: Literal["dag"] = Field(default="dag", description="Discriminator for a DAG topology.")
+    edges: list[tuple[NodeID, NodeID]] = Field(default_factory=list, description="List of edges between nodes.")
     allow_cycles: bool = Field(
         default=False,
         description="Configuration indicating if cycles are allowed during validation.",
@@ -77,6 +78,12 @@ class CouncilTopology(BaseTopology):
     diversity_policy: DiversityConstraint | None = Field(
         default=None, description="Constraints enforcing cognitive heterogeneity across the council."
     )
+
+    @model_validator(mode='after')
+    def check_adjudicator_id(self) -> CouncilTopology:
+        if self.adjudicator_id not in self.nodes:
+            raise ValueError(f"Adjudicator ID '{self.adjudicator_id}' is not in nodes registry.")
+        return self
 
 
 class SwarmTopology(BaseTopology):

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -79,7 +79,7 @@ class CouncilTopology(BaseTopology):
         default=None, description="Constraints enforcing cognitive heterogeneity across the council."
     )
 
-    @model_validator(mode='after')
+    @model_validator(mode="after")
     def check_adjudicator_id(self) -> CouncilTopology:
         if self.adjudicator_id not in self.nodes:
             raise ValueError(f"Adjudicator ID '{self.adjudicator_id}' is not in nodes registry.")

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -67,6 +67,15 @@ class DAGTopology(BaseTopology):
         default=None, description="Declarative backpressure constraints for the graph edges."
     )
 
+    @model_validator(mode="after")
+    def verify_edges_exist(self) -> DAGTopology:
+        for source, target in self.edges:
+            if source not in self.nodes:
+                raise ValueError(f"Edge source '{source}' does not exist in nodes registry.")
+            if target not in self.nodes:
+                raise ValueError(f"Edge target '{target}' does not exist in nodes registry.")
+        return self
+
 
 class CouncilTopology(BaseTopology):
     """

--- a/tests/domains/test_workflow_topology.py
+++ b/tests/domains/test_workflow_topology.py
@@ -1,0 +1,100 @@
+from typing import Any
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from hypothesis.strategies import DataObject
+from pydantic import ValidationError
+
+from coreason_manifest.workflow.nodes import (
+    AgentNode,
+    EpistemicScanner,
+    HumanNode,
+    SelfCorrectionPolicy,
+    System1Reflex,
+    SystemNode,
+)
+from coreason_manifest.workflow.topologies import CouncilTopology
+
+# Strategy for valid NodeIDs (alphanumeric, underscores, hyphens)
+# Also must have a minimum length of 1 based on core primitives.
+valid_node_id_st = st.from_regex(r"^[a-zA-Z0-9_-]+$", fullmatch=True).filter(lambda x: len(x) > 0)
+
+# Strategy for BaseNode attributes
+base_node_attrs = {
+    "description": st.text(),
+}
+
+# Strategies for nodes
+agent_node_st = st.builds(AgentNode, **base_node_attrs)
+human_node_st = st.builds(HumanNode, **base_node_attrs)
+system_node_st = st.builds(SystemNode, **base_node_attrs)
+
+# Strategy for any valid node
+any_node_st = st.one_of(agent_node_st, human_node_st, system_node_st)
+
+
+# Strategy for a valid nodes dictionary
+@st.composite
+def nodes_dict_st(draw: Any) -> Any:
+    return draw(st.dictionaries(keys=valid_node_id_st, values=any_node_st, min_size=1, max_size=10))
+
+
+@given(nodes=nodes_dict_st(), adjudicator_id=st.data())
+def test_council_topology_referential_integrity_success(nodes: dict[str, Any], adjudicator_id: DataObject) -> None:
+    """Test 1: Prove CouncilTopology instantiated with adjudicator_id from nodes dictionary never fails."""
+    # Draw a valid key from the generated nodes
+    valid_id_str = adjudicator_id.draw(st.sampled_from(list(nodes.keys())))
+
+    topology = CouncilTopology(
+        nodes=nodes,
+        adjudicator_id=valid_id_str
+    )
+    assert topology.adjudicator_id == valid_id_str
+
+@given(nodes=nodes_dict_st())
+def test_council_topology_referential_integrity_adversarial(nodes: dict[str, Any]) -> None:
+    """Test 2: Prove that injecting a guaranteed dangling pointer always raises a ValidationError."""
+    rogue_id = "rogue_ghost_node"
+    # Ensure it's strictly not in the nodes dictionary
+    if rogue_id in nodes:
+        del nodes[rogue_id]
+        if not nodes:
+            return  # Skip if nodes becomes empty
+
+    with pytest.raises(ValidationError) as exc_info:
+        CouncilTopology(
+            nodes=nodes,
+            adjudicator_id=rogue_id
+        )
+
+    assert "Adjudicator ID" in str(exc_info.value) or "Value error" in str(exc_info.value)
+
+@given(confidence_threshold=st.floats().filter(lambda x: x < 0.0 or x > 1.0 or x != x)) # filter nans
+def test_system1_reflex_mathematical_bounds(confidence_threshold: float) -> None:
+    """Test 3: Prove System1Reflex decisively rejects values outside [0.0, 1.0]."""
+    with pytest.raises(ValidationError):
+        System1Reflex(
+            confidence_threshold=confidence_threshold,
+            allowed_read_only_tools=["tool_a"]
+        )
+
+
+@given(dissonance_threshold=st.floats().filter(lambda x: x < 0.0 or x > 1.0 or x != x)) # filter nans
+def test_epistemic_scanner_mathematical_bounds(dissonance_threshold: float) -> None:
+    """Test 4: Prove EpistemicScanner decisively rejects values outside [0.0, 1.0]."""
+    with pytest.raises(ValidationError):
+        EpistemicScanner(
+            active=True,
+            dissonance_threshold=dissonance_threshold,
+            action_on_gap="probe"
+        )
+
+@given(max_loops=st.integers().filter(lambda x: x < 0 or x > 50))
+def test_self_correction_policy_mathematical_bounds(max_loops: int) -> None:
+    """Test 5: Prove SelfCorrectionPolicy decisively rejects values outside [0, 50]."""
+    with pytest.raises(ValidationError):
+        SelfCorrectionPolicy(
+            max_loops=max_loops,
+            rollback_on_failure=True
+        )

--- a/tests/domains/test_workflow_topology.py
+++ b/tests/domains/test_workflow_topology.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any
 
 import pytest
@@ -14,7 +15,7 @@ from coreason_manifest.workflow.nodes import (
     System1Reflex,
     SystemNode,
 )
-from coreason_manifest.workflow.topologies import CouncilTopology
+from coreason_manifest.workflow.topologies import CouncilTopology, DAGTopology
 
 # Strategy for valid NodeIDs (alphanumeric, underscores, hyphens)
 # Also must have a minimum length of 1 based on core primitives.
@@ -38,6 +39,40 @@ any_node_st = st.one_of(agent_node_st, human_node_st, system_node_st)
 @st.composite
 def nodes_dict_st(draw: Any) -> Any:
     return draw(st.dictionaries(keys=valid_node_id_st, values=any_node_st, min_size=1, max_size=10))
+
+
+@given(nodes=nodes_dict_st(), edge_data=st.data())
+def test_dag_topology_referential_integrity_success(nodes: dict[str, Any], edge_data: DataObject) -> None:
+    """Prove DAGTopology instantiated with edges connecting valid nodes never fails."""
+    # Draw valid keys from the generated nodes
+    keys = list(nodes.keys())
+    source_id = edge_data.draw(st.sampled_from(keys))
+    target_id = edge_data.draw(st.sampled_from(keys))
+
+    topology = DAGTopology(nodes=nodes, edges=[(source_id, target_id)])
+    assert topology.edges == [(source_id, target_id)]
+
+
+@given(nodes=nodes_dict_st(), edge_data=st.data())
+def test_dag_topology_referential_integrity_adversarial(nodes: dict[str, Any], edge_data: DataObject) -> None:
+    """Prove that injecting a ghost node into an edge tuple always raises a ValidationError."""
+    ghost_node = "ghost_node_123"
+    # Ensure it's strictly not in the nodes dictionary
+    if ghost_node in nodes:
+        del nodes[ghost_node]
+        if not nodes:
+            return  # Skip if nodes becomes empty
+
+    # valid node for the other end
+    valid_id_str = edge_data.draw(st.sampled_from(list(nodes.keys())))
+
+    with pytest.raises(ValidationError) as exc_info:
+        DAGTopology(nodes=nodes, edges=[(valid_id_str, ghost_node)])
+    assert "does not exist in nodes registry" in str(exc_info.value)
+
+    with pytest.raises(ValidationError) as exc_info:
+        DAGTopology(nodes=nodes, edges=[(ghost_node, valid_id_str)])
+    assert "does not exist in nodes registry" in str(exc_info.value)
 
 
 @given(nodes=nodes_dict_st(), adjudicator_id=st.data())
@@ -85,3 +120,17 @@ def test_self_correction_policy_mathematical_bounds(max_loops: int) -> None:
     """Test 5: Prove SelfCorrectionPolicy decisively rejects values outside [0, 50]."""
     with pytest.raises(ValidationError):
         SelfCorrectionPolicy(max_loops=max_loops, rollback_on_failure=True)
+
+
+@given(max_loops=st.integers(max_value=-1) | st.integers(min_value=51))
+def test_self_correction_policy_extreme_bounds(max_loops: int) -> None:
+    """Prove SelfCorrectionPolicy decisively rejects extreme out-of-bounds loops."""
+    with pytest.raises(ValidationError):
+        SelfCorrectionPolicy(max_loops=max_loops, rollback_on_failure=True)
+
+
+@given(confidence_threshold=st.sampled_from([math.nan, math.inf, -math.inf]))
+def test_system1_reflex_toxic_floats(confidence_threshold: float) -> None:
+    """Prove System1Reflex decisively rejects toxic floats (NaN, Inf, -Inf)."""
+    with pytest.raises(ValidationError):
+        System1Reflex(confidence_threshold=confidence_threshold, allowed_read_only_tools=["tool_a"])

--- a/tests/domains/test_workflow_topology.py
+++ b/tests/domains/test_workflow_topology.py
@@ -46,11 +46,9 @@ def test_council_topology_referential_integrity_success(nodes: dict[str, Any], a
     # Draw a valid key from the generated nodes
     valid_id_str = adjudicator_id.draw(st.sampled_from(list(nodes.keys())))
 
-    topology = CouncilTopology(
-        nodes=nodes,
-        adjudicator_id=valid_id_str
-    )
+    topology = CouncilTopology(nodes=nodes, adjudicator_id=valid_id_str)
     assert topology.adjudicator_id == valid_id_str
+
 
 @given(nodes=nodes_dict_st())
 def test_council_topology_referential_integrity_adversarial(nodes: dict[str, Any]) -> None:
@@ -63,38 +61,27 @@ def test_council_topology_referential_integrity_adversarial(nodes: dict[str, Any
             return  # Skip if nodes becomes empty
 
     with pytest.raises(ValidationError) as exc_info:
-        CouncilTopology(
-            nodes=nodes,
-            adjudicator_id=rogue_id
-        )
+        CouncilTopology(nodes=nodes, adjudicator_id=rogue_id)
 
     assert "Adjudicator ID" in str(exc_info.value) or "Value error" in str(exc_info.value)
 
-@given(confidence_threshold=st.floats().filter(lambda x: x < 0.0 or x > 1.0 or x != x)) # filter nans
+
+@given(confidence_threshold=st.floats().filter(lambda x: x < 0.0 or x > 1.0 or x != x))  # filter nans
 def test_system1_reflex_mathematical_bounds(confidence_threshold: float) -> None:
     """Test 3: Prove System1Reflex decisively rejects values outside [0.0, 1.0]."""
     with pytest.raises(ValidationError):
-        System1Reflex(
-            confidence_threshold=confidence_threshold,
-            allowed_read_only_tools=["tool_a"]
-        )
+        System1Reflex(confidence_threshold=confidence_threshold, allowed_read_only_tools=["tool_a"])
 
 
-@given(dissonance_threshold=st.floats().filter(lambda x: x < 0.0 or x > 1.0 or x != x)) # filter nans
+@given(dissonance_threshold=st.floats().filter(lambda x: x < 0.0 or x > 1.0 or x != x))  # filter nans
 def test_epistemic_scanner_mathematical_bounds(dissonance_threshold: float) -> None:
     """Test 4: Prove EpistemicScanner decisively rejects values outside [0.0, 1.0]."""
     with pytest.raises(ValidationError):
-        EpistemicScanner(
-            active=True,
-            dissonance_threshold=dissonance_threshold,
-            action_on_gap="probe"
-        )
+        EpistemicScanner(active=True, dissonance_threshold=dissonance_threshold, action_on_gap="probe")
+
 
 @given(max_loops=st.integers().filter(lambda x: x < 0 or x > 50))
 def test_self_correction_policy_mathematical_bounds(max_loops: int) -> None:
     """Test 5: Prove SelfCorrectionPolicy decisively rejects values outside [0, 50]."""
     with pytest.raises(ValidationError):
-        SelfCorrectionPolicy(
-            max_loops=max_loops,
-            rollback_on_failure=True
-        )
+        SelfCorrectionPolicy(max_loops=max_loops, rollback_on_failure=True)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -37,7 +37,7 @@ resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResilienc
         st.none(),
         st.fixed_dictionaries(
             {
-                "confidence_threshold": st.floats(allow_nan=False, allow_infinity=False),
+                "confidence_threshold": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
                 "allowed_read_only_tools": st.lists(st.text()),
             }
         ),
@@ -47,7 +47,7 @@ resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResilienc
         st.fixed_dictionaries(
             {
                 "active": st.booleans(),
-                "dissonance_threshold": st.floats(allow_nan=False, allow_infinity=False),
+                "dissonance_threshold": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
                 "action_on_gap": st.sampled_from(["fail", "probe", "clarify"]),
             }
         ),
@@ -56,7 +56,7 @@ resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResilienc
         st.none(),
         st.fixed_dictionaries(
             {
-                "max_loops": st.integers(),
+                "max_loops": st.integers(min_value=0, max_value=50),
                 "rollback_on_failure": st.booleans(),
             }
         ),


### PR DESCRIPTION
This pull request aims to fulfill the requested hardening of Pydantic models in `topologies.py` and `nodes.py` by ensuring mathematical bounding and referential integrity, while shifting to high-coverage Generative BDD testing.

**Key Changes**
- Added missing `edges: list[tuple[NodeID, NodeID]]` state mapping to `DAGTopology`.
- Restricted `adjudicator_id` initialization in `CouncilTopology` via `model_validator` ensuring that the identifier explicitly maps back to the topology's bounded `nodes` dictionary to prevent dangling pointer bugs.
- Tightened mathematical bounds for node parameters (`confidence_threshold` in `System1Reflex`, `dissonance_threshold` in `EpistemicScanner`, and `max_loops` in `SelfCorrectionPolicy`).
- Implemented `tests/domains/test_workflow_topology.py` introducing a multi-dimensional generative BDD test suite using `hypothesis` that bombards schemas with mathematically robust node/id mappings.
- Re-adjusted bounds in `tests/test_fuzzing.py` so preexisting test batteries honor the stricter schemas.

---
*PR created automatically by Jules for task [8545889279312327017](https://jules.google.com/task/8545889279312327017) started by @gowthamrao*