### PR TITLE
fix: Patch semantic_diff script failing logic

### DIFF
--- a/scripts/semantic_diff.py
+++ b/scripts/semantic_diff.py
@@ -14,11 +14,19 @@ def main() -> None:
     file_path = sys.argv[2]
 
     try:
-        base_file_content = subprocess.check_output(["git", "show", f"{git_ref}:{file_path}"]).decode("utf-8")  # noqa: S603, S607
+        base_file_content = subprocess.check_output(  # noqa: S603
+            ["git", "show", f"{git_ref}:{file_path}"],  # noqa: S607
+            stderr=subprocess.PIPE,
+        ).decode("utf-8")
         base_json = json.loads(base_file_content)
-    except subprocess.CalledProcessError:
-        print(f"Warning: Could not fetch {file_path} from {git_ref}. Assuming new file.")
-        base_json = {}
+    except subprocess.CalledProcessError as e:
+        stderr_output = e.stderr.decode("utf-8") if e.stderr else ""
+        if "exists on disk, but not in" in stderr_output or "does not exist" in stderr_output:
+            print(f"Warning: Could not fetch {file_path} from {git_ref}. Assuming new file.")
+            base_json = {}
+        else:
+            print(f"Critical Error: Git ref {git_ref} could not be resolved. Git stderr: {stderr_output.strip()}")
+            sys.exit(1)
 
     with open(file_path, encoding="utf-8") as f:
         local_json = json.loads(f.read())
@@ -33,6 +41,13 @@ def main() -> None:
     if "iterable_item_added" in diff:
         for path in diff["iterable_item_added"]:
             # e.g. root['$defs']['AgentNode']['required'][1]
+            if "['required']" in path:
+                print(f"Error: Backward-breaking schema change detected! A new required field was added: {path}")
+                sys.exit(1)
+
+    if "dictionary_item_added" in diff:
+        for path in diff["dictionary_item_added"]:
+            # e.g. root['$defs']['AgentNode']['required']
             if "['required']" in path:
                 print(f"Error: Backward-breaking schema change detected! A new required field was added: {path}")
                 sys.exit(1)


### PR DESCRIPTION
We observed two critical vulnerabilities inside of the scripts/semantic_diff.py script which bypassed regression checks. 

Firstly, missing models failed open even in instances where a git diff was actually not capable of running because of a bad reference pointer.
Secondly, there was an edge case logic missing where DeepDiff returned a dictionary item rather than an iterable item addition when the first required block is placed on an optional data schema structure.

Both are now patched and return proper exit failures.

---
*PR created automatically by Jules for task [11703467238068430217](https://jules.google.com/task/11703467238068430217) started by @gowthamrao*