### PR TITLE
chore: configure pytest to output missing coverage lines by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
         run: echo "PYTHON_GIL=0" >> $GITHUB_ENV
 
       - name: Pytest
-        run: uv run pytest tests/ --cov=coreason_manifest --cov-report=xml --cov-fail-under=95
+        run: uv run pytest
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4
@@ -166,7 +166,7 @@ jobs:
         run: echo "PYTHON_GIL=0" >> $GITHUB_ENV
 
       - name: Pytest
-        run: uv run pytest tests/ --cov=coreason_manifest --cov-report=xml --cov-fail-under=95
+        run: uv run pytest
 
       - name: Upload coverage
         uses: codecov/codecov-action@v4

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,6 @@ We run `mypy` in `strict = true` mode. There are no implicit optionals, and `Any
 
 ### 3. Test Coverage
 Ensure your new logic maintains the strict 95% coverage mandate and passes all behavioral checks:
-`uv run pytest --cov --cov-fail-under=95`
+`uv run pytest`
 
 *Note: Do not bypass type hints or add `# type: ignore` unless interacting with deeply dynamic external modules, and only do so with an explicit explanatory comment.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-addopts = ""
+addopts = "--cov=coreason_manifest --cov-report=term-missing --cov-report=xml --cov-fail-under=95"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 filterwarnings = ["ignore:Pydantic serializer warnings:UserWarning"]


### PR DESCRIPTION
This PR configures pytest to output the exact missing coverage lines to the terminal by default (`--cov-report=term-missing`). To make this truly the default for both local development and CI, we centralized the pytest arguments in `pyproject.toml` and simplified the CI workflow and developer instructions.

Tasks completed:
1. Updated `pyproject.toml` `[tool.pytest.ini_options]` `addopts`.
2. Simplified `.github/workflows/ci.yml` `Pytest` steps to `uv run pytest`.
3. Updated `AGENTS.md` `Test Coverage` instruction to just `uv run pytest`.

---
*PR created automatically by Jules for task [73471046178310609](https://jules.google.com/task/73471046178310609) started by @gowthamrao*