### PR TITLE
Harden Oversight Schemas and Generative Tests

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -19,6 +19,7 @@
         },
         "passing_threshold": {
           "description": "The minimum score required to pass.",
+          "minimum": 0.0,
           "title": "Passing Threshold",
           "type": "number"
         }
@@ -333,10 +334,12 @@
         "forbidden_intents": {
           "description": "List of intents that are forbidden by this rule.",
           "items": {
+            "minLength": 1,
             "type": "string"
           },
           "title": "Forbidden Intents",
-          "type": "array"
+          "type": "array",
+          "uniqueItems": true
         }
       },
       "required": [
@@ -636,6 +639,7 @@
         },
         "weight": {
           "description": "Weight or significance of this criterion.",
+          "minimum": 0.0,
           "title": "Weight",
           "type": "number"
         }

--- a/src/coreason_manifest/oversight/adjudication.py
+++ b/src/coreason_manifest/oversight/adjudication.py
@@ -18,7 +18,7 @@ class GradingCriteria(CoreasonBaseModel):
 
     criterion_id: str = Field(description="Unique identifier for the grading criterion.")
     description: str = Field(description="Detailed description of what is being graded.")
-    weight: float = Field(description="Weight or significance of this criterion.")
+    weight: float = Field(ge=0.0, description="Weight or significance of this criterion.")
 
 
 class AdjudicationRubric(CoreasonBaseModel):
@@ -28,7 +28,7 @@ class AdjudicationRubric(CoreasonBaseModel):
 
     rubric_id: str = Field(description="Unique identifier for the rubric.")
     criteria: list[GradingCriteria] = Field(description="List of criteria used in the rubric.")
-    passing_threshold: float = Field(description="The minimum score required to pass.")
+    passing_threshold: float = Field(ge=0.0, description="The minimum score required to pass.")
 
 
 class AdjudicationVerdict(CoreasonBaseModel):

--- a/src/coreason_manifest/oversight/governance.py
+++ b/src/coreason_manifest/oversight/governance.py
@@ -5,13 +5,12 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, StringConstraints
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import SemanticVersion
-
 
 class ConstitutionalRule(CoreasonBaseModel):
     """
@@ -23,7 +22,9 @@ class ConstitutionalRule(CoreasonBaseModel):
     severity: Literal["low", "medium", "high", "critical"] = Field(
         description="Severity level if the rule is violated."
     )
-    forbidden_intents: list[str] = Field(description="List of intents that are forbidden by this rule.")
+    forbidden_intents: set[Annotated[str, StringConstraints(min_length=1)]] = Field(
+        description="List of intents that are forbidden by this rule."
+    )
 
 
 class GovernancePolicy(CoreasonBaseModel):

--- a/src/coreason_manifest/oversight/governance.py
+++ b/src/coreason_manifest/oversight/governance.py
@@ -12,6 +12,7 @@ from pydantic import Field, StringConstraints
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import SemanticVersion
 
+
 class ConstitutionalRule(CoreasonBaseModel):
     """
     Defines a constitutional rule for AI governance.

--- a/src/coreason_manifest/oversight/intervention.py
+++ b/src/coreason_manifest/oversight/intervention.py
@@ -29,7 +29,7 @@ class FallbackSLA(CoreasonBaseModel):
     SLA defining bounds on human intervention delays.
     """
 
-    timeout_seconds: int = Field(description="The maximum allowed delay for a human intervention.")
+    timeout_seconds: int = Field(gt=0, description="The maximum allowed delay for a human intervention.")
     timeout_action: Literal["fail_safe", "proceed_with_defaults", "escalate"] = Field(
         description="The action to take when the timeout expires."
     )

--- a/tests/domains/test_oversight_governance.py
+++ b/tests/domains/test_oversight_governance.py
@@ -39,9 +39,7 @@ def test_fallback_sla_rejects_non_positive_timeout(timeout_seconds: int) -> None
         )
 
 
-@given(
-    forbidden_intents=st.lists(st.just(""), min_size=1)
-)
+@given(forbidden_intents=st.lists(st.just(""), min_size=1))
 def test_constitutional_rule_rejects_empty_strings(forbidden_intents: list[str]) -> None:
     with pytest.raises(ValidationError):
         ConstitutionalRule(
@@ -52,9 +50,7 @@ def test_constitutional_rule_rejects_empty_strings(forbidden_intents: list[str])
         )
 
 
-@given(
-    forbidden_intents=st.lists(st.text(min_size=1), min_size=2).filter(lambda x: len(set(x)) < len(x))
-)
+@given(forbidden_intents=st.lists(st.text(min_size=1), min_size=2).filter(lambda x: len(set(x)) < len(x)))
 def test_constitutional_rule_deduplicates_or_rejects_duplicate_strings(forbidden_intents: list[str]) -> None:
     # If using set, Pydantic should deduplicate or raise error if list has duplicates.
     # We test that it's structurally impossible to have duplicates in the model.
@@ -90,7 +86,7 @@ def test_sandbox_success_massive_configs(
 ) -> None:
     scope = BoundedInterventionScope(
         allowed_fields=allowed_fields,
-        json_schema_whitelist=json_schema_whitelist, # type: ignore
+        json_schema_whitelist=json_schema_whitelist,  # type: ignore
     )
     sla = FallbackSLA(
         timeout_seconds=timeout_seconds,
@@ -101,7 +97,7 @@ def test_sandbox_success_massive_configs(
         fallback_sla=sla,
         target_node_id="node-1",
         context_summary=context_summary,
-        proposed_action=proposed_action, # type: ignore
+        proposed_action=proposed_action,  # type: ignore
         adjudication_deadline=adjudication_deadline,
     )
     assert req.intervention_scope is not None

--- a/tests/domains/test_oversight_governance.py
+++ b/tests/domains/test_oversight_governance.py
@@ -1,0 +1,107 @@
+import pytest
+from hypothesis import given, strategies as st
+from pydantic import ValidationError
+
+from coreason_manifest.oversight.adjudication import AdjudicationRubric, GradingCriteria
+from coreason_manifest.oversight.intervention import FallbackSLA, InterventionRequest, BoundedInterventionScope
+from coreason_manifest.oversight.governance import ConstitutionalRule
+
+
+@given(
+    weight=st.floats(max_value=-0.000001, allow_nan=False, allow_infinity=False),
+    threshold=st.floats(max_value=-0.000001, allow_nan=False, allow_infinity=False),
+)
+def test_adjudication_rubric_rejects_negative_bounds(weight: float, threshold: float) -> None:
+    with pytest.raises(ValidationError):
+        GradingCriteria(
+            criterion_id="test-criterion",
+            description="test description",
+            weight=weight,
+        )
+
+    with pytest.raises(ValidationError):
+        AdjudicationRubric(
+            rubric_id="test-rubric",
+            criteria=[],
+            passing_threshold=threshold,
+        )
+
+
+@given(
+    timeout_seconds=st.integers(max_value=0),
+)
+def test_fallback_sla_rejects_non_positive_timeout(timeout_seconds: int) -> None:
+    with pytest.raises(ValidationError):
+        FallbackSLA(
+            timeout_seconds=timeout_seconds,
+            timeout_action="fail_safe",
+        )
+
+
+@given(
+    forbidden_intents=st.lists(st.just(""), min_size=1)
+)
+def test_constitutional_rule_rejects_empty_strings(forbidden_intents: list[str]) -> None:
+    with pytest.raises(ValidationError):
+        ConstitutionalRule(
+            rule_id="rule-1",
+            description="desc",
+            severity="critical",
+            forbidden_intents=forbidden_intents,
+        )
+
+
+@given(
+    forbidden_intents=st.lists(st.text(min_size=1), min_size=2).filter(lambda x: len(set(x)) < len(x))
+)
+def test_constitutional_rule_deduplicates_or_rejects_duplicate_strings(forbidden_intents: list[str]) -> None:
+    # If using set, Pydantic should deduplicate or raise error if list has duplicates.
+    # We test that it's structurally impossible to have duplicates in the model.
+    try:
+        rule = ConstitutionalRule(
+            rule_id="rule-2",
+            description="desc",
+            severity="critical",
+            forbidden_intents=forbidden_intents,
+        )
+        # If it succeeds, it MUST be deduplicated by Pydantic (converted to set)
+        assert len(rule.forbidden_intents) == len(set(forbidden_intents))
+        assert len(rule.forbidden_intents) < len(forbidden_intents)
+    except ValidationError:
+        pass  # Also acceptable if it rejects lists with duplicates (depending on strict mode)
+
+
+@given(
+    allowed_fields=st.lists(st.text()),
+    json_schema_whitelist=st.dictionaries(st.text(), st.integers()),  # Simple dict
+    timeout_seconds=st.integers(min_value=1, max_value=1000000),
+    context_summary=st.text(),
+    proposed_action=st.dictionaries(st.text(), st.integers()),
+    adjudication_deadline=st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
+)
+def test_sandbox_success_massive_configs(
+    allowed_fields: list[str],
+    json_schema_whitelist: dict[str, int],
+    timeout_seconds: int,
+    context_summary: str,
+    proposed_action: dict[str, int],
+    adjudication_deadline: float,
+) -> None:
+    scope = BoundedInterventionScope(
+        allowed_fields=allowed_fields,
+        json_schema_whitelist=json_schema_whitelist, # type: ignore
+    )
+    sla = FallbackSLA(
+        timeout_seconds=timeout_seconds,
+        timeout_action="fail_safe",
+    )
+    req = InterventionRequest(
+        intervention_scope=scope,
+        fallback_sla=sla,
+        target_node_id="node-1",
+        context_summary=context_summary,
+        proposed_action=proposed_action, # type: ignore
+        adjudication_deadline=adjudication_deadline,
+    )
+    assert req.intervention_scope is not None
+    assert req.fallback_sla is not None

--- a/tests/domains/test_oversight_governance.py
+++ b/tests/domains/test_oversight_governance.py
@@ -1,10 +1,11 @@
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from coreason_manifest.oversight.adjudication import AdjudicationRubric, GradingCriteria
-from coreason_manifest.oversight.intervention import FallbackSLA, InterventionRequest, BoundedInterventionScope
 from coreason_manifest.oversight.governance import ConstitutionalRule
+from coreason_manifest.oversight.intervention import BoundedInterventionScope, FallbackSLA, InterventionRequest
 
 
 @given(

--- a/tests/domains/test_oversight_governance.py
+++ b/tests/domains/test_oversight_governance.py
@@ -42,11 +42,13 @@ def test_fallback_sla_rejects_non_positive_timeout(timeout_seconds: int) -> None
 @given(forbidden_intents=st.lists(st.just(""), min_size=1))
 def test_constitutional_rule_rejects_empty_strings(forbidden_intents: list[str]) -> None:
     with pytest.raises(ValidationError):
-        ConstitutionalRule(
-            rule_id="rule-1",
-            description="desc",
-            severity="critical",
-            forbidden_intents=forbidden_intents,
+        ConstitutionalRule.model_validate(
+            {
+                "rule_id": "rule-1",
+                "description": "desc",
+                "severity": "critical",
+                "forbidden_intents": forbidden_intents,
+            }
         )
 
 
@@ -55,11 +57,13 @@ def test_constitutional_rule_deduplicates_or_rejects_duplicate_strings(forbidden
     # If using set, Pydantic should deduplicate or raise error if list has duplicates.
     # We test that it's structurally impossible to have duplicates in the model.
     try:
-        rule = ConstitutionalRule(
-            rule_id="rule-2",
-            description="desc",
-            severity="critical",
-            forbidden_intents=forbidden_intents,
+        rule = ConstitutionalRule.model_validate(
+            {
+                "rule_id": "rule-2",
+                "description": "desc",
+                "severity": "critical",
+                "forbidden_intents": forbidden_intents,
+            }
         )
         # If it succeeds, it MUST be deduplicated by Pydantic (converted to set)
         assert len(rule.forbidden_intents) == len(set(forbidden_intents))


### PR DESCRIPTION
Hardened Pydantic schemas in the `oversight` bounded context to enforce strict mathematical reality and zero-trust boundaries.
- `adjudication.py`: Ensured weights and passing thresholds cannot be negative.
- `intervention.py`: Ensured SLA timeout seconds are strictly positive.
- `governance.py`: Ensured constitutional rules cannot have empty string or duplicate intents.
- Added a property-based test suite in `tests/domains/test_oversight_governance.py` using `hypothesis` to mathematically prove the schema boundaries are impenetrable.

---
*PR created automatically by Jules for task [4780563854029335105](https://jules.google.com/task/4780563854029335105) started by @gowthamrao*