### PR TITLE
ci: exclude windows 3.14t from test-extended matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,9 @@ jobs:
       matrix:
         os: [macos-latest, windows-latest]
         python-version: ["3.14", "3.14t"]
+        exclude:
+          - os: windows-latest
+            python-version: "3.14t"
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The CI pipeline is failing during the `test-extended` job specifically on the `windows-latest` + `3.14t` matrix combination. The error is: `Distribution 'pywin32==311...' can't be installed because it doesn't have a source distribution or wheel for the current platform.` This occurs because `mcp` depends on `pywin32` on Windows, but `pywin32` has not published experimental free-threaded (`cp314t`) wheels yet.

This commit updates `.github/workflows/ci.yml` to exclude `os: windows-latest` + `python-version: "3.14t"` from the `test-extended` job matrix, while preserving the macOS and Ubuntu canary runs.

---
*PR created automatically by Jules for task [4876800705672278077](https://jules.google.com/task/4876800705672278077) started by @gowthamrao*