### PR TITLE
feat(epic-13): introduce Universal Tooling & MCP Action Spaces

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1,5 +1,37 @@
 {
   "$defs": {
+    "ActionSpace": {
+      "additionalProperties": false,
+      "description": "A curated environment of tools accessible to an agent or node.",
+      "properties": {
+        "action_space_id": {
+          "description": "The unique identifier for this curated environment of tools.",
+          "title": "Action Space Id",
+          "type": "string"
+        },
+        "native_tools": {
+          "description": "The list of discrete, natively defined tools available in this space.",
+          "items": {
+            "$ref": "#/$defs/ToolDefinition"
+          },
+          "title": "Native Tools",
+          "type": "array"
+        },
+        "mcp_servers": {
+          "description": "The list of MCP servers mounted into this action space.",
+          "items": {
+            "$ref": "#/$defs/MCPClientBinding"
+          },
+          "title": "Mcp Servers",
+          "type": "array"
+        }
+      },
+      "required": [
+        "action_space_id"
+      ],
+      "title": "ActionSpace",
+      "type": "object"
+    },
     "AdjudicationRubric": {
       "additionalProperties": false,
       "description": "Rubric defining multiple criteria and passing threshold for algorithmic adjudication.",
@@ -73,6 +105,19 @@
           "description": "Discriminator for an Agent node.",
           "title": "Type",
           "type": "string"
+        },
+        "action_space_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The ID of the specific ActionSpace (curated tool environment) bound to this agent.",
+          "title": "Action Space Id"
         },
         "reflex_policy": {
           "anyOf": [
@@ -550,6 +595,35 @@
       "title": "EpistemicScanner",
       "type": "object"
     },
+    "ExecutionSLA": {
+      "additionalProperties": false,
+      "description": "Service Level Agreement (limits) for executing a tool.",
+      "properties": {
+        "max_execution_time_ms": {
+          "description": "The maximum allowed execution time in milliseconds before the orchestrator kills the process.",
+          "title": "Max Execution Time Ms",
+          "type": "integer"
+        },
+        "max_memory_mb": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum memory footprint allowed for the tool's execution sandbox.",
+          "title": "Max Memory Mb"
+        }
+      },
+      "required": [
+        "max_execution_time_ms"
+      ],
+      "title": "ExecutionSLA",
+      "type": "object"
+    },
     "FaultInjectionProfile": {
       "additionalProperties": false,
       "properties": {
@@ -714,6 +788,51 @@
       "title": "LogEnvelope",
       "type": "object"
     },
+    "MCPClientBinding": {
+      "additionalProperties": false,
+      "description": "Binding configuration for a Model Context Protocol (MCP) server.",
+      "properties": {
+        "server_uri": {
+          "description": "The URI or command path to the MCP server.",
+          "title": "Server Uri",
+          "type": "string"
+        },
+        "transport_type": {
+          "$ref": "#/$defs/MCPTransport",
+          "description": "The transport protocol used to communicate with the MCP server."
+        },
+        "allowed_mcp_tools": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An explicit whitelist of tools the agent is allowed to invoke from this server. If None, all discovered tools are allowed.",
+          "title": "Allowed Mcp Tools"
+        }
+      },
+      "required": [
+        "server_uri",
+        "transport_type"
+      ],
+      "title": "MCPClientBinding",
+      "type": "object"
+    },
+    "MCPTransport": {
+      "enum": [
+        "stdio",
+        "sse",
+        "http"
+      ],
+      "type": "string"
+    },
     "MetadataDict": {
       "additionalProperties": {
         "anyOf": [
@@ -812,6 +931,44 @@
       "title": "ObservationEvent",
       "type": "object"
     },
+    "PermissionBoundary": {
+      "additionalProperties": false,
+      "description": "Zero-trust security boundaries for tool execution.",
+      "properties": {
+        "network_access": {
+          "description": "Whether the tool is permitted to make external network requests.",
+          "title": "Network Access",
+          "type": "boolean"
+        },
+        "allowed_domains": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Whitelist of allowed network domains if network access is true.",
+          "title": "Allowed Domains"
+        },
+        "file_system_read_only": {
+          "description": "True if the tool is strictly forbidden from writing to the disk.",
+          "title": "File System Read Only",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "network_access",
+        "file_system_read_only"
+      ],
+      "title": "PermissionBoundary",
+      "type": "object"
+    },
     "RateCard": {
       "additionalProperties": false,
       "description": "Economic constraints for liquid compute operations.",
@@ -873,6 +1030,28 @@
       ],
       "pattern": "^\\d+\\.\\d+\\.\\d+$",
       "type": "string"
+    },
+    "SideEffectProfile": {
+      "additionalProperties": false,
+      "description": "Profile for describing the side effects and idempotency of a tool.",
+      "properties": {
+        "is_idempotent": {
+          "description": "True if the tool can be safely retried multiple times without altering state beyond the first call.",
+          "title": "Is Idempotent",
+          "type": "boolean"
+        },
+        "mutates_state": {
+          "description": "True if the tool performs write operations or side-effects.",
+          "title": "Mutates State",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "is_idempotent",
+        "mutates_state"
+      ],
+      "title": "SideEffectProfile",
+      "type": "object"
     },
     "SpanTrace": {
       "additionalProperties": false,
@@ -1111,6 +1290,57 @@
           "type": "null"
         }
       ]
+    },
+    "ToolDefinition": {
+      "additionalProperties": false,
+      "description": "Declarative mathematical definition of a tool.",
+      "properties": {
+        "tool_name": {
+          "description": "The exact identifier of the tool.",
+          "title": "Tool Name",
+          "type": "string"
+        },
+        "description": {
+          "description": "Semantic description of what the tool does, used by the LLM for selection.",
+          "title": "Description",
+          "type": "string"
+        },
+        "input_schema": {
+          "additionalProperties": true,
+          "description": "The strict JSON Schema dictionary defining the required arguments.",
+          "title": "Input Schema",
+          "type": "object"
+        },
+        "side_effects": {
+          "$ref": "#/$defs/SideEffectProfile",
+          "description": "The declarative side-effect and idempotency profile of the tool."
+        },
+        "permissions": {
+          "$ref": "#/$defs/PermissionBoundary",
+          "description": "The zero-trust security boundaries for the tool's execution."
+        },
+        "sla": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ExecutionSLA"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Execution limits for the tool."
+        }
+      },
+      "required": [
+        "tool_name",
+        "description",
+        "input_schema",
+        "side_effects",
+        "permissions"
+      ],
+      "title": "ToolDefinition",
+      "type": "object"
     },
     "WorkflowEnvelope": {
       "additionalProperties": false,

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -18,9 +18,19 @@ from coreason_manifest.state import EpistemicLedger, WorkingMemorySnapshot
 from coreason_manifest.telemetry import LogEnvelope, SpanTrace
 from coreason_manifest.testing.chaos import ChaosExperiment, FaultInjectionProfile, FaultType, SteadyStateHypothesis
 from coreason_manifest.testing.red_team import AdversaryProfile, AiTMStrategy, AttackVector
+from coreason_manifest.tooling import (
+    ActionSpace,
+    ExecutionSLA,
+    MCPClientBinding,
+    MCPTransport,
+    PermissionBoundary,
+    SideEffectProfile,
+    ToolDefinition,
+)
 from coreason_manifest.workflow import WorkflowEnvelope
 
 __all__ = [
+    "ActionSpace",
     "AdjudicationRubric",
     "AdversaryProfile",
     "AiTMStrategy",
@@ -31,16 +41,22 @@ __all__ = [
     "ConstitutionalRule",
     "CoreasonBaseModel",
     "EpistemicLedger",
+    "ExecutionSLA",
     "FaultInjectionProfile",
     "FaultType",
     "GovernancePolicy",
     "LogEnvelope",
+    "MCPClientBinding",
+    "MCPTransport",
     "ModelProfile",
     "NodeID",
+    "PermissionBoundary",
     "RateCard",
     "SemanticVersion",
+    "SideEffectProfile",
     "SpanTrace",
     "SteadyStateHypothesis",
+    "ToolDefinition",
     "WorkflowEnvelope",
     "WorkingMemorySnapshot",
 ]

--- a/src/coreason_manifest/tooling/__init__.py
+++ b/src/coreason_manifest/tooling/__init__.py
@@ -1,0 +1,19 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from coreason_manifest.tooling.environments import ActionSpace, MCPClientBinding, MCPTransport
+from coreason_manifest.tooling.schemas import ExecutionSLA, PermissionBoundary, SideEffectProfile, ToolDefinition
+
+__all__ = [
+    "ActionSpace",
+    "ExecutionSLA",
+    "MCPClientBinding",
+    "MCPTransport",
+    "PermissionBoundary",
+    "SideEffectProfile",
+    "ToolDefinition",
+]

--- a/src/coreason_manifest/tooling/environments.py
+++ b/src/coreason_manifest/tooling/environments.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.tooling.schemas import ToolDefinition
+
+type MCPTransport = Literal["stdio", "sse", "http"]
+
+
+class MCPClientBinding(CoreasonBaseModel):
+    """
+    Binding configuration for a Model Context Protocol (MCP) server.
+    """
+
+    server_uri: str = Field(description="The URI or command path to the MCP server.")
+    transport_type: MCPTransport = Field(description="The transport protocol used to communicate with the MCP server.")
+    allowed_mcp_tools: list[str] | None = Field(
+        default=None,
+        description=(
+            "An explicit whitelist of tools the agent is allowed to invoke from this server. "
+            "If None, all discovered tools are allowed."
+        ),
+    )
+
+
+class ActionSpace(CoreasonBaseModel):
+    """
+    A curated environment of tools accessible to an agent or node.
+    """
+
+    action_space_id: str = Field(description="The unique identifier for this curated environment of tools.")
+    native_tools: list[ToolDefinition] = Field(
+        default_factory=list, description="The list of discrete, natively defined tools available in this space."
+    )
+    mcp_servers: list[MCPClientBinding] = Field(
+        default_factory=list, description="The list of MCP servers mounted into this action space."
+    )

--- a/src/coreason_manifest/tooling/schemas.py
+++ b/src/coreason_manifest/tooling/schemas.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Any
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class SideEffectProfile(CoreasonBaseModel):
+    """
+    Profile for describing the side effects and idempotency of a tool.
+    """
+
+    is_idempotent: bool = Field(
+        description=(
+            "True if the tool can be safely retried multiple times without altering state beyond the first call."
+        )
+    )
+    mutates_state: bool = Field(description="True if the tool performs write operations or side-effects.")
+
+
+class PermissionBoundary(CoreasonBaseModel):
+    """
+    Zero-trust security boundaries for tool execution.
+    """
+
+    network_access: bool = Field(description="Whether the tool is permitted to make external network requests.")
+    allowed_domains: list[str] | None = Field(
+        default=None, description="Whitelist of allowed network domains if network access is true."
+    )
+    file_system_read_only: bool = Field(description="True if the tool is strictly forbidden from writing to the disk.")
+
+
+class ExecutionSLA(CoreasonBaseModel):
+    """
+    Service Level Agreement (limits) for executing a tool.
+    """
+
+    max_execution_time_ms: int = Field(
+        description="The maximum allowed execution time in milliseconds before the orchestrator kills the process."
+    )
+    max_memory_mb: int | None = Field(
+        default=None, description="The maximum memory footprint allowed for the tool's execution sandbox."
+    )
+
+
+class ToolDefinition(CoreasonBaseModel):
+    """
+    Declarative mathematical definition of a tool.
+    """
+
+    tool_name: str = Field(description="The exact identifier of the tool.")
+    description: str = Field(description="Semantic description of what the tool does, used by the LLM for selection.")
+    input_schema: dict[str, Any] = Field(
+        description="The strict JSON Schema dictionary defining the required arguments."
+    )
+    side_effects: SideEffectProfile = Field(
+        description="The declarative side-effect and idempotency profile of the tool."
+    )
+    permissions: PermissionBoundary = Field(description="The zero-trust security boundaries for the tool's execution.")
+    sla: ExecutionSLA | None = Field(default=None, description="Execution limits for the tool.")

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -60,6 +60,9 @@ class AgentNode(BaseNode):
     """
 
     type: Literal["agent"] = Field(default="agent", description="Discriminator for an Agent node.")
+    action_space_id: str | None = Field(
+        default=None, description="The ID of the specific ActionSpace (curated tool environment) bound to this agent."
+    )
     reflex_policy: System1Reflex | None = Field(
         default=None, description="The policy governing System 1 reflex actions."
     )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -21,10 +21,13 @@ from coreason_manifest.oversight.resilience import (
 from coreason_manifest.presentation.scivis import AnyPanel, CohortAttritionGrid, InsightCard, TimeSeriesPanel
 from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, ObservationEvent, SystemFaultEvent
 from coreason_manifest.testing.chaos import ChaosExperiment
+from coreason_manifest.tooling import ActionSpace, ToolDefinition
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, HumanNode, SystemNode
 
 node_adapter: TypeAdapter[AnyNode] = TypeAdapter(AnyNode)
 chaos_adapter: TypeAdapter[ChaosExperiment] = TypeAdapter(ChaosExperiment)
+action_space_adapter: TypeAdapter[ActionSpace] = TypeAdapter(ActionSpace)
+tool_definition_adapter: TypeAdapter[ToolDefinition] = TypeAdapter(ToolDefinition)
 event_adapter: TypeAdapter[AnyStateEvent] = TypeAdapter(AnyStateEvent)
 panel_adapter: TypeAdapter[AnyPanel] = TypeAdapter(AnyPanel)
 resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResiliencePayload)
@@ -33,6 +36,7 @@ resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResilienc
 @given(
     st.sampled_from(["agent", "human", "system"]),
     st.text(),
+    st.one_of(st.none(), st.text()),
     st.one_of(
         st.none(),
         st.fixed_dictionaries(
@@ -65,12 +69,15 @@ resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResilienc
 def test_anynode_routing(
     node_type: str,
     description: str,
+    action_space_id: str | None,
     reflex_policy: dict[str, Any] | None,
     epistemic_policy: dict[str, Any] | None,
     correction_policy: dict[str, Any] | None,
 ) -> None:
     payload: dict[str, Any] = {"type": node_type, "description": description}
     if node_type == "agent":
+        if action_space_id is not None:
+            payload["action_space_id"] = action_space_id
         if reflex_policy is not None:
             payload["reflex_policy"] = reflex_policy
         if epistemic_policy is not None:
@@ -232,3 +239,56 @@ def test_chaosexperiment_fuzzing(
     parsed = chaos_adapter.validate_python(payload)
     assert isinstance(parsed, ChaosExperiment)
     assert parsed.experiment_id == experiment_id
+
+
+@given(
+    st.fixed_dictionaries(
+        {
+            "action_space_id": st.text(),
+            "native_tools": st.lists(
+                st.fixed_dictionaries(
+                    {
+                        "tool_name": st.text(),
+                        "description": st.text(),
+                        "input_schema": st.dictionaries(st.text(), st.one_of(st.text(), st.integers())),
+                        "side_effects": st.fixed_dictionaries(
+                            {
+                                "is_idempotent": st.booleans(),
+                                "mutates_state": st.booleans(),
+                            }
+                        ),
+                        "permissions": st.fixed_dictionaries(
+                            {
+                                "network_access": st.booleans(),
+                                "allowed_domains": st.one_of(st.none(), st.lists(st.text())),
+                                "file_system_read_only": st.booleans(),
+                            }
+                        ),
+                        "sla": st.one_of(
+                            st.none(),
+                            st.fixed_dictionaries(
+                                {
+                                    "max_execution_time_ms": st.integers(),
+                                    "max_memory_mb": st.one_of(st.none(), st.integers()),
+                                }
+                            ),
+                        ),
+                    }
+                )
+            ),
+            "mcp_servers": st.lists(
+                st.fixed_dictionaries(
+                    {
+                        "server_uri": st.text(),
+                        "transport_type": st.sampled_from(["stdio", "sse", "http"]),
+                        "allowed_mcp_tools": st.one_of(st.none(), st.lists(st.text())),
+                    }
+                )
+            ),
+        }
+    )
+)
+def test_actionspace_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = action_space_adapter.validate_python(payload)
+    assert isinstance(parsed, ActionSpace)
+    assert parsed.action_space_id == payload["action_space_id"]


### PR DESCRIPTION
This implements Epic 13: Universal Tooling & MCP Action Spaces.

- Added `src/coreason_manifest/tooling/schemas.py` for mathematical definitions of tools, side-effects, permissions, and SLAs.
- Added `src/coreason_manifest/tooling/environments.py` for MCP binding and curated Action Spaces.
- Added `action_space_id` to `AgentNode`.
- All models strictly use Python 3.14 native typings (e.g., `list`, `dict`, `|`) and inherit from `CoreasonBaseModel` for immutability and canonical sorting.
- Updated `tests/test_fuzzing.py` with deeply-nested generative tests for `ActionSpace`.
- Cleanly exported all new tools via `src/coreason_manifest/__init__.py`.

---
*PR created automatically by Jules for task [528733215969760302](https://jules.google.com/task/528733215969760302) started by @gowthamrao*