### PR TITLE
feat: Semantic Memory Plane Schemas (Epic 13)

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -277,6 +277,16 @@
       "title": "BeliefUpdateEvent",
       "type": "object"
     },
+    "CausalInterval": {
+      "enum": [
+        "strictly_precedes",
+        "overlaps",
+        "contains",
+        "causes",
+        "mitigates"
+      ],
+      "type": "string"
+    },
     "ChaosExperiment": {
       "additionalProperties": false,
       "properties": {
@@ -714,6 +724,34 @@
       "title": "LogEnvelope",
       "type": "object"
     },
+    "MemoryProvenance": {
+      "additionalProperties": false,
+      "properties": {
+        "extracted_by": {
+          "$ref": "#/$defs/NodeID",
+          "description": "The ID of the agent node that extracted this memory."
+        },
+        "source_event_id": {
+          "description": "The exact event ID in the EpistemicLedger that generated this fact.",
+          "title": "Source Event Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "extracted_by",
+        "source_event_id"
+      ],
+      "title": "MemoryProvenance",
+      "type": "object"
+    },
+    "MemoryTier": {
+      "enum": [
+        "working",
+        "episodic",
+        "semantic"
+      ],
+      "type": "string"
+    },
     "MetadataDict": {
       "additionalProperties": {
         "anyOf": [
@@ -840,6 +878,27 @@
       "title": "RateCard",
       "type": "object"
     },
+    "SalienceProfile": {
+      "additionalProperties": false,
+      "properties": {
+        "baseline_importance": {
+          "description": "The starting importance score of this memory from 0.0 to 1.0.",
+          "title": "Baseline Importance",
+          "type": "number"
+        },
+        "decay_rate": {
+          "description": "The rate at which this memory's relevance decays over time.",
+          "title": "Decay Rate",
+          "type": "number"
+        }
+      },
+      "required": [
+        "baseline_importance",
+        "decay_rate"
+      ],
+      "title": "SalienceProfile",
+      "type": "object"
+    },
     "SelfCorrectionPolicy": {
       "additionalProperties": false,
       "description": "Policy for self-correction and iterative refinement.",
@@ -862,6 +921,148 @@
         "rollback_on_failure"
       ],
       "title": "SelfCorrectionPolicy",
+      "type": "object"
+    },
+    "SemanticEdge": {
+      "additionalProperties": false,
+      "properties": {
+        "edge_id": {
+          "description": "The unique identifier of this relationship.",
+          "title": "Edge Id",
+          "type": "string"
+        },
+        "subject_node_id": {
+          "description": "The origin SemanticNode ID.",
+          "title": "Subject Node Id",
+          "type": "string"
+        },
+        "object_node_id": {
+          "description": "The destination SemanticNode ID.",
+          "title": "Object Node Id",
+          "type": "string"
+        },
+        "predicate": {
+          "description": "The string representation of the relationship (e.g., 'WORKS_FOR').",
+          "title": "Predicate",
+          "type": "string"
+        },
+        "embedding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VectorEmbedding"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dense vector representing the relationship semantics."
+        },
+        "provenance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MemoryProvenance"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional distinct provenance if the relationship was inferred separately from the nodes."
+        },
+        "temporal_bounds": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemporalBounds"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The time window during which this relationship holds true."
+        }
+      },
+      "required": [
+        "edge_id",
+        "subject_node_id",
+        "object_node_id",
+        "predicate"
+      ],
+      "title": "SemanticEdge",
+      "type": "object"
+    },
+    "SemanticNode": {
+      "additionalProperties": false,
+      "properties": {
+        "node_id": {
+          "description": "The unique identifier of this semantic concept.",
+          "title": "Node Id",
+          "type": "string"
+        },
+        "label": {
+          "description": "The categorical label of the node (e.g., 'Person', 'Concept').",
+          "title": "Label",
+          "type": "string"
+        },
+        "text_chunk": {
+          "description": "The raw natural language representation of the memory.",
+          "title": "Text Chunk",
+          "type": "string"
+        },
+        "embedding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VectorEmbedding"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dense vector representation of the text chunk."
+        },
+        "provenance": {
+          "$ref": "#/$defs/MemoryProvenance",
+          "description": "The cryptographic chain of custody for this memory."
+        },
+        "tier": {
+          "$ref": "#/$defs/MemoryTier",
+          "default": "semantic",
+          "description": "The cognitive tier this memory resides in."
+        },
+        "temporal_bounds": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TemporalBounds"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The time window during which this node is considered valid."
+        },
+        "salience": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SalienceProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The importance profile used for memory pruning."
+        }
+      },
+      "required": [
+        "node_id",
+        "label",
+        "text_chunk",
+        "provenance"
+      ],
+      "title": "SemanticNode",
       "type": "object"
     },
     "SemanticVersion": {
@@ -1111,6 +1312,81 @@
           "type": "null"
         }
       ]
+    },
+    "TemporalBounds": {
+      "additionalProperties": false,
+      "properties": {
+        "valid_from": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The UNIX timestamp when this memory became true.",
+          "title": "Valid From"
+        },
+        "valid_to": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The UNIX timestamp when this memory was invalidated.",
+          "title": "Valid To"
+        },
+        "interval_type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CausalInterval"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The Allen's interval algebra or causal relationship classification."
+        }
+      },
+      "title": "TemporalBounds",
+      "type": "object"
+    },
+    "VectorEmbedding": {
+      "additionalProperties": false,
+      "properties": {
+        "vector": {
+          "description": "The raw high-dimensional floating-point array.",
+          "items": {
+            "type": "number"
+          },
+          "title": "Vector",
+          "type": "array"
+        },
+        "dimensionality": {
+          "description": "The size of the vector array.",
+          "title": "Dimensionality",
+          "type": "integer"
+        },
+        "model_name": {
+          "description": "The provenance of the embedding model used (e.g., 'text-embedding-3-large').",
+          "title": "Model Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "vector",
+        "dimensionality",
+        "model_name"
+      ],
+      "title": "VectorEmbedding",
+      "type": "object"
     },
     "WorkflowEnvelope": {
       "additionalProperties": false,

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -14,7 +14,18 @@ from coreason_manifest.oversight import (
     ConstitutionalRule,
     GovernancePolicy,
 )
-from coreason_manifest.state import EpistemicLedger, WorkingMemorySnapshot
+from coreason_manifest.state import (
+    CausalInterval,
+    EpistemicLedger,
+    MemoryProvenance,
+    MemoryTier,
+    SalienceProfile,
+    SemanticEdge,
+    SemanticNode,
+    TemporalBounds,
+    VectorEmbedding,
+    WorkingMemorySnapshot,
+)
 from coreason_manifest.telemetry import LogEnvelope, SpanTrace
 from coreason_manifest.testing.chaos import ChaosExperiment, FaultInjectionProfile, FaultType, SteadyStateHypothesis
 from coreason_manifest.testing.red_team import AdversaryProfile, AiTMStrategy, AttackVector
@@ -27,6 +38,7 @@ __all__ = [
     "AnyInterventionPayload",
     "AnyResiliencePayload",
     "AttackVector",
+    "CausalInterval",
     "ChaosExperiment",
     "ConstitutionalRule",
     "CoreasonBaseModel",
@@ -35,12 +47,19 @@ __all__ = [
     "FaultType",
     "GovernancePolicy",
     "LogEnvelope",
+    "MemoryProvenance",
+    "MemoryTier",
     "ModelProfile",
     "NodeID",
     "RateCard",
+    "SalienceProfile",
+    "SemanticEdge",
+    "SemanticNode",
     "SemanticVersion",
     "SpanTrace",
     "SteadyStateHypothesis",
+    "TemporalBounds",
+    "VectorEmbedding",
     "WorkflowEnvelope",
     "WorkingMemorySnapshot",
 ]

--- a/src/coreason_manifest/state/__init__.py
+++ b/src/coreason_manifest/state/__init__.py
@@ -17,6 +17,16 @@ from coreason_manifest.state.memory import (
     FederatedStateSnapshot,
     WorkingMemorySnapshot,
 )
+from coreason_manifest.state.semantic import (
+    CausalInterval,
+    MemoryProvenance,
+    MemoryTier,
+    SalienceProfile,
+    SemanticEdge,
+    SemanticNode,
+    TemporalBounds,
+    VectorEmbedding,
+)
 from coreason_manifest.state.toolchains import (
     BrowserStateSnapshot,
     TerminalStateSnapshot,
@@ -27,10 +37,18 @@ __all__ = [
     "BaseStateEvent",
     "BeliefUpdateEvent",
     "BrowserStateSnapshot",
+    "CausalInterval",
     "EpistemicLedger",
     "FederatedStateSnapshot",
+    "MemoryProvenance",
+    "MemoryTier",
     "ObservationEvent",
+    "SalienceProfile",
+    "SemanticEdge",
+    "SemanticNode",
     "SystemFaultEvent",
+    "TemporalBounds",
     "TerminalStateSnapshot",
+    "VectorEmbedding",
     "WorkingMemorySnapshot",
 ]

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -1,0 +1,74 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.core.primitives import NodeID
+
+type MemoryTier = Literal["working", "episodic", "semantic"]
+type CausalInterval = Literal["strictly_precedes", "overlaps", "contains", "causes", "mitigates"]
+
+
+class VectorEmbedding(CoreasonBaseModel):
+    vector: list[float] = Field(description="The raw high-dimensional floating-point array.")
+    dimensionality: int = Field(description="The size of the vector array.")
+    model_name: str = Field(description="The provenance of the embedding model used (e.g., 'text-embedding-3-large').")
+
+
+class TemporalBounds(CoreasonBaseModel):
+    valid_from: float | None = Field(default=None, description="The UNIX timestamp when this memory became true.")
+    valid_to: float | None = Field(default=None, description="The UNIX timestamp when this memory was invalidated.")
+    interval_type: CausalInterval | None = Field(
+        default=None, description="The Allen's interval algebra or causal relationship classification."
+    )
+
+
+class MemoryProvenance(CoreasonBaseModel):
+    extracted_by: NodeID = Field(description="The ID of the agent node that extracted this memory.")
+    source_event_id: str = Field(description="The exact event ID in the EpistemicLedger that generated this fact.")
+
+
+class SalienceProfile(CoreasonBaseModel):
+    baseline_importance: float = Field(description="The starting importance score of this memory from 0.0 to 1.0.")
+    decay_rate: float = Field(description="The rate at which this memory's relevance decays over time.")
+
+
+class SemanticNode(CoreasonBaseModel):
+    node_id: str = Field(description="The unique identifier of this semantic concept.")
+    label: str = Field(description="The categorical label of the node (e.g., 'Person', 'Concept').")
+    text_chunk: str = Field(description="The raw natural language representation of the memory.")
+    embedding: VectorEmbedding | None = Field(
+        default=None, description="The dense vector representation of the text chunk."
+    )
+    provenance: MemoryProvenance = Field(description="The cryptographic chain of custody for this memory.")
+    tier: MemoryTier = Field(default="semantic", description="The cognitive tier this memory resides in.")
+    temporal_bounds: TemporalBounds | None = Field(
+        default=None, description="The time window during which this node is considered valid."
+    )
+    salience: SalienceProfile | None = Field(
+        default=None, description="The importance profile used for memory pruning."
+    )
+
+
+class SemanticEdge(CoreasonBaseModel):
+    edge_id: str = Field(description="The unique identifier of this relationship.")
+    subject_node_id: str = Field(description="The origin SemanticNode ID.")
+    object_node_id: str = Field(description="The destination SemanticNode ID.")
+    predicate: str = Field(description="The string representation of the relationship (e.g., 'WORKS_FOR').")
+    embedding: VectorEmbedding | None = Field(
+        default=None, description="The dense vector representing the relationship semantics."
+    )
+    provenance: MemoryProvenance | None = Field(
+        default=None,
+        description="Optional distinct provenance if the relationship was inferred separately from the nodes.",
+    )
+    temporal_bounds: TemporalBounds | None = Field(
+        default=None, description="The time window during which this relationship holds true."
+    )

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -9,6 +9,7 @@ from coreason_manifest.presentation.intents import DraftingIntent, PresentationE
 from coreason_manifest.presentation.scivis import InsightCard, MacroGrid
 from coreason_manifest.state.events import ObservationEvent
 from coreason_manifest.state.memory import EpistemicLedger
+from coreason_manifest.state.semantic import MemoryProvenance, SemanticNode, TemporalBounds, VectorEmbedding
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AgentNode
 from coreason_manifest.workflow.topologies import DAGTopology
@@ -53,3 +54,34 @@ def test_epistemic_ledger_determinism() -> None:
 
     assert ledger1.model_dump_canonical() == ledger2.model_dump_canonical()
     assert hash(ledger1) == hash(ledger2)
+
+
+def test_semantic_memory_determinism() -> None:
+    embedding1 = VectorEmbedding(vector=[0.1, 0.2, 0.3], dimensionality=3, model_name="test-model")
+    embedding2 = VectorEmbedding(vector=[0.1, 0.2, 0.3], dimensionality=3, model_name="test-model")
+
+    bounds1 = TemporalBounds(valid_from=100.0, valid_to=200.0, interval_type="contains")
+    bounds2 = TemporalBounds(valid_from=100.0, valid_to=200.0, interval_type="contains")
+
+    provenance1 = MemoryProvenance(extracted_by="agent_1", source_event_id="event_1")
+    provenance2 = MemoryProvenance(extracted_by="agent_1", source_event_id="event_1")
+
+    node1 = SemanticNode(
+        node_id="node_1",
+        label="Concept",
+        text_chunk="A test chunk",
+        embedding=embedding1,
+        provenance=provenance1,
+        temporal_bounds=bounds1,
+    )
+    node2 = SemanticNode(
+        node_id="node_1",
+        label="Concept",
+        text_chunk="A test chunk",
+        embedding=embedding2,
+        provenance=provenance2,
+        temporal_bounds=bounds2,
+    )
+
+    assert node1.model_dump_canonical() == node2.model_dump_canonical()
+    assert hash(node1) == hash(node2)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -20,6 +20,7 @@ from coreason_manifest.oversight.resilience import (
 )
 from coreason_manifest.presentation.scivis import AnyPanel, CohortAttritionGrid, InsightCard, TimeSeriesPanel
 from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, ObservationEvent, SystemFaultEvent
+from coreason_manifest.state.semantic import SemanticEdge, SemanticNode
 from coreason_manifest.testing.chaos import ChaosExperiment
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, HumanNode, SystemNode
 
@@ -28,6 +29,8 @@ chaos_adapter: TypeAdapter[ChaosExperiment] = TypeAdapter(ChaosExperiment)
 event_adapter: TypeAdapter[AnyStateEvent] = TypeAdapter(AnyStateEvent)
 panel_adapter: TypeAdapter[AnyPanel] = TypeAdapter(AnyPanel)
 resilience_adapter: TypeAdapter[AnyResiliencePayload] = TypeAdapter(AnyResiliencePayload)
+semantic_node_adapter: TypeAdapter[SemanticNode] = TypeAdapter(SemanticNode)
+semantic_edge_adapter: TypeAdapter[SemanticEdge] = TypeAdapter(SemanticEdge)
 
 
 @given(
@@ -232,3 +235,107 @@ def test_chaosexperiment_fuzzing(
     parsed = chaos_adapter.validate_python(payload)
     assert isinstance(parsed, ChaosExperiment)
     assert parsed.experiment_id == experiment_id
+
+
+@given(
+    st.fixed_dictionaries(
+        {
+            "node_id": st.text(),
+            "label": st.text(),
+            "text_chunk": st.text(),
+            "embedding": st.one_of(
+                st.none(),
+                st.fixed_dictionaries(
+                    {
+                        "vector": st.lists(st.floats(allow_nan=False, allow_infinity=False)),
+                        "dimensionality": st.integers(),
+                        "model_name": st.text(),
+                    }
+                ),
+            ),
+            "provenance": st.fixed_dictionaries(
+                {
+                    "extracted_by": st.text(
+                        min_size=1, max_size=128, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                    ),
+                    "source_event_id": st.text(),
+                }
+            ),
+            "tier": st.sampled_from(["working", "episodic", "semantic"]),
+            "temporal_bounds": st.one_of(
+                st.none(),
+                st.fixed_dictionaries(
+                    {
+                        "valid_from": st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+                        "valid_to": st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+                        "interval_type": st.one_of(
+                            st.none(),
+                            st.sampled_from(["strictly_precedes", "overlaps", "contains", "causes", "mitigates"]),
+                        ),
+                    }
+                ),
+            ),
+            "salience": st.one_of(
+                st.none(),
+                st.fixed_dictionaries(
+                    {
+                        "baseline_importance": st.floats(allow_nan=False, allow_infinity=False),
+                        "decay_rate": st.floats(allow_nan=False, allow_infinity=False),
+                    }
+                ),
+            ),
+        }
+    )
+)
+def test_semanticnode_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = semantic_node_adapter.validate_python(payload)
+    assert isinstance(parsed, SemanticNode)
+
+
+@given(
+    st.fixed_dictionaries(
+        {
+            "edge_id": st.text(),
+            "subject_node_id": st.text(),
+            "object_node_id": st.text(),
+            "predicate": st.text(),
+            "embedding": st.one_of(
+                st.none(),
+                st.fixed_dictionaries(
+                    {
+                        "vector": st.lists(st.floats(allow_nan=False, allow_infinity=False)),
+                        "dimensionality": st.integers(),
+                        "model_name": st.text(),
+                    }
+                ),
+            ),
+            "provenance": st.one_of(
+                st.none(),
+                st.fixed_dictionaries(
+                    {
+                        "extracted_by": st.text(
+                            min_size=1, max_size=128, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                        ),
+                        "source_event_id": st.text(),
+                    }
+                ),
+            ),
+            "temporal_bounds": st.one_of(
+                st.none(),
+                st.fixed_dictionaries(
+                    {
+                        "valid_from": st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+                        "valid_to": st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+                        "interval_type": st.one_of(
+                            st.none(),
+                            st.sampled_from(["strictly_precedes", "overlaps", "contains", "causes", "mitigates"]),
+                        ),
+                    }
+                ),
+            ),
+        }
+    )
+)
+def test_semanticedge_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = semantic_edge_adapter.validate_python(payload)
+    assert isinstance(parsed, SemanticEdge)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -256,7 +256,9 @@ def test_chaosexperiment_fuzzing(
             "provenance": st.fixed_dictionaries(
                 {
                     "extracted_by": st.text(
-                        min_size=1, max_size=128, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                        min_size=1,
+                        max_size=128,
+                        alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-",
                     ),
                     "source_event_id": st.text(),
                 }
@@ -314,7 +316,9 @@ def test_semanticnode_fuzzing(payload: dict[str, Any]) -> None:
                 st.fixed_dictionaries(
                     {
                         "extracted_by": st.text(
-                            min_size=1, max_size=128, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                            min_size=1,
+                            max_size=128,
+                            alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-",
                         ),
                         "source_event_id": st.text(),
                     }


### PR DESCRIPTION
Epic 13 implementation: The Semantic Memory Plane. Created pure data schemas for a free-threaded data plane of Vector-Graph Dualism using Pydantic, incorporating native Python 3.14/3.12 type parameters and Field documentation. Includes comprehensive determinism and fuzzing test suites.

---
*PR created automatically by Jules for task [10336883581886502232](https://jules.google.com/task/10336883581886502232) started by @gowthamrao*