### PR TITLE
test: refactor fuzzer to composable strategies and add missing determinism coverage

### DIFF
--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -16,6 +16,8 @@ from coreason_manifest.state.semantic import (
     TemporalBounds,
     VectorEmbedding,
 )
+from coreason_manifest.testing.chaos import ChaosExperiment, FaultInjectionProfile, SteadyStateHypothesis
+from coreason_manifest.tooling import ActionSpace, PermissionBoundary, SideEffectProfile, ToolDefinition
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AgentNode
 from coreason_manifest.workflow.topologies import DAGTopology
@@ -42,6 +44,33 @@ def test_workflow_envelope_determinism() -> None:
 
     assert env1.model_dump_canonical() == env2.model_dump_canonical()
     assert hash(env1) == hash(env2)
+
+
+def test_tooling_determinism() -> None:
+    side_effects = SideEffectProfile(is_idempotent=True, mutates_state=False)
+    permissions = PermissionBoundary(network_access=False, allowed_domains=None, file_system_read_only=True)
+
+    tool1 = ToolDefinition(
+        tool_name="my_tool",
+        description="A deterministic tool",
+        input_schema={"a": 1, "b": 2},
+        side_effects=side_effects,
+        permissions=permissions,
+    )
+
+    tool2 = ToolDefinition(
+        tool_name="my_tool",
+        description="A deterministic tool",
+        input_schema={"b": 2, "a": 1},
+        side_effects=side_effects,
+        permissions=permissions,
+    )
+
+    space1 = ActionSpace(action_space_id="space_1", native_tools=[tool1], mcp_servers=[])
+    space2 = ActionSpace(action_space_id="space_1", native_tools=[tool2], mcp_servers=[])
+
+    assert space1.model_dump_canonical() == space2.model_dump_canonical()
+    assert hash(space1) == hash(space2)
 
 
 def test_presentation_envelope_determinism() -> None:
@@ -102,3 +131,17 @@ def test_semantic_memory_determinism() -> None:
 
     assert node1.model_dump_canonical() == node2.model_dump_canonical()
     assert hash(node1) == hash(node2)
+
+
+def test_chaos_determinism() -> None:
+    fault1 = FaultInjectionProfile(fault_type="latency_spike", target_node_id="node_a", intensity=0.8)
+    fault2 = FaultInjectionProfile(fault_type="context_overload", target_node_id="node_b", intensity=0.5)
+
+    hypothesis = SteadyStateHypothesis(expected_max_latency=100.0, max_loops_allowed=5, required_tool_usage=["tool_x"])
+
+    env1 = ChaosExperiment(experiment_id="exp_01", hypothesis=hypothesis, faults=[fault1, fault2])
+
+    env2 = ChaosExperiment(experiment_id="exp_01", hypothesis=hypothesis, faults=[fault1, fault2])
+
+    assert env1.model_dump_canonical() == env2.model_dump_canonical()
+    assert hash(env1) == hash(env2)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -31,7 +31,7 @@ from coreason_manifest.workflow.topologies import StateContract
 
 @st.composite
 def draw_reflex_policy(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "confidence_threshold": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
@@ -39,11 +39,12 @@ def draw_reflex_policy(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite
 def draw_epistemic_policy(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "active": st.booleans(),
@@ -52,11 +53,12 @@ def draw_epistemic_policy(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite
 def draw_correction_policy(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "max_loops": st.integers(min_value=0, max_value=50),
@@ -64,11 +66,12 @@ def draw_correction_policy(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite
 def draw_intervention_policy(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "trigger": st.sampled_from(
@@ -96,6 +99,7 @@ def draw_intervention_policy(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -28,6 +28,108 @@ from coreason_manifest.tooling import ActionSpace, ToolDefinition
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, HumanNode, SystemNode
 from coreason_manifest.workflow.topologies import StateContract
 
+
+@st.composite
+def draw_reflex_policy(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "confidence_threshold": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+                "allowed_read_only_tools": st.lists(st.text()),
+            }
+        )
+    )
+
+
+@st.composite
+def draw_epistemic_policy(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "active": st.booleans(),
+                "dissonance_threshold": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+                "action_on_gap": st.sampled_from(["fail", "probe", "clarify"]),
+            }
+        )
+    )
+
+
+@st.composite
+def draw_correction_policy(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "max_loops": st.integers(min_value=0, max_value=50),
+                "rollback_on_failure": st.booleans(),
+            }
+        )
+    )
+
+
+@st.composite
+def draw_intervention_policy(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "trigger": st.sampled_from(
+                    [
+                        "on_start",
+                        "on_node_transition",
+                        "before_tool_execution",
+                        "on_failure",
+                        "on_consensus_reached",
+                        "on_max_loops_reached",
+                    ]
+                ),
+                "blocking": st.booleans(),
+                "scope": st.one_of(
+                    st.none(),
+                    st.fixed_dictionaries(
+                        {
+                            "allowed_fields": st.lists(st.text()),
+                            "json_schema_whitelist": st.dictionaries(
+                                st.text(), st.one_of(st.text(), st.integers(), st.booleans())
+                            ),
+                        }
+                    ),
+                ),
+            }
+        )
+    )
+
+
+@st.composite
+def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"type": "agent", "description": draw(st.text())}
+    if draw(st.booleans()):
+        payload["intervention_policies"] = draw(st.lists(draw_intervention_policy()))
+    if draw(st.booleans()):
+        payload["action_space_id"] = draw(st.text())
+    if draw(st.booleans()):
+        payload["reflex_policy"] = draw(draw_reflex_policy())
+    if draw(st.booleans()):
+        payload["epistemic_policy"] = draw(draw_epistemic_policy())
+    if draw(st.booleans()):
+        payload["correction_policy"] = draw(draw_correction_policy())
+    return payload
+
+
+@st.composite
+def draw_human_node_payload(draw: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"type": "human", "description": draw(st.text())}
+    if draw(st.booleans()):
+        payload["intervention_policies"] = draw(st.lists(draw_intervention_policy()))
+    return payload
+
+
+@st.composite
+def draw_system_node_payload(draw: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = {"type": "system", "description": draw(st.text())}
+    if draw(st.booleans()):
+        payload["intervention_policies"] = draw(st.lists(draw_intervention_policy()))
+    return payload
+
+
 node_adapter: TypeAdapter[AnyNode] = TypeAdapter(AnyNode)
 chaos_adapter: TypeAdapter[ChaosExperiment] = TypeAdapter(ChaosExperiment)
 action_space_adapter: TypeAdapter[ActionSpace] = TypeAdapter(ActionSpace)
@@ -40,94 +142,10 @@ state_contract_adapter: TypeAdapter[StateContract] = TypeAdapter(StateContract)
 intervention_policy_adapter: TypeAdapter[InterventionPolicy] = TypeAdapter(InterventionPolicy)
 
 
-@given(
-    st.sampled_from(["agent", "human", "system"]),
-    st.text(),
-    st.one_of(st.none(), st.text()),
-    st.one_of(
-        st.none(),
-        st.fixed_dictionaries(
-            {
-                "confidence_threshold": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
-                "allowed_read_only_tools": st.lists(st.text()),
-            }
-        ),
-    ),
-    st.one_of(
-        st.none(),
-        st.fixed_dictionaries(
-            {
-                "active": st.booleans(),
-                "dissonance_threshold": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
-                "action_on_gap": st.sampled_from(["fail", "probe", "clarify"]),
-            }
-        ),
-    ),
-    st.one_of(
-        st.none(),
-        st.fixed_dictionaries(
-            {
-                "max_loops": st.integers(min_value=0, max_value=50),
-                "rollback_on_failure": st.booleans(),
-            }
-        ),
-    ),
-    st.one_of(
-        st.none(),
-        st.lists(
-            st.fixed_dictionaries(
-                {
-                    "trigger": st.sampled_from(
-                        [
-                            "on_start",
-                            "on_node_transition",
-                            "before_tool_execution",
-                            "on_failure",
-                            "on_consensus_reached",
-                            "on_max_loops_reached",
-                        ]
-                    ),
-                    "blocking": st.booleans(),
-                    "scope": st.one_of(
-                        st.none(),
-                        st.fixed_dictionaries(
-                            {
-                                "allowed_fields": st.lists(st.text()),
-                                "json_schema_whitelist": st.dictionaries(
-                                    st.text(), st.one_of(st.text(), st.integers(), st.booleans())
-                                ),
-                            }
-                        ),
-                    ),
-                }
-            )
-        ),
-    ),
-)
-def test_anynode_routing(
-    node_type: str,
-    description: str,
-    action_space_id: str | None,
-    reflex_policy: dict[str, Any] | None,
-    epistemic_policy: dict[str, Any] | None,
-    correction_policy: dict[str, Any] | None,
-    intervention_policies: list[dict[str, Any]] | None,
-) -> None:
-    payload: dict[str, Any] = {"type": node_type, "description": description}
-    if intervention_policies is not None:
-        payload["intervention_policies"] = intervention_policies
-
-    if node_type == "agent":
-        if action_space_id is not None:
-            payload["action_space_id"] = action_space_id
-        if reflex_policy is not None:
-            payload["reflex_policy"] = reflex_policy
-        if epistemic_policy is not None:
-            payload["epistemic_policy"] = epistemic_policy
-        if correction_policy is not None:
-            payload["correction_policy"] = correction_policy
-
+@given(st.one_of(draw_agent_node_payload(), draw_human_node_payload(), draw_system_node_payload()))
+def test_anynode_routing(payload: dict[str, Any]) -> None:
     parsed = node_adapter.validate_python(payload)
+    node_type = payload["type"]
     if node_type == "agent":
         assert isinstance(parsed, AgentNode)
     elif node_type == "human":


### PR DESCRIPTION
This pull request refactors the monolithic fuzzer in `test_fuzzing.py` into composable `hypothesis` strategies yielding dict payloads, eliminating testing debt. It also adds new tests to `test_determinism.py` to ensure cryptographic completeness and "Identity is State" constraints, verifying proper sorting and hashing of action spaces (with unordered JSON schema keys) and chaos experiments. The changes are strictly confined to the `tests/` directory and fully adhere to Python 3.14 native maximization constraints.

---
*PR created automatically by Jules for task [2734527198315330716](https://jules.google.com/task/2734527198315330716) started by @gowthamrao*