### PR TITLE
feat(state): Add ArgumentGraph for defeasible logic

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -112,7 +112,7 @@
           "type": "string"
         },
         "attack_vector": {
-          "$ref": "#/$defs/AttackVector",
+          "$ref": "#/$defs/coreason_manifest__testing__red_team__AttackVector",
           "description": "The method or angle of the adversarial attack."
         },
         "goal": {
@@ -331,15 +331,66 @@
         }
       ]
     },
-    "AttackVector": {
-      "enum": [
-        "semantic_hijacking",
-        "system_prompt_extraction",
-        "sabotage",
-        "deception",
-        "data_exfiltration"
+    "ArgumentClaim": {
+      "additionalProperties": false,
+      "properties": {
+        "claim_id": {
+          "description": "Unique identifier for this specific logical proposition.",
+          "title": "Claim Id",
+          "type": "string"
+        },
+        "proponent_id": {
+          "description": "The NodeID of the agent or system that advanced this claim.",
+          "title": "Proponent Id",
+          "type": "string"
+        },
+        "text_chunk": {
+          "description": "The natural language representation of the proposition.",
+          "title": "Text Chunk",
+          "type": "string"
+        },
+        "warrants": {
+          "description": "The foundational premises supporting this claim.",
+          "items": {
+            "$ref": "#/$defs/EvidentiaryWarrant"
+          },
+          "title": "Warrants",
+          "type": "array"
+        }
+      },
+      "required": [
+        "claim_id",
+        "proponent_id",
+        "text_chunk"
       ],
-      "type": "string"
+      "title": "ArgumentClaim",
+      "type": "object"
+    },
+    "ArgumentGraph": {
+      "additionalProperties": false,
+      "properties": {
+        "claims": {
+          "additionalProperties": {
+            "$ref": "#/$defs/ArgumentClaim"
+          },
+          "description": "A registry of all active claims, keyed by claim_id.",
+          "title": "Claims",
+          "type": "object"
+        },
+        "attacks": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DefeasibleAttack"
+          },
+          "description": "A registry of all directed attack edges, keyed by attack_id.",
+          "title": "Attacks",
+          "type": "object"
+        }
+      },
+      "required": [
+        "claims"
+      ],
+      "title": "ArgumentGraph",
+      "type": "object"
     },
     "BackpressurePolicy": {
       "additionalProperties": false,
@@ -797,6 +848,38 @@
       "title": "DAGTopology",
       "type": "object"
     },
+    "DefeasibleAttack": {
+      "additionalProperties": false,
+      "properties": {
+        "attack_id": {
+          "description": "Unique identifier for this directed attack edge.",
+          "title": "Attack Id",
+          "type": "string"
+        },
+        "source_claim_id": {
+          "description": "The ID of the claim mounting the attack.",
+          "title": "Source Claim Id",
+          "type": "string"
+        },
+        "target_claim_id": {
+          "description": "The ID of the claim being attacked.",
+          "title": "Target Claim Id",
+          "type": "string"
+        },
+        "attack_vector": {
+          "$ref": "#/$defs/coreason_manifest__state__argumentation__AttackVector",
+          "description": "The specific defeasible logic vector (e.g., attacking the premise, the link, or the conclusion)."
+        }
+      },
+      "required": [
+        "attack_id",
+        "source_claim_id",
+        "target_claim_id",
+        "attack_vector"
+      ],
+      "title": "DefeasibleAttack",
+      "type": "object"
+    },
     "DiversityConstraint": {
       "additionalProperties": false,
       "description": "Constraints enforcing cognitive heterogeneity.",
@@ -883,6 +966,47 @@
         "action_on_gap"
       ],
       "title": "EpistemicScanner",
+      "type": "object"
+    },
+    "EvidentiaryWarrant": {
+      "additionalProperties": false,
+      "properties": {
+        "source_event_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A link to a specific observation in the EpistemicLedger.",
+          "title": "Source Event Id"
+        },
+        "source_semantic_node_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A link to a specific concept in the Semantic Knowledge Graph.",
+          "title": "Source Semantic Node Id"
+        },
+        "justification": {
+          "description": "The logical premise explaining why this evidence supports the claim.",
+          "title": "Justification",
+          "type": "string"
+        }
+      },
+      "required": [
+        "justification"
+      ],
+      "title": "EvidentiaryWarrant",
       "type": "object"
     },
     "ExecutionSLA": {
@@ -2356,6 +2480,18 @@
           "description": "A dictionary representing the active context variables for the agent.",
           "title": "Active Context",
           "type": "object"
+        },
+        "argumentation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ArgumentGraph"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal graph of non-monotonic claims and defeasible attacks currently active in the swarm's working memory."
         }
       },
       "required": [
@@ -2364,6 +2500,24 @@
       ],
       "title": "WorkingMemorySnapshot",
       "type": "object"
+    },
+    "coreason_manifest__state__argumentation__AttackVector": {
+      "enum": [
+        "rebuttal",
+        "undercutter",
+        "underminer"
+      ],
+      "type": "string"
+    },
+    "coreason_manifest__testing__red_team__AttackVector": {
+      "enum": [
+        "semantic_hijacking",
+        "system_prompt_extraction",
+        "sabotage",
+        "deception",
+        "data_exfiltration"
+      ],
+      "type": "string"
     }
   },
   "title": "Coreason Ontology",

--- a/src/coreason_manifest/state/__init__.py
+++ b/src/coreason_manifest/state/__init__.py
@@ -5,6 +5,13 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from coreason_manifest.state.argumentation import (
+    ArgumentClaim,
+    ArgumentGraph,
+    AttackVector,
+    DefeasibleAttack,
+    EvidentiaryWarrant,
+)
 from coreason_manifest.state.events import (
     AnyStateEvent,
     BaseStateEvent,
@@ -34,11 +41,16 @@ from coreason_manifest.state.toolchains import (
 
 __all__ = [
     "AnyStateEvent",
+    "ArgumentClaim",
+    "ArgumentGraph",
+    "AttackVector",
     "BaseStateEvent",
     "BeliefUpdateEvent",
     "BrowserStateSnapshot",
     "CausalInterval",
+    "DefeasibleAttack",
     "EpistemicLedger",
+    "EvidentiaryWarrant",
     "FederatedStateSnapshot",
     "MemoryProvenance",
     "MemoryTier",

--- a/src/coreason_manifest/state/argumentation.py
+++ b/src/coreason_manifest/state/argumentation.py
@@ -1,0 +1,49 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+type AttackVector = Literal["rebuttal", "undercutter", "underminer"]
+
+
+class EvidentiaryWarrant(CoreasonBaseModel):
+    source_event_id: str | None = Field(
+        default=None, description="A link to a specific observation in the EpistemicLedger."
+    )
+    source_semantic_node_id: str | None = Field(
+        default=None, description="A link to a specific concept in the Semantic Knowledge Graph."
+    )
+    justification: str = Field(description="The logical premise explaining why this evidence supports the claim.")
+
+
+class ArgumentClaim(CoreasonBaseModel):
+    claim_id: str = Field(description="Unique identifier for this specific logical proposition.")
+    proponent_id: str = Field(description="The NodeID of the agent or system that advanced this claim.")
+    text_chunk: str = Field(description="The natural language representation of the proposition.")
+    warrants: list[EvidentiaryWarrant] = Field(
+        default_factory=list, description="The foundational premises supporting this claim."
+    )
+
+
+class DefeasibleAttack(CoreasonBaseModel):
+    attack_id: str = Field(description="Unique identifier for this directed attack edge.")
+    source_claim_id: str = Field(description="The ID of the claim mounting the attack.")
+    target_claim_id: str = Field(description="The ID of the claim being attacked.")
+    attack_vector: AttackVector = Field(
+        description="The specific defeasible logic vector (e.g., attacking the premise, the link, or the conclusion)."
+    )
+
+
+class ArgumentGraph(CoreasonBaseModel):
+    claims: dict[str, ArgumentClaim] = Field(description="A registry of all active claims, keyed by claim_id.")
+    attacks: dict[str, DefeasibleAttack] = Field(
+        default_factory=dict, description="A registry of all directed attack edges, keyed by attack_id."
+    )

--- a/src/coreason_manifest/state/memory.py
+++ b/src/coreason_manifest/state/memory.py
@@ -10,6 +10,7 @@ from typing import Self
 from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.state.argumentation import ArgumentGraph
 from coreason_manifest.state.events import AnyStateEvent
 
 
@@ -26,6 +27,10 @@ class WorkingMemorySnapshot(CoreasonBaseModel):
     system_prompt: str = Field(description="The active system prompt guiding the agent's behavior.")
     active_context: dict[str, str] = Field(
         description="A dictionary representing the active context variables for the agent."
+    )
+    argumentation: ArgumentGraph | None = Field(
+        default=None,
+        description="The formal graph of non-monotonic claims and defeasible attacks currently active in the swarm's working memory.",
     )
 
 

--- a/src/coreason_manifest/state/memory.py
+++ b/src/coreason_manifest/state/memory.py
@@ -30,7 +30,10 @@ class WorkingMemorySnapshot(CoreasonBaseModel):
     )
     argumentation: ArgumentGraph | None = Field(
         default=None,
-        description="The formal graph of non-monotonic claims and defeasible attacks currently active in the swarm's working memory.",
+        description=(
+            "The formal graph of non-monotonic claims and defeasible "
+            "attacks currently active in the swarm's working memory."
+        ),
     )
 
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -7,6 +7,7 @@
 
 from coreason_manifest.presentation.intents import DraftingIntent, PresentationEnvelope
 from coreason_manifest.presentation.scivis import InsightCard, MacroGrid
+from coreason_manifest.state.argumentation import ArgumentClaim, ArgumentGraph, DefeasibleAttack
 from coreason_manifest.state.events import ObservationEvent
 from coreason_manifest.state.memory import EpistemicLedger
 from coreason_manifest.state.semantic import (
@@ -44,6 +45,35 @@ def test_workflow_envelope_determinism() -> None:
 
     assert env1.model_dump_canonical() == env2.model_dump_canonical()
     assert hash(env1) == hash(env2)
+
+
+def test_argumentation_determinism() -> None:
+    claim1 = ArgumentClaim(
+        claim_id="claim_1", proponent_id="agent_x", text_chunk="This sentence is false.", warrants=[]
+    )
+    claim2 = ArgumentClaim(
+        claim_id="claim_2", proponent_id="agent_y", text_chunk="The previous sentence is true.", warrants=[]
+    )
+
+    attack1 = DefeasibleAttack(
+        attack_id="attack_1", source_claim_id="claim_1", target_claim_id="claim_2", attack_vector="rebuttal"
+    )
+    attack2 = DefeasibleAttack(
+        attack_id="attack_2", source_claim_id="claim_2", target_claim_id="claim_1", attack_vector="undercutter"
+    )
+
+    graph1 = ArgumentGraph(
+        claims={"claim_1": claim1, "claim_2": claim2},
+        attacks={"attack_1": attack1, "attack_2": attack2},
+    )
+
+    graph2 = ArgumentGraph(
+        claims={"claim_2": claim2, "claim_1": claim1},
+        attacks={"attack_2": attack2, "attack_1": attack1},
+    )
+
+    assert graph1.model_dump_canonical() == graph2.model_dump_canonical()
+    assert hash(graph1) == hash(graph2)
 
 
 def test_tooling_determinism() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -21,6 +21,7 @@ from coreason_manifest.oversight.resilience import (
     QuarantineOrder,
 )
 from coreason_manifest.presentation.scivis import AnyPanel, CohortAttritionGrid, InsightCard, TimeSeriesPanel
+from coreason_manifest.state.argumentation import ArgumentGraph
 from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, ObservationEvent, SystemFaultEvent
 from coreason_manifest.state.semantic import SemanticEdge, SemanticNode
 from coreason_manifest.testing.chaos import ChaosExperiment
@@ -495,3 +496,68 @@ def test_state_contract_fuzzing(payload: dict[str, Any]) -> None:
     parsed = state_contract_adapter.validate_python(payload)
     assert isinstance(parsed, StateContract)
     assert parsed.strict_validation == payload["strict_validation"]
+
+
+@st.composite
+def draw_evidentiary_warrant(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "source_event_id": st.one_of(st.none(), st.text()),
+                "source_semantic_node_id": st.one_of(st.none(), st.text()),
+                "justification": st.text(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_argument_claim(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "claim_id": st.text(),
+                "proponent_id": st.text(),
+                "text_chunk": st.text(),
+                "warrants": st.lists(draw_evidentiary_warrant()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_defeasible_attack(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "attack_id": st.text(),
+                "source_claim_id": st.text(),
+                "target_claim_id": st.text(),
+                "attack_vector": st.sampled_from(["rebuttal", "undercutter", "underminer"]),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_argument_graph(draw: Any) -> dict[str, Any]:
+    claims = draw(st.lists(draw_argument_claim()))
+    claims_dict = {claim["claim_id"]: claim for claim in claims}
+
+    attacks = draw(st.lists(draw_defeasible_attack()))
+    attacks_dict = {attack["attack_id"]: attack for attack in attacks}
+
+    res: dict[str, Any] = {"claims": claims_dict, "attacks": attacks_dict}
+    return res
+
+
+argument_graph_adapter: TypeAdapter[ArgumentGraph] = TypeAdapter(ArgumentGraph)
+
+
+@given(draw_argument_graph())
+def test_argument_graph_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = argument_graph_adapter.validate_python(payload)
+    assert isinstance(parsed, ArgumentGraph)


### PR DESCRIPTION
Implemented Epic 16: Argumentation & Non-Monotonic Reasoning. 

This introduces the mathematical shape of an argument graph into the `coreason-manifest` data plane. It includes new purely data-driven, free-threaded models for formal logic and debate (`ArgumentClaim`, `DefeasibleAttack`, `EvidentiaryWarrant`) linked into the state memory plane. Deterministic cyclical parsing is proven via hashing tests in `test_determinism.py` and fuzzed in `test_fuzzing.py`.

Compliant with Python 3.14 constraints.

---
*PR created automatically by Jules for task [10600541736054075217](https://jules.google.com/task/10600541736054075217) started by @gowthamrao*