### PR TITLE
Epic 17 - Frontier 2: Market-Based Task Auctions

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -129,6 +129,41 @@
       "title": "AdversaryProfile",
       "type": "object"
     },
+    "AgentBid": {
+      "additionalProperties": false,
+      "properties": {
+        "agent_id": {
+          "description": "The NodeID of the bidder.",
+          "title": "Agent Id",
+          "type": "string"
+        },
+        "estimated_cost_usd": {
+          "description": "The node's calculated cost to fulfill the task.",
+          "title": "Estimated Cost Usd",
+          "type": "number"
+        },
+        "estimated_latency_ms": {
+          "description": "The node's estimated time to completion.",
+          "title": "Estimated Latency Ms",
+          "type": "integer"
+        },
+        "confidence_score": {
+          "description": "The node's epistemic certainty of success.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Score",
+          "type": "number"
+        }
+      },
+      "required": [
+        "agent_id",
+        "estimated_cost_usd",
+        "estimated_latency_ms",
+        "confidence_score"
+      ],
+      "title": "AgentBid",
+      "type": "object"
+    },
     "AgentNode": {
       "additionalProperties": false,
       "description": "A node representing an autonomous agent.",
@@ -391,6 +426,73 @@
       ],
       "title": "ArgumentGraph",
       "type": "object"
+    },
+    "AuctionPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "auction_type": {
+          "$ref": "#/$defs/AuctionType",
+          "description": "The market mechanism governing the auction."
+        },
+        "tie_breaker": {
+          "$ref": "#/$defs/TieBreaker",
+          "description": "The deterministic rule for resolving tied bids."
+        },
+        "max_bidding_window_ms": {
+          "description": "The absolute timeout in milliseconds for nodes to submit proposals.",
+          "title": "Max Bidding Window Ms",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "auction_type",
+        "tie_breaker",
+        "max_bidding_window_ms"
+      ],
+      "title": "AuctionPolicy",
+      "type": "object"
+    },
+    "AuctionState": {
+      "additionalProperties": false,
+      "properties": {
+        "announcement": {
+          "$ref": "#/$defs/TaskAnnouncement",
+          "description": "The original call for proposals."
+        },
+        "bids": {
+          "description": "The array of received bids.",
+          "items": {
+            "$ref": "#/$defs/AgentBid"
+          },
+          "title": "Bids",
+          "type": "array"
+        },
+        "award": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TaskAward"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The final cryptographic receipt of the auction, if resolved."
+        }
+      },
+      "required": [
+        "announcement"
+      ],
+      "title": "AuctionState",
+      "type": "object"
+    },
+    "AuctionType": {
+      "enum": [
+        "sealed_bid",
+        "dutch",
+        "vickrey"
+      ],
+      "type": "string"
     },
     "BackpressurePolicy": {
       "additionalProperties": false,
@@ -2159,6 +2261,18 @@
           "description": "The absolute ceiling for concurrent agent threads.",
           "title": "Max Concurrent Agents",
           "type": "integer"
+        },
+        "auction_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AuctionPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical policy governing task decentralization via Spot Markets."
         }
       },
       "required": [
@@ -2251,6 +2365,67 @@
         "description"
       ],
       "title": "SystemNode",
+      "type": "object"
+    },
+    "TaskAnnouncement": {
+      "additionalProperties": false,
+      "properties": {
+        "task_id": {
+          "description": "Unique identifier for the required task.",
+          "title": "Task Id",
+          "type": "string"
+        },
+        "required_action_space_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional restriction forcing bidders to possess a specific toolset.",
+          "title": "Required Action Space Id"
+        },
+        "max_budget_usd": {
+          "description": "The absolute ceiling price the orchestrator is willing to pay.",
+          "title": "Max Budget Usd",
+          "type": "number"
+        }
+      },
+      "required": [
+        "task_id",
+        "max_budget_usd"
+      ],
+      "title": "TaskAnnouncement",
+      "type": "object"
+    },
+    "TaskAward": {
+      "additionalProperties": false,
+      "properties": {
+        "task_id": {
+          "description": "The identifier of the resolved task.",
+          "title": "Task Id",
+          "type": "string"
+        },
+        "awarded_agent_id": {
+          "description": "The winning NodeID.",
+          "title": "Awarded Agent Id",
+          "type": "string"
+        },
+        "cleared_price_usd": {
+          "description": "The final cryptographic clearing price.",
+          "title": "Cleared Price Usd",
+          "type": "number"
+        }
+      },
+      "required": [
+        "task_id",
+        "awarded_agent_id",
+        "cleared_price_usd"
+      ],
+      "title": "TaskAward",
       "type": "object"
     },
     "TelemetryScalar": {
@@ -2351,6 +2526,15 @@
       ],
       "title": "TerminalStateSnapshot",
       "type": "object"
+    },
+    "TieBreaker": {
+      "enum": [
+        "lowest_cost",
+        "lowest_latency",
+        "highest_confidence",
+        "random"
+      ],
+      "type": "string"
     },
     "ToolDefinition": {
       "additionalProperties": false,

--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -5,6 +5,15 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from coreason_manifest.workflow.auctions import (
+    AgentBid,
+    AuctionPolicy,
+    AuctionState,
+    AuctionType,
+    TaskAnnouncement,
+    TaskAward,
+    TieBreaker,
+)
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import (
     AgentNode,
@@ -26,9 +35,13 @@ from coreason_manifest.workflow.topologies import (
 )
 
 __all__ = [
+    "AgentBid",
     "AgentNode",
     "AnyNode",
     "AnyTopology",
+    "AuctionPolicy",
+    "AuctionState",
+    "AuctionType",
     "BackpressurePolicy",
     "CouncilTopology",
     "DAGTopology",
@@ -40,5 +53,8 @@ __all__ = [
     "SwarmTopology",
     "System1Reflex",
     "SystemNode",
+    "TaskAnnouncement",
+    "TaskAward",
+    "TieBreaker",
     "WorkflowEnvelope",
 ]

--- a/src/coreason_manifest/workflow/auctions.py
+++ b/src/coreason_manifest/workflow/auctions.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+type AuctionType = Literal["sealed_bid", "dutch", "vickrey"]
+type TieBreaker = Literal["lowest_cost", "lowest_latency", "highest_confidence", "random"]
+
+
+class AuctionPolicy(CoreasonBaseModel):
+    auction_type: AuctionType = Field(description="The market mechanism governing the auction.")
+    tie_breaker: TieBreaker = Field(description="The deterministic rule for resolving tied bids.")
+    max_bidding_window_ms: int = Field(
+        description="The absolute timeout in milliseconds for nodes to submit proposals."
+    )
+
+
+class TaskAnnouncement(CoreasonBaseModel):
+    task_id: str = Field(description="Unique identifier for the required task.")
+    required_action_space_id: str | None = Field(
+        default=None, description="Optional restriction forcing bidders to possess a specific toolset."
+    )
+    max_budget_usd: float = Field(description="The absolute ceiling price the orchestrator is willing to pay.")
+
+
+class AgentBid(CoreasonBaseModel):
+    agent_id: str = Field(description="The NodeID of the bidder.")
+    estimated_cost_usd: float = Field(description="The node's calculated cost to fulfill the task.")
+    estimated_latency_ms: int = Field(description="The node's estimated time to completion.")
+    confidence_score: float = Field(ge=0.0, le=1.0, description="The node's epistemic certainty of success.")
+
+
+class TaskAward(CoreasonBaseModel):
+    task_id: str = Field(description="The identifier of the resolved task.")
+    awarded_agent_id: str = Field(description="The winning NodeID.")
+    cleared_price_usd: float = Field(description="The final cryptographic clearing price.")
+
+
+class AuctionState(CoreasonBaseModel):
+    announcement: TaskAnnouncement = Field(description="The original call for proposals.")
+    bids: list[AgentBid] = Field(default_factory=list, description="The array of received bids.")
+    award: TaskAward | None = Field(
+        default=None, description="The final cryptographic receipt of the auction, if resolved."
+    )
+
+    @model_validator(mode="after")
+    def sort_bids(self) -> AuctionState:
+        """Mathematically sort bids by agent_id for deterministic hashing."""
+        self.bids.sort(key=lambda bid: bid.agent_id)
+        return self

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -11,6 +11,7 @@ from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
+from coreason_manifest.workflow.auctions import AuctionPolicy
 from coreason_manifest.workflow.nodes import AnyNode
 
 
@@ -150,6 +151,9 @@ class SwarmTopology(BaseTopology):
         description="Threshold limit for dynamic spawning of additional nodes.",
     )
     max_concurrent_agents: int = Field(default=10, description="The absolute ceiling for concurrent agent threads.")
+    auction_policy: AuctionPolicy | None = Field(
+        default=None, description="The mathematical policy governing task decentralization via Spot Markets."
+    )
 
     @model_validator(mode="after")
     def enforce_concurrency_ceiling(self) -> Self:

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -19,6 +19,7 @@ from coreason_manifest.state.semantic import (
 )
 from coreason_manifest.testing.chaos import ChaosExperiment, FaultInjectionProfile, SteadyStateHypothesis
 from coreason_manifest.tooling import ActionSpace, PermissionBoundary, SideEffectProfile, ToolDefinition
+from coreason_manifest.workflow.auctions import AgentBid, AuctionState, TaskAnnouncement
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AgentNode
 from coreason_manifest.workflow.topologies import DAGTopology
@@ -45,6 +46,20 @@ def test_workflow_envelope_determinism() -> None:
 
     assert env1.model_dump_canonical() == env2.model_dump_canonical()
     assert hash(env1) == hash(env2)
+
+
+def test_auction_determinism() -> None:
+    ann = TaskAnnouncement(task_id="t1", max_budget_usd=100.0)
+
+    bid_1 = AgentBid(agent_id="agent_a", estimated_cost_usd=10.0, estimated_latency_ms=100, confidence_score=0.9)
+    bid_2 = AgentBid(agent_id="agent_b", estimated_cost_usd=12.0, estimated_latency_ms=90, confidence_score=0.85)
+    bid_3 = AgentBid(agent_id="agent_c", estimated_cost_usd=9.0, estimated_latency_ms=110, confidence_score=0.95)
+
+    state1 = AuctionState(announcement=ann, bids=[bid_1, bid_2, bid_3])
+    state2 = AuctionState(announcement=ann, bids=[bid_3, bid_1, bid_2])
+
+    assert state1.model_dump_canonical() == state2.model_dump_canonical()
+    assert hash(state1) == hash(state2)
 
 
 def test_argumentation_determinism() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -26,6 +26,7 @@ from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, Obs
 from coreason_manifest.state.semantic import SemanticEdge, SemanticNode
 from coreason_manifest.testing.chaos import ChaosExperiment
 from coreason_manifest.tooling import ActionSpace, ToolDefinition
+from coreason_manifest.workflow.auctions import AuctionState
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, HumanNode, SystemNode
 from coreason_manifest.workflow.topologies import StateContract
 
@@ -561,3 +562,69 @@ argument_graph_adapter: TypeAdapter[ArgumentGraph] = TypeAdapter(ArgumentGraph)
 def test_argument_graph_fuzzing(payload: dict[str, Any]) -> None:
     parsed = argument_graph_adapter.validate_python(payload)
     assert isinstance(parsed, ArgumentGraph)
+
+
+@st.composite
+def draw_task_announcement(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "task_id": st.text(),
+                "required_action_space_id": st.one_of(st.none(), st.text()),
+                "max_budget_usd": st.floats(allow_nan=False, allow_infinity=False),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_agent_bid(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "agent_id": st.text(),
+                "estimated_cost_usd": st.floats(allow_nan=False, allow_infinity=False),
+                "estimated_latency_ms": st.integers(),
+                "confidence_score": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_task_award(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "task_id": st.text(),
+                "awarded_agent_id": st.text(),
+                "cleared_price_usd": st.floats(allow_nan=False, allow_infinity=False),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_auction_state(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "announcement": draw_task_announcement(),
+                "bids": st.lists(draw_agent_bid()),
+                "award": st.one_of(st.none(), draw_task_award()),
+            }
+        )
+    )
+    return res
+
+
+auction_state_adapter: TypeAdapter[AuctionState] = TypeAdapter(AuctionState)
+
+
+@given(draw_auction_state())
+def test_auction_state_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = auction_state_adapter.validate_python(payload)
+    assert isinstance(parsed, AuctionState)


### PR DESCRIPTION
Epic 17 implementation for **Frontier 2: Market-Based Task Auctions**.

This introduces pure data structures for the FIPA Contract Net Protocol (CNP), shifting the swarm from rigid DAG routing to Liquid Compute Spot Markets:
- `AuctionType` and `TieBreaker` models defined utilizing PEP 695 native type parameters
- The entire market ontology, implemented entirely as `frozen=True` Pydantic models with mathematically robust deterministic validations to counteract node jitter hash mismatching
- Topological configuration integration with `SwarmTopology`
- Expanded determinism proofs and random composite fuzzer coverage against new SOTA schemas

---
*PR created automatically by Jules for task [8905280378449257954](https://jules.google.com/task/8905280378449257954) started by @gowthamrao*