### PR TITLE
feat: introduce InformationFlowPolicy for deterministic Data Loss Prevention

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -815,6 +815,18 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
+        },
         "type": {
           "const": "council",
           "default": "council",
@@ -900,6 +912,18 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
+        },
         "type": {
           "const": "dag",
           "default": "dag",
@@ -949,6 +973,16 @@
       ],
       "title": "DAGTopology",
       "type": "object"
+    },
+    "DataClassification": {
+      "enum": [
+        "phi",
+        "pii",
+        "pci",
+        "confidential",
+        "public"
+      ],
+      "type": "string"
     },
     "DefeasibleAttack": {
       "additionalProperties": false,
@@ -1384,6 +1418,36 @@
         "description"
       ],
       "title": "HumanNode",
+      "type": "object"
+    },
+    "InformationFlowPolicy": {
+      "additionalProperties": false,
+      "description": "Mathematical Data Loss Prevention (DLP) contract that bounds the graph.",
+      "properties": {
+        "policy_id": {
+          "description": "Unique identifier for this macroscopic flow control policy.",
+          "title": "Policy Id",
+          "type": "string"
+        },
+        "active": {
+          "default": true,
+          "description": "Whether this policy is currently enforcing data sanitization.",
+          "title": "Active",
+          "type": "boolean"
+        },
+        "rules": {
+          "description": "The array of sanitization rules to enforce.",
+          "items": {
+            "$ref": "#/$defs/RedactionRule"
+          },
+          "title": "Rules",
+          "type": "array"
+        }
+      },
+      "required": [
+        "policy_id"
+      ],
+      "title": "InformationFlowPolicy",
       "type": "object"
     },
     "InterventionPolicy": {
@@ -1867,6 +1931,51 @@
       "title": "RateCard",
       "type": "object"
     },
+    "RedactionRule": {
+      "additionalProperties": false,
+      "description": "A specific rule for algorithmic data sanitization.",
+      "properties": {
+        "rule_id": {
+          "description": "Unique identifier for the sanitization rule.",
+          "title": "Rule Id",
+          "type": "string"
+        },
+        "classification": {
+          "$ref": "#/$defs/DataClassification",
+          "description": "The category of sensitive data this rule targets."
+        },
+        "target_pattern": {
+          "description": "The semantic entity type or declarative regex pattern to identify.",
+          "title": "Target Pattern",
+          "type": "string"
+        },
+        "action": {
+          "$ref": "#/$defs/SanitizationAction",
+          "description": "The required algorithmic response when this pattern is detected."
+        },
+        "replacement_token": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strictly typed string to insert if the action is 'redact'.",
+          "title": "Replacement Token"
+        }
+      },
+      "required": [
+        "rule_id",
+        "classification",
+        "target_pattern",
+        "action"
+      ],
+      "title": "RedactionRule",
+      "type": "object"
+    },
     "SalienceProfile": {
       "additionalProperties": false,
       "properties": {
@@ -1887,6 +1996,15 @@
       ],
       "title": "SalienceProfile",
       "type": "object"
+    },
+    "SanitizationAction": {
+      "enum": [
+        "redact",
+        "hash",
+        "drop_event",
+        "trigger_quarantine"
+      ],
+      "type": "string"
     },
     "SelfCorrectionPolicy": {
       "additionalProperties": false,
@@ -2242,6 +2360,18 @@
           ],
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
+        },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
         },
         "type": {
           "const": "swarm",

--- a/src/coreason_manifest/oversight/__init__.py
+++ b/src/coreason_manifest/oversight/__init__.py
@@ -6,6 +6,7 @@
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
 from .adjudication import AdjudicationRubric, AdjudicationVerdict, GradingCriteria
+from .dlp import DataClassification, InformationFlowPolicy, RedactionRule, SanitizationAction
 from .governance import ConstitutionalRule, GlobalGovernance, GovernancePolicy
 from .intervention import (
     AnyInterventionPayload,
@@ -26,14 +27,18 @@ __all__ = [
     "BoundedInterventionScope",
     "CircuitBreakerTrip",
     "ConstitutionalRule",
+    "DataClassification",
     "FallbackSLA",
     "FallbackTrigger",
     "GlobalGovernance",
     "GovernancePolicy",
     "GradingCriteria",
+    "InformationFlowPolicy",
     "InterventionPolicy",
     "InterventionRequest",
     "InterventionVerdict",
     "LifecycleTrigger",
     "QuarantineOrder",
+    "RedactionRule",
+    "SanitizationAction",
 ]

--- a/src/coreason_manifest/oversight/dlp.py
+++ b/src/coreason_manifest/oversight/dlp.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+type DataClassification = Literal["phi", "pii", "pci", "confidential", "public"]
+type SanitizationAction = Literal["redact", "hash", "drop_event", "trigger_quarantine"]
+
+
+class RedactionRule(CoreasonBaseModel):
+    """
+    A specific rule for algorithmic data sanitization.
+    """
+
+    rule_id: str = Field(description="Unique identifier for the sanitization rule.")
+    classification: DataClassification = Field(description="The category of sensitive data this rule targets.")
+    target_pattern: str = Field(description="The semantic entity type or declarative regex pattern to identify.")
+    action: SanitizationAction = Field(description="The required algorithmic response when this pattern is detected.")
+    replacement_token: str | None = Field(
+        default=None, description="The strictly typed string to insert if the action is 'redact'."
+    )
+
+
+class InformationFlowPolicy(CoreasonBaseModel):
+    """
+    Mathematical Data Loss Prevention (DLP) contract that bounds the graph.
+    """
+
+    policy_id: str = Field(description="Unique identifier for this macroscopic flow control policy.")
+    active: bool = Field(default=True, description="Whether this policy is currently enforcing data sanitization.")
+    rules: list[RedactionRule] = Field(default_factory=list, description="The array of sanitization rules to enforce.")
+
+    @model_validator(mode="after")
+    def sort_rules(self) -> Self:
+        """
+        Mathematically sorts rules by rule_id to guarantee deterministic hashing.
+        """
+        # Because the model is frozen, we bypass attribute assignment tracking
+        object.__setattr__(self, "rules", sorted(self.rules, key=lambda r: r.rule_id))
+        return self

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -11,6 +11,7 @@ from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
+from coreason_manifest.oversight.dlp import InformationFlowPolicy
 from coreason_manifest.workflow.auctions import AuctionPolicy
 from coreason_manifest.workflow.nodes import AnyNode
 
@@ -67,6 +68,11 @@ class BaseTopology(CoreasonBaseModel):
     nodes: dict[NodeID, AnyNode] = Field(description="Flat registry of all nodes in this topology.")
     shared_state_contract: StateContract | None = Field(
         default=None, description="The schema-on-write contract governing the internal state of this topology."
+    )
+    information_flow: InformationFlowPolicy | None = Field(
+        default=None,
+        description="The structural Data Loss Prevention (DLP) contract governing all state mutations in this "
+        "topology.",
     )
 
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -5,6 +5,7 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from coreason_manifest.oversight.dlp import InformationFlowPolicy, RedactionRule
 from coreason_manifest.presentation.intents import DraftingIntent, PresentationEnvelope
 from coreason_manifest.presentation.scivis import InsightCard, MacroGrid
 from coreason_manifest.state.argumentation import ArgumentClaim, ArgumentGraph, DefeasibleAttack
@@ -46,6 +47,23 @@ def test_workflow_envelope_determinism() -> None:
 
     assert env1.model_dump_canonical() == env2.model_dump_canonical()
     assert hash(env1) == hash(env2)
+
+
+def test_dlp_determinism() -> None:
+    rule_a = RedactionRule(
+        rule_id="a_phi_redact",
+        classification="phi",
+        target_pattern="pattern_a",
+        action="redact",
+        replacement_token="[REDACTED]",  # noqa: S106
+    )
+    rule_b = RedactionRule(rule_id="b_pii_hash", classification="pii", target_pattern="pattern_b", action="hash")
+
+    policy1 = InformationFlowPolicy(policy_id="p1", rules=[rule_a, rule_b])
+    policy2 = InformationFlowPolicy(policy_id="p1", rules=[rule_b, rule_a])
+
+    assert policy1.model_dump_canonical() == policy2.model_dump_canonical()
+    assert hash(policy1) == hash(policy2)
 
 
 def test_auction_determinism() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -12,6 +12,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import TypeAdapter, ValidationError
 
+from coreason_manifest.oversight.dlp import InformationFlowPolicy
 from coreason_manifest.oversight.governance import GlobalGovernance
 from coreason_manifest.oversight.intervention import InterventionPolicy
 from coreason_manifest.oversight.resilience import (
@@ -628,3 +629,42 @@ auction_state_adapter: TypeAdapter[AuctionState] = TypeAdapter(AuctionState)
 def test_auction_state_fuzzing(payload: dict[str, Any]) -> None:
     parsed = auction_state_adapter.validate_python(payload)
     assert isinstance(parsed, AuctionState)
+
+
+@st.composite
+def draw_redaction_rule(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "rule_id": st.text(),
+                "classification": st.sampled_from(["phi", "pii", "pci", "confidential", "public"]),
+                "target_pattern": st.text(),
+                "action": st.sampled_from(["redact", "hash", "drop_event", "trigger_quarantine"]),
+                "replacement_token": st.one_of(st.none(), st.text()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_information_flow_policy(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "policy_id": st.text(),
+                "active": st.booleans(),
+                "rules": st.lists(draw_redaction_rule()),
+            }
+        )
+    )
+    return res
+
+
+information_flow_policy_adapter: TypeAdapter[InformationFlowPolicy] = TypeAdapter(InformationFlowPolicy)
+
+
+@given(draw_information_flow_policy())
+def test_dlp_policy_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = information_flow_policy_adapter.validate_python(payload)
+    assert isinstance(parsed, InformationFlowPolicy)


### PR DESCRIPTION
Implemented Epic 18: Information Flow Control & Data Sanitization for coreason-manifest. Includes SOTA Python 3.14 native schemas, deterministic hashable array validators, and rigorous fuzzing/determinism tests.

---
*PR created automatically by Jules for task [809973341815027349](https://jules.google.com/task/809973341815027349) started by @gowthamrao*