### PR TITLE
Epic 19: Formal Declarative Visualization Grammars

### DIFF
--- a/src/coreason_manifest/presentation/__init__.py
+++ b/src/coreason_manifest/presentation/__init__.py
@@ -16,10 +16,15 @@ from .intents import (
 from .scivis import (
     AnyPanel,
     BasePanel,
-    CohortAttritionGrid,
+    ChannelEncoding,
+    EncodingChannel,
+    FacetMatrix,
+    GrammarPanel,
     InsightCard,
     MacroGrid,
-    TimeSeriesPanel,
+    MarkType,
+    ScaleDefinition,
+    ScaleType,
 )
 from .templates import DynamicLayoutTemplate
 
@@ -29,12 +34,17 @@ __all__ = [
     "AnyPanel",
     "BaseIntent",
     "BasePanel",
-    "CohortAttritionGrid",
+    "ChannelEncoding",
     "DraftingIntent",
     "DynamicLayoutTemplate",
+    "EncodingChannel",
     "FYIIntent",
+    "FacetMatrix",
+    "GrammarPanel",
     "InsightCard",
     "MacroGrid",
+    "MarkType",
     "PresentationEnvelope",
-    "TimeSeriesPanel",
+    "ScaleDefinition",
+    "ScaleType",
 ]

--- a/src/coreason_manifest/presentation/scivis.py
+++ b/src/coreason_manifest/presentation/scivis.py
@@ -18,27 +18,51 @@ class BasePanel(CoreasonBaseModel):
     panel_id: str = Field(description="Unique identifier for the panel.")
 
 
-class TimeSeriesPanel(BasePanel):
-    """Panel representing a time-series chart."""
+type MarkType = Literal["point", "line", "area", "bar", "rect", "arc"]
+type ScaleType = Literal["linear", "log", "time", "ordinal", "nominal"]
+type EncodingChannel = Literal["x", "y", "color", "size", "opacity", "shape", "text"]
 
-    type: Literal["timeseries"] = Field(default="timeseries", description="Discriminator for a time-series panel.")
-    x_axis_label: str = Field(description="The label for the x-axis.")
-    y_axis_label: str = Field(description="The label for the y-axis.")
-    data_series: list[dict[str, str | int | float]] = Field(
-        description="A list of data points representing the time-series data."
+
+class ScaleDefinition(CoreasonBaseModel):
+    """The mathematical mapping constraint for a channel."""
+
+    type: ScaleType = Field(description="The mathematical scaling function.")
+    domain_min: float | None = Field(default=None, description="Optional hard floor for the scale.")
+    domain_max: float | None = Field(default=None, description="Optional hard ceiling for the scale.")
+
+
+class ChannelEncoding(CoreasonBaseModel):
+    """The visual property being manipulated."""
+
+    channel: EncodingChannel = Field(description="The visual property being manipulated.")
+    field: str = Field(description="The exact data key/column to bind to this channel.")
+    scale: ScaleDefinition | None = Field(
+        default=None, description="The mathematical mapping constraint for this channel."
     )
 
 
-class CohortAttritionGrid(BasePanel):
-    """Panel representing a table or grid of cohort data attrition."""
+class FacetMatrix(CoreasonBaseModel):
+    """Optional small-multiple faceting layout."""
 
-    type: Literal["cohort_attrition"] = Field(
-        default="cohort_attrition",
-        description="Discriminator for a cohort attrition grid.",
-    )
-    grid_data: list[dict[str, str | int | float]] = Field(
-        description="A list of data rows representing cohort attrition over steps."
-    )
+    row_field: str | None = Field(default=None, description="Categorical field to split into rows.")
+    column_field: str | None = Field(default=None, description="Categorical field to split into columns.")
+
+
+class GrammarPanel(BasePanel):
+    """Panel representing a deterministic, declarative visual grammar."""
+
+    type: Literal["grammar"] = Field(default="grammar", description="Discriminator for a grammar panel.")
+    title: str = Field(description="The title of the visualization.")
+    data_source_id: str = Field(description="Pointer to the data matrix being visualized.")
+    mark: MarkType = Field(description="The geometric primitive representing the data points.")
+    encodings: list[ChannelEncoding] = Field(default_factory=list, description="The array of visual bindings.")
+    facet: FacetMatrix | None = Field(default=None, description="Optional small-multiple faceting layout.")
+
+    @model_validator(mode="after")
+    def sort_encodings(self) -> Self:
+        """Mathematically sorts self.encodings by the string value of channel for deterministic hashing."""
+        object.__setattr__(self, "encodings", sorted(self.encodings, key=lambda e: e.channel))
+        return self
 
 
 class InsightCard(BasePanel):
@@ -59,7 +83,7 @@ class InsightCard(BasePanel):
         return v
 
 
-type AnyPanel = Annotated[TimeSeriesPanel | CohortAttritionGrid | InsightCard, Field(discriminator="type")]
+type AnyPanel = Annotated[GrammarPanel | InsightCard, Field(discriminator="type")]
 
 
 class MacroGrid(CoreasonBaseModel):

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -5,7 +5,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
-from coreason_manifest.presentation.scivis import AnyPanel, CohortAttritionGrid, InsightCard, MacroGrid, TimeSeriesPanel
+from coreason_manifest.presentation.scivis import AnyPanel, ChannelEncoding, GrammarPanel, InsightCard, MacroGrid
 from coreason_manifest.presentation.templates import DynamicLayoutTemplate
 
 
@@ -61,7 +61,9 @@ def test_visual_ghost_node_test(ghost_id: str) -> None:
     """
     panels: list[AnyPanel] = [
         InsightCard(panel_id="panel_1", title="A", markdown_content="Safe text"),
-        TimeSeriesPanel(panel_id="panel_2", x_axis_label="X", y_axis_label="Y", data_series=[]),
+        GrammarPanel(
+            panel_id="panel_2", title="B", data_source_id="d1", mark="point", encodings=[]
+        ),
     ]
 
     escaped_ghost_id = re.escape(ghost_id)
@@ -84,8 +86,20 @@ def test_safe_rendering_test(title: str, safe_text: str, x_label: str, y_label: 
     """
     panels: list[AnyPanel] = [
         InsightCard(panel_id="panel_1", title=title, markdown_content=safe_text),
-        TimeSeriesPanel(panel_id="panel_2", x_axis_label=x_label, y_axis_label=y_label, data_series=[{"x": 1, "y": 2}]),
-        CohortAttritionGrid(panel_id="panel_3", grid_data=[{"step": "A", "count": 100}]),
+        GrammarPanel(
+            panel_id="panel_2",
+            title=x_label,
+            data_source_id="d2",
+            mark="point",
+            encodings=[ChannelEncoding(channel="x", field="x"), ChannelEncoding(channel="y", field="y")],
+        ),
+        GrammarPanel(
+            panel_id="panel_3",
+            title=y_label,
+            data_source_id="d3",
+            mark="bar",
+            encodings=[ChannelEncoding(channel="x", field="step"), ChannelEncoding(channel="y", field="count")],
+        ),
     ]
 
     # Instantiate without error

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -61,9 +61,7 @@ def test_visual_ghost_node_test(ghost_id: str) -> None:
     """
     panels: list[AnyPanel] = [
         InsightCard(panel_id="panel_1", title="A", markdown_content="Safe text"),
-        GrammarPanel(
-            panel_id="panel_2", title="B", data_source_id="d1", mark="point", encodings=[]
-        ),
+        GrammarPanel(panel_id="panel_2", title="B", data_source_id="d1", mark="point", encodings=[]),
     ]
 
     escaped_ghost_id = re.escape(ghost_id)

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -7,7 +7,7 @@
 
 from coreason_manifest.oversight.dlp import InformationFlowPolicy, RedactionRule
 from coreason_manifest.presentation.intents import DraftingIntent, PresentationEnvelope
-from coreason_manifest.presentation.scivis import InsightCard, MacroGrid
+from coreason_manifest.presentation.scivis import ChannelEncoding, GrammarPanel, InsightCard, MacroGrid
 from coreason_manifest.state.argumentation import ArgumentClaim, ArgumentGraph, DefeasibleAttack
 from coreason_manifest.state.events import ObservationEvent
 from coreason_manifest.state.memory import EpistemicLedger
@@ -134,6 +134,30 @@ def test_tooling_determinism() -> None:
 
     assert space1.model_dump_canonical() == space2.model_dump_canonical()
     assert hash(space1) == hash(space2)
+
+
+def test_grammar_determinism() -> None:
+    enc_x = ChannelEncoding(channel="x", field="date")
+    enc_color = ChannelEncoding(channel="color", field="category")
+
+    panel1 = GrammarPanel(
+        panel_id="p1",
+        title="T",
+        data_source_id="d1",
+        mark="point",
+        encodings=[enc_x, enc_color],
+    )
+
+    panel2 = GrammarPanel(
+        panel_id="p1",
+        title="T",
+        data_source_id="d1",
+        mark="point",
+        encodings=[enc_color, enc_x],  # Simulated out-of-order generation
+    )
+
+    assert panel1.model_dump_canonical() == panel2.model_dump_canonical()
+    assert hash(panel1) == hash(panel2)
 
 
 def test_presentation_envelope_determinism() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -21,7 +21,7 @@ from coreason_manifest.oversight.resilience import (
     FallbackTrigger,
     QuarantineOrder,
 )
-from coreason_manifest.presentation.scivis import AnyPanel, CohortAttritionGrid, InsightCard, TimeSeriesPanel
+from coreason_manifest.presentation.scivis import AnyPanel, GrammarPanel, InsightCard
 from coreason_manifest.state.argumentation import ArgumentGraph
 from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, ObservationEvent, SystemFaultEvent
 from coreason_manifest.state.semantic import SemanticEdge, SemanticNode
@@ -195,38 +195,69 @@ def test_anystateevent_invalid(invalid_type: str) -> None:
         event_adapter.validate_python(payload)
 
 
-@given(
-    st.text(),
-    st.text(),
-    st.lists(
-        st.dictionaries(
-            st.text(), st.one_of(st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False))
-        )
-    ),
-)
-def test_anypanel_timeseries(x_axis: str, y_axis: str, data: list[dict[str, Any]]) -> None:
-    payload = {
-        "panel_id": "p1",
-        "type": "timeseries",
-        "x_axis_label": x_axis,
-        "y_axis_label": y_axis,
-        "data_series": data,
-    }
-    parsed = panel_adapter.validate_python(payload)
-    assert isinstance(parsed, TimeSeriesPanel)
-
-
-@given(
-    st.lists(
-        st.dictionaries(
-            st.text(), st.one_of(st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False))
+@st.composite
+def draw_scale_definition(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.sampled_from(["linear", "log", "time", "ordinal", "nominal"]),
+                "domain_min": st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+                "domain_max": st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+            }
         )
     )
-)
-def test_anypanel_cohort(data: list[dict[str, Any]]) -> None:
-    payload = {"panel_id": "p2", "type": "cohort_attrition", "grid_data": data}
+    return res
+
+
+@st.composite
+def draw_channel_encoding(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "channel": st.sampled_from(["x", "y", "color", "size", "opacity", "shape", "text"]),
+                "field": st.text(),
+                "scale": st.one_of(st.none(), draw_scale_definition()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_facet_matrix(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "row_field": st.one_of(st.none(), st.text()),
+                "column_field": st.one_of(st.none(), st.text()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_grammar_panel_payload(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "panel_id": st.text(),
+                "type": st.just("grammar"),
+                "title": st.text(),
+                "data_source_id": st.text(),
+                "mark": st.sampled_from(["point", "line", "area", "bar", "rect", "arc"]),
+                "encodings": st.lists(draw_channel_encoding()),
+                "facet": st.one_of(st.none(), draw_facet_matrix()),
+            }
+        )
+    )
+    return res
+
+
+@given(st.one_of(draw_grammar_panel_payload()))
+def test_grammar_panel_routing(payload: dict[str, Any]) -> None:
     parsed = panel_adapter.validate_python(payload)
-    assert isinstance(parsed, CohortAttritionGrid)
+    assert isinstance(parsed, GrammarPanel)
 
 
 @given(


### PR DESCRIPTION
This submission closes Epic 19 by deprecating hardcoded presentation widgets (`TimeSeriesPanel`, `CohortAttritionGrid`) and replacing them with a formal, mathematical declarative visualization ontology. The changes exclusively use native Python 3.14 type aliases (`type MarkType = Literal[...]`) and strictly enforce deterministic array hashing constraints.

### Key Changes
- **Graphics Ontology:** Removed hardcoded dashboard widgets and implemented SOTA models (`GrammarPanel`, `ChannelEncoding`, `ScaleDefinition`, `FacetMatrix`, etc.).
- **Array Determinism Proof:** Added an `@model_validator(mode="after")` to `GrammarPanel` to mathematically sort the `encodings` array on initialization using `object.__setattr__` to preserve `frozen=True` immutability while guaranteeing state determinism for LLM generation.
- **Fuzzer Integration:** Built new composite generators and test payloads in `tests/test_fuzzing.py` for all new presentation primitives.
- **Cleanup & Compatibility:** Handled dependent tests (e.g., `tests/domains/test_presentation_quarantine.py`) to migrate legacy implementations to the new `GrammarPanel` schema. Updated all exports and ran formatting tools locally to verify tests.

---
*PR created automatically by Jules for task [1272408754662059503](https://jules.google.com/task/1272408754662059503) started by @gowthamrao*