### PR TITLE
feat: Implement Epic 23 - Normalized Protocol Observability

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -350,6 +350,7 @@
         "mapping": {
           "council": "#/$defs/CouncilTopology",
           "dag": "#/$defs/DAGTopology",
+          "evolutionary": "#/$defs/EvolutionaryTopology",
           "swarm": "#/$defs/SwarmTopology"
         },
         "propertyName": "type"
@@ -363,6 +364,9 @@
         },
         {
           "$ref": "#/$defs/SwarmTopology"
+        },
+        {
+          "$ref": "#/$defs/EvolutionaryTopology"
         }
       ]
     },
@@ -827,6 +831,18 @@
           "default": null,
           "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
         },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
         "type": {
           "const": "council",
           "default": "council",
@@ -857,6 +873,37 @@
       ],
       "title": "CouncilTopology",
       "type": "object"
+    },
+    "CrossoverStrategy": {
+      "additionalProperties": false,
+      "description": "The mathematical rules for combining elite agents.",
+      "properties": {
+        "strategy_type": {
+          "$ref": "#/$defs/CrossoverType",
+          "description": "The heuristic method for blending successful parent agents."
+        },
+        "blending_factor": {
+          "description": "The proportional mix ratio when merging vector properties.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Blending Factor",
+          "type": "number"
+        }
+      },
+      "required": [
+        "strategy_type",
+        "blending_factor"
+      ],
+      "title": "CrossoverStrategy",
+      "type": "object"
+    },
+    "CrossoverType": {
+      "enum": [
+        "uniform_blend",
+        "single_point",
+        "heuristic"
+      ],
+      "type": "string"
     },
     "CustodyRecord": {
       "additionalProperties": false,
@@ -923,6 +970,18 @@
           ],
           "default": null,
           "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
         },
         "type": {
           "const": "dag",
@@ -1015,6 +1074,78 @@
       ],
       "title": "DefeasibleAttack",
       "type": "object"
+    },
+    "DistributionProfile": {
+      "additionalProperties": false,
+      "description": "Profile defining a probability density function.",
+      "properties": {
+        "distribution_type": {
+          "$ref": "#/$defs/DistributionType",
+          "description": "The mathematical shape of the probability density function."
+        },
+        "mean": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The expected value (mu) of the distribution.",
+          "title": "Mean"
+        },
+        "variance": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical variance (sigma squared).",
+          "title": "Variance"
+        },
+        "confidence_interval_95": {
+          "anyOf": [
+            {
+              "maxItems": 2,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The 95% probability bounds.",
+          "title": "Confidence Interval 95"
+        }
+      },
+      "required": [
+        "distribution_type"
+      ],
+      "title": "DistributionProfile",
+      "type": "object"
+    },
+    "DistributionType": {
+      "enum": [
+        "gaussian",
+        "uniform",
+        "beta"
+      ],
+      "type": "string"
     },
     "DiversityConstraint": {
       "additionalProperties": false,
@@ -1161,6 +1292,101 @@
       "title": "EvidentiaryWarrant",
       "type": "object"
     },
+    "EvolutionaryTopology": {
+      "additionalProperties": false,
+      "description": "An Evolutionary workflow topology that mutates and breeds agents over generations.",
+      "properties": {
+        "nodes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AnyNode"
+          },
+          "description": "Flat registry of all nodes in this topology.",
+          "propertyNames": {
+            "$ref": "#/$defs/NodeID"
+          },
+          "title": "Nodes",
+          "type": "object"
+        },
+        "shared_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The schema-on-write contract governing the internal state of this topology."
+        },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
+        "type": {
+          "const": "evolutionary",
+          "default": "evolutionary",
+          "description": "Discriminator for an Evolutionary topology.",
+          "title": "Type",
+          "type": "string"
+        },
+        "generations": {
+          "description": "The absolute limit on evolutionary breeding cycles.",
+          "title": "Generations",
+          "type": "integer"
+        },
+        "population_size": {
+          "description": "The number of concurrent agents instantiated per generation.",
+          "title": "Population Size",
+          "type": "integer"
+        },
+        "mutation": {
+          "$ref": "#/$defs/MutationPolicy",
+          "description": "The constraints governing random heuristic mutations."
+        },
+        "crossover": {
+          "$ref": "#/$defs/CrossoverStrategy"
+        },
+        "fitness_objectives": {
+          "description": "The multi-dimensional criteria used to score and cull the population.",
+          "items": {
+            "$ref": "#/$defs/FitnessObjective"
+          },
+          "title": "Fitness Objectives",
+          "type": "array"
+        }
+      },
+      "required": [
+        "nodes",
+        "generations",
+        "population_size",
+        "mutation",
+        "crossover",
+        "fitness_objectives"
+      ],
+      "title": "EvolutionaryTopology",
+      "type": "object"
+    },
     "ExecutionSLA": {
       "additionalProperties": false,
       "description": "Service Level Agreement (limits) for executing a tool.",
@@ -1188,6 +1414,83 @@
         "max_execution_time_ms"
       ],
       "title": "ExecutionSLA",
+      "type": "object"
+    },
+    "ExecutionSpan": {
+      "additionalProperties": false,
+      "properties": {
+        "trace_id": {
+          "description": "The global identifier for the entire execution causal tree.",
+          "title": "Trace Id",
+          "type": "string"
+        },
+        "span_id": {
+          "description": "The unique identifier for this specific operation.",
+          "title": "Span Id",
+          "type": "string"
+        },
+        "parent_span_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The causal link to the invoking node.",
+          "title": "Parent Span Id"
+        },
+        "name": {
+          "description": "The semantic identifier for the operation.",
+          "title": "Name",
+          "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/SpanKind",
+          "default": "internal",
+          "description": "The role of the span."
+        },
+        "start_time_unix_nano": {
+          "description": "Temporal start bound.",
+          "title": "Start Time Unix Nano",
+          "type": "integer"
+        },
+        "end_time_unix_nano": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Temporal end bound, if completed.",
+          "title": "End Time Unix Nano"
+        },
+        "status": {
+          "$ref": "#/$defs/SpanStatusCode",
+          "default": "unset",
+          "description": "The execution health flag."
+        },
+        "events": {
+          "description": "Structured log records emitted during the span.",
+          "items": {
+            "$ref": "#/$defs/SpanEvent"
+          },
+          "title": "Events",
+          "type": "array"
+        }
+      },
+      "required": [
+        "trace_id",
+        "span_id",
+        "name",
+        "start_time_unix_nano"
+      ],
+      "title": "ExecutionSpan",
       "type": "object"
     },
     "FallbackSLA": {
@@ -1306,6 +1609,33 @@
         }
       },
       "title": "FederatedStateSnapshot",
+      "type": "object"
+    },
+    "FitnessObjective": {
+      "additionalProperties": false,
+      "description": "A specific objective function to optimize within a generation.",
+      "properties": {
+        "target_metric": {
+          "description": "The specific telemetry or execution metric to evaluate (e.g., 'latency', 'accuracy').",
+          "title": "Target Metric",
+          "type": "string"
+        },
+        "direction": {
+          "$ref": "#/$defs/OptimizationDirection",
+          "description": "Whether the algorithm should maximize or minimize this metric."
+        },
+        "weight": {
+          "default": 1.0,
+          "description": "The relative importance of this objective in a multi-objective generation.",
+          "title": "Weight",
+          "type": "number"
+        }
+      },
+      "required": [
+        "target_metric",
+        "direction"
+      ],
+      "title": "FitnessObjective",
       "type": "object"
     },
     "GitSHA": {
@@ -1804,6 +2134,30 @@
       "title": "ModelProfile",
       "type": "object"
     },
+    "MutationPolicy": {
+      "additionalProperties": false,
+      "description": "Constraints governing random heuristic mutations.",
+      "properties": {
+        "mutation_rate": {
+          "description": "The probability that a given agent parameter will randomly mutate between generations.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Mutation Rate",
+          "type": "number"
+        },
+        "temperature_shift_variance": {
+          "description": "The maximum allowed delta for an agent's temperature during mutation.",
+          "title": "Temperature Shift Variance",
+          "type": "number"
+        }
+      },
+      "required": [
+        "mutation_rate",
+        "temperature_shift_variance"
+      ],
+      "title": "MutationPolicy",
+      "type": "object"
+    },
     "NodeID": {
       "description": "Unique identifier for a node in the graph. Alphanumeric, underscores, hyphens only.",
       "examples": [
@@ -1815,6 +2169,25 @@
       "minLength": 1,
       "pattern": "^[a-zA-Z0-9_-]+$",
       "type": "string"
+    },
+    "ObservabilityPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "traces_sampled": {
+          "default": true,
+          "description": "Whether the orchestrator must record telemetry for this topology.",
+          "title": "Traces Sampled",
+          "type": "boolean"
+        },
+        "detailed_events": {
+          "default": false,
+          "description": "Whether to include granular intra-tool loop events.",
+          "title": "Detailed Events",
+          "type": "boolean"
+        }
+      },
+      "title": "ObservabilityPolicy",
+      "type": "object"
     },
     "ObservationEvent": {
       "additionalProperties": false,
@@ -1843,6 +2216,13 @@
       ],
       "title": "ObservationEvent",
       "type": "object"
+    },
+    "OptimizationDirection": {
+      "enum": [
+        "maximize",
+        "minimize"
+      ],
+      "type": "string"
     },
     "PatchOperation": {
       "enum": [
@@ -2260,6 +2640,51 @@
       "title": "SideEffectProfile",
       "type": "object"
     },
+    "SpanEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "description": "The semantic name of the event.",
+          "title": "Name",
+          "type": "string"
+        },
+        "timestamp_unix_nano": {
+          "description": "The precise temporal execution point.",
+          "title": "Timestamp Unix Nano",
+          "type": "integer"
+        },
+        "attributes": {
+          "additionalProperties": true,
+          "description": "Typed metadata bound to the event.",
+          "title": "Attributes",
+          "type": "object"
+        }
+      },
+      "required": [
+        "name",
+        "timestamp_unix_nano"
+      ],
+      "title": "SpanEvent",
+      "type": "object"
+    },
+    "SpanKind": {
+      "enum": [
+        "client",
+        "server",
+        "producer",
+        "consumer",
+        "internal"
+      ],
+      "type": "string"
+    },
+    "SpanStatusCode": {
+      "enum": [
+        "unset",
+        "ok",
+        "error"
+      ],
+      "type": "string"
+    },
     "SpanTrace": {
       "additionalProperties": false,
       "description": "An execution window span trace.",
@@ -2482,6 +2907,18 @@
           ],
           "default": null,
           "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
         },
         "type": {
           "const": "swarm",
@@ -2852,6 +3289,29 @@
         "permissions"
       ],
       "title": "ToolDefinition",
+      "type": "object"
+    },
+    "TraceExportBatch": {
+      "additionalProperties": false,
+      "properties": {
+        "batch_id": {
+          "description": "Unique identifier for this telemetry snapshot.",
+          "title": "Batch Id",
+          "type": "string"
+        },
+        "spans": {
+          "description": "A collection of execution spans to be serialized.",
+          "items": {
+            "$ref": "#/$defs/ExecutionSpan"
+          },
+          "title": "Spans",
+          "type": "array"
+        }
+      },
+      "required": [
+        "batch_id"
+      ],
+      "title": "TraceExportBatch",
       "type": "object"
     },
     "VectorEmbedding": {

--- a/src/coreason_manifest/telemetry/__init__.py
+++ b/src/coreason_manifest/telemetry/__init__.py
@@ -6,13 +6,28 @@
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
 from coreason_manifest.telemetry.custody import CustodyRecord
-from coreason_manifest.telemetry.schemas import LogEnvelope, SpanTrace
+from coreason_manifest.telemetry.schemas import (
+    ExecutionSpan,
+    LogEnvelope,
+    ObservabilityPolicy,
+    SpanEvent,
+    SpanKind,
+    SpanStatusCode,
+    SpanTrace,
+    TraceExportBatch,
+)
 from coreason_manifest.telemetry.ux import AmbientSignal, SuspenseEnvelope
 
 __all__ = [
     "AmbientSignal",
     "CustodyRecord",
+    "ExecutionSpan",
     "LogEnvelope",
+    "ObservabilityPolicy",
+    "SpanEvent",
+    "SpanKind",
+    "SpanStatusCode",
     "SpanTrace",
     "SuspenseEnvelope",
+    "TraceExportBatch",
 ]

--- a/src/coreason_manifest/telemetry/schemas.py
+++ b/src/coreason_manifest/telemetry/schemas.py
@@ -8,7 +8,7 @@
 import re
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, Field
+from pydantic import BeforeValidator, Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 
@@ -32,6 +32,51 @@ PrivacySentinel = Annotated[Any, BeforeValidator(_redact_toxic_string)]
 
 type TelemetryScalar = str | int | float | bool | None
 type MetadataDict = dict[str, TelemetryScalar | list[TelemetryScalar]]
+
+type SpanKind = Literal["client", "server", "producer", "consumer", "internal"]
+type SpanStatusCode = Literal["unset", "ok", "error"]
+
+
+class SpanEvent(CoreasonBaseModel):
+    name: str = Field(description="The semantic name of the event.")
+    timestamp_unix_nano: int = Field(description="The precise temporal execution point.")
+    attributes: dict[str, Any] = Field(default_factory=dict, description="Typed metadata bound to the event.")
+
+
+class ExecutionSpan(CoreasonBaseModel):
+    trace_id: str = Field(description="The global identifier for the entire execution causal tree.")
+    span_id: str = Field(description="The unique identifier for this specific operation.")
+    parent_span_id: str | None = Field(default=None, description="The causal link to the invoking node.")
+    name: str = Field(description="The semantic identifier for the operation.")
+    kind: SpanKind = Field(default="internal", description="The role of the span.")
+    start_time_unix_nano: int = Field(description="Temporal start bound.")
+    end_time_unix_nano: int | None = Field(default=None, description="Temporal end bound, if completed.")
+    status: SpanStatusCode = Field(default="unset", description="The execution health flag.")
+    events: list[SpanEvent] = Field(default_factory=list, description="Structured log records emitted during the span.")
+
+    @model_validator(mode="after")
+    def sort_events(self) -> Any:
+        object.__setattr__(self, "events", sorted(self.events, key=lambda e: e.timestamp_unix_nano))
+        return self
+
+
+class TraceExportBatch(CoreasonBaseModel):
+    batch_id: str = Field(description="Unique identifier for this telemetry snapshot.")
+    spans: list[ExecutionSpan] = Field(
+        default_factory=list, description="A collection of execution spans to be serialized."
+    )
+
+    @model_validator(mode="after")
+    def sort_spans(self) -> Any:
+        object.__setattr__(self, "spans", sorted(self.spans, key=lambda s: s.span_id))
+        return self
+
+
+class ObservabilityPolicy(CoreasonBaseModel):
+    traces_sampled: bool = Field(
+        default=True, description="Whether the orchestrator must record telemetry for this topology."
+    )
+    detailed_events: bool = Field(default=False, description="Whether to include granular intra-tool loop events.")
 
 
 class LogEnvelope(CoreasonBaseModel):

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -13,6 +13,7 @@ from coreason_manifest.compute.stochastic import CrossoverStrategy, FitnessObjec
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
 from coreason_manifest.oversight.dlp import InformationFlowPolicy
+from coreason_manifest.telemetry.schemas import ObservabilityPolicy
 from coreason_manifest.workflow.auctions import AuctionPolicy
 from coreason_manifest.workflow.nodes import AnyNode
 
@@ -74,6 +75,9 @@ class BaseTopology(CoreasonBaseModel):
         default=None,
         description="The structural Data Loss Prevention (DLP) contract governing all state mutations in this "
         "topology.",
+    )
+    observability: ObservabilityPolicy | None = Field(
+        default=None, description="The distributed tracing rules bound to this specific execution graph."
     )
 
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -20,6 +20,7 @@ from coreason_manifest.state.semantic import (
     TemporalBounds,
     VectorEmbedding,
 )
+from coreason_manifest.telemetry.schemas import ExecutionSpan, SpanEvent, TraceExportBatch
 from coreason_manifest.testing.chaos import ChaosExperiment, FaultInjectionProfile, SteadyStateHypothesis
 from coreason_manifest.tooling import ActionSpace, PermissionBoundary, SideEffectProfile, ToolDefinition
 from coreason_manifest.workflow.auctions import AgentBid, AuctionState, TaskAnnouncement
@@ -49,6 +50,32 @@ def test_workflow_envelope_determinism() -> None:
 
     assert env1.model_dump_canonical() == env2.model_dump_canonical()
     assert hash(env1) == hash(env2)
+
+
+def test_telemetry_determinism() -> None:
+    event_late = SpanEvent(name="late_event", timestamp_unix_nano=200, attributes={})
+    event_early = SpanEvent(name="early_event", timestamp_unix_nano=100, attributes={})
+
+    span_b = ExecutionSpan(
+        trace_id="t1",
+        span_id="s_b",
+        name="span_b",
+        start_time_unix_nano=100,
+        events=[event_late, event_early],
+    )
+    span_a = ExecutionSpan(
+        trace_id="t1",
+        span_id="s_a",
+        name="span_a",
+        start_time_unix_nano=100,
+        events=[event_early, event_late],
+    )
+
+    batch1 = TraceExportBatch(batch_id="b1", spans=[span_a, span_b])
+    batch2 = TraceExportBatch(batch_id="b1", spans=[span_b, span_a])
+
+    assert batch1.model_dump_canonical() == batch2.model_dump_canonical()
+    assert hash(batch1) == hash(batch2)
 
 
 def test_evolutionary_determinism() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -26,6 +26,7 @@ from coreason_manifest.state.argumentation import ArgumentGraph
 from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, ObservationEvent, SystemFaultEvent
 from coreason_manifest.state.memory import EpistemicLedger
 from coreason_manifest.state.semantic import SemanticEdge, SemanticNode
+from coreason_manifest.telemetry.schemas import TraceExportBatch
 from coreason_manifest.testing.chaos import ChaosExperiment
 from coreason_manifest.tooling import ActionSpace, ToolDefinition
 from coreason_manifest.workflow.auctions import AuctionState
@@ -233,14 +234,28 @@ def draw_crossover_strategy(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
-def draw_evolutionary_topology_payload(draw: Any) -> dict[str, Any]:
+def draw_observability_policy(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "traces_sampled": st.booleans(),
+                "detailed_events": st.booleans(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_evolutionary_topology_payload(draw: Any) -> dict[str, Any]:
+    payload: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "type": st.just("evolutionary"),
                 "nodes": st.just({}),  # For simplicity, empty nodes
                 "shared_state_contract": st.none(),
                 "information_flow": st.none(),
+                "observability": st.one_of(st.none(), draw_observability_policy()),
                 "generations": st.integers(min_value=1),
                 "population_size": st.integers(min_value=1),
                 "mutation": draw_mutation_policy(),
@@ -249,7 +264,7 @@ def draw_evolutionary_topology_payload(draw: Any) -> dict[str, Any]:
             }
         )
     )
-    return res
+    return payload
 
 
 topology_adapter: TypeAdapter[AnyTopology] = TypeAdapter(AnyTopology)
@@ -881,3 +896,59 @@ def draw_epistemic_ledger(draw: Any) -> dict[str, Any]:
 def test_differentials_routing(payload: dict[str, Any]) -> None:
     parsed = epistemic_ledger_adapter.validate_python(payload)
     assert isinstance(parsed, EpistemicLedger)
+
+
+@st.composite
+def draw_span_event(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "name": st.text(min_size=1),
+                "timestamp_unix_nano": st.integers(min_value=0),
+                "attributes": st.dictionaries(st.text(), st.one_of(st.text(), st.integers(), st.booleans())),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_execution_span(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "trace_id": st.text(min_size=1),
+                "span_id": st.text(min_size=1),
+                "parent_span_id": st.one_of(st.none(), st.text(min_size=1)),
+                "name": st.text(min_size=1),
+                "kind": st.sampled_from(["client", "server", "producer", "consumer", "internal"]),
+                "start_time_unix_nano": st.integers(min_value=0),
+                "end_time_unix_nano": st.one_of(st.none(), st.integers(min_value=0)),
+                "status": st.sampled_from(["unset", "ok", "error"]),
+                "events": st.lists(draw_span_event()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_trace_export_batch(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "batch_id": st.text(min_size=1),
+                "spans": st.lists(draw_execution_span()),
+            }
+        )
+    )
+    return res
+
+
+trace_export_batch_adapter: TypeAdapter[TraceExportBatch] = TypeAdapter(TraceExportBatch)
+
+
+@given(draw_trace_export_batch())
+def test_telemetry_routing(payload: dict[str, Any]) -> None:
+    parsed = trace_export_batch_adapter.validate_python(payload)
+    assert isinstance(parsed, TraceExportBatch)


### PR DESCRIPTION
- **Epic 23:** Introduces Normalized Protocol Observability (Distributed Tracing).
- Defined type aliases (`SpanKind`, `SpanStatusCode`) and structural models (`SpanEvent`, `ExecutionSpan`, `TraceExportBatch`, `ObservabilityPolicy`) natively in Python 3.14 syntax without future annotations.
- Implemented `model_validator(mode="after")` bypasses using `object.__setattr__` on execution arrays to sort and ensure cryptographic determinism despite asynchronous network jitter.
- Integrated `ObservabilityPolicy` into `BaseTopology` to universally govern multi-agent graphs.
- Developed robust composite generators and implemented deep topological fuzzing (`test_telemetry_routing`).
- Provided mathematical proofs in `test_determinism.py` that out-of-order `SpanEvent` and `ExecutionSpan` ingestions safely resolve to identical hashes.
- Successfully verified using SOTA formatter (`ruff format`) and native typing constructs.

---
*PR created automatically by Jules for task [16483633986952793549](https://jules.google.com/task/16483633986952793549) started by @gowthamrao*