### PR TITLE
feat(core): add foundational StrEnum types

### DIFF
--- a/src/coreason_manifest/core/__init__.py
+++ b/src/coreason_manifest/core/__init__.py
@@ -6,6 +6,20 @@
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
 from .base import CoreasonBaseModel
+from .enums import (
+    CrossoverType,
+    DistributionType,
+    EncodingChannel,
+    InterventionTrigger,
+    MarkType,
+    NodeType,
+    OptimizationDirection,
+    PatchOperation,
+    ScaleType,
+    SpanKind,
+    SpanStatusCode,
+    TopologyType,
+)
 from .primitives import (
     DataClassification,
     GitSHA,
@@ -19,12 +33,24 @@ from .primitives import (
 
 __all__ = [
     "CoreasonBaseModel",
+    "CrossoverType",
     "DataClassification",
+    "DistributionType",
+    "EncodingChannel",
     "GitSHA",
+    "InterventionTrigger",
+    "MarkType",
     "NodeID",
+    "NodeType",
+    "OptimizationDirection",
+    "PatchOperation",
     "ProfileID",
     "RiskLevel",
+    "ScaleType",
     "SemanticVersion",
+    "SpanKind",
+    "SpanStatusCode",
     "SystemRole",
     "ToolID",
+    "TopologyType",
 ]

--- a/src/coreason_manifest/core/enums.py
+++ b/src/coreason_manifest/core/enums.py
@@ -1,0 +1,91 @@
+from enum import StrEnum
+
+
+class NodeType(StrEnum):
+    AGENT = "agent"
+    HUMAN = "human"
+    SYSTEM = "system"
+    SANDBOXED = "sandboxed"
+
+
+class TopologyType(StrEnum):
+    DAG = "dag"
+    COUNCIL = "council"
+    SWARM = "swarm"
+    EVOLUTIONARY = "evolutionary"
+
+
+class PatchOperation(StrEnum):
+    ADD = "add"
+    REMOVE = "remove"
+    REPLACE = "replace"
+    COPY = "copy"
+    MOVE = "move"
+    TEST = "test"
+
+
+class InterventionTrigger(StrEnum):
+    ON_START = "on_start"
+    ON_NODE_TRANSITION = "on_node_transition"
+    BEFORE_TOOL_EXECUTION = "before_tool_execution"
+    ON_FAILURE = "on_failure"
+    ON_CONSENSUS_REACHED = "on_consensus_reached"
+    ON_MAX_LOOPS_REACHED = "on_max_loops_reached"
+
+
+class SpanKind(StrEnum):
+    CLIENT = "client"
+    SERVER = "server"
+    PRODUCER = "producer"
+    CONSUMER = "consumer"
+    INTERNAL = "internal"
+
+
+class SpanStatusCode(StrEnum):
+    UNSET = "unset"
+    OK = "ok"
+    ERROR = "error"
+
+
+class DistributionType(StrEnum):
+    GAUSSIAN = "gaussian"
+    UNIFORM = "uniform"
+    BETA = "beta"
+
+
+class OptimizationDirection(StrEnum):
+    MAXIMIZE = "maximize"
+    MINIMIZE = "minimize"
+
+
+class CrossoverType(StrEnum):
+    UNIFORM_BLEND = "uniform_blend"
+    SINGLE_POINT = "single_point"
+    HEURISTIC = "heuristic"
+
+
+class MarkType(StrEnum):
+    POINT = "point"
+    LINE = "line"
+    AREA = "area"
+    BAR = "bar"
+    RECT = "rect"
+    ARC = "arc"
+
+
+class ScaleType(StrEnum):
+    LINEAR = "linear"
+    LOG = "log"
+    TIME = "time"
+    ORDINAL = "ordinal"
+    NOMINAL = "nominal"
+
+
+class EncodingChannel(StrEnum):
+    X = "x"
+    Y = "y"
+    COLOR = "color"
+    SIZE = "size"
+    OPACITY = "opacity"
+    SHAPE = "shape"
+    TEXT = "text"


### PR DESCRIPTION
Added strictly-typed `StrEnum` foundation to eventually replace magic string `Literal` types across the data plane.

Included Enums:
- `NodeType`
- `TopologyType`
- `PatchOperation`
- `InterventionTrigger`
- `SpanKind`
- `SpanStatusCode`
- `DistributionType`
- `OptimizationDirection`
- `CrossoverType`
- `MarkType`
- `ScaleType`
- `EncodingChannel`

---
*PR created automatically by Jules for task [15522222581260887405](https://jules.google.com/task/15522222581260887405) started by @gowthamrao*