### PR TITLE
feat: upgrade state structures for lossless semantic memory (Epic 28)

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -570,11 +570,30 @@
           "description": "Discriminator type for a belief update event.",
           "title": "Type",
           "type": "string"
+        },
+        "payload": {
+          "additionalProperties": true,
+          "description": "The semantic representation of the agent's internal cognitive shift or synthesis.",
+          "title": "Payload",
+          "type": "object"
+        },
+        "source_node_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeID"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific topological node that synthesized this belief update."
         }
       },
       "required": [
         "event_id",
-        "timestamp"
+        "timestamp",
+        "payload"
       ],
       "title": "BeliefUpdateEvent",
       "type": "object"
@@ -2213,11 +2232,30 @@
           "description": "Discriminator type for an observation event.",
           "title": "Type",
           "type": "string"
+        },
+        "payload": {
+          "additionalProperties": true,
+          "description": "The raw, lossless semantic output captured from the environment or tool execution.",
+          "title": "Payload",
+          "type": "object"
+        },
+        "source_node_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeID"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific topological node that generated this observation."
         }
       },
       "required": [
         "event_id",
-        "timestamp"
+        "timestamp",
+        "payload"
       ],
       "title": "ObservationEvent",
       "type": "object"

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -5,11 +5,12 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.core.primitives import NodeID
 
 
 class BaseStateEvent(CoreasonBaseModel):
@@ -21,13 +22,23 @@ class ObservationEvent(BaseStateEvent):
     type: Literal["observation"] = Field(
         default="observation", description="Discriminator type for an observation event."
     )
-    # Adding arbitrary payload to make it useful, even though not explicitly asked,
-    # to be safe, I'll just stick strictly to the requested structure or minimalist
+    payload: dict[str, Any] = Field(
+        description="The raw, lossless semantic output captured from the environment or tool execution."
+    )
+    source_node_id: NodeID | None = Field(
+        default=None, description="The specific topological node that generated this observation."
+    )
 
 
 class BeliefUpdateEvent(BaseStateEvent):
     type: Literal["belief_update"] = Field(
         default="belief_update", description="Discriminator type for a belief update event."
+    )
+    payload: dict[str, Any] = Field(
+        description="The semantic representation of the agent's internal cognitive shift or synthesis."
+    )
+    source_node_id: NodeID | None = Field(
+        default=None, description="The specific topological node that synthesized this belief update."
     )
 
 

--- a/tests/domains/test_state_memory.py
+++ b/tests/domains/test_state_memory.py
@@ -18,11 +18,18 @@ def state_event_strategy(draw: st.DrawFn) -> AnyStateEvent:
     event_type = draw(st.sampled_from(["observation", "belief_update", "system_fault"]))
     event_id = draw(st.text(min_size=1, max_size=50))
     timestamp = draw(st.floats(min_value=0.0, max_value=1e10, allow_nan=False, allow_infinity=False))
+    payload = draw(
+        st.dictionaries(
+            st.text(),
+            st.one_of(st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False), st.booleans()),
+            max_size=5,
+        )
+    )
 
     if event_type == "observation":
-        return ObservationEvent(event_id=event_id, timestamp=timestamp, type="observation")
+        return ObservationEvent(event_id=event_id, timestamp=timestamp, type="observation", payload=payload)
     if event_type == "belief_update":
-        return BeliefUpdateEvent(event_id=event_id, timestamp=timestamp, type="belief_update")
+        return BeliefUpdateEvent(event_id=event_id, timestamp=timestamp, type="belief_update", payload=payload)
     return SystemFaultEvent(event_id=event_id, timestamp=timestamp, type="system_fault")
 
 

--- a/tests/test_concurrency.py
+++ b/tests/test_concurrency.py
@@ -48,9 +48,9 @@ def instantiate_and_hash(index: int) -> tuple[int, int, int]:
 
     # StateEvent
     if index % 3 == 0:
-        event: Any = ObservationEvent(event_id=f"ev_{index}", timestamp=index * 1.5)
+        event: Any = ObservationEvent(event_id=f"ev_{index}", timestamp=index * 1.5, payload={})
     elif index % 3 == 1:
-        event = BeliefUpdateEvent(event_id=f"ev_{index}", timestamp=index * 1.5)
+        event = BeliefUpdateEvent(event_id=f"ev_{index}", timestamp=index * 1.5, payload={})
     else:
         event = SystemFaultEvent(event_id=f"ev_{index}", timestamp=index * 1.5)
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -244,14 +244,25 @@ def test_presentation_envelope_determinism() -> None:
 
 
 def test_epistemic_ledger_determinism() -> None:
-    event1 = ObservationEvent(event_id="obs_1", timestamp=100.0)
-    event2 = ObservationEvent(event_id="obs_2", timestamp=200.0)
+    event1 = ObservationEvent(event_id="obs_1", timestamp=100.0, payload={})
+    event2 = ObservationEvent(event_id="obs_2", timestamp=200.0, payload={})
 
     ledger1 = EpistemicLedger(history=[event1, event2])
     ledger2 = EpistemicLedger(history=[event1, event2])
 
     assert ledger1.model_dump_canonical() == ledger2.model_dump_canonical()
     assert hash(ledger1) == hash(ledger2)
+
+
+def test_epistemic_payload_canonical_hashing() -> None:
+    data = {"temperature": 72, "humidity": 0.5, "status": "nominal"}
+    scrambled_data = {"status": "nominal", "temperature": 72, "humidity": 0.5}
+
+    event_a = ObservationEvent(event_id="obs_1", timestamp=100.0, payload=data)
+    event_b = ObservationEvent(event_id="obs_1", timestamp=100.0, payload=scrambled_data)
+
+    assert hash(event_a) == hash(event_b)
+    assert event_a.model_dump_canonical() == event_b.model_dump_canonical()
 
 
 def test_semantic_memory_determinism() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -285,14 +285,39 @@ def test_anytopology_routing(payload: dict[str, Any]) -> None:
     assert parsed.type == "evolutionary"
 
 
-@given(
-    st.sampled_from(["observation", "belief_update", "system_fault"]),
-    st.text(),
-    st.floats(allow_nan=False, allow_infinity=False),
-)
-def test_anystateevent_routing(event_type: str, event_id: str, timestamp: float) -> None:
-    payload = {"type": event_type, "event_id": event_id, "timestamp": timestamp}
+@st.composite
+def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
+    event_type = draw(st.sampled_from(["observation", "belief_update", "system_fault"]))
+    payload: dict[str, Any] = {
+        "type": event_type,
+        "event_id": draw(st.text()),
+        "timestamp": draw(st.floats(allow_nan=False, allow_infinity=False)),
+    }
+    if event_type in ("observation", "belief_update"):
+        payload["payload"] = draw(
+            st.dictionaries(
+                st.text(),
+                st.one_of(st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False), st.booleans()),
+                max_size=5,
+            )
+        )
+        payload["source_node_id"] = draw(
+            st.one_of(
+                st.none(),
+                st.text(
+                    min_size=1,
+                    max_size=128,
+                    alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-",
+                ),
+            )
+        )
+    return payload
+
+
+@given(_local_draw_any_state_event())
+def test_anystateevent_routing(payload: dict[str, Any]) -> None:
     parsed = event_adapter.validate_python(payload)
+    event_type = payload["type"]
     if event_type == "observation":
         assert isinstance(parsed, ObservationEvent)
     elif event_type == "belief_update":
@@ -876,13 +901,7 @@ epistemic_ledger_adapter: TypeAdapter[EpistemicLedger] = TypeAdapter(EpistemicLe
 
 @st.composite
 def draw_any_state_event(draw: Any) -> dict[str, Any]:
-    event_type = draw(st.sampled_from(["observation", "belief_update", "system_fault"]))
-    payload: dict[str, Any] = {
-        "type": event_type,
-        "event_id": draw(st.text()),
-        "timestamp": draw(st.floats(allow_nan=False, allow_infinity=False)),
-    }
-    return payload
+    return draw(_local_draw_any_state_event())
 
 
 @st.composite

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -901,7 +901,8 @@ epistemic_ledger_adapter: TypeAdapter[EpistemicLedger] = TypeAdapter(EpistemicLe
 
 @st.composite
 def draw_any_state_event(draw: Any) -> dict[str, Any]:
-    return draw(_local_draw_any_state_event())
+    res: dict[str, Any] = draw(_local_draw_any_state_event())
+    return res
 
 
 @st.composite


### PR DESCRIPTION
In this change, I upgraded the state structures (`ObservationEvent` and `BeliefUpdateEvent`) in `src/coreason_manifest/state/events.py` to capture lossless semantic data (`payload: dict[str, Any]`) and track its source (`source_node_id: NodeID | None`), completing Epic 28.

As part of this epic:
- I ensured the orthogonal firewall is maintained: there are absolutely no cross imports between the `state` (Epistemology) and `telemetry` (OpenTelemetry/IT Control Plane) modules.
- I updated the generative fuzzer tests (`tests/test_fuzzing.py`) to properly generate constrained dictionaries for the `payload` using `st.dictionaries`, avoiding infinite recursion and OOM errors.
- I wrote a mathematical proof in `tests/test_determinism.py` to demonstrate that `CoreasonBaseModel`'s RFC 8785 canonical serialization handles scrambled dictionary payloads losslessly and deterministically.
- I also successfully ran validation commands (linters and pytest) to ensure regressions weren't introduced.

---
*PR created automatically by Jules for task [4224106690001063781](https://jules.google.com/task/4224106690001063781) started by @gowthamrao*