### PR TITLE
Formal Governance Rulesets Integration

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -837,6 +837,52 @@
       "title": "ComputeProvisioningRequest",
       "type": "object"
     },
+    "ConsensusPolicy": {
+      "additionalProperties": false,
+      "description": "Explicit ruleset governing how a council resolves disagreements.",
+      "properties": {
+        "strategy": {
+          "description": "The mathematical rule for reaching agreement.",
+          "enum": [
+            "unanimous",
+            "majority",
+            "debate_rounds"
+          ],
+          "title": "Strategy",
+          "type": "string"
+        },
+        "tie_breaker_node_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeID"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The node authorized to break deadlocks if unanimity or majority fails."
+        },
+        "max_debate_rounds": {
+          "anyOf": [
+            {
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum number of argument/rebuttal cycles permitted before forced adjudication.",
+          "title": "Max Debate Rounds"
+        }
+      },
+      "required": [
+        "strategy"
+      ],
+      "title": "ConsensusPolicy",
+      "type": "object"
+    },
     "ConstitutionalRule": {
       "additionalProperties": false,
       "description": "Defines a constitutional rule for AI governance.",
@@ -955,6 +1001,18 @@
           ],
           "default": null,
           "description": "Constraints enforcing cognitive heterogeneity across the council."
+        },
+        "consensus_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConsensusPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The explicit ruleset governing how the council resolves disagreements."
         }
       },
       "required": [
@@ -1635,6 +1693,18 @@
           ],
           "title": "Timeout Action",
           "type": "string"
+        },
+        "escalation_target_node_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeID"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific NodeID to route the execution to if the escalate action is triggered."
         }
       },
       "required": [
@@ -2398,6 +2468,65 @@
         "parent_key"
       ],
       "title": "OutputMapping",
+      "type": "object"
+    },
+    "OverrideIntent": {
+      "additionalProperties": false,
+      "description": "Dictatorial oversight override payload.",
+      "properties": {
+        "type": {
+          "const": "override",
+          "default": "override",
+          "description": "The type of the intervention payload.",
+          "title": "Type",
+          "type": "string"
+        },
+        "authorized_node_id": {
+          "$ref": "#/$defs/NodeID",
+          "description": "The NodeID of the human or agent executing the override."
+        },
+        "target_node_id": {
+          "$ref": "#/$defs/NodeID",
+          "description": "The NodeID being forcefully overridden."
+        },
+        "override_action": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "description": "The exact payload forcefully injected into the state.",
+          "title": "Override Action",
+          "type": "object"
+        },
+        "justification": {
+          "description": "Cryptographic audit justification for bypassing algorithmic consensus.",
+          "maxLength": 2000,
+          "title": "Justification",
+          "type": "string"
+        }
+      },
+      "required": [
+        "authorized_node_id",
+        "target_node_id",
+        "override_action",
+        "justification"
+      ],
+      "title": "OverrideIntent",
       "type": "object"
     },
     "PatchOperation": {

--- a/src/coreason_manifest/oversight/__init__.py
+++ b/src/coreason_manifest/oversight/__init__.py
@@ -7,7 +7,7 @@
 
 from .adjudication import AdjudicationRubric, AdjudicationVerdict, GradingCriteria
 from .dlp import DataClassification, InformationFlowPolicy, RedactionRule, SanitizationAction, SecureSubSession
-from .governance import ConstitutionalRule, GlobalGovernance, GovernancePolicy
+from .governance import ConsensusPolicy, ConstitutionalRule, GlobalGovernance, GovernancePolicy
 from .intervention import (
     AnyInterventionPayload,
     BoundedInterventionScope,
@@ -16,6 +16,7 @@ from .intervention import (
     InterventionRequest,
     InterventionVerdict,
     LifecycleTrigger,
+    OverrideIntent,
 )
 from .resilience import AnyResiliencePayload, CircuitBreakerTrip, FallbackTrigger, QuarantineOrder
 
@@ -26,6 +27,7 @@ __all__ = [
     "AnyResiliencePayload",
     "BoundedInterventionScope",
     "CircuitBreakerTrip",
+    "ConsensusPolicy",
     "ConstitutionalRule",
     "DataClassification",
     "FallbackSLA",
@@ -38,6 +40,7 @@ __all__ = [
     "InterventionRequest",
     "InterventionVerdict",
     "LifecycleTrigger",
+    "OverrideIntent",
     "QuarantineOrder",
     "RedactionRule",
     "SanitizationAction",

--- a/src/coreason_manifest/oversight/governance.py
+++ b/src/coreason_manifest/oversight/governance.py
@@ -10,7 +10,7 @@ from typing import Annotated, Literal
 from pydantic import Field, StringConstraints
 
 from coreason_manifest.core.base import CoreasonBaseModel
-from coreason_manifest.core.primitives import SemanticVersion
+from coreason_manifest.core.primitives import NodeID, SemanticVersion
 
 
 class ConstitutionalRule(CoreasonBaseModel):
@@ -36,6 +36,23 @@ class GovernancePolicy(CoreasonBaseModel):
     policy_name: str = Field(description="Name of the governance policy.")
     version: SemanticVersion = Field(description="Semantic version of the governance policy.")
     rules: list[ConstitutionalRule] = Field(description="List of constitutional rules included in this policy.")
+
+
+class ConsensusPolicy(CoreasonBaseModel):
+    """
+    Explicit ruleset governing how a council resolves disagreements.
+    """
+
+    strategy: Literal["unanimous", "majority", "debate_rounds"] = Field(
+        description="The mathematical rule for reaching agreement."
+    )
+    tie_breaker_node_id: NodeID | None = Field(
+        default=None, description="The node authorized to break deadlocks if unanimity or majority fails."
+    )
+    max_debate_rounds: int | None = Field(
+        default=None,
+        description="The maximum number of argument/rebuttal cycles permitted before forced adjudication.",
+    )
 
 
 class GlobalGovernance(CoreasonBaseModel):

--- a/src/coreason_manifest/oversight/intervention.py
+++ b/src/coreason_manifest/oversight/intervention.py
@@ -62,6 +62,9 @@ class FallbackSLA(CoreasonBaseModel):
     timeout_action: Literal["fail_safe", "proceed_with_defaults", "escalate"] = Field(
         description="The action to take when the timeout expires."
     )
+    escalation_target_node_id: NodeID | None = Field(
+        default=None, description="The specific NodeID to route the execution to if the escalate action is triggered."
+    )
 
 
 class InterventionRequest(CoreasonBaseModel):
@@ -93,4 +96,22 @@ class InterventionVerdict(CoreasonBaseModel):
     feedback: str | None = Field(description="Optional feedback provided along with the verdict.")
 
 
-type AnyInterventionPayload = Annotated[InterventionRequest | InterventionVerdict, Field(discriminator="type")]
+class OverrideIntent(CoreasonBaseModel):
+    """
+    Dictatorial oversight override payload.
+    """
+
+    type: Literal["override"] = Field(default="override", description="The type of the intervention payload.")
+    authorized_node_id: NodeID = Field(description="The NodeID of the human or agent executing the override.")
+    target_node_id: NodeID = Field(description="The NodeID being forcefully overridden.")
+    override_action: dict[str, str | int | float | bool | None] = Field(
+        description="The exact payload forcefully injected into the state."
+    )
+    justification: str = Field(
+        max_length=2000, description="Cryptographic audit justification for bypassing algorithmic consensus."
+    )
+
+
+type AnyInterventionPayload = Annotated[
+    InterventionRequest | InterventionVerdict | OverrideIntent, Field(discriminator="type")
+]

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -13,6 +13,7 @@ from coreason_manifest.compute.stochastic import CrossoverStrategy, FitnessObjec
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
 from coreason_manifest.oversight.dlp import InformationFlowPolicy
+from coreason_manifest.oversight.governance import ConsensusPolicy
 from coreason_manifest.telemetry.schemas import ObservabilityPolicy
 from coreason_manifest.workflow.auctions import AuctionPolicy
 from coreason_manifest.workflow.nodes import AnyNode
@@ -152,6 +153,9 @@ class CouncilTopology(BaseTopology):
     adjudicator_id: NodeID = Field(description="The NodeID of the adjudicator that synthesizes the council's output.")
     diversity_policy: DiversityConstraint | None = Field(
         default=None, description="Constraints enforcing cognitive heterogeneity across the council."
+    )
+    consensus_policy: ConsensusPolicy | None = Field(
+        default=None, description="The explicit ruleset governing how the council resolves disagreements."
     )
 
     @model_validator(mode="after")

--- a/tests/domains/test_oversight_governance.py
+++ b/tests/domains/test_oversight_governance.py
@@ -79,6 +79,9 @@ def test_constitutional_rule_deduplicates_or_rejects_duplicate_strings(forbidden
     context_summary=st.text(),
     proposed_action=st.dictionaries(st.text(), st.integers()),
     adjudication_deadline=st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
+    escalation_target_node_id=st.one_of(
+        st.none(), st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-")
+    ),
 )
 def test_sandbox_success_massive_configs(
     allowed_fields: list[str],
@@ -87,6 +90,7 @@ def test_sandbox_success_massive_configs(
     context_summary: str,
     proposed_action: dict[str, int],
     adjudication_deadline: float,
+    escalation_target_node_id: str | None,
 ) -> None:
     scope = BoundedInterventionScope(
         allowed_fields=allowed_fields,
@@ -95,6 +99,7 @@ def test_sandbox_success_massive_configs(
     sla = FallbackSLA(
         timeout_seconds=timeout_seconds,
         timeout_action="fail_safe",
+        escalation_target_node_id=escalation_target_node_id,
     )
     req = InterventionRequest(
         intervention_scope=scope,

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -14,7 +14,13 @@ from pydantic import TypeAdapter, ValidationError
 
 from coreason_manifest.oversight.dlp import InformationFlowPolicy
 from coreason_manifest.oversight.governance import GlobalGovernance
-from coreason_manifest.oversight.intervention import InterventionPolicy
+from coreason_manifest.oversight.intervention import (
+    AnyInterventionPayload,
+    InterventionPolicy,
+    InterventionRequest,
+    InterventionVerdict,
+    OverrideIntent,
+)
 from coreason_manifest.oversight.resilience import (
     AnyResiliencePayload,
     CircuitBreakerTrip,
@@ -171,10 +177,25 @@ def draw_output_mapping(draw: Any) -> dict[str, Any]:
     return {"child_key": draw(st.text()), "parent_key": draw(st.text())}
 
 
+@st.composite
+def draw_consensus_policy(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "strategy": st.sampled_from(["unanimous", "majority", "debate_rounds"]),
+                "tie_breaker_node_id": st.one_of(
+                    st.none(),
+                    st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"),
+                ),
+                "max_debate_rounds": st.one_of(st.none(), st.integers(min_value=1, max_value=100)),
+            }
+        )
+    )
+    return res
+
+
 def draw_topology_payload(nodes_strategy: st.SearchStrategy[dict[str, Any]]) -> st.SearchStrategy[dict[str, Any]]:
-    # Instead of defining a complex topology that needs many other policies not yet defined,
-    # we just define a simple DAG topology. NodeID pattern requires '^[a-zA-Z0-9_-]+$'
-    return st.fixed_dictionaries(
+    dag_strategy = st.fixed_dictionaries(
         {
             "type": st.just("dag"),
             "nodes": st.dictionaries(
@@ -190,6 +211,38 @@ def draw_topology_payload(nodes_strategy: st.SearchStrategy[dict[str, Any]]) -> 
             "backpressure": st.none(),
         }
     )
+
+    # To satisfy the model_validator `check_adjudicator_id` in `CouncilTopology`,
+    # `adjudicator_id` MUST be present in `nodes`.
+    # Let's write a small map strategy to ensure `adjudicator_id` is a key in `nodes`.
+    def _council_mapper(payload: dict[str, Any]) -> dict[str, Any]:
+        if not payload["nodes"]:
+            return payload
+        # Pick the first node ID as the adjudicator_id
+        payload["adjudicator_id"] = next(iter(payload["nodes"].keys()))
+        return payload
+
+    council_strategy = st.fixed_dictionaries(
+        {
+            "type": st.just("council"),
+            "nodes": st.dictionaries(
+                st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"),
+                nodes_strategy,
+                min_size=1,
+                max_size=5,
+            ),
+            "shared_state_contract": st.none(),
+            "information_flow": st.none(),
+            "observability": st.none(),
+            "adjudicator_id": st.text(
+                min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+            ),
+            "diversity_policy": st.none(),
+            "consensus_policy": st.one_of(st.none(), draw_consensus_policy()),
+        }
+    ).map(_council_mapper)
+
+    return st.one_of(dag_strategy, council_strategy)
 
 
 def draw_composite_node_payload(
@@ -1089,3 +1142,83 @@ def test_custody_routing(payload: dict[str, Any]) -> None:
 @given(draw_trace_export_batch())
 def test_telemetry_routing(payload: dict[str, Any]) -> None:
     trace_export_batch_adapter.validate_python(payload)
+
+
+@st.composite
+def draw_override_intent(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("override"),
+                "authorized_node_id": st.text(
+                    min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                ),
+                "target_node_id": st.text(
+                    min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                ),
+                "override_action": st.dictionaries(
+                    st.text(), st.one_of(st.text(), st.integers(), st.floats(), st.booleans(), st.none())
+                ),
+                "justification": st.text(max_size=2000),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_intervention_request(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("request"),
+                "intervention_scope": st.none(),
+                "fallback_sla": st.none(),
+                "target_node_id": st.text(
+                    min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                ),
+                "context_summary": st.text(),
+                "proposed_action": st.dictionaries(
+                    st.text(), st.one_of(st.text(), st.integers(), st.floats(), st.booleans(), st.none())
+                ),
+                "adjudication_deadline": st.floats(allow_nan=False, allow_infinity=False),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_intervention_verdict(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("verdict"),
+                "target_node_id": st.text(
+                    min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                ),
+                "approved": st.booleans(),
+                "feedback": st.one_of(st.none(), st.text()),
+            }
+        )
+    )
+    return res
+
+
+def draw_any_intervention_payload() -> st.SearchStrategy[dict[str, Any]]:
+    return st.one_of(draw_intervention_request(), draw_intervention_verdict(), draw_override_intent())
+
+
+intervention_payload_adapter: TypeAdapter[AnyInterventionPayload] = TypeAdapter(AnyInterventionPayload)
+
+
+@given(draw_any_intervention_payload())
+def test_anyinterventionpayload_routing(payload: dict[str, Any]) -> None:
+    parsed = intervention_payload_adapter.validate_python(payload)
+    payload_type = payload["type"]
+    if payload_type == "request":
+        assert isinstance(parsed, InterventionRequest)
+    elif payload_type == "verdict":
+        assert isinstance(parsed, InterventionVerdict)
+    elif payload_type == "override":
+        assert isinstance(parsed, OverrideIntent)


### PR DESCRIPTION
Formalize governance rulesets by repairing routing dead-ends in `FallbackSLA`, introducing explicit consensus mechanics for `CouncilTopology`, and creating an administrative `OverrideIntent` vector. Also integrates comprehensive fuzzing tests to ensure robust validation.

---
*PR created automatically by Jules for task [7588597667853387896](https://jules.google.com/task/7588597667853387896) started by @gowthamrao*