### PR TITLE
test(workflow): add adversarial synthetic suite for CWE-674 memory immunity

### DIFF
--- a/test_mypy.py
+++ b/test_mypy.py
@@ -1,4 +1,0 @@
-from pydantic import TypeAdapter
-from coreason_manifest.workflow.topologies import AnyTopology
-
-topology_adapter: TypeAdapter[AnyTopology] = TypeAdapter(AnyTopology)

--- a/test_mypy.py
+++ b/test_mypy.py
@@ -1,0 +1,4 @@
+from pydantic import TypeAdapter
+from coreason_manifest.workflow.topologies import AnyTopology
+
+topology_adapter: TypeAdapter[AnyTopology] = TypeAdapter(AnyTopology)

--- a/tests/test_graph_overflow.py
+++ b/tests/test_graph_overflow.py
@@ -1,0 +1,46 @@
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from coreason_manifest.workflow.topologies import AnyTopology
+
+topology_adapter = TypeAdapter(AnyTopology)
+
+
+def test_cwe_674_deep_linear_chain() -> None:
+    """
+    Prove that a 5000-deep linear chain can be validated without RecursionError.
+    """
+    payload = {
+        "type": "dag",
+        "nodes": {f"node_{i}": {"type": "system", "description": "pass"} for i in range(5000)},
+        "edges": [(f"node_{i}", f"node_{i + 1}") for i in range(4999)],
+        "allow_cycles": False,
+    }
+
+    # This should succeed and not raise any exception.
+    # If the DFS implementation is recursive instead of iterative,
+    # this will raise a RecursionError because the default limit is 1000.
+    topology_adapter.validate_python(payload)
+
+
+def test_cwe_674_deep_cycle_detection() -> None:
+    """
+    Prove that a 5000-deep graph containing a cycle raises a ValidationError
+    without causing a RecursionError or hanging.
+    """
+    edges = [(f"node_{i}", f"node_{i + 1}") for i in range(4999)]
+    # Connect the tail to the head to create a loop-back cycle
+    edges.append(("node_4999", "node_0"))
+
+    payload = {
+        "type": "dag",
+        "nodes": {f"node_{i}": {"type": "system", "description": "pass"} for i in range(5000)},
+        "edges": edges,
+        "allow_cycles": False,
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        topology_adapter.validate_python(payload)
+
+    # Verify the error message proves the DFS safely traversed the graph and found the cycle
+    assert "Graph contains cycles" in str(exc_info.value)

--- a/tests/test_graph_overflow.py
+++ b/tests/test_graph_overflow.py
@@ -3,7 +3,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from coreason_manifest.workflow.topologies import AnyTopology
 
-topology_adapter = TypeAdapter(AnyTopology)
+topology_adapter: TypeAdapter[AnyTopology] = TypeAdapter(AnyTopology)
 
 
 def test_cwe_674_deep_linear_chain() -> None:


### PR DESCRIPTION
Adds adversarial synthetic testing suite `tests/test_graph_overflow.py` using pure Python loops and comprehensions to create a 5,000-deep computational graph to mathematically prove that `DAGTopology` is immune to CWE-674 Stack Overflow attacks and correctly bubbles up cyclic validation errors over deep chains without hitting Python's recursion limits.

---
*PR created automatically by Jules for task [3099193487550763443](https://jules.google.com/task/3099193487550763443) started by @gowthamrao*