### PR TITLE
feat(tests): Implement Epic 33 Snapshot Testing for JSON Serialization Contract

### DIFF
--- a/tests/__snapshots__/test_snapshots.ambr
+++ b/tests/__snapshots__/test_snapshots.ambr
@@ -1,0 +1,10 @@
+# serializer version: 1
+# name: test_custody_record_snapshot
+  '{"record_id":"rec_1","source_node_id":"node_1","applied_policy_id":"pol_1","pre_redaction_hash":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","post_redaction_hash":"e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855","redaction_timestamp_unix_nano":1700000000000000000}'
+# ---
+# name: test_epistemic_ledger_snapshot
+  '{"history":[{"event_id":"evt_1","timestamp":1700000000.0,"type":"belief_update","payload":{"semantic_node":{"node_id":"node_1","label":"Person","scope":"tenant","text_chunk":"John Doe","provenance":{"extracted_by":"agent_1","source_event_id":"evt_0","spatial_anchor":{"bounding_box":[10.5,20.0,100.5,200.0],"block_type":"figure"}}},"semantic_edge":{"edge_id":"edge_1","subject_node_id":"node_1","object_node_id":"node_2","confidence_score":0.85,"predicate":"WORKS_FOR"}},"source_node_id":"node_1"}],"checkpoints":[],"active_rollbacks":[]}'
+# ---
+# name: test_fractal_router_snapshot
+  '{"manifest_version":"1.0.0","topology":{"nodes":{"comp_1":{"description":"Outer topology","intervention_policies":[],"type":"composite","topology":{"nodes":{"adj_1":{"description":"The adjudicator","intervention_policies":[],"type":"system"}},"type":"council","adjudicator_id":"adj_1","consensus_policy":{"strategy":"debate_rounds","max_debate_rounds":3}},"input_mappings":[],"output_mappings":[]}},"type":"dag","edges":[],"allow_cycles":false},"tenant_id":"tenant_acme_corp","session_id":"session_98765"}'
+# ---

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,0 +1,82 @@
+from pydantic import TypeAdapter
+
+from coreason_manifest.state import EpistemicLedger
+from coreason_manifest.telemetry import CustodyRecord
+from coreason_manifest.workflow import WorkflowEnvelope
+
+
+from syrupy.assertion import SnapshotAssertion
+
+def test_epistemic_ledger_snapshot(snapshot: SnapshotAssertion) -> None:
+    payload = {
+        "history": [
+            {
+                "type": "belief_update",
+                "event_id": "evt_1",
+                "timestamp": 1700000000.0,
+                "source_node_id": "node_1",
+                "payload": {
+                    "semantic_node": {
+                        "node_id": "node_1",
+                        "label": "Person",
+                        "scope": "tenant",
+                        "text_chunk": "John Doe",
+                        "provenance": {
+                            "extracted_by": "agent_1",
+                            "source_event_id": "evt_0",
+                            "spatial_anchor": {"bounding_box": [10.5, 20.0, 100.5, 200.0], "block_type": "figure"},
+                        },
+                    },
+                    "semantic_edge": {
+                        "edge_id": "edge_1",
+                        "subject_node_id": "node_1",
+                        "object_node_id": "node_2",
+                        "confidence_score": 0.85,
+                        "predicate": "WORKS_FOR",
+                    },
+                },
+            }
+        ],
+        "checkpoints": [],
+        "active_rollbacks": [],
+    }
+    ledger = TypeAdapter(EpistemicLedger).validate_python(payload)
+    assert snapshot == ledger.model_dump_json(by_alias=True, exclude_none=True)
+
+
+def test_custody_record_snapshot(snapshot: SnapshotAssertion) -> None:
+    payload = {
+        "record_id": "rec_1",
+        "source_node_id": "node_1",
+        "applied_policy_id": "pol_1",
+        "pre_redaction_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "post_redaction_hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "redaction_timestamp_unix_nano": 1700000000000000000,
+    }
+    record = TypeAdapter(CustodyRecord).validate_python(payload)
+    assert snapshot == record.model_dump_json(by_alias=True, exclude_none=True)
+
+
+def test_fractal_router_snapshot(snapshot: SnapshotAssertion) -> None:
+    payload = {
+        "manifest_version": "1.0.0",
+        "tenant_id": "tenant_acme_corp",
+        "session_id": "session_98765",
+        "topology": {
+            "type": "dag",
+            "nodes": {
+                "comp_1": {
+                    "type": "composite",
+                    "description": "Outer topology",
+                    "topology": {
+                        "type": "council",
+                        "adjudicator_id": "adj_1",
+                        "nodes": {"adj_1": {"type": "system", "description": "The adjudicator"}},
+                        "consensus_policy": {"strategy": "debate_rounds", "max_debate_rounds": 3},
+                    },
+                }
+            },
+        },
+    }
+    envelope = TypeAdapter(WorkflowEnvelope).validate_python(payload)
+    assert snapshot == envelope.model_dump_json(by_alias=True, exclude_none=True)

--- a/tests/test_snapshots.py
+++ b/tests/test_snapshots.py
@@ -1,11 +1,10 @@
 from pydantic import TypeAdapter
+from syrupy.assertion import SnapshotAssertion
 
 from coreason_manifest.state import EpistemicLedger
 from coreason_manifest.telemetry import CustodyRecord
 from coreason_manifest.workflow import WorkflowEnvelope
 
-
-from syrupy.assertion import SnapshotAssertion
 
 def test_epistemic_ledger_snapshot(snapshot: SnapshotAssertion) -> None:
     payload = {


### PR DESCRIPTION
Implemented strict mathematical snapshot testing to lock down cross-runtime JSON serialization output for `WorkflowEnvelope`, `EpistemicLedger`, and `CustodyRecord` using `pytest-syrupy`, ensuring 100% determinism in adherence to Epic 33 validation constraints.

---
*PR created automatically by Jules for task [7189343101637069875](https://jules.google.com/task/7189343101637069875) started by @gowthamrao*