### PR TITLE
Refactor: implement lazy hashing for CoreasonBaseModel

### DIFF
--- a/src/coreason_manifest/core/base.py
+++ b/src/coreason_manifest/core/base.py
@@ -29,9 +29,6 @@ class CoreasonBaseModel(BaseModel):
         strict=True,
     )
 
-    def model_post_init(self, __context: Any) -> None:
-        object.__setattr__(self, "_cached_hash", hash(self.model_dump_canonical()))
-
     def __hash__(self) -> int:
         try:
             h: int = object.__getattribute__(self, "_cached_hash")

--- a/src/coreason_manifest/oversight/dlp.py
+++ b/src/coreason_manifest/oversight/dlp.py
@@ -62,6 +62,4 @@ class InformationFlowPolicy(CoreasonBaseModel):
         """
         # Because the model is frozen, we bypass attribute assignment tracking
         object.__setattr__(self, "rules", sorted(self.rules, key=lambda r: r.rule_id))
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self

--- a/src/coreason_manifest/presentation/scivis.py
+++ b/src/coreason_manifest/presentation/scivis.py
@@ -62,8 +62,6 @@ class GrammarPanel(BasePanel):
     def sort_encodings(self) -> Self:
         """Mathematically sorts self.encodings by the string value of channel for deterministic hashing."""
         object.__setattr__(self, "encodings", sorted(self.encodings, key=lambda e: e.channel))
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 
@@ -102,6 +100,4 @@ class MacroGrid(CoreasonBaseModel):
             for panel_id in row:
                 if panel_id not in panel_ids:
                     raise ValueError(f"Ghost Panel referenced in layout_matrix: {panel_id}")
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self

--- a/src/coreason_manifest/state/differentials.py
+++ b/src/coreason_manifest/state/differentials.py
@@ -38,8 +38,6 @@ class RollbackRequest(CoreasonBaseModel):
     @model_validator(mode="after")
     def sort_invalidated_nodes(self) -> Self:
         object.__setattr__(self, "invalidated_node_ids", sorted(self.invalidated_node_ids))
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 

--- a/src/coreason_manifest/state/memory.py
+++ b/src/coreason_manifest/state/memory.py
@@ -29,8 +29,6 @@ class EpistemicLedger(CoreasonBaseModel):
     @model_validator(mode="after")
     def sort_history(self) -> Self:
         self.history.sort(key=lambda event: event.timestamp)
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 

--- a/src/coreason_manifest/telemetry/schemas.py
+++ b/src/coreason_manifest/telemetry/schemas.py
@@ -41,15 +41,11 @@ class ExecutionSpan(CoreasonBaseModel):
     def validate_temporal_bounds(self) -> Any:
         if self.end_time_unix_nano is not None and self.end_time_unix_nano < self.start_time_unix_nano:
             raise ValueError("end_time_unix_nano cannot be before start_time_unix_nano")
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
     @model_validator(mode="after")
     def sort_events(self) -> Any:
         object.__setattr__(self, "events", sorted(self.events, key=lambda e: e.timestamp_unix_nano))
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 
@@ -62,8 +58,6 @@ class TraceExportBatch(CoreasonBaseModel):
     @model_validator(mode="after")
     def sort_spans(self) -> Any:
         object.__setattr__(self, "spans", sorted(self.spans, key=lambda s: s.span_id))
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 

--- a/src/coreason_manifest/workflow/auctions.py
+++ b/src/coreason_manifest/workflow/auctions.py
@@ -55,6 +55,4 @@ class AuctionState(CoreasonBaseModel):
     def sort_bids(self) -> AuctionState:
         """Mathematically sort bids by agent_id for deterministic hashing."""
         self.bids.sort(key=lambda bid: bid.agent_id)
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -139,8 +139,6 @@ class DAGTopology(BaseTopology):
                         recursion_stack.remove(curr)
                         stack.pop()
 
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 
@@ -162,8 +160,6 @@ class CouncilTopology(BaseTopology):
     def check_adjudicator_id(self) -> Self:
         if self.adjudicator_id not in self.nodes:
             raise ValueError(f"Adjudicator ID '{self.adjudicator_id}' is not in nodes registry.")
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 
@@ -186,8 +182,6 @@ class SwarmTopology(BaseTopology):
     def enforce_concurrency_ceiling(self) -> Self:
         if self.spawning_threshold > self.max_concurrent_agents:
             raise ValueError("spawning_threshold cannot exceed max_concurrent_agents")
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 
@@ -212,8 +206,6 @@ class EvolutionaryTopology(BaseTopology):
         object.__setattr__(
             self, "fitness_objectives", sorted(self.fitness_objectives, key=lambda obj: obj.target_metric)
         )
-        if hasattr(self, "_cached_hash"):
-            object.__delattr__(self, "_cached_hash")
         return self
 
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -91,6 +91,33 @@ def test_workflow_envelope_determinism() -> None:
     assert hash(env1) == hash(env2)
 
 
+def test_lazy_hashing_performance_and_coverage() -> None:
+    """
+    Prove that CoreasonBaseModel uses lazy hashing.
+    It should not have a _cached_hash upon instantiation, but should compute
+    and store it when hash() is explicitly called, hitting the AttributeError fallback.
+    """
+    from coreason_manifest.workflow.nodes import SystemNode
+
+    # Instantiate a frozen model
+    node = SystemNode(description="Test lazy hash")
+
+    # 1. Prove the hash is NOT eagerly computed (saves performance)
+    assert not hasattr(node, "_cached_hash")
+
+    # 2. Trigger the __hash__ method (hits the except AttributeError block)
+    first_hash = hash(node)
+
+    # 3. Prove the hash is now cached
+    assert hasattr(node, "_cached_hash")
+
+    # 4. Trigger the __hash__ method again (hits the try block)
+    second_hash = hash(node)
+
+    # 5. Prove determinism and cache retrieval
+    assert first_hash == second_hash
+
+
 def test_telemetry_determinism() -> None:
     event_late = SpanEvent(name="late_event", timestamp_unix_nano=200, attributes={})
     event_early = SpanEvent(name="early_event", timestamp_unix_nano=100, attributes={})


### PR DESCRIPTION
This PR resolves a 100% test coverage blocker caused by a Pydantic V2 lifecycle paradox where `_cached_hash` was eagerly computed inside `model_post_init`. Because Pydantic V2 executes `model_validator(mode="after")` before `model_post_init` and all models are `frozen=True`, cache invalidation logic across 8 domain models became completely mathematically unreachable. 

This PR implements lazy evaluation logic:
1. Removed the eager hash computation from `model_post_init` in `CoreasonBaseModel`.
2. Purged the dead cache invalidation logic (`hasattr(self, "_cached_hash")`) from all domain models.
3. Added the targeted coverage test in `tests/test_determinism.py` to prove that `__hash__` properly handles the `AttributeError` fallback.

---
*PR created automatically by Jules for task [6248619847075226205](https://jules.google.com/task/6248619847075226205) started by @gowthamrao*