### PR TITLE
Fix immutability violations and tighten constraints

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1577,12 +1577,14 @@
       "properties": {
         "max_execution_time_ms": {
           "description": "The maximum allowed execution time in milliseconds before the orchestrator kills the process.",
+          "exclusiveMinimum": 0,
           "title": "Max Execution Time Ms",
           "type": "integer"
         },
         "max_memory_mb": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "type": "integer"
             },
             {
@@ -1638,12 +1640,14 @@
         },
         "start_time_unix_nano": {
           "description": "Temporal start bound.",
+          "minimum": 0,
           "title": "Start Time Unix Nano",
           "type": "integer"
         },
         "end_time_unix_nano": {
           "anyOf": [
             {
+              "minimum": 0,
               "type": "integer"
             },
             {

--- a/src/coreason_manifest/presentation/scivis.py
+++ b/src/coreason_manifest/presentation/scivis.py
@@ -80,10 +80,8 @@ class InsightCard(BasePanel):
         v_lower = v.lower()
         if re.search(r"on[a-zA-Z]+\s*=", v_lower):
             raise ValueError("Forbidden HTML event handler detected.")
-        forbidden_tags = ["<script", "javascript:", "<iframe", "<object", "<embed"]
-        for tag in forbidden_tags:
-            if tag in v_lower:
-                raise ValueError(f"Forbidden HTML tag detected: {tag}")
+        if re.search(r"<\s*[a-zA-Z/]", v):
+            raise ValueError("HTML tags are strictly prohibited. Use standard Markdown.")
         return v
 
 

--- a/src/coreason_manifest/state/memory.py
+++ b/src/coreason_manifest/state/memory.py
@@ -28,7 +28,7 @@ class EpistemicLedger(CoreasonBaseModel):
 
     @model_validator(mode="after")
     def sort_history(self) -> Self:
-        self.history.sort(key=lambda event: event.timestamp)
+        object.__setattr__(self, "history", sorted(self.history, key=lambda event: event.timestamp))
         return self
 
 

--- a/src/coreason_manifest/telemetry/schemas.py
+++ b/src/coreason_manifest/telemetry/schemas.py
@@ -30,8 +30,8 @@ class ExecutionSpan(CoreasonBaseModel):
     parent_span_id: str | None = Field(default=None, description="The causal link to the invoking node.")
     name: str = Field(description="The semantic identifier for the operation.")
     kind: SpanKind = Field(default="internal", description="The role of the span.")
-    start_time_unix_nano: int = Field(description="Temporal start bound.")
-    end_time_unix_nano: int | None = Field(default=None, description="Temporal end bound, if completed.")
+    start_time_unix_nano: int = Field(ge=0, description="Temporal start bound.")
+    end_time_unix_nano: int | None = Field(default=None, ge=0, description="Temporal end bound, if completed.")
     status: SpanStatusCode = Field(default="unset", description="The execution health flag.")
     events: list[SpanEvent] = Field(
         default_factory=list, max_length=10000, description="Structured log records emitted during the span."

--- a/src/coreason_manifest/tooling/schemas.py
+++ b/src/coreason_manifest/tooling/schemas.py
@@ -43,10 +43,11 @@ class ExecutionSLA(CoreasonBaseModel):
     """
 
     max_execution_time_ms: int = Field(
-        description="The maximum allowed execution time in milliseconds before the orchestrator kills the process."
+        gt=0,
+        description="The maximum allowed execution time in milliseconds before the orchestrator kills the process.",
     )
     max_memory_mb: int | None = Field(
-        default=None, description="The maximum memory footprint allowed for the tool's execution sandbox."
+        default=None, gt=0, description="The maximum memory footprint allowed for the tool's execution sandbox."
     )
 
 

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -47,7 +47,7 @@ def test_polymorphic_xss_proof(payload: str) -> None:
     Generate adversarial Markdown strings containing malicious tags
     and prove that InsightCard definitively rejects them via a ValidationError.
     """
-    with pytest.raises(ValidationError, match="Forbidden HTML tag detected"):
+    with pytest.raises(ValidationError, match="HTML tags are strictly prohibited"):
         InsightCard(panel_id="panel_1", title="Insight Title", markdown_content=payload)
 
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -539,12 +539,7 @@ def test_grammar_panel_routing(payload: dict[str, Any]) -> None:
 
 @given(
     st.text(),
-    st.text().filter(
-        lambda x: (
-            not any(tag in x.lower() for tag in ["<script", "<iframe", "javascript:", "<object", "<embed"])
-            and not re.search(r"on[a-zA-Z]+\s*=", x.lower())
-        )
-    ),
+    st.text().filter(lambda x: not re.search(r"<\s*[a-zA-Z/]", x) and not re.search(r"on[a-zA-Z]+\s*=", x.lower())),
 )
 def test_anypanel_insight(title: str, content: str) -> None:
     payload = {"panel_id": "p3", "type": "insight_card", "title": title, "markdown_content": content}
@@ -653,8 +648,10 @@ def test_chaosexperiment_fuzzing(
                             st.none(),
                             st.fixed_dictionaries(
                                 {
-                                    "max_execution_time_ms": st.integers(),
-                                    "max_memory_mb": st.one_of(st.none(), st.integers()),
+                                    "max_execution_time_ms": st.integers(min_value=1, max_value=2**63 - 1),
+                                    "max_memory_mb": st.one_of(
+                                        st.none(), st.integers(min_value=1, max_value=2**63 - 1)
+                                    ),
                                 }
                             ),
                         ),
@@ -1107,7 +1104,7 @@ def draw_span_event(draw: Any) -> dict[str, Any]:
         st.fixed_dictionaries(
             {
                 "name": st.text(min_size=1),
-                "timestamp_unix_nano": st.integers(min_value=0),
+                "timestamp_unix_nano": st.integers(min_value=0, max_value=2**63 - 1),
                 "attributes": st.dictionaries(st.text(), st.one_of(st.text(), st.integers(), st.booleans())),
             }
         )
@@ -1117,11 +1114,11 @@ def draw_span_event(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_execution_span(draw: Any) -> dict[str, Any]:
-    start_time_unix_nano = draw(st.integers(min_value=0))
+    start_time_unix_nano = draw(st.integers(min_value=0, max_value=2**63 - 1))
     has_end_time = draw(st.booleans())
     end_time_unix_nano = None
     if has_end_time:
-        delta = draw(st.integers(min_value=0))
+        delta = draw(st.integers(min_value=0, max_value=2**63 - 1))
         end_time_unix_nano = start_time_unix_nano + delta
 
     res: dict[str, Any] = {


### PR DESCRIPTION
Patch immutability violations, add Smart HTML ban to `InsightCard`, enforce Non-Negativity & Zero-State bounds in Execution SLA schemas, and restrict fuzzers to 64-bit boundaries.

---
*PR created automatically by Jules for task [4338167584949094222](https://jules.google.com/task/4338167584949094222) started by @gowthamrao*