### PR TITLE
fix: Update InsightCard HTML tag blocklist to strict structural allowlist

### DIFF
--- a/src/coreason_manifest/presentation/scivis.py
+++ b/src/coreason_manifest/presentation/scivis.py
@@ -76,12 +76,15 @@ class InsightCard(BasePanel):
     @field_validator("markdown_content")
     @classmethod
     def sanitize_markdown(cls, v: str) -> str:
-        """Reject adversarial HTML tags."""
+        """Strictly restrict '<' to mathematical contexts to prevent XSS."""
         v_lower = v.lower()
         if re.search(r"on[a-zA-Z]+\s*=", v_lower):
             raise ValueError("Forbidden HTML event handler detected.")
-        if re.search(r"<\s*[a-zA-Z/]", v):
-            raise ValueError("HTML tags are strictly prohibited. Use standard Markdown.")
+        if re.search(r"<[^=\s\d]", v):
+            raise ValueError(
+                "HTML tags are prohibited. '<' may only be used as a mathematical operator "
+                "followed by a space, digit, or '='."
+            )
         return v
 
 

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -47,7 +47,7 @@ def test_polymorphic_xss_proof(payload: str) -> None:
     Generate adversarial Markdown strings containing malicious tags
     and prove that InsightCard definitively rejects them via a ValidationError.
     """
-    with pytest.raises(ValidationError, match="HTML tags are prohibited."):
+    with pytest.raises(ValidationError, match="HTML tags are prohibited"):
         InsightCard(panel_id="panel_1", title="Insight Title", markdown_content=payload)
 
 

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -47,7 +47,7 @@ def test_polymorphic_xss_proof(payload: str) -> None:
     Generate adversarial Markdown strings containing malicious tags
     and prove that InsightCard definitively rejects them via a ValidationError.
     """
-    with pytest.raises(ValidationError, match="HTML tags are strictly prohibited"):
+    with pytest.raises(ValidationError, match="HTML tags are prohibited."):
         InsightCard(panel_id="panel_1", title="Insight Title", markdown_content=payload)
 
 
@@ -92,10 +92,7 @@ def test_visual_ghost_node_test(ghost_id: str) -> None:
 @given(
     title=st.text(min_size=1),
     safe_text=st.text().filter(
-        lambda x: (
-            not any(tag in x.lower() for tag in ["<script", "<iframe", "javascript:", "<object", "<embed"])
-            and not re.search(r"on[a-zA-Z]+\s*=", x.lower())
-        )
+        lambda x: not bool(re.search(r"<[^=\s\d]", x)) and not bool(re.search(r"on[a-zA-Z]+\s*=", x.lower()))
     ),
     x_label=st.text(min_size=1),
     y_label=st.text(min_size=1),

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -539,7 +539,9 @@ def test_grammar_panel_routing(payload: dict[str, Any]) -> None:
 
 @given(
     st.text(),
-    st.text().filter(lambda x: not re.search(r"<\s*[a-zA-Z/]", x) and not re.search(r"on[a-zA-Z]+\s*=", x.lower())),
+    st.text().filter(
+        lambda x: not bool(re.search(r"<[^=\s\d]", x)) and not bool(re.search(r"on[a-zA-Z]+\s*=", x.lower()))
+    ),
 )
 def test_anypanel_insight(title: str, content: str) -> None:
     payload = {"panel_id": "p3", "type": "insight_card", "title": title, "markdown_content": content}


### PR DESCRIPTION
1. Replaced `re.search(r"<\s*[a-zA-Z/]", v)` with `re.search(r"<[^=\s\d]", v)` in `InsightCard.sanitize_markdown`.
2. Updated the Hypothesis `st.text().filter()` lambdas in `tests/test_fuzzing.py` and `tests/domains/test_presentation_quarantine.py` to match the new context-aware validator logic.
3. Updated the `test_polymorphic_xss_proof` exception message assertion to match the new `ValueError` message string.
4. Ran `uv run ruff check --fix src/ tests/`, `uv run ruff format src/ tests/`, and `uv run pytest tests/` to ensure the codebase passes linting, formatting, and tests.

---
*PR created automatically by Jules for task [17228506003870004780](https://jules.google.com/task/17228506003870004780) started by @gowthamrao*