### PR TITLE
Epic 39: Zero-Trust Node Authorization

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -132,6 +132,36 @@
       "title": "AdversaryProfile",
       "type": "object"
     },
+    "AgentAttestation": {
+      "additionalProperties": false,
+      "description": "Cryptographic identity passport and AI-BOM for the agent.",
+      "properties": {
+        "training_lineage_hash": {
+          "description": "The exact SHA-256 Merkle root of the agent's training lineage.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Training Lineage Hash",
+          "type": "string"
+        },
+        "developer_signature": {
+          "description": "The cryptographic signature of the developer/vendor.",
+          "title": "Developer Signature",
+          "type": "string"
+        },
+        "capability_merkle_root": {
+          "description": "The SHA-256 Merkle root of the agent's verified semantic capabilities.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Capability Merkle Root",
+          "type": "string"
+        }
+      },
+      "required": [
+        "training_lineage_hash",
+        "developer_signature",
+        "capability_merkle_root"
+      ],
+      "title": "AgentAttestation",
+      "type": "object"
+    },
     "AgentBid": {
       "additionalProperties": false,
       "properties": {
@@ -191,6 +221,18 @@
           "description": "Discriminator for an Agent node.",
           "title": "Type",
           "type": "string"
+        },
+        "agent_attestation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AgentAttestation"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic identity passport and AI-BOM for the agent."
         },
         "action_space_id": {
           "anyOf": [
@@ -2590,6 +2632,22 @@
           "description": "True if the tool is strictly forbidden from writing to the disk.",
           "title": "File System Read Only",
           "type": "boolean"
+        },
+        "auth_requirements": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "An explicit list of authentication protocol identifiers (e.g., 'oauth2:github', 'mtls:internal') the orchestrator must negotiate before allocating compute.",
+          "title": "Auth Requirements"
         }
       },
       "required": [

--- a/src/coreason_manifest/tooling/schemas.py
+++ b/src/coreason_manifest/tooling/schemas.py
@@ -35,6 +35,12 @@ class PermissionBoundary(CoreasonBaseModel):
         default=None, description="Whitelist of allowed network domains if network access is true."
     )
     file_system_read_only: bool = Field(description="True if the tool is strictly forbidden from writing to the disk.")
+    auth_requirements: list[str] | None = Field(
+        default=None,
+        description="An explicit list of authentication protocol identifiers "
+        "(e.g., 'oauth2:github', 'mtls:internal') the orchestrator "
+        "must negotiate before allocating compute.",
+    )
 
 
 class ExecutionSLA(CoreasonBaseModel):

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -65,12 +65,29 @@ class SelfCorrectionPolicy(CoreasonBaseModel):
     rollback_on_failure: bool = Field(description="Whether to rollback to the previous state on failure.")
 
 
+class AgentAttestation(CoreasonBaseModel):
+    """
+    Cryptographic identity passport and AI-BOM for the agent.
+    """
+
+    training_lineage_hash: str = Field(
+        pattern=r"^[a-f0-9]{64}$", description="The exact SHA-256 Merkle root of the agent's training lineage."
+    )
+    developer_signature: str = Field(description="The cryptographic signature of the developer/vendor.")
+    capability_merkle_root: str = Field(
+        pattern=r"^[a-f0-9]{64}$", description="The SHA-256 Merkle root of the agent's verified semantic capabilities."
+    )
+
+
 class AgentNode(BaseNode):
     """
     A node representing an autonomous agent.
     """
 
     type: Literal["agent"] = Field(default="agent", description="Discriminator for an Agent node.")
+    agent_attestation: AgentAttestation | None = Field(
+        default=None, description="The cryptographic identity passport and AI-BOM for the agent."
+    )
     action_space_id: str | None = Field(
         default=None, description="The ID of the specific ActionSpace (curated tool environment) bound to this agent."
     )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -132,8 +132,23 @@ def draw_secure_sub_session(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_agent_attestation(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "training_lineage_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+                "developer_signature": st.text(min_size=1),
+                "capability_merkle_root": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+            }
+        )
+    )
+
+
+@st.composite
 def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"type": "agent", "description": draw(st.text())}
+    if draw(st.booleans()):
+        payload["agent_attestation"] = draw(draw_agent_attestation())
     if draw(st.booleans()):
         payload["intervention_policies"] = draw(st.lists(draw_intervention_policy(), max_size=100))
     if draw(st.booleans()):
@@ -644,6 +659,7 @@ def test_chaosexperiment_fuzzing(
                                 "network_access": st.booleans(),
                                 "allowed_domains": st.one_of(st.none(), st.lists(st.text(), max_size=100)),
                                 "file_system_read_only": st.booleans(),
+                                "auth_requirements": st.one_of(st.none(), st.lists(st.text(), max_size=100)),
                             }
                         ),
                         "sla": st.one_of(

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -133,7 +133,7 @@ def draw_secure_sub_session(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_agent_attestation(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "training_lineage_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
@@ -142,6 +142,7 @@ def draw_agent_attestation(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite


### PR DESCRIPTION
Implements Epic 39: Zero-Trust Node Authorization

- Extends `PermissionBoundary` with `auth_requirements` for declarative AOT credential binding.
- Adds `AgentAttestation` cryptographic passport schema bound with rigid SHA-256 regex constraints.
- Attaches the new attestation layer to `AgentNode`.
- Synchronizes the `test_fuzzing.py` Hypothesis generators (`test_actionspace_fuzzing` and `draw_agent_node_payload`) to produce strictly conforming payloads, avoiding Ci/CD CI build-breaking fuzz cascades.

---
*PR created automatically by Jules for task [6625108451103276583](https://jules.google.com/task/6625108451103276583) started by @gowthamrao*