### PR TITLE
feat(chaos): Add advanced SRE environmental fault literals

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1788,7 +1788,10 @@
         "incorrect_context",
         "format_corruption",
         "latency_spike",
-        "token_throttle"
+        "token_throttle",
+        "network_degradation",
+        "temporal_dilation",
+        "dependency_blackout"
       ],
       "type": "string"
     },

--- a/src/coreason_manifest/testing/chaos.py
+++ b/src/coreason_manifest/testing/chaos.py
@@ -17,6 +17,9 @@ type FaultType = Literal[
     "format_corruption",
     "latency_spike",
     "token_throttle",
+    "network_degradation",
+    "temporal_dilation",
+    "dependency_blackout",
 ]
 
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -588,6 +588,9 @@ def test_anyresilience_routing(res_type: str, target: str, fallback: str, reason
                         "format_corruption",
                         "latency_spike",
                         "token_throttle",
+                        "network_degradation",
+                        "temporal_dilation",
+                        "dependency_blackout",
                     ]
                 ),
                 "target_node_id": st.one_of(st.none(), st.text()),


### PR DESCRIPTION
Epic 42: SRE Environmental Sandboxing

Expands the declarative vocabulary of the `ChaosExperiment` schema to support state-of-the-art environmental fault injections. Updates `FaultType` in the pure data layer to include:
- `network_degradation`
- `temporal_dilation`
- `dependency_blackout`

Synchronizes the Hypothesis fuzzer payload definitions in `tests/test_fuzzing.py` so the property-based testing engine naturally discovers and validates models with these new parameters.

All checks (Ruff, Mypy, Pytest) passed locally according to the Shared Kernel architectural mandates.

---
*PR created automatically by Jules for task [16143599535039899051](https://jules.google.com/task/16143599535039899051) started by @gowthamrao*