### PR TITLE
feat(state): expand StateDiff schema with CRDT metadata

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -3387,6 +3387,25 @@
           "title": "Diff Id",
           "type": "string"
         },
+        "author_node_id": {
+          "description": "The exact NodeID of the agent or system that authored this state mutation.",
+          "title": "Author Node Id",
+          "type": "string"
+        },
+        "lamport_timestamp": {
+          "description": "Strict scalar logical clock used for deterministic LWW (Last-Writer-Wins) conflict resolution.",
+          "minimum": 0,
+          "title": "Lamport Timestamp",
+          "type": "integer"
+        },
+        "vector_clock": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "Causal history mapping of all known NodeIDs to their latest logical mutation count at the time of authoring.",
+          "title": "Vector Clock",
+          "type": "object"
+        },
         "patches": {
           "description": "The exact, ordered sequence of operations to apply.",
           "items": {
@@ -3397,7 +3416,10 @@
         }
       },
       "required": [
-        "diff_id"
+        "diff_id",
+        "author_node_id",
+        "lamport_timestamp",
+        "vector_clock"
       ],
       "title": "StateDiff",
       "type": "object"

--- a/src/coreason_manifest/state/differentials.py
+++ b/src/coreason_manifest/state/differentials.py
@@ -22,6 +22,16 @@ class StatePatch(CoreasonBaseModel):
 
 class StateDiff(CoreasonBaseModel):
     diff_id: str = Field(description="Unique identifier for this state differential.")
+    author_node_id: str = Field(
+        description="The exact NodeID of the agent or system that authored this state mutation."
+    )
+    lamport_timestamp: int = Field(
+        ge=0,
+        description="Strict scalar logical clock used for deterministic LWW (Last-Writer-Wins) conflict resolution.",
+    )
+    vector_clock: dict[str, int] = Field(
+        description="Causal history mapping of all known NodeIDs to their latest logical mutation count at the time of authoring."
+    )
     patches: list[StatePatch] = Field(
         default_factory=list, description="The exact, ordered sequence of operations to apply."
     )

--- a/src/coreason_manifest/state/differentials.py
+++ b/src/coreason_manifest/state/differentials.py
@@ -30,7 +30,8 @@ class StateDiff(CoreasonBaseModel):
         description="Strict scalar logical clock used for deterministic LWW (Last-Writer-Wins) conflict resolution.",
     )
     vector_clock: dict[str, int] = Field(
-        description="Causal history mapping of all known NodeIDs to their latest logical mutation count at the time of authoring."
+        description="Causal history mapping of all known NodeIDs to their latest logical "
+        "mutation count at the time of authoring."
     )
     patches: list[StatePatch] = Field(
         default_factory=list, description="The exact, ordered sequence of operations to apply."

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1096,6 +1096,14 @@ def draw_state_diff(draw: Any) -> dict[str, Any]:
         st.fixed_dictionaries(
             {
                 "diff_id": st.text(),
+                "author_node_id": st.text(
+                    min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                ),
+                "lamport_timestamp": st.integers(min_value=0),
+                "vector_clock": st.dictionaries(
+                    st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"),
+                    st.integers(min_value=0),
+                ),
                 "patches": st.lists(draw_state_patch(), max_size=100),
             }
         )


### PR DESCRIPTION
- **StateDiff Schema Update**: Added strictly bound `author_node_id`, `lamport_timestamp`, and `vector_clock` fields.
- **Fuzzer Alignment**: Updated `draw_state_diff` in `tests/test_fuzzing.py` to correctly map the new state differentials.
- **Constraints Maintained**: Used native `int` for logical clocks to preserve determinism (no floats). Maintained "Hollow Data Plane" by only updating Pydantic properties.

---
*PR created automatically by Jules for task [17078636220689439719](https://jules.google.com/task/17078636220689439719) started by @gowthamrao*