### PR TITLE
feat: Implement Liquid Compute Pareto Frontiers

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -222,6 +222,18 @@
           "title": "Type",
           "type": "string"
         },
+        "compute_frontier": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoutingFrontier"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic spot-market compute requirements for this agent."
+        },
         "agent_attestation": {
           "anyOf": [
             {
@@ -2880,6 +2892,50 @@
         "target_event_id"
       ],
       "title": "RollbackRequest",
+      "type": "object"
+    },
+    "RoutingFrontier": {
+      "additionalProperties": false,
+      "description": "Mathematical Pareto boundaries for dynamic spot-market liquid compute.",
+      "properties": {
+        "max_latency_ms": {
+          "description": "The absolute physical speed limit acceptable for time-to-first-token or total generation.",
+          "exclusiveMinimum": 0,
+          "title": "Max Latency Ms",
+          "type": "integer"
+        },
+        "max_cost_microcents_per_token": {
+          "description": "The strict financial ceiling. MUST be an integer to maintain cryptographic determinism.",
+          "exclusiveMinimum": 0,
+          "title": "Max Cost Microcents Per Token",
+          "type": "integer"
+        },
+        "min_capability_score": {
+          "description": "The cognitive capability floor required for the task (0.0 to 1.0).",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Min Capability Score",
+          "type": "number"
+        },
+        "tradeoff_preference": {
+          "description": "The mathematical optimization vector to break ties within the frontier.",
+          "enum": [
+            "latency_optimized",
+            "cost_optimized",
+            "capability_optimized",
+            "balanced"
+          ],
+          "title": "Tradeoff Preference",
+          "type": "string"
+        }
+      },
+      "required": [
+        "max_latency_ms",
+        "max_cost_microcents_per_token",
+        "min_capability_score",
+        "tradeoff_preference"
+      ],
+      "title": "RoutingFrontier",
       "type": "object"
     },
     "SalienceProfile": {

--- a/src/coreason_manifest/compute/profiles.py
+++ b/src/coreason_manifest/compute/profiles.py
@@ -14,6 +14,25 @@ from coreason_manifest.core.base import CoreasonBaseModel
 type QoSClassification = Literal["critical", "high", "interactive", "background_batch"]
 
 
+class RoutingFrontier(CoreasonBaseModel):
+    """
+    Mathematical Pareto boundaries for dynamic spot-market liquid compute.
+    """
+
+    max_latency_ms: int = Field(
+        gt=0, description="The absolute physical speed limit acceptable for time-to-first-token or total generation."
+    )
+    max_cost_microcents_per_token: int = Field(
+        gt=0, description="The strict financial ceiling. MUST be an integer to maintain cryptographic determinism."
+    )
+    min_capability_score: float = Field(
+        ge=0.0, le=1.0, description="The cognitive capability floor required for the task (0.0 to 1.0)."
+    )
+    tradeoff_preference: Literal["latency_optimized", "cost_optimized", "capability_optimized", "balanced"] = Field(
+        description="The mathematical optimization vector to break ties within the frontier."
+    )
+
+
 class RateCard(CoreasonBaseModel):
     """
     Economic constraints for liquid compute operations.

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Annotated, Literal
 
 from pydantic import Field
 
+from coreason_manifest.compute.profiles import RoutingFrontier
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.oversight.dlp import SecureSubSession
 
@@ -85,6 +86,9 @@ class AgentNode(BaseNode):
     """
 
     type: Literal["agent"] = Field(default="agent", description="Discriminator for an Agent node.")
+    compute_frontier: RoutingFrontier | None = Field(
+        default=None, description="The dynamic spot-market compute requirements for this agent."
+    )
     agent_attestation: AgentAttestation | None = Field(
         default=None, description="The cryptographic identity passport and AI-BOM for the agent."
     )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -147,8 +147,26 @@ def draw_agent_attestation(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_routing_frontier(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "max_latency_ms": st.integers(min_value=1),
+                "max_cost_microcents_per_token": st.integers(min_value=1),
+                "min_capability_score": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+                "tradeoff_preference": st.sampled_from(
+                    ["latency_optimized", "cost_optimized", "capability_optimized", "balanced"]
+                ),
+            }
+        )
+    )
+
+
+@st.composite
 def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"type": "agent", "description": draw(st.text())}
+    if draw(st.booleans()):
+        payload["compute_frontier"] = draw(draw_routing_frontier())
     if draw(st.booleans()):
         payload["agent_attestation"] = draw(draw_agent_attestation())
     if draw(st.booleans()):

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -148,7 +148,7 @@ def draw_agent_attestation(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_routing_frontier(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "max_latency_ms": st.integers(min_value=1),
@@ -160,6 +160,7 @@ def draw_routing_frontier(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite


### PR DESCRIPTION
Implemented Epic 45: Liquid Compute Pareto Frontiers

- Created `RoutingFrontier` schema to define multi-objective routing boundaries for spot-market LLM execution.
- Configured mathematical bounding boxes: `max_latency_ms`, `max_cost_microcents_per_token` (strictly integer to maintain cryptographic determinism), `min_capability_score`, and `tradeoff_preference`.
- Attached `compute_frontier` field to the `AgentNode` topology.
- Updated the `draw_agent_node_payload` Hypothesis fuzzer generator with `@st.composite` generator `draw_routing_frontier` to prevent CI/CD failures and test the new strictly bounded limits accurately.

---
*PR created automatically by Jules for task [18304734028658134485](https://jules.google.com/task/18304734028658134485) started by @gowthamrao*