### PR TITLE
feat: Implement BilateralSLA for federated B2B boundaries

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -696,6 +696,42 @@
       "title": "BeliefUpdateEvent",
       "type": "object"
     },
+    "BilateralSLA": {
+      "additionalProperties": false,
+      "properties": {
+        "receiving_tenant_id": {
+          "description": "The strict enterprise identifier of the foreign B2B tenant receiving this payload.",
+          "maxLength": 255,
+          "title": "Receiving Tenant Id",
+          "type": "string"
+        },
+        "max_permitted_classification": {
+          "$ref": "#/$defs/coreason_manifest__core__primitives__DataClassification",
+          "description": "The absolute highest data sensitivity allowed to cross this federated boundary."
+        },
+        "liability_limit_cents": {
+          "description": "The strict financial cap on cross-tenant economic liability.",
+          "minimum": 0,
+          "title": "Liability Limit Cents",
+          "type": "integer"
+        },
+        "permitted_geographic_regions": {
+          "description": "Explicit whitelist of geographic regions or cloud enclaves where execution is legally permitted (Data Residency Pinning).",
+          "items": {
+            "type": "string"
+          },
+          "title": "Permitted Geographic Regions",
+          "type": "array"
+        }
+      },
+      "required": [
+        "receiving_tenant_id",
+        "max_permitted_classification",
+        "liability_limit_cents"
+      ],
+      "title": "BilateralSLA",
+      "type": "object"
+    },
     "BoundedInterventionScope": {
       "additionalProperties": false,
       "description": "Constraints bounding human interaction for interventions.",
@@ -4037,6 +4073,18 @@
           "default": null,
           "description": "The declarative whitelist of data classifications permitted to flow through this graph.",
           "title": "Allowed Data Classifications"
+        },
+        "federated_sla": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BilateralSLA"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The B2B Service Level Agreement contract that must be mathematically satisfied before multi-tenant graph coupling."
         }
       },
       "required": [

--- a/src/coreason_manifest/workflow/envelope.py
+++ b/src/coreason_manifest/workflow/envelope.py
@@ -23,7 +23,10 @@ class BilateralSLA(CoreasonBaseModel):
     liability_limit_cents: int = Field(ge=0, description="The strict financial cap on cross-tenant economic liability.")
     permitted_geographic_regions: list[str] = Field(
         default_factory=list,
-        description="Explicit whitelist of geographic regions or cloud enclaves where execution is legally permitted (Data Residency Pinning).",
+        description=(
+            "Explicit whitelist of geographic regions or cloud enclaves where execution "
+            "is legally permitted (Data Residency Pinning)."
+        ),
     )
 
 
@@ -52,5 +55,8 @@ class WorkflowEnvelope(CoreasonBaseModel):
     )
     federated_sla: BilateralSLA | None = Field(
         default=None,
-        description="The B2B Service Level Agreement contract that must be mathematically satisfied before multi-tenant graph coupling.",
+        description=(
+            "The B2B Service Level Agreement contract that must be mathematically "
+            "satisfied before multi-tenant graph coupling."
+        ),
     )

--- a/src/coreason_manifest/workflow/envelope.py
+++ b/src/coreason_manifest/workflow/envelope.py
@@ -13,6 +13,20 @@ from coreason_manifest.oversight.governance import GlobalGovernance
 from coreason_manifest.workflow.topologies import AnyTopology
 
 
+class BilateralSLA(CoreasonBaseModel):
+    receiving_tenant_id: str = Field(
+        max_length=255, description="The strict enterprise identifier of the foreign B2B tenant receiving this payload."
+    )
+    max_permitted_classification: DataClassification = Field(
+        description="The absolute highest data sensitivity allowed to cross this federated boundary."
+    )
+    liability_limit_cents: int = Field(ge=0, description="The strict financial cap on cross-tenant economic liability.")
+    permitted_geographic_regions: list[str] = Field(
+        default_factory=list,
+        description="Explicit whitelist of geographic regions or cloud enclaves where execution is legally permitted (Data Residency Pinning).",
+    )
+
+
 class WorkflowEnvelope(CoreasonBaseModel):
     """
     The root envelope for an orchestrated workflow payload.
@@ -35,4 +49,8 @@ class WorkflowEnvelope(CoreasonBaseModel):
     allowed_data_classifications: list[DataClassification] | None = Field(
         default=None,
         description="The declarative whitelist of data classifications permitted to flow through this graph.",
+    )
+    federated_sla: BilateralSLA | None = Field(
+        default=None,
+        description="The B2B Service Level Agreement contract that must be mathematically satisfied before multi-tenant graph coupling.",
     )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1329,7 +1329,7 @@ workflow_envelope_adapter: TypeAdapter[WorkflowEnvelope] = TypeAdapter(WorkflowE
 
 @st.composite
 def draw_bilateral_sla(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "receiving_tenant_id": st.text(min_size=1, max_size=255),
@@ -1346,6 +1346,7 @@ def draw_bilateral_sla(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1328,6 +1328,27 @@ workflow_envelope_adapter: TypeAdapter[WorkflowEnvelope] = TypeAdapter(WorkflowE
 
 
 @st.composite
+def draw_bilateral_sla(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "receiving_tenant_id": st.text(min_size=1, max_size=255),
+                "max_permitted_classification": st.sampled_from(
+                    [
+                        DataClassification.PUBLIC,
+                        DataClassification.INTERNAL,
+                        DataClassification.CONFIDENTIAL,
+                        DataClassification.RESTRICTED,
+                    ]
+                ),
+                "liability_limit_cents": st.integers(min_value=0),
+                "permitted_geographic_regions": st.lists(st.text(min_size=1), max_size=10),
+            }
+        )
+    )
+
+
+@st.composite
 def draw_workflow_envelope(draw: Any) -> dict[str, Any]:
     # We will generate a basic workflow envelope payload with optional tenant_id and session_id
     res: dict[str, Any] = draw(
@@ -1365,6 +1386,7 @@ def draw_workflow_envelope(draw: Any) -> dict[str, Any]:
                         max_size=10,
                     ),
                 ),
+                "federated_sla": st.one_of(st.none(), draw_bilateral_sla()),
             }
         )
     )


### PR DESCRIPTION
Introduces strictly typed BilateralSLA schema and attaches it to the WorkflowEnvelope. Updates the Hypothesis fuzzer strategy to properly generate valid payloads for federated handshakes, ensuring adherence to the Hollow Data Plane rule and integer currency constraints.

---
*PR created automatically by Jules for task [16668851003502731031](https://jules.google.com/task/16668851003502731031) started by @gowthamrao*