### PR TITLE
Implement Zero-Knowledge Proof (ZKP) Schemas

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -698,6 +698,18 @@
           },
           "title": "Causal Attributions",
           "type": "array"
+        },
+        "zk_proof": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ZeroKnowledgeProof"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical attestation proving this belief synthesis was generated securely without model-downgrade fraud."
         }
       },
       "required": [
@@ -2653,6 +2665,18 @@
           ],
           "default": null,
           "description": "The specific topological node that generated this observation."
+        },
+        "zk_proof": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ZeroKnowledgeProof"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical attestation proving this observation was generated securely."
         }
       },
       "required": [
@@ -4300,6 +4324,45 @@
         "active_context"
       ],
       "title": "WorkingMemorySnapshot",
+      "type": "object"
+    },
+    "ZeroKnowledgeProof": {
+      "additionalProperties": false,
+      "properties": {
+        "proof_protocol": {
+          "description": "The mathematical dialect of the cryptographic proof.",
+          "enum": [
+            "zk-SNARK",
+            "zk-STARK",
+            "plonk",
+            "bulletproofs"
+          ],
+          "title": "Proof Protocol",
+          "type": "string"
+        },
+        "public_inputs_hash": {
+          "description": "The SHA-256 hash of the public inputs (e.g., prompt, Lamport clock) anchoring this proof to the specific state index.",
+          "title": "Public Inputs Hash",
+          "type": "string"
+        },
+        "verifier_key_id": {
+          "description": "The identifier of the public evaluation key the orchestrator must load to verify this proof.",
+          "title": "Verifier Key Id",
+          "type": "string"
+        },
+        "cryptographic_blob": {
+          "description": "The base64-encoded succinct cryptographic proof payload.",
+          "title": "Cryptographic Blob",
+          "type": "string"
+        }
+      },
+      "required": [
+        "proof_protocol",
+        "public_inputs_hash",
+        "verifier_key_id",
+        "cryptographic_blob"
+      ],
+      "title": "ZeroKnowledgeProof",
       "type": "object"
     },
     "coreason_manifest__core__primitives__DataClassification": {

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -18,6 +18,20 @@ class BaseStateEvent(CoreasonBaseModel):
     timestamp: float = Field(description="The timestamp when the event occurred.")
 
 
+class ZeroKnowledgeProof(CoreasonBaseModel):
+    proof_protocol: Literal["zk-SNARK", "zk-STARK", "plonk", "bulletproofs"] = Field(
+        description="The mathematical dialect of the cryptographic proof."
+    )
+    public_inputs_hash: str = Field(
+        description="The SHA-256 hash of the public inputs (e.g., prompt, Lamport clock) "
+        "anchoring this proof to the specific state index."
+    )
+    verifier_key_id: str = Field(
+        description="The identifier of the public evaluation key the orchestrator must load to verify this proof."
+    )
+    cryptographic_blob: str = Field(description="The base64-encoded succinct cryptographic proof payload.")
+
+
 class ObservationEvent(BaseStateEvent):
     type: Literal["observation"] = Field(
         default="observation", description="Discriminator type for an observation event."
@@ -27,6 +41,9 @@ class ObservationEvent(BaseStateEvent):
     )
     source_node_id: NodeID | None = Field(
         default=None, description="The specific topological node that generated this observation."
+    )
+    zk_proof: ZeroKnowledgeProof | None = Field(
+        default=None, description="The mathematical attestation proving this observation was generated securely."
     )
 
 
@@ -52,6 +69,11 @@ class BeliefUpdateEvent(BaseStateEvent):
     causal_attributions: list[CausalAttribution] = Field(
         default_factory=list,
         description="Immutable audit trail of prior states that forced this specific cognitive synthesis.",
+    )
+    zk_proof: ZeroKnowledgeProof | None = Field(
+        default=None,
+        description="The mathematical attestation proving this belief synthesis was generated "
+        "securely without model-downgrade fraud.",
     )
 
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -488,7 +488,7 @@ def draw_causal_attribution(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_zkp(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "proof_protocol": st.sampled_from(["zk-SNARK", "zk-STARK", "plonk", "bulletproofs"]),
@@ -498,6 +498,7 @@ def draw_zkp(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -487,6 +487,20 @@ def draw_causal_attribution(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_zkp(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "proof_protocol": st.sampled_from(["zk-SNARK", "zk-STARK", "plonk", "bulletproofs"]),
+                "public_inputs_hash": st.text(min_size=1),
+                "verifier_key_id": st.text(min_size=1),
+                "cryptographic_blob": st.text(min_size=10),
+            }
+        )
+    )
+
+
+@st.composite
 def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
     event_type = draw(st.sampled_from(["observation", "belief_update", "system_fault"]))
     payload: dict[str, Any] = {
@@ -514,6 +528,8 @@ def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
         )
         if event_type == "belief_update":
             payload["causal_attributions"] = draw(st.lists(draw_causal_attribution(), max_size=10))
+        if draw(st.booleans()):
+            payload["zk_proof"] = draw(draw_zkp())
     return payload
 
 


### PR DESCRIPTION
This implements strictly typed, passive schemas for Zero-Knowledge Proofs (ZKPs) allowing federated nodes to mathematically prove instruction execution without revealing proprietary model weights, fulfilling Epic 47.

---
*PR created automatically by Jules for task [3977662483317889316](https://jules.google.com/task/3977662483317889316) started by @gowthamrao*