### PR TITLE
feat: Swarm Economic Escrow Policy (Epic 49)

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1586,6 +1586,34 @@
       "title": "EpistemicScanner",
       "type": "object"
     },
+    "EscrowPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "escrow_locked_cents": {
+          "description": "The strictly typed integer amount of capital cryptographically locked prior to execution.",
+          "minimum": 0,
+          "title": "Escrow Locked Cents",
+          "type": "integer"
+        },
+        "release_condition_metric": {
+          "description": "A declarative pointer to the SLA or QA rubric required to release the funds.",
+          "title": "Release Condition Metric",
+          "type": "string"
+        },
+        "refund_target_node_id": {
+          "description": "The exact NodeID to return funds to if the release condition fails.",
+          "title": "Refund Target Node Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "escrow_locked_cents",
+        "release_condition_metric",
+        "refund_target_node_id"
+      ],
+      "title": "EscrowPolicy",
+      "type": "object"
+    },
     "EvictionPolicy": {
       "additionalProperties": false,
       "properties": {
@@ -3916,6 +3944,18 @@
           "description": "The final cryptographic clearing price.",
           "title": "Cleared Price Cents",
           "type": "integer"
+        },
+        "escrow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EscrowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The conditional economic escrow locking the compute budget."
         }
       },
       "required": [

--- a/src/coreason_manifest/workflow/auctions.py
+++ b/src/coreason_manifest/workflow/auctions.py
@@ -31,6 +31,18 @@ class TaskAnnouncement(CoreasonBaseModel):
     max_budget_cents: int = Field(description="The absolute ceiling price the orchestrator is willing to pay.")
 
 
+class EscrowPolicy(CoreasonBaseModel):
+    escrow_locked_cents: int = Field(
+        ge=0, description="The strictly typed integer amount of capital cryptographically locked prior to execution."
+    )
+    release_condition_metric: str = Field(
+        description="A declarative pointer to the SLA or QA rubric required to release the funds."
+    )
+    refund_target_node_id: str = Field(
+        description="The exact NodeID to return funds to if the release condition fails."
+    )
+
+
 class AgentBid(CoreasonBaseModel):
     agent_id: str = Field(description="The NodeID of the bidder.")
     estimated_cost_cents: int = Field(description="The node's calculated cost to fulfill the task.")
@@ -44,6 +56,16 @@ class TaskAward(CoreasonBaseModel):
         description="Strict mapping of agent NodeIDs to their exact fractional payout in cents."
     )
     cleared_price_cents: int = Field(description="The final cryptographic clearing price.")
+    escrow: EscrowPolicy | None = Field(
+        default=None, description="The conditional economic escrow locking the compute budget."
+    )
+
+    @model_validator(mode="after")
+    def validate_escrow_bounds(self) -> Self:
+        """Ensures locked funds do not exceed the cleared auction price."""
+        if self.escrow is not None and self.escrow.escrow_locked_cents > self.cleared_price_cents:
+            raise ValueError("Escrow locked amount cannot exceed the total cleared price.")
+        return self
 
     @model_validator(mode="after")
     def verify_syndicate_allocation(self) -> Self:

--- a/tests/domains/test_workflow_auctions.py
+++ b/tests/domains/test_workflow_auctions.py
@@ -1,0 +1,19 @@
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from coreason_manifest.workflow.auctions import TaskAward
+
+
+def test_task_award_escrow_invalid() -> None:
+    payload = {
+        "task_id": "test_task",
+        "awarded_syndicate": {"agent_1": 100},
+        "cleared_price_cents": 100,
+        "escrow": {
+            "escrow_locked_cents": 150,
+            "release_condition_metric": "quality_score > 0.9",
+            "refund_target_node_id": "org_wallet_1",
+        },
+    }
+    with pytest.raises(ValidationError, match=r"Escrow locked amount cannot exceed the total cleared price"):
+        TypeAdapter(TaskAward).validate_python(payload)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1008,7 +1008,7 @@ def draw_agent_bid(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_escrow_policy(draw: Any, max_escrow: int) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "escrow_locked_cents": st.integers(min_value=0, max_value=max_escrow),
@@ -1019,6 +1019,7 @@ def draw_escrow_policy(draw: Any, max_escrow: int) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1074,6 +1074,21 @@ def test_task_award_syndicate_invalid() -> None:
         TypeAdapter(TaskAward).validate_python(payload)
 
 
+def test_task_award_escrow_invalid() -> None:
+    payload = {
+        "task_id": "test_task",
+        "awarded_syndicate": {"agent_1": 100},
+        "cleared_price_cents": 100,
+        "escrow": {
+            "escrow_locked_cents": 150,
+            "release_condition_metric": "quality_score > 0.9",
+            "refund_target_node_id": "org_wallet_1",
+        }
+    }
+    with pytest.raises(ValueError, match="Escrow locked amount cannot exceed the total cleared price."):
+        TypeAdapter(TaskAward).validate_python(payload)
+
+
 @st.composite
 def draw_redaction_rule(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1007,16 +1007,37 @@ def draw_agent_bid(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_escrow_policy(draw: Any, max_escrow: int) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "escrow_locked_cents": st.integers(min_value=0, max_value=max_escrow),
+                "release_condition_metric": st.text(min_size=1),
+                "refund_target_node_id": st.text(
+                    min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+                ),
+            }
+        )
+    )
+
+
+@st.composite
 def draw_task_award(draw: Any) -> dict[str, Any]:
     price = draw(st.integers(min_value=0))
-    # To strictly satisfy the zero-sum validator without fuzzer timeouts,
-    # we allocate 100% of the price to a single generated agent ID.
+    # Allocate 100% of the price to a single generated agent ID to satisfy zero-sum rules
     agent_id = draw(st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"))
-    return {
+
+    award: dict[str, Any] = {
         "task_id": draw(st.text()),
         "awarded_syndicate": {agent_id: price},
         "cleared_price_cents": price,
     }
+
+    if draw(st.booleans()):
+        # CRITICAL: Pass the generated price to bound the escrow generation
+        award["escrow"] = draw(draw_escrow_policy(max_escrow=price))
+
+    return award
 
 
 @st.composite

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1085,7 +1085,7 @@ def test_task_award_escrow_invalid() -> None:
             "refund_target_node_id": "org_wallet_1",
         }
     }
-    with pytest.raises(ValueError, match="Escrow locked amount cannot exceed the total cleared price."):
+    with pytest.raises(ValueError, match=r"Escrow locked amount cannot exceed the total cleared price\."):
         TypeAdapter(TaskAward).validate_python(payload)
 
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1074,21 +1074,6 @@ def test_task_award_syndicate_invalid() -> None:
         TypeAdapter(TaskAward).validate_python(payload)
 
 
-def test_task_award_escrow_invalid() -> None:
-    payload = {
-        "task_id": "test_task",
-        "awarded_syndicate": {"agent_1": 100},
-        "cleared_price_cents": 100,
-        "escrow": {
-            "escrow_locked_cents": 150,
-            "release_condition_metric": "quality_score > 0.9",
-            "refund_target_node_id": "org_wallet_1",
-        }
-    }
-    with pytest.raises(ValueError, match=r"Escrow locked amount cannot exceed the total cleared price\."):
-        TypeAdapter(TaskAward).validate_python(payload)
-
-
 @st.composite
 def draw_redaction_rule(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(


### PR DESCRIPTION
This PR implements **Epic 49: Swarm Economic Escrow** on the `coreason-manifest` architecture. It defines strictly typed, passive schemas for Conditional Economic Escrow Policies to cryptographically lock and release funds without introducing active execution logic. The mathematical constraints are bounded using Pydantic's `@model_validator`. In addition, Hypothesis fuzzing boundaries in `tests/test_fuzzing.py` have been dynamically synchronized with the final clearing prices to maintain testing stability.

---
*PR created automatically by Jules for task [2546112764637789668](https://jules.google.com/task/2546112764637789668) started by @gowthamrao*