### PR TITLE
Epic 50: Homomorphic Memory Boundaries

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2116,6 +2116,39 @@
       "title": "GradingCriteria",
       "type": "object"
     },
+    "HomomorphicEncryptionProfile": {
+      "additionalProperties": false,
+      "properties": {
+        "fhe_scheme": {
+          "description": "The specific homomorphic encryption dialect used to encode the ciphertext.",
+          "enum": [
+            "ckks",
+            "bgv",
+            "bfv",
+            "tfhe"
+          ],
+          "title": "Fhe Scheme",
+          "type": "string"
+        },
+        "public_key_id": {
+          "description": "The identifier of the public evaluation key the orchestrator must load to perform math on this payload.",
+          "title": "Public Key Id",
+          "type": "string"
+        },
+        "ciphertext_blob": {
+          "description": "The base64-encoded homomorphic ciphertext.",
+          "title": "Ciphertext Blob",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fhe_scheme",
+        "public_key_id",
+        "ciphertext_blob"
+      ],
+      "title": "HomomorphicEncryptionProfile",
+      "type": "object"
+    },
     "HumanNode": {
       "additionalProperties": false,
       "description": "A node representing a human participant in the workflow.",
@@ -3322,6 +3355,18 @@
           ],
           "default": null,
           "description": "The importance profile used for memory pruning."
+        },
+        "fhe_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HomomorphicEncryptionProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic envelope enabling privacy-preserving computation directly on this node's encrypted state."
         }
       },
       "required": [

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -69,6 +69,16 @@ class SalienceProfile(CoreasonBaseModel):
     decay_rate: float = Field(description="The rate at which this memory's relevance decays over time.")
 
 
+class HomomorphicEncryptionProfile(CoreasonBaseModel):
+    fhe_scheme: Literal["ckks", "bgv", "bfv", "tfhe"] = Field(
+        description="The specific homomorphic encryption dialect used to encode the ciphertext."
+    )
+    public_key_id: str = Field(
+        description="The identifier of the public evaluation key the orchestrator must load to perform math on this payload."
+    )
+    ciphertext_blob: str = Field(description="The base64-encoded homomorphic ciphertext.")
+
+
 class SemanticNode(CoreasonBaseModel):
     node_id: str = Field(description="The unique identifier of this semantic concept.")
     label: str = Field(description="The categorical label of the node (e.g., 'Person', 'Concept').")
@@ -90,6 +100,10 @@ class SemanticNode(CoreasonBaseModel):
     )
     salience: SalienceProfile | None = Field(
         default=None, description="The importance profile used for memory pruning."
+    )
+    fhe_profile: HomomorphicEncryptionProfile | None = Field(
+        default=None,
+        description="The cryptographic envelope enabling privacy-preserving computation directly on this node's encrypted state.",
     )
 
 

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -74,7 +74,9 @@ class HomomorphicEncryptionProfile(CoreasonBaseModel):
         description="The specific homomorphic encryption dialect used to encode the ciphertext."
     )
     public_key_id: str = Field(
-        description="The identifier of the public evaluation key the orchestrator must load to perform math on this payload."
+        description=(
+            "The identifier of the public evaluation key the orchestrator must load to perform math on this payload."
+        )
     )
     ciphertext_blob: str = Field(description="The base64-encoded homomorphic ciphertext.")
 
@@ -103,7 +105,10 @@ class SemanticNode(CoreasonBaseModel):
     )
     fhe_profile: HomomorphicEncryptionProfile | None = Field(
         default=None,
-        description="The cryptographic envelope enabling privacy-preserving computation directly on this node's encrypted state.",
+        description=(
+            "The cryptographic envelope enabling privacy-preserving computation "
+            "directly on this node's encrypted state."
+        ),
     )
 
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -813,7 +813,7 @@ def draw_temporal_bounds(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_fhe_profile(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "fhe_scheme": st.sampled_from(["ckks", "bgv", "bfv", "tfhe"]),
@@ -822,6 +822,7 @@ def draw_fhe_profile(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @given(

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -811,6 +811,19 @@ def draw_temporal_bounds(draw: Any) -> dict[str, Any]:
     }
 
 
+@st.composite
+def draw_fhe_profile(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "fhe_scheme": st.sampled_from(["ckks", "bgv", "bfv", "tfhe"]),
+                "public_key_id": st.text(min_size=1),
+                "ciphertext_blob": st.text(min_size=10),
+            }
+        )
+    )
+
+
 @given(
     st.fixed_dictionaries(
         {
@@ -839,6 +852,7 @@ def draw_temporal_bounds(draw: Any) -> dict[str, Any]:
                     }
                 ),
             ),
+            "fhe_profile": st.one_of(st.none(), draw_fhe_profile()),
         }
     )
 )


### PR DESCRIPTION
Implemented strictly typed, passive schemas for Fully Homomorphic Encryption (FHE) profiles for `SemanticNode` to process semantic memory mathematically without decryption.

Changes include:
- Added `HomomorphicEncryptionProfile` to `src/coreason_manifest/state/semantic.py` with strictly bound `fhe_scheme` (`Literal["ckks", "bgv", "bfv", "tfhe"]`), `public_key_id`, and `ciphertext_blob`.
- Attached `fhe_profile` to `SemanticNode` as an optional field.
- Updated `tests/test_fuzzing.py` with a new `@st.composite` generator `draw_fhe_profile` and integrated it into the `test_semanticnode_fuzzing` payload to align with the new schema constraints.
- Ran formatting tools and ensured all tests pass.

---
*PR created automatically by Jules for task [3827326420001748901](https://jules.google.com/task/3827326420001748901) started by @gowthamrao*