### PR TITLE
Feat: Declarative Formal Verification Contracts

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2088,6 +2088,40 @@
       "title": "FitnessObjective",
       "type": "object"
     },
+    "FormalVerificationContract": {
+      "additionalProperties": false,
+      "description": "Passive schema defining a mathematical proof of safety invariants.",
+      "properties": {
+        "proof_system": {
+          "description": "The mathematical dialect and theorem prover used to compile the proof.",
+          "enum": [
+            "tla_plus",
+            "lean4",
+            "coq",
+            "z3"
+          ],
+          "title": "Proof System",
+          "type": "string"
+        },
+        "invariant_theorem": {
+          "description": "The exact mathematical assertion or safety invariant being proven (e.g., 'No data classified as CONFIDENTIAL routes externally').",
+          "title": "Invariant Theorem",
+          "type": "string"
+        },
+        "compiled_proof_hash": {
+          "description": "The SHA-256 fingerprint of the verified proof object that the Rust/C++ orchestrator must load and check.",
+          "title": "Compiled Proof Hash",
+          "type": "string"
+        }
+      },
+      "required": [
+        "proof_system",
+        "invariant_theorem",
+        "compiled_proof_hash"
+      ],
+      "title": "FormalVerificationContract",
+      "type": "object"
+    },
     "GlobalGovernance": {
       "additionalProperties": false,
       "description": "Global governance bounds for a swarm executing a workflow envelope.",
@@ -2107,6 +2141,18 @@
           "minimum": 0,
           "title": "Global Timeout Seconds",
           "type": "integer"
+        },
+        "formal_verification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FormalVerificationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical proof of structural correctness mandated for this execution graph."
         }
       },
       "required": [

--- a/src/coreason_manifest/oversight/governance.py
+++ b/src/coreason_manifest/oversight/governance.py
@@ -55,6 +55,27 @@ class ConsensusPolicy(CoreasonBaseModel):
     )
 
 
+class FormalVerificationContract(CoreasonBaseModel):
+    """
+    Passive schema defining a mathematical proof of safety invariants.
+    """
+
+    proof_system: Literal["tla_plus", "lean4", "coq", "z3"] = Field(
+        description="The mathematical dialect and theorem prover used to compile the proof."
+    )
+    invariant_theorem: str = Field(
+        description=(
+            "The exact mathematical assertion or safety invariant being proven "
+            "(e.g., 'No data classified as CONFIDENTIAL routes externally')."
+        )
+    )
+    compiled_proof_hash: str = Field(
+        description=(
+            "The SHA-256 fingerprint of the verified proof object that the Rust/C++ orchestrator must load and check."
+        )
+    )
+
+
 class GlobalGovernance(CoreasonBaseModel):
     """
     Global governance bounds for a swarm executing a workflow envelope.
@@ -66,4 +87,8 @@ class GlobalGovernance(CoreasonBaseModel):
     max_global_tokens: int = Field(description="The maximum aggregate token usage allowed across all nodes.")
     global_timeout_seconds: int = Field(
         ge=0, description="The absolute Time-To-Live (TTL) for the execution envelope before graceful termination."
+    )
+    formal_verification: FormalVerificationContract | None = Field(
+        default=None,
+        description="The mathematical proof of structural correctness mandated for this execution graph.",
     )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -930,7 +930,7 @@ def test_semanticedge_fuzzing(payload: dict[str, Any]) -> None:
 
 @st.composite
 def draw_formal_verification_contract(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "proof_system": st.sampled_from(["tla_plus", "lean4", "coq", "z3"]),
@@ -939,6 +939,7 @@ def draw_formal_verification_contract(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @given(

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -928,12 +928,26 @@ def test_semanticedge_fuzzing(payload: dict[str, Any]) -> None:
     assert parsed.edge_id == payload["edge_id"]
 
 
+@st.composite
+def draw_formal_verification_contract(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "proof_system": st.sampled_from(["tla_plus", "lean4", "coq", "z3"]),
+                "invariant_theorem": st.text(min_size=1),
+                "compiled_proof_hash": st.text(min_size=10),
+            }
+        )
+    )
+
+
 @given(
     st.fixed_dictionaries(
         {
             "max_budget_cents": st.integers(min_value=0),
             "max_global_tokens": st.integers(),
             "global_timeout_seconds": st.integers(min_value=0),
+            "formal_verification": st.one_of(st.none(), draw_formal_verification_contract()),
         }
     )
 )
@@ -1508,6 +1522,7 @@ def draw_workflow_envelope(draw: Any) -> dict[str, Any]:
                             "max_budget_cents": st.integers(min_value=0),
                             "max_global_tokens": st.integers(),
                             "global_timeout_seconds": st.integers(min_value=0),
+                            "formal_verification": st.one_of(st.none(), draw_formal_verification_contract()),
                         }
                     ),
                 ),


### PR DESCRIPTION
Epic 53: Declarative Formal Verification Contracts
Implemented strictly typed, passive schemas for Formal Verification Contracts allowing orchestrators to demand mathematical proofs of safety invariants. Added the FormalVerificationContract schema and updated GlobalGovernance and relevant fuzzing strategies.

---
*PR created automatically by Jules for task [12313339127088557744](https://jules.google.com/task/12313339127088557744) started by @gowthamrao*