### PR TITLE
feat: implement cryptographic lineage watermarking schema

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2472,6 +2472,41 @@
       ],
       "type": "string"
     },
+    "LineageWatermark": {
+      "additionalProperties": false,
+      "properties": {
+        "watermark_protocol": {
+          "description": "The mathematical methodology used to embed the chain of custody.",
+          "enum": [
+            "merkle_dag",
+            "statistical_token",
+            "homomorphic_mac"
+          ],
+          "title": "Watermark Protocol",
+          "type": "string"
+        },
+        "hop_signatures": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "A dictionary mapping intermediate participant NodeIDs to their deterministic execution signatures.",
+          "title": "Hop Signatures",
+          "type": "object"
+        },
+        "tamper_evident_root": {
+          "description": "The overarching cryptographic hash (e.g., Merkle Root) proving the dataset has not been laundered or structurally modified.",
+          "title": "Tamper Evident Root",
+          "type": "string"
+        }
+      },
+      "required": [
+        "watermark_protocol",
+        "hop_signatures",
+        "tamper_evident_root"
+      ],
+      "title": "LineageWatermark",
+      "type": "object"
+    },
     "LogEnvelope": {
       "additionalProperties": false,
       "description": "An out-of-band telemetry log envelope.",
@@ -2579,6 +2614,18 @@
           ],
           "default": null,
           "description": "The physical coordinate matrix where this data was extracted."
+        },
+        "lineage_watermark": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LineageWatermark"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic, tamper-evident chain of custody tracing this memory across multiple swarm hops."
         }
       },
       "required": [

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -56,11 +56,32 @@ class TemporalBounds(CoreasonBaseModel):
         return self
 
 
+class LineageWatermark(CoreasonBaseModel):
+    watermark_protocol: Literal["merkle_dag", "statistical_token", "homomorphic_mac"] = Field(
+        description="The mathematical methodology used to embed the chain of custody."
+    )
+    hop_signatures: dict[str, str] = Field(
+        description="A dictionary mapping intermediate participant NodeIDs to their deterministic execution signatures."
+    )
+    tamper_evident_root: str = Field(
+        description=(
+            "The overarching cryptographic hash (e.g., Merkle Root) proving "
+            "the dataset has not been laundered or structurally modified."
+        )
+    )
+
+
 class MemoryProvenance(CoreasonBaseModel):
     extracted_by: NodeID = Field(description="The ID of the agent node that extracted this memory.")
     source_event_id: str = Field(description="The exact event ID in the EpistemicLedger that generated this fact.")
     spatial_anchor: SpatialAnchor | None = Field(
         default=None, description="The physical coordinate matrix where this data was extracted."
+    )
+    lineage_watermark: LineageWatermark | None = Field(
+        default=None,
+        description=(
+            "The cryptographic, tamper-evident chain of custody tracing this memory across multiple swarm hops."
+        ),
     )
 
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -721,6 +721,23 @@ def test_chaosexperiment_fuzzing(
     assert parsed.experiment_id == experiment_id
 
 
+@st.composite
+def draw_lineage_watermark(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "watermark_protocol": st.sampled_from(["merkle_dag", "statistical_token", "homomorphic_mac"]),
+                "hop_signatures": st.dictionaries(
+                    st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"),
+                    st.text(min_size=10),
+                    max_size=5,
+                ),
+                "tamper_evident_root": st.text(min_size=10),
+            }
+        )
+    )
+
+
 @given(
     st.fixed_dictionaries(
         {
@@ -873,6 +890,7 @@ def draw_fhe_profile(draw: Any) -> dict[str, Any]:
                     ),
                     "source_event_id": st.text(),
                     "spatial_anchor": st.one_of(st.none(), draw_spatial_anchor()),
+                    "lineage_watermark": st.one_of(st.none(), draw_lineage_watermark()),
                 }
             ),
             "tier": st.sampled_from(["working", "episodic", "semantic"]),
@@ -915,6 +933,7 @@ def test_semanticnode_fuzzing(payload: dict[str, Any]) -> None:
                             min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
                         ),
                         "source_event_id": st.text(),
+                        "lineage_watermark": st.one_of(st.none(), draw_lineage_watermark()),
                     }
                 ),
             ),

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -723,7 +723,7 @@ def test_chaosexperiment_fuzzing(
 
 @st.composite
 def draw_lineage_watermark(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "watermark_protocol": st.sampled_from(["merkle_dag", "statistical_token", "homomorphic_mac"]),
@@ -736,6 +736,7 @@ def draw_lineage_watermark(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @given(


### PR DESCRIPTION
feat: implement cryptographic lineage watermarking schema

- Defined strictly typed passive schemas for Cryptographic Lineage Watermarks.
- Added LineageWatermark schema in src/coreason_manifest/state/semantic.py.
- Attached LineageWatermark to MemoryProvenance.
- Updated test fuzzer alignments in tests/test_fuzzing.py.
- Verified formatting, typing and ran tests correctly.

---
*PR created automatically by Jules for task [734491108824735332](https://jules.google.com/task/734491108824735332) started by @gowthamrao*