### PR TITLE
feat(workflow): add post-quantum signature schema to workflow boundaries

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -746,6 +746,18 @@
           },
           "title": "Permitted Geographic Regions",
           "type": "array"
+        },
+        "pq_signature": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PostQuantumSignature"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The quantum-resistant signature securing the multi-tenant legal boundary."
         }
       },
       "required": [
@@ -2976,6 +2988,39 @@
       "title": "PermissionBoundary",
       "type": "object"
     },
+    "PostQuantumSignature": {
+      "additionalProperties": false,
+      "properties": {
+        "pq_algorithm": {
+          "description": "The NIST FIPS post-quantum cryptographic algorithm used.",
+          "enum": [
+            "ml-dsa",
+            "slh-dsa",
+            "falcon"
+          ],
+          "title": "Pq Algorithm",
+          "type": "string"
+        },
+        "public_key_id": {
+          "description": "The identifier of the post-quantum public evaluation key.",
+          "title": "Public Key Id",
+          "type": "string"
+        },
+        "pq_signature_blob": {
+          "description": "The base64-encoded post-quantum signature. Bounded to 100KB to safely accommodate massive SPHINCS+ hash trees without OOM crashes.",
+          "maxLength": 100000,
+          "title": "Pq Signature Blob",
+          "type": "string"
+        }
+      },
+      "required": [
+        "pq_algorithm",
+        "public_key_id",
+        "pq_signature_blob"
+      ],
+      "title": "PostQuantumSignature",
+      "type": "object"
+    },
     "QoSClassification": {
       "enum": [
         "critical",
@@ -4472,6 +4517,18 @@
           ],
           "default": null,
           "description": "The B2B Service Level Agreement contract that must be mathematically satisfied before multi-tenant graph coupling."
+        },
+        "pq_signature": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PostQuantumSignature"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The quantum-resistant signature securing the root execution graph."
         }
       },
       "required": [

--- a/src/coreason_manifest/workflow/envelope.py
+++ b/src/coreason_manifest/workflow/envelope.py
@@ -5,12 +5,28 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from typing import Literal
+
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import DataClassification, RiskLevel, SemanticVersion
 from coreason_manifest.oversight.governance import GlobalGovernance
 from coreason_manifest.workflow.topologies import AnyTopology
+
+
+class PostQuantumSignature(CoreasonBaseModel):
+    pq_algorithm: Literal["ml-dsa", "slh-dsa", "falcon"] = Field(
+        description="The NIST FIPS post-quantum cryptographic algorithm used."
+    )
+    public_key_id: str = Field(description="The identifier of the post-quantum public evaluation key.")
+    pq_signature_blob: str = Field(
+        max_length=100000,
+        description=(
+            "The base64-encoded post-quantum signature. Bounded to 100KB to safely accommodate "
+            "massive SPHINCS+ hash trees without OOM crashes."
+        ),
+    )
 
 
 class BilateralSLA(CoreasonBaseModel):
@@ -27,6 +43,9 @@ class BilateralSLA(CoreasonBaseModel):
             "Explicit whitelist of geographic regions or cloud enclaves where execution "
             "is legally permitted (Data Residency Pinning)."
         ),
+    )
+    pq_signature: PostQuantumSignature | None = Field(
+        default=None, description="The quantum-resistant signature securing the multi-tenant legal boundary."
     )
 
 
@@ -59,4 +78,7 @@ class WorkflowEnvelope(CoreasonBaseModel):
             "The B2B Service Level Agreement contract that must be mathematically "
             "satisfied before multi-tenant graph coupling."
         ),
+    )
+    pq_signature: PostQuantumSignature | None = Field(
+        default=None, description="The quantum-resistant signature securing the root execution graph."
     )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1472,6 +1472,20 @@ workflow_envelope_adapter: TypeAdapter[WorkflowEnvelope] = TypeAdapter(WorkflowE
 
 
 @st.composite
+def draw_pq_signature(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "pq_algorithm": st.sampled_from(["ml-dsa", "slh-dsa", "falcon"]),
+                "public_key_id": st.text(min_size=1),
+                "pq_signature_blob": st.text(min_size=10, max_size=100000),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_bilateral_sla(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
@@ -1487,6 +1501,7 @@ def draw_bilateral_sla(draw: Any) -> dict[str, Any]:
                 ),
                 "liability_limit_cents": st.integers(min_value=0),
                 "permitted_geographic_regions": st.lists(st.text(min_size=1), max_size=10),
+                "pq_signature": st.one_of(st.none(), draw_pq_signature()),
             }
         )
     )
@@ -1532,6 +1547,7 @@ def draw_workflow_envelope(draw: Any) -> dict[str, Any]:
                     ),
                 ),
                 "federated_sla": st.one_of(st.none(), draw_bilateral_sla()),
+                "pq_signature": st.one_of(st.none(), draw_pq_signature()),
             }
         )
     )


### PR DESCRIPTION
This PR implements Epic 56 by introducing post-quantum (PQ) signature boundaries to the `coreason-manifest` architecture. The schema is purely passive and strictly typed to prevent payload bloat or OOM attacks via SPHINCS+ hash trees, ensuring B2B contract integrity against "Store Now, Forge Later" attacks. Corresponding testing strategies for generating massive PQ signatures have also been integrated.

---
*PR created automatically by Jules for task [8176523507273569563](https://jules.google.com/task/8176523507273569563) started by @gowthamrao*