### PR TITLE
Implement SMPC Topology Schema

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -425,6 +425,7 @@
           "council": "#/$defs/CouncilTopology",
           "dag": "#/$defs/DAGTopology",
           "evolutionary": "#/$defs/EvolutionaryTopology",
+          "smpc": "#/$defs/SMPCTopology",
           "swarm": "#/$defs/SwarmTopology"
         },
         "propertyName": "type"
@@ -441,6 +442,9 @@
         },
         {
           "$ref": "#/$defs/EvolutionaryTopology"
+        },
+        {
+          "$ref": "#/$defs/SMPCTopology"
         }
       ]
     },
@@ -3191,6 +3195,98 @@
         "tradeoff_preference"
       ],
       "title": "RoutingFrontier",
+      "type": "object"
+    },
+    "SMPCTopology": {
+      "additionalProperties": false,
+      "description": "A Secure Multi-Party Computation topology.",
+      "properties": {
+        "nodes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AnyNode"
+          },
+          "description": "Flat registry of all nodes in this topology.",
+          "propertyNames": {
+            "$ref": "#/$defs/NodeID"
+          },
+          "title": "Nodes",
+          "type": "object"
+        },
+        "shared_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The schema-on-write contract governing the internal state of this topology."
+        },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
+        "type": {
+          "const": "smpc",
+          "default": "smpc",
+          "description": "Discriminator for SMPC Topology.",
+          "title": "Type",
+          "type": "string"
+        },
+        "smpc_protocol": {
+          "description": "The exact cryptographic P2P protocol the nodes must use to evaluate the function.",
+          "enum": [
+            "garbled_circuits",
+            "secret_sharing",
+            "oblivious_transfer"
+          ],
+          "title": "Smpc Protocol",
+          "type": "string"
+        },
+        "joint_function_uri": {
+          "description": "The URI or hash pointing to the exact math circuit or polynomial function the ring will collaboratively compute.",
+          "title": "Joint Function Uri",
+          "type": "string"
+        },
+        "participant_node_ids": {
+          "description": "The strict ordered list of NodeIDs participating in the Secure Multi-Party Computation ring.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 2,
+          "title": "Participant Node Ids",
+          "type": "array"
+        }
+      },
+      "required": [
+        "nodes",
+        "smpc_protocol",
+        "joint_function_uri",
+        "participant_node_ids"
+      ],
+      "title": "SMPCTopology",
       "type": "object"
     },
     "SalienceProfile": {

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -219,7 +219,26 @@ class EvolutionaryTopology(BaseTopology):
         return self
 
 
+class SMPCTopology(BaseTopology):
+    """
+    A Secure Multi-Party Computation topology.
+    """
+
+    type: Literal["smpc"] = Field(default="smpc", description="Discriminator for SMPC Topology.")
+    smpc_protocol: Literal["garbled_circuits", "secret_sharing", "oblivious_transfer"] = Field(
+        description="The exact cryptographic P2P protocol the nodes must use to evaluate the function."
+    )
+    joint_function_uri: str = Field(
+        description="The URI or hash pointing to the exact math circuit or polynomial function "
+        "the ring will collaboratively compute."
+    )
+    participant_node_ids: list[str] = Field(
+        min_length=2,
+        description="The strict ordered list of NodeIDs participating in the Secure Multi-Party Computation ring.",
+    )
+
+
 type AnyTopology = Annotated[
-    DAGTopology | CouncilTopology | SwarmTopology | EvolutionaryTopology,
+    DAGTopology | CouncilTopology | SwarmTopology | EvolutionaryTopology | SMPCTopology,
     Field(discriminator="type", description="A discriminated union of workflow topologies."),
 ]

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -297,7 +297,29 @@ def draw_topology_payload(nodes_strategy: st.SearchStrategy[dict[str, Any]]) -> 
         }
     ).map(_council_mapper)
 
-    return st.one_of(dag_strategy, council_strategy)
+    smpc_strategy = st.fixed_dictionaries(
+        {
+            "type": st.just("smpc"),
+            "nodes": st.dictionaries(
+                st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"),
+                nodes_strategy,
+                min_size=2,
+                max_size=5,
+            ),
+            "shared_state_contract": st.none(),
+            "information_flow": st.none(),
+            "observability": st.none(),
+            "smpc_protocol": st.sampled_from(["garbled_circuits", "secret_sharing", "oblivious_transfer"]),
+            "joint_function_uri": st.text(min_size=1),
+            "participant_node_ids": st.lists(
+                st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"),
+                min_size=2,
+                max_size=5,
+            ),
+        }
+    )
+
+    return st.one_of(dag_strategy, council_strategy, smpc_strategy)
 
 
 def draw_composite_node_payload(


### PR DESCRIPTION
This implements the Epic 54 constraints to define strictly typed, passive schemas for Secure Multi-Party Computation (SMPC) topologies in the `coreason-manifest` architecture. It introduces a new `SMPCTopology` class utilizing `Literal` types to ensure rigid Pydantic validation over execution rings, routing, and functions evaluated over private data. The fuzzer payload generation has been precisely aligned to assert topological validation correctness.

---
*PR created automatically by Jules for task [3530269785628395574](https://jules.google.com/task/3530269785628395574) started by @gowthamrao*