### PR TITLE
Epic 60: Declarative Adversarial Simulation Profiles

### DIFF
--- a/src/coreason_manifest/testing/red_team.py
+++ b/src/coreason_manifest/testing/red_team.py
@@ -5,11 +5,33 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class AdversarialSimulationProfile(CoreasonBaseModel):
+    """
+    A deterministic red-team configuration defining a structural attack vector
+    to continuously validate semantic firewalls and execution bounds.
+    """
+
+    simulation_id: str = Field(description="The unique identifier for this red-team experiment.")
+    target_node_id: str = Field(description="The exact NodeID the 'Judas Node' will attempt to compromise.")
+    attack_vector: Literal["prompt_extraction", "data_exfiltration", "semantic_hijacking", "tool_poisoning"] = Field(
+        description="The mathematically predictable category of structural sabotage being simulated."
+    )
+    synthetic_payload: dict[str, Any] | str = Field(
+        description="The raw poisoned text or malicious JSON-RPC schema injected into the target's context window."
+    )
+    expected_firewall_trip: str | None = Field(
+        default=None,
+        description="The exact rule_id of the InformationFlowPolicy or Governance bound expected "
+        "to block this attack. Used for automated test assertions.",
+    )
+
 
 type AttackVector = Literal[
     "semantic_hijacking",

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -37,6 +37,7 @@ from coreason_manifest.state.semantic import SemanticEdge, SemanticNode
 from coreason_manifest.telemetry.custody import CustodyRecord
 from coreason_manifest.telemetry.schemas import TraceExportBatch
 from coreason_manifest.testing.chaos import ChaosExperiment
+from coreason_manifest.testing.red_team import AdversarialSimulationProfile
 from coreason_manifest.tooling import ActionSpace, ToolDefinition
 from coreason_manifest.workflow.auctions import AuctionState, TaskAward
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
@@ -1632,3 +1633,34 @@ def draw_workflow_envelope(draw: Any) -> dict[str, Any]:
 def test_workflow_envelope_fuzzing(payload: dict[str, Any]) -> None:
     parsed = workflow_envelope_adapter.validate_python(payload)
     assert isinstance(parsed, WorkflowEnvelope)
+
+
+adversarial_adapter: TypeAdapter[AdversarialSimulationProfile] = TypeAdapter(AdversarialSimulationProfile)
+
+
+@st.composite
+def draw_adversarial_simulation_profile(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "simulation_id": st.text(min_size=1),
+                "target_node_id": st.text(min_size=1),
+                "attack_vector": st.sampled_from(
+                    ["prompt_extraction", "data_exfiltration", "semantic_hijacking", "tool_poisoning"]
+                ),
+                "synthetic_payload": st.one_of(
+                    st.text(), st.dictionaries(st.text(), st.one_of(st.text(), st.integers(), st.booleans()))
+                ),
+                "expected_firewall_trip": st.one_of(st.none(), st.text(min_size=1)),
+            }
+        )
+    )
+    return res
+
+
+@given(draw_adversarial_simulation_profile())
+def test_adversarial_simulation_routing(payload: dict[str, Any]) -> None:
+    parsed = adversarial_adapter.validate_python(payload)
+    assert isinstance(parsed, AdversarialSimulationProfile)
+    assert parsed.simulation_id == payload["simulation_id"]
+    assert parsed.target_node_id == payload["target_node_id"]


### PR DESCRIPTION
Added the `AdversarialSimulationProfile` schema and an accompanying fuzzer test as part of Epic 60. The attack payloads follow a strict declarative contract.

---
*PR created automatically by Jules for task [9627528339163785179](https://jules.google.com/task/9627528339163785179) started by @gowthamrao*