### PR TITLE
feat: native MCP interface bindings

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -18,9 +18,9 @@
           "type": "array"
         },
         "mcp_servers": {
-          "description": "The list of MCP servers mounted into this action space.",
+          "description": "The array of verified external Model Context Protocol servers mounted into this action space.",
           "items": {
-            "$ref": "#/$defs/MCPClientBinding"
+            "$ref": "#/$defs/MCPServerManifest"
           },
           "title": "Mcp Servers",
           "type": "array"
@@ -2653,6 +2653,38 @@
       "title": "LogEnvelope",
       "type": "object"
     },
+    "MCPCapabilityWhitelist": {
+      "additionalProperties": false,
+      "description": "A zero-trust boundary defining exactly which JSON-RPC capabilities\nthe execution node is authorized to mount from the remote server.",
+      "properties": {
+        "allowed_tools": {
+          "description": "The explicit whitelist of function names the node is allowed to call.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Allowed Tools",
+          "type": "array"
+        },
+        "allowed_resources": {
+          "description": "The explicit whitelist of resource URIs the node is allowed to read.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Allowed Resources",
+          "type": "array"
+        },
+        "allowed_prompts": {
+          "description": "The explicit whitelist of workflow templates the node is allowed to trigger.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Allowed Prompts",
+          "type": "array"
+        }
+      },
+      "title": "MCPCapabilityWhitelist",
+      "type": "object"
+    },
     "MCPClientBinding": {
       "additionalProperties": false,
       "description": "Binding configuration for a Model Context Protocol (MCP) server.",
@@ -2688,6 +2720,51 @@
         "transport_type"
       ],
       "title": "MCPClientBinding",
+      "type": "object"
+    },
+    "MCPServerManifest": {
+      "additionalProperties": false,
+      "description": "The structural contract for mounting an external Model Context Protocol server.",
+      "properties": {
+        "server_uri": {
+          "description": "The network URI for SSE/HTTP, or the command execution string for stdio.",
+          "title": "Server Uri",
+          "type": "string"
+        },
+        "transport_type": {
+          "description": "The physical transport layer protocol used to stream the JSON-RPC packets.",
+          "enum": [
+            "stdio",
+            "sse",
+            "http"
+          ],
+          "title": "Transport Type",
+          "type": "string"
+        },
+        "binary_hash": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional SHA-256 hash of the local binary to prevent supply-chain execution attacks over stdio.",
+          "title": "Binary Hash"
+        },
+        "capability_whitelist": {
+          "$ref": "#/$defs/MCPCapabilityWhitelist",
+          "description": "The strict capability bounds enforced by the orchestrator prior to connection."
+        }
+      },
+      "required": [
+        "server_uri",
+        "transport_type",
+        "capability_whitelist"
+      ],
+      "title": "MCPServerManifest",
       "type": "object"
     },
     "MCPTransport": {

--- a/src/coreason_manifest/adapters/mcp/schemas.py
+++ b/src/coreason_manifest/adapters/mcp/schemas.py
@@ -18,6 +18,41 @@ from pydantic import Field, HttpUrl, field_validator
 from coreason_manifest.core.base import CoreasonBaseModel
 
 
+class MCPCapabilityWhitelist(CoreasonBaseModel):
+    """
+    A zero-trust boundary defining exactly which JSON-RPC capabilities
+    the execution node is authorized to mount from the remote server.
+    """
+
+    allowed_tools: list[str] = Field(
+        default_factory=list, description="The explicit whitelist of function names the node is allowed to call."
+    )
+    allowed_resources: list[str] = Field(
+        default_factory=list, description="The explicit whitelist of resource URIs the node is allowed to read."
+    )
+    allowed_prompts: list[str] = Field(
+        default_factory=list, description="The explicit whitelist of workflow templates the node is allowed to trigger."
+    )
+
+
+class MCPServerManifest(CoreasonBaseModel):
+    """
+    The structural contract for mounting an external Model Context Protocol server.
+    """
+
+    server_uri: str = Field(description="The network URI for SSE/HTTP, or the command execution string for stdio.")
+    transport_type: Literal["stdio", "sse", "http"] = Field(
+        description="The physical transport layer protocol used to stream the JSON-RPC packets."
+    )
+    binary_hash: str | None = Field(
+        default=None,
+        description="Optional SHA-256 hash of the local binary to prevent supply-chain execution attacks over stdio.",
+    )
+    capability_whitelist: MCPCapabilityWhitelist = Field(
+        description="The strict capability bounds enforced by the orchestrator prior to connection."
+    )
+
+
 class JSONRPCError(CoreasonBaseModel):
     """JSON-RPC 2.0 Error object."""
 

--- a/src/coreason_manifest/tooling/environments.py
+++ b/src/coreason_manifest/tooling/environments.py
@@ -9,6 +9,7 @@ from typing import Any, Literal
 
 from pydantic import Field, model_validator
 
+from coreason_manifest.adapters.mcp.schemas import MCPServerManifest
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.tooling.schemas import ToolDefinition
 
@@ -40,8 +41,9 @@ class ActionSpace(CoreasonBaseModel):
     native_tools: list[ToolDefinition] = Field(
         default_factory=list, description="The list of discrete, natively defined tools available in this space."
     )
-    mcp_servers: list[MCPClientBinding] = Field(
-        default_factory=list, description="The list of MCP servers mounted into this action space."
+    mcp_servers: list[MCPServerManifest] = Field(
+        default_factory=list,
+        description="The array of verified external Model Context Protocol servers mounted into this action space.",
     )
 
     @model_validator(mode="after")

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -777,6 +777,33 @@ def draw_lineage_watermark(draw: Any) -> dict[str, Any]:
     return res
 
 
+@st.composite
+def draw_mcp_capability_whitelist(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "allowed_tools": st.lists(st.text(), max_size=100),
+                "allowed_resources": st.lists(st.text(), max_size=100),
+                "allowed_prompts": st.lists(st.text(), max_size=100),
+            }
+        )
+    )
+
+
+@st.composite
+def draw_mcp_server_manifest(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "server_uri": st.text(min_size=1),
+                "transport_type": st.sampled_from(["stdio", "sse", "http"]),
+                "binary_hash": st.one_of(st.none(), st.text(min_size=10)),
+                "capability_whitelist": draw_mcp_capability_whitelist(),
+            }
+        )
+    )
+
+
 @given(
     st.fixed_dictionaries(
         {
@@ -820,15 +847,7 @@ def draw_lineage_watermark(draw: Any) -> dict[str, Any]:
                 ),
                 unique_by=lambda t: t["tool_name"] if isinstance(t, dict) and "tool_name" in t else str(t),
             ),
-            "mcp_servers": st.lists(
-                st.fixed_dictionaries(
-                    {
-                        "server_uri": st.text(),
-                        "transport_type": st.sampled_from(["stdio", "sse", "http"]),
-                        "allowed_mcp_tools": st.one_of(st.none(), st.lists(st.text(), max_size=100)),
-                    }
-                )
-            ),
+            "mcp_servers": st.lists(draw_mcp_server_manifest(), max_size=10),
         }
     )
 )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -779,7 +779,7 @@ def draw_lineage_watermark(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_mcp_capability_whitelist(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "allowed_tools": st.lists(st.text(), max_size=100),
@@ -788,11 +788,12 @@ def draw_mcp_capability_whitelist(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite
 def draw_mcp_server_manifest(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "server_uri": st.text(min_size=1),
@@ -802,6 +803,7 @@ def draw_mcp_server_manifest(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @given(


### PR DESCRIPTION
Implemented Native Model Context Protocol (MCP) Interface Bindings according to Epic 61 mandates. Replaced loose dict definitions with strictly typed, passive Pydantic schemas enforcing zero-trust capability whitelists, transport boundaries, and supply-chain execution attack prevention. Updated the ActionSpace and the test fuzzing logic to match.

---
*PR created automatically by Jules for task [3327114134962543014](https://jules.google.com/task/3327114134962543014) started by @gowthamrao*