### PR TITLE
feat: implement Phase 1 Cognitive and Embodied schemas

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -271,6 +271,18 @@
           "default": null,
           "description": "Declarative boundary for handling unredacted secrets within a temporarily isolated memory partition."
         },
+        "baseline_cognitive_state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CognitiveStateProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The default biochemical 'mood' simulated for this agent via Representation Engineering."
+        },
         "reflex_policy": {
           "anyOf": [
             {
@@ -726,6 +738,18 @@
           ],
           "default": null,
           "description": "The mathematical attestation proving this belief synthesis was generated securely without model-downgrade fraud."
+        },
+        "uncertainty_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CognitiveUncertaintyProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical quantification of doubt associated with this synthesized belief."
         }
       },
       "required": [
@@ -987,6 +1011,92 @@
         "error_signature"
       ],
       "title": "CircuitBreakerTrip",
+      "type": "object"
+    },
+    "CognitiveStateProfile": {
+      "additionalProperties": false,
+      "properties": {
+        "urgency_index": {
+          "description": "Drives latency requirements; high urgency forces fast, heuristic System 1 routing.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Urgency Index",
+          "type": "number"
+        },
+        "caution_index": {
+          "description": "Drives precision; high caution injects analytical/falsification steering vectors.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Caution Index",
+          "type": "number"
+        },
+        "divergence_tolerance": {
+          "description": "The 'curiosity' metric; dictates how far the MoE router is allowed to stray from high-probability distributions.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Divergence Tolerance",
+          "type": "number"
+        },
+        "active_steering_vector_hash": {
+          "anyOf": [
+            {
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The SHA-256 hash of the specific Representation Engineering control vector applied to the residual stream.",
+          "title": "Active Steering Vector Hash"
+        }
+      },
+      "required": [
+        "urgency_index",
+        "caution_index",
+        "divergence_tolerance"
+      ],
+      "title": "CognitiveStateProfile",
+      "type": "object"
+    },
+    "CognitiveUncertaintyProfile": {
+      "additionalProperties": false,
+      "properties": {
+        "aleatoric_entropy": {
+          "description": "Irreducible ambiguity detected in the input task or environment.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Aleatoric Entropy",
+          "type": "number"
+        },
+        "epistemic_uncertainty": {
+          "description": "The model's internal lack of knowledge, calculated via semantic disagreement.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Epistemic Uncertainty",
+          "type": "number"
+        },
+        "semantic_consistency_score": {
+          "description": "The degree to which multiple sampled latent thoughts align on the same conclusion.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Semantic Consistency Score",
+          "type": "number"
+        },
+        "requires_abductive_escalation": {
+          "description": "True if epistemic_uncertainty breaches the safety threshold, requiring System 2 test-time compute.",
+          "title": "Requires Abductive Escalation",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "aleatoric_entropy",
+        "epistemic_uncertainty",
+        "semantic_consistency_score",
+        "requires_abductive_escalation"
+      ],
+      "title": "CognitiveUncertaintyProfile",
       "type": "object"
     },
     "CompositeNode": {
@@ -1595,6 +1705,46 @@
         "model_variance_required"
       ],
       "title": "DiversityConstraint",
+      "type": "object"
+    },
+    "EmbodiedSensoryVector": {
+      "additionalProperties": false,
+      "properties": {
+        "sensory_modality": {
+          "description": "The continuous data stream being monitored.",
+          "enum": [
+            "video",
+            "audio",
+            "spatial_telemetry"
+          ],
+          "title": "Sensory Modality",
+          "type": "string"
+        },
+        "bayesian_surprise_score": {
+          "description": "The calculated KL divergence between the agent's prior belief and the incoming sensory evidence.",
+          "minimum": 0.0,
+          "title": "Bayesian Surprise Score",
+          "type": "number"
+        },
+        "temporal_duration_ms": {
+          "description": "The exact length of the continuous stream segment encapsulated by this observation.",
+          "exclusiveMinimum": 0,
+          "title": "Temporal Duration Ms",
+          "type": "integer"
+        },
+        "salience_threshold_breached": {
+          "default": true,
+          "description": "Mathematical proof that the anomaly was severe enough to warrant a memory snapshot.",
+          "title": "Salience Threshold Breached",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "sensory_modality",
+        "bayesian_surprise_score",
+        "temporal_duration_ms"
+      ],
+      "title": "EmbodiedSensoryVector",
       "type": "object"
     },
     "EpistemicLedger": {
@@ -3125,6 +3275,18 @@
           "default": null,
           "description": "The immutable cryptographic snapshot of the external environment at the moment of observation.",
           "title": "Toolchain Snapshot"
+        },
+        "sensory_trigger": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EmbodiedSensoryVector"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The continuous multimodal trigger that forced this discrete observation."
         }
       },
       "required": [

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1729,6 +1729,7 @@
         "temporal_duration_ms": {
           "description": "The exact length of the continuous stream segment encapsulated by this observation.",
           "exclusiveMinimum": 0,
+          "maximum": 86400000,
           "title": "Temporal Duration Ms",
           "type": "integer"
         },

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -7,6 +7,8 @@
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID, SemanticVersion
+from coreason_manifest.state.cognition import CognitiveStateProfile, CognitiveUncertaintyProfile
+from coreason_manifest.state.embodied import EmbodiedSensoryVector
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AnyNode
 from coreason_manifest.workflow.topologies import AnyTopology
@@ -14,7 +16,10 @@ from coreason_manifest.workflow.topologies import AnyTopology
 __all__ = [
     "AnyNode",
     "AnyTopology",
+    "CognitiveStateProfile",
+    "CognitiveUncertaintyProfile",
     "CoreasonBaseModel",
+    "EmbodiedSensoryVector",
     "NodeID",
     "SemanticVersion",
     "WorkflowEnvelope",

--- a/src/coreason_manifest/state/__init__.py
+++ b/src/coreason_manifest/state/__init__.py
@@ -12,12 +12,19 @@ from coreason_manifest.state.argumentation import (
     DefeasibleAttack,
     EvidentiaryWarrant,
 )
+from coreason_manifest.state.cognition import (
+    CognitiveStateProfile,
+    CognitiveUncertaintyProfile,
+)
 from coreason_manifest.state.differentials import (
     PatchOperation,
     RollbackRequest,
     StateDiff,
     StatePatch,
     TemporalCheckpoint,
+)
+from coreason_manifest.state.embodied import (
+    EmbodiedSensoryVector,
 )
 from coreason_manifest.state.events import (
     AnyStateEvent,
@@ -58,7 +65,10 @@ __all__ = [
     "BeliefUpdateEvent",
     "BrowserDOMState",
     "CausalInterval",
+    "CognitiveStateProfile",
+    "CognitiveUncertaintyProfile",
     "DefeasibleAttack",
+    "EmbodiedSensoryVector",
     "EpistemicLedger",
     "EvidentiaryWarrant",
     "FederatedStateSnapshot",

--- a/src/coreason_manifest/state/cognition.py
+++ b/src/coreason_manifest/state/cognition.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class CognitiveUncertaintyProfile(CoreasonBaseModel):
+    aleatoric_entropy: float = Field(
+        ge=0.0, le=1.0, description="Irreducible ambiguity detected in the input task or environment."
+    )
+    epistemic_uncertainty: float = Field(
+        ge=0.0, le=1.0, description="The model's internal lack of knowledge, calculated via semantic disagreement."
+    )
+    semantic_consistency_score: float = Field(
+        ge=0.0, le=1.0, description="The degree to which multiple sampled latent thoughts align on the same conclusion."
+    )
+    requires_abductive_escalation: bool = Field(
+        description="True if epistemic_uncertainty breaches the safety threshold, requiring System 2 test-time compute."
+    )
+
+
+class CognitiveStateProfile(CoreasonBaseModel):
+    urgency_index: float = Field(
+        ge=0.0, le=1.0, description="Drives latency requirements; high urgency forces fast, heuristic System 1 routing."
+    )
+    caution_index: float = Field(
+        ge=0.0, le=1.0, description="Drives precision; high caution injects analytical/falsification steering vectors."
+    )
+    divergence_tolerance: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The 'curiosity' metric; dictates how far the MoE router is allowed to stray "
+        "from high-probability distributions.",
+    )
+    active_steering_vector_hash: str | None = Field(
+        default=None,
+        pattern=r"^[a-f0-9]{64}$",
+        description="The SHA-256 hash of the specific Representation Engineering control vector "
+        "applied to the residual stream.",
+    )

--- a/src/coreason_manifest/state/embodied.py
+++ b/src/coreason_manifest/state/embodied.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class EmbodiedSensoryVector(CoreasonBaseModel):
+    sensory_modality: Literal["video", "audio", "spatial_telemetry"] = Field(
+        description="The continuous data stream being monitored."
+    )
+    bayesian_surprise_score: float = Field(
+        ge=0.0,
+        description="The calculated KL divergence between the agent's prior belief and the incoming sensory evidence.",
+    )
+    temporal_duration_ms: int = Field(
+        gt=0, description="The exact length of the continuous stream segment encapsulated by this observation."
+    )
+    salience_threshold_breached: bool = Field(
+        default=True, description="Mathematical proof that the anomaly was severe enough to warrant a memory snapshot."
+    )

--- a/src/coreason_manifest/state/embodied.py
+++ b/src/coreason_manifest/state/embodied.py
@@ -21,7 +21,9 @@ class EmbodiedSensoryVector(CoreasonBaseModel):
         description="The calculated KL divergence between the agent's prior belief and the incoming sensory evidence.",
     )
     temporal_duration_ms: int = Field(
-        gt=0, description="The exact length of the continuous stream segment encapsulated by this observation."
+        gt=0,
+        le=86400000,
+        description="The exact length of the continuous stream segment encapsulated by this observation.",
     )
     salience_threshold_breached: bool = Field(
         default=True, description="Mathematical proof that the anomaly was severe enough to warrant a memory snapshot."

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -11,6 +11,8 @@ from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
+from coreason_manifest.state.cognition import CognitiveUncertaintyProfile
+from coreason_manifest.state.embodied import EmbodiedSensoryVector
 from coreason_manifest.state.toolchains import AnyToolchainState
 
 
@@ -67,6 +69,10 @@ class ObservationEvent(BaseStateEvent):
         default=None,
         description="The immutable cryptographic snapshot of the external environment at the moment of observation.",
     )
+    sensory_trigger: EmbodiedSensoryVector | None = Field(
+        default=None,
+        description="The continuous multimodal trigger that forced this discrete observation.",
+    )
 
 
 class CausalAttribution(CoreasonBaseModel):
@@ -100,6 +106,10 @@ class BeliefUpdateEvent(BaseStateEvent):
         default=None,
         description="The mathematical attestation proving this belief synthesis was generated "
         "securely without model-downgrade fraud.",
+    )
+    uncertainty_profile: CognitiveUncertaintyProfile | None = Field(
+        default=None,
+        description="The mathematical quantification of doubt associated with this synthesized belief.",
     )
 
 

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -12,6 +12,7 @@ from pydantic import Field
 from coreason_manifest.compute.profiles import RoutingFrontier
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.oversight.dlp import SecureSubSession
+from coreason_manifest.state.cognition import CognitiveStateProfile
 
 if TYPE_CHECKING:
     from coreason_manifest.workflow.topologies import AnyTopology
@@ -99,6 +100,10 @@ class AgentNode(BaseNode):
         default=None,
         description="Declarative boundary for handling unredacted secrets "
         "within a temporarily isolated memory partition.",
+    )
+    baseline_cognitive_state: CognitiveStateProfile | None = Field(
+        default=None,
+        description="The default biochemical 'mood' simulated for this agent via Representation Engineering.",
     )
     reflex_policy: System1Reflex | None = Field(
         default=None, description="The policy governing System 1 reflex actions."

--- a/tests/domains/test_state_cognition.py
+++ b/tests/domains/test_state_cognition.py
@@ -81,6 +81,7 @@ def test_invalid_bounds_rejected() -> None:
 
 def test_canonical_hashing_determinism() -> None:
     from typing import Any
+
     kwargs1: dict[str, Any] = {
         "aleatoric_entropy": 0.5,
         "epistemic_uncertainty": 0.2,

--- a/tests/domains/test_state_cognition.py
+++ b/tests/domains/test_state_cognition.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from coreason_manifest.state.cognition import CognitiveStateProfile, CognitiveUncertaintyProfile
+
+
+@given(
+    aleatoric_entropy=st.floats(min_value=0.0, max_value=1.0),
+    epistemic_uncertainty=st.floats(min_value=0.0, max_value=1.0),
+    semantic_consistency_score=st.floats(min_value=0.0, max_value=1.0),
+    requires_abductive_escalation=st.booleans(),
+)
+def test_cognitive_uncertainty_profile_fuzzing(
+    aleatoric_entropy: float,
+    epistemic_uncertainty: float,
+    semantic_consistency_score: float,
+    requires_abductive_escalation: bool,
+) -> None:
+    profile = CognitiveUncertaintyProfile(
+        aleatoric_entropy=aleatoric_entropy,
+        epistemic_uncertainty=epistemic_uncertainty,
+        semantic_consistency_score=semantic_consistency_score,
+        requires_abductive_escalation=requires_abductive_escalation,
+    )
+    assert profile.aleatoric_entropy == aleatoric_entropy
+    assert profile.epistemic_uncertainty == epistemic_uncertainty
+
+
+@given(
+    urgency_index=st.floats(min_value=0.0, max_value=1.0),
+    caution_index=st.floats(min_value=0.0, max_value=1.0),
+    divergence_tolerance=st.floats(min_value=0.0, max_value=1.0),
+    active_steering_vector_hash=st.one_of(st.none(), st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True)),
+)
+def test_cognitive_state_profile_fuzzing(
+    urgency_index: float, caution_index: float, divergence_tolerance: float, active_steering_vector_hash: str | None
+) -> None:
+    profile = CognitiveStateProfile(
+        urgency_index=urgency_index,
+        caution_index=caution_index,
+        divergence_tolerance=divergence_tolerance,
+        active_steering_vector_hash=active_steering_vector_hash,
+    )
+    assert profile.urgency_index == urgency_index
+
+
+def test_invalid_bounds_rejected() -> None:
+    # Test negative floats
+    with pytest.raises(ValidationError):
+        CognitiveUncertaintyProfile(
+            aleatoric_entropy=-0.1,
+            epistemic_uncertainty=0.5,
+            semantic_consistency_score=0.5,
+            requires_abductive_escalation=False,
+        )
+
+    # Test floats > 1.0
+    with pytest.raises(ValidationError):
+        CognitiveUncertaintyProfile(
+            aleatoric_entropy=1.1,
+            epistemic_uncertainty=0.5,
+            semantic_consistency_score=0.5,
+            requires_abductive_escalation=False,
+        )
+
+    # Test invalid SHA-256 hash
+    with pytest.raises(ValidationError):
+        CognitiveStateProfile(
+            urgency_index=0.5, caution_index=0.5, divergence_tolerance=0.5, active_steering_vector_hash="invalidhash"
+        )
+
+
+def test_canonical_hashing_determinism() -> None:
+    from typing import Any
+    kwargs1: dict[str, Any] = {
+        "aleatoric_entropy": 0.5,
+        "epistemic_uncertainty": 0.2,
+        "semantic_consistency_score": 0.8,
+        "requires_abductive_escalation": False,
+    }
+
+    kwargs2: dict[str, Any] = {
+        "requires_abductive_escalation": False,
+        "semantic_consistency_score": 0.8,
+        "epistemic_uncertainty": 0.2,
+        "aleatoric_entropy": 0.5,
+    }
+
+    profile1 = CognitiveUncertaintyProfile(**kwargs1)
+    profile2 = CognitiveUncertaintyProfile(**kwargs2)
+
+    assert profile1.model_dump_canonical() == profile2.model_dump_canonical()
+    assert hash(profile1) == hash(profile2)
+
+    kwargs3: dict[str, Any] = {
+        "urgency_index": 0.5,
+        "caution_index": 0.5,
+        "divergence_tolerance": 0.5,
+        "active_steering_vector_hash": "a" * 64,
+    }
+
+    kwargs4: dict[str, Any] = {
+        "active_steering_vector_hash": "a" * 64,
+        "divergence_tolerance": 0.5,
+        "caution_index": 0.5,
+        "urgency_index": 0.5,
+    }
+
+    profile3 = CognitiveStateProfile(**kwargs3)
+    profile4 = CognitiveStateProfile(**kwargs4)
+
+    assert profile3.model_dump_canonical() == profile4.model_dump_canonical()
+    assert hash(profile3) == hash(profile4)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -59,6 +59,51 @@ def draw_reflex_policy(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_cognitive_state_profile(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "urgency_index": st.floats(min_value=0.0, max_value=1.0),
+                "caution_index": st.floats(min_value=0.0, max_value=1.0),
+                "divergence_tolerance": st.floats(min_value=0.0, max_value=1.0),
+                "active_steering_vector_hash": st.one_of(st.none(), st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True)),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_cognitive_uncertainty_profile(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "aleatoric_entropy": st.floats(min_value=0.0, max_value=1.0),
+                "epistemic_uncertainty": st.floats(min_value=0.0, max_value=1.0),
+                "semantic_consistency_score": st.floats(min_value=0.0, max_value=1.0),
+                "requires_abductive_escalation": st.booleans(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_embodied_sensory_vector(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "sensory_modality": st.sampled_from(["video", "audio", "spatial_telemetry"]),
+                "bayesian_surprise_score": st.floats(min_value=0.0),
+                "temporal_duration_ms": st.integers(min_value=1, max_value=86400000),
+                "salience_threshold_breached": st.booleans(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_epistemic_policy(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
@@ -183,6 +228,8 @@ def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
         payload["reflex_policy"] = draw(draw_reflex_policy())
     if draw(st.booleans()):
         payload["epistemic_policy"] = draw(draw_epistemic_policy())
+    if draw(st.booleans()):
+        payload["baseline_cognitive_state"] = draw(draw_cognitive_state_profile())
     if draw(st.booleans()):
         payload["correction_policy"] = draw(draw_correction_policy())
     return payload
@@ -625,6 +672,10 @@ def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
             payload["hardware_attestation"] = draw(draw_hardware_attestation())
         if event_type == "observation" and draw(st.booleans()):
             payload["toolchain_snapshot"] = draw(draw_any_toolchain_state())
+        if event_type == "observation" and draw(st.booleans()):
+            payload["sensory_trigger"] = draw(draw_embodied_sensory_vector())
+        if event_type == "belief_update" and draw(st.booleans()):
+            payload["uncertainty_profile"] = draw(draw_cognitive_uncertainty_profile())
     return payload
 
 


### PR DESCRIPTION
Implemented **Phase 1: Foundational Epistemology & Affect (The Base Primitives)** for the `coreason-manifest` shared kernel. 

Created `CognitiveUncertaintyProfile` and `CognitiveStateProfile` in the new `state/cognition.py` module to formalize epistemic uncertainty and representation engineering states. Created `EmbodiedSensoryVector` in the new `state/embodied.py` module to process continuous sensory streams.

Integrated these primitives into `state/events.py` (`ObservationEvent`, `BeliefUpdateEvent`) and `workflow/nodes.py` (`AgentNode`). Ensured all models use strict Pydantic `Field` bounds, exported them in `__init__.py` files, regenerated the `coreason_ontology.schema.json` with no backward-breaking changes, and added comprehensive fuzzing and determinism tests using `hypothesis` to meet the strict 100% test coverage and type checking requirements.

---
*PR created automatically by Jules for task [5093401990527392004](https://jules.google.com/task/5093401990527392004) started by @gowthamrao*