### PR TITLE
feat: Implement Deterministic HITL Presentation Intents

### DIFF
--- a/src/coreason_manifest/presentation/intents.py
+++ b/src/coreason_manifest/presentation/intents.py
@@ -69,7 +69,8 @@ class EscalationIntent(CoreasonBaseModel):
         description="The ID of the Data Loss Prevention (DLP) or Governance rule that blocked execution."
     )
     resolution_schema: dict[str, Any] = Field(
-        description="The strict JSON Schema requiring an explicit cryptographic sign-off or justification string to bypass the breaker."
+        description="The strict JSON Schema requiring an explicit cryptographic "
+        "sign-off or justification string to bypass the breaker."
     )
     timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
         description="The default action is usually terminate or rollback for security escalations."
@@ -80,7 +81,8 @@ type AnyPresentationIntent = Annotated[
     InformationalIntent | DraftingIntent | AdjudicationIntent | EscalationIntent, Field(discriminator="type")
 ]
 
-# Provide backwards compatibility for AnyIntent, which tests might still refer to via PresentationEnvelope if not changed there, or __init__.py
+# Provide backwards compatibility for AnyIntent, which tests might still refer
+# to via PresentationEnvelope if not changed there, or __init__.py
 type AnyIntent = AnyPresentationIntent
 
 

--- a/src/coreason_manifest/presentation/intents.py
+++ b/src/coreason_manifest/presentation/intents.py
@@ -5,7 +5,7 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
 from pydantic import Field
 
@@ -17,32 +17,75 @@ class BaseIntent(CoreasonBaseModel):
     """Base class for presentation intents."""
 
 
-class DraftingIntent(BaseIntent):
-    """Intent indicating the AI is proposing a draft."""
-
-    type: Literal["drafting"] = Field(default="drafting", description="Discriminator for a drafting intent.")
-
-
-class AdjudicationIntent(BaseIntent):
-    """Intent indicating the presentation requires human approval/rejection."""
-
-    type: Literal["adjudication"] = Field(
-        default="adjudication",
-        description="Discriminator for an adjudication intent.",
-    )
-
-
 class FYIIntent(BaseIntent):
     """Intent indicating the presentation is informational only."""
 
     type: Literal["fyi"] = Field(default="fyi", description="Discriminator for an FYI intent.")
 
 
-type AnyIntent = Annotated[DraftingIntent | AdjudicationIntent | FYIIntent, Field(discriminator="type")]
+class InformationalIntent(CoreasonBaseModel):
+    type: Literal["informational"] = Field(
+        default="informational", description="Discriminator for read-only informational handoffs."
+    )
+    message: str = Field(description="The context or summary to display to the human operator.")
+    timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
+        description="The orchestrator's automatic fallback if the human does not acknowledge the intent in time."
+    )
+
+
+class DraftingIntent(CoreasonBaseModel):
+    type: Literal["drafting"] = Field(
+        default="drafting", description="Discriminator for requesting specific missing context from a human."
+    )
+    context_prompt: str = Field(description="The prompt explaining what information the swarm is missing.")
+    resolution_schema: dict[str, Any] = Field(
+        description="The strict JSON Schema the human's input must satisfy before the graph can resume."
+    )
+    timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
+        description="The action to take if the human fails to provide the draft."
+    )
+
+
+class AdjudicationIntent(CoreasonBaseModel):
+    type: Literal["forced_adjudication"] = Field(
+        default="forced_adjudication", description="Discriminator for breaking deadlocks within a CouncilTopology."
+    )
+    deadlocked_claims: list[str] = Field(
+        min_length=2, description="The conflicting claim IDs or proposals the human must choose between."
+    )
+    resolution_schema: dict[str, Any] = Field(
+        description="The strict JSON Schema for the tie-breaking response (usually an enum of the deadlocked_claims)."
+    )
+    timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
+        description="The action to take if the oracle is unresponsive."
+    )
+
+
+class EscalationIntent(CoreasonBaseModel):
+    type: Literal["escalation"] = Field(
+        default="escalation", description="Discriminator for security or economic boundary overrides."
+    )
+    tripped_rule_id: str = Field(
+        description="The ID of the Data Loss Prevention (DLP) or Governance rule that blocked execution."
+    )
+    resolution_schema: dict[str, Any] = Field(
+        description="The strict JSON Schema requiring an explicit cryptographic sign-off or justification string to bypass the breaker."
+    )
+    timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
+        description="The default action is usually terminate or rollback for security escalations."
+    )
+
+
+type AnyPresentationIntent = Annotated[
+    InformationalIntent | DraftingIntent | AdjudicationIntent | EscalationIntent, Field(discriminator="type")
+]
+
+# Provide backwards compatibility for AnyIntent, which tests might still refer to via PresentationEnvelope if not changed there, or __init__.py
+type AnyIntent = AnyPresentationIntent
 
 
 class PresentationEnvelope(CoreasonBaseModel):
     """An envelope wrapping a grid presentation and its intent."""
 
-    intent: AnyIntent = Field(description="The reason an agent is presenting this data to a human.")
+    intent: AnyPresentationIntent = Field(description="The reason an agent is presenting this data to a human.")
     grid: MacroGrid = Field(description="The grid of panels being presented.")

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -300,8 +300,8 @@ def test_grammar_determinism() -> None:
 
 
 def test_presentation_envelope_determinism() -> None:
-    intent1 = DraftingIntent()
-    intent2 = DraftingIntent()
+    intent1 = DraftingIntent(context_prompt="Missing context", resolution_schema={"type": "string"}, timeout_action="rollback")
+    intent2 = DraftingIntent(context_prompt="Missing context", resolution_schema={"type": "string"}, timeout_action="rollback")
 
     panel1 = InsightCard(panel_id="panel_1", title="Insight 1", markdown_content="Content 1")
     panel2 = InsightCard(panel_id="panel_2", title="Insight 2", markdown_content="Content 2")

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -300,8 +300,12 @@ def test_grammar_determinism() -> None:
 
 
 def test_presentation_envelope_determinism() -> None:
-    intent1 = DraftingIntent(context_prompt="Missing context", resolution_schema={"type": "string"}, timeout_action="rollback")
-    intent2 = DraftingIntent(context_prompt="Missing context", resolution_schema={"type": "string"}, timeout_action="rollback")
+    intent1 = DraftingIntent(
+        context_prompt="Missing context", resolution_schema={"type": "string"}, timeout_action="rollback"
+    )
+    intent2 = DraftingIntent(
+        context_prompt="Missing context", resolution_schema={"type": "string"}, timeout_action="rollback"
+    )
 
     panel1 = InsightCard(panel_id="panel_1", title="Insight 1", markdown_content="Content 1")
     panel2 = InsightCard(panel_id="panel_2", title="Insight 2", markdown_content="Content 2")

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -4,7 +4,6 @@
 # The issuer of the Prosperity Public License for this software is CoReason, Inc..
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
-
 import re
 from typing import Any
 
@@ -28,6 +27,13 @@ from coreason_manifest.oversight.resilience import (
     CircuitBreakerTrip,
     FallbackTrigger,
     QuarantineOrder,
+)
+from coreason_manifest.presentation.intents import (
+    AdjudicationIntent,
+    AnyPresentationIntent,
+    DraftingIntent,
+    EscalationIntent,
+    InformationalIntent,
 )
 from coreason_manifest.presentation.scivis import AnyPanel, GrammarPanel, InsightCard
 from coreason_manifest.state.argumentation import ArgumentGraph
@@ -1724,3 +1730,95 @@ def test_adversarial_simulation_routing(payload: dict[str, Any]) -> None:
     assert isinstance(parsed, AdversarialSimulationProfile)
     assert parsed.simulation_id == payload["simulation_id"]
     assert parsed.target_node_id == payload["target_node_id"]
+
+
+any_presentation_intent_adapter: TypeAdapter[AnyPresentationIntent] = TypeAdapter(AnyPresentationIntent)
+
+
+@st.composite
+def draw_informational_intent(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("informational"),
+                "message": st.text(),
+                "timeout_action": st.sampled_from(["rollback", "proceed_default", "terminate"]),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_drafting_intent(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("drafting"),
+                "context_prompt": st.text(),
+                "resolution_schema": st.dictionaries(st.text(), st.one_of(st.text(), st.integers(), st.booleans())),
+                "timeout_action": st.sampled_from(["rollback", "proceed_default", "terminate"]),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_adjudication_intent(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("forced_adjudication"),
+                "deadlocked_claims": st.lists(st.text(), min_size=2),
+                "resolution_schema": st.dictionaries(st.text(), st.one_of(st.text(), st.integers(), st.booleans())),
+                "timeout_action": st.sampled_from(["rollback", "proceed_default", "terminate"]),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_escalation_intent(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("escalation"),
+                "tripped_rule_id": st.text(),
+                "resolution_schema": st.dictionaries(st.text(), st.one_of(st.text(), st.integers(), st.booleans())),
+                "timeout_action": st.sampled_from(["rollback", "proceed_default", "terminate"]),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_any_presentation_intent(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.one_of(
+            draw_informational_intent(),
+            draw_drafting_intent(),
+            draw_adjudication_intent(),
+            draw_escalation_intent(),
+        )
+    )
+    return res
+
+
+@given(draw_any_presentation_intent())
+def test_presentation_intent_routing(payload: dict[str, Any]) -> None:
+    parsed = any_presentation_intent_adapter.validate_python(payload)
+    if payload["type"] == "informational":
+        assert isinstance(parsed, InformationalIntent)
+        assert parsed.message == payload["message"]
+    elif payload["type"] == "drafting":
+        assert isinstance(parsed, DraftingIntent)
+        assert parsed.context_prompt == payload["context_prompt"]
+    elif payload["type"] == "forced_adjudication":
+        assert isinstance(parsed, AdjudicationIntent)
+        assert parsed.deadlocked_claims == payload["deadlocked_claims"]
+    elif payload["type"] == "escalation":
+        assert isinstance(parsed, EscalationIntent)
+        assert parsed.tripped_rule_id == payload["tripped_rule_id"]


### PR DESCRIPTION
Implemented the strict typed passive schemas for presentation intents to ensure proper "Schema-on-Resume" for Human-in-the-Loop workflows per Epic 58 directives. The `AnyPresentationIntent` correctly discriminates type, all classes have strict schemas devoid of active functionality. Fuzzing routing and generation functions are fully updated.

---
*PR created automatically by Jules for task [1119345837910373991](https://jules.google.com/task/1119345837910373991) started by @gowthamrao*