### PR TITLE
feat: Implement Scratchpad trace and Test-Time Compute contracts

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -318,6 +318,30 @@
           ],
           "default": null,
           "description": "The policy governing self-correction loops."
+        },
+        "escalation_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EscalationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical boundary authorizing the agent to spin up Test-Time Compute."
+        },
+        "prm_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProcessRewardContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The ruleset governing how intermediate thoughts are scored and pruned."
         }
       },
       "required": [
@@ -750,6 +774,18 @@
           ],
           "default": null,
           "description": "The mathematical quantification of doubt associated with this synthesized belief."
+        },
+        "scratchpad_trace": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LatentScratchpadTrace"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic record of the non-monotonic internal monologue that justifies this belief."
         }
       },
       "required": [
@@ -1838,6 +1874,37 @@
       "title": "EpistemicScanner",
       "type": "object"
     },
+    "EscalationContract": {
+      "additionalProperties": false,
+      "properties": {
+        "uncertainty_escalation_threshold": {
+          "description": "The exact Epistemic Uncertainty score that triggers the opening of the Latent Scratchpad.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Uncertainty Escalation Threshold",
+          "type": "number"
+        },
+        "max_latent_tokens_budget": {
+          "description": "The maximum number of hidden tokens the orchestrator is authorized to buy for the internal monologue.",
+          "exclusiveMinimum": 0,
+          "title": "Max Latent Tokens Budget",
+          "type": "integer"
+        },
+        "max_test_time_compute_ms": {
+          "description": "The physical time limit allowed for the scratchpad search before forcing a timeout.",
+          "exclusiveMinimum": 0,
+          "title": "Max Test Time Compute Ms",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "uncertainty_escalation_threshold",
+        "max_latent_tokens_budget",
+        "max_test_time_compute_ms"
+      ],
+      "title": "EscalationContract",
+      "type": "object"
+    },
     "EscrowPolicy": {
       "additionalProperties": false,
       "properties": {
@@ -2760,6 +2827,60 @@
       "title": "InterventionVerdict",
       "type": "object"
     },
+    "LatentScratchpadTrace": {
+      "additionalProperties": false,
+      "properties": {
+        "trace_id": {
+          "description": "Unique identifier for this entire test-time compute session.",
+          "minLength": 1,
+          "title": "Trace Id",
+          "type": "string"
+        },
+        "explored_branches": {
+          "description": "All logical paths the agent attempted.",
+          "items": {
+            "$ref": "#/$defs/ThoughtBranch"
+          },
+          "title": "Explored Branches",
+          "type": "array"
+        },
+        "discarded_branches": {
+          "description": "A list of branch_ids that were explicitly pruned due to logical dead-ends.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Discarded Branches",
+          "type": "array"
+        },
+        "resolution_branch_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The branch_id that successfully resolved the uncertainty and led to the final output.",
+          "title": "Resolution Branch Id"
+        },
+        "total_latent_tokens": {
+          "description": "The total compute expenditure (in tokens) spent purely on internal reasoning.",
+          "minimum": 0,
+          "title": "Total Latent Tokens",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "trace_id",
+        "explored_branches",
+        "discarded_branches",
+        "total_latent_tokens"
+      ],
+      "title": "LatentScratchpadTrace",
+      "type": "object"
+    },
     "LifecycleTrigger": {
       "enum": [
         "on_start",
@@ -3482,6 +3603,43 @@
         "pq_signature_blob"
       ],
       "title": "PostQuantumSignature",
+      "type": "object"
+    },
+    "ProcessRewardContract": {
+      "additionalProperties": false,
+      "properties": {
+        "pruning_threshold": {
+          "description": "If a ThoughtBranch's prm_score falls below this threshold, the orchestrator MUST halt its generation.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Pruning Threshold",
+          "type": "number"
+        },
+        "max_backtracks_allowed": {
+          "description": "The absolute limit on how many times the agent can start a new branch before throwing a SystemFaultEvent.",
+          "minimum": 0,
+          "title": "Max Backtracks Allowed",
+          "type": "integer"
+        },
+        "evaluator_model_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific PRM model used to score the logic (e.g., 'math-prm-v2').",
+          "title": "Evaluator Model Name"
+        }
+      },
+      "required": [
+        "pruning_threshold",
+        "max_backtracks_allowed"
+      ],
+      "title": "ProcessRewardContract",
       "type": "object"
     },
     "QoSClassification": {
@@ -4840,6 +4998,57 @@
         "env_variables_hash"
       ],
       "title": "TerminalBufferState",
+      "type": "object"
+    },
+    "ThoughtBranch": {
+      "additionalProperties": false,
+      "properties": {
+        "branch_id": {
+          "description": "Unique identifier for this line of reasoning.",
+          "minLength": 1,
+          "title": "Branch Id",
+          "type": "string"
+        },
+        "parent_branch_id": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The branch this thought diverged from, enabling tree reconstruction.",
+          "title": "Parent Branch Id"
+        },
+        "latent_content_hash": {
+          "description": "The SHA-256 hash of the raw scratchpad text generated in this branch.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Latent Content Hash",
+          "type": "string"
+        },
+        "prm_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The logical validity score assigned to this branch by the Process Reward Model.",
+          "title": "Prm Score"
+        }
+      },
+      "required": [
+        "branch_id",
+        "latent_content_hash"
+      ],
+      "title": "ThoughtBranch",
       "type": "object"
     },
     "TieBreaker": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -5,10 +5,12 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID, SemanticVersion
 from coreason_manifest.state.cognition import CognitiveStateProfile, CognitiveUncertaintyProfile
 from coreason_manifest.state.embodied import EmbodiedSensoryVector
+from coreason_manifest.state.scratchpad import LatentScratchpadTrace, ThoughtBranch
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AnyNode
 from coreason_manifest.workflow.topologies import AnyTopology
@@ -20,7 +22,11 @@ __all__ = [
     "CognitiveUncertaintyProfile",
     "CoreasonBaseModel",
     "EmbodiedSensoryVector",
+    "EscalationContract",
+    "LatentScratchpadTrace",
     "NodeID",
+    "ProcessRewardContract",
     "SemanticVersion",
+    "ThoughtBranch",
     "WorkflowEnvelope",
 ]

--- a/src/coreason_manifest/compute/test_time.py
+++ b/src/coreason_manifest/compute/test_time.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class ProcessRewardContract(CoreasonBaseModel):
+    pruning_threshold: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="If a ThoughtBranch's prm_score falls below this threshold, "
+        "the orchestrator MUST halt its generation.",
+    )
+    max_backtracks_allowed: int = Field(
+        ge=0,
+        description="The absolute limit on how many times the agent can start a new branch "
+        "before throwing a SystemFaultEvent.",
+    )
+    evaluator_model_name: str | None = Field(
+        default=None,
+        description="The specific PRM model used to score the logic (e.g., 'math-prm-v2').",
+    )
+
+
+class EscalationContract(CoreasonBaseModel):
+    uncertainty_escalation_threshold: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The exact Epistemic Uncertainty score that triggers the opening of the Latent Scratchpad.",
+    )
+    max_latent_tokens_budget: int = Field(
+        gt=0,
+        description="The maximum number of hidden tokens the orchestrator is authorized to buy "
+        "for the internal monologue.",
+    )
+    max_test_time_compute_ms: int = Field(
+        gt=0,
+        description="The physical time limit allowed for the scratchpad search before forcing a timeout.",
+    )

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -13,6 +13,7 @@ from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
 from coreason_manifest.state.cognition import CognitiveUncertaintyProfile
 from coreason_manifest.state.embodied import EmbodiedSensoryVector
+from coreason_manifest.state.scratchpad import LatentScratchpadTrace
 from coreason_manifest.state.toolchains import AnyToolchainState
 
 
@@ -110,6 +111,10 @@ class BeliefUpdateEvent(BaseStateEvent):
     uncertainty_profile: CognitiveUncertaintyProfile | None = Field(
         default=None,
         description="The mathematical quantification of doubt associated with this synthesized belief.",
+    )
+    scratchpad_trace: LatentScratchpadTrace | None = Field(
+        default=None,
+        description="The cryptographic record of the non-monotonic internal monologue that justifies this belief.",
     )
 
 

--- a/src/coreason_manifest/state/scratchpad.py
+++ b/src/coreason_manifest/state/scratchpad.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class ThoughtBranch(CoreasonBaseModel):
+    branch_id: str = Field(min_length=1, description="Unique identifier for this line of reasoning.")
+    parent_branch_id: str | None = Field(
+        default=None, description="The branch this thought diverged from, enabling tree reconstruction."
+    )
+    latent_content_hash: str = Field(
+        pattern=r"^[a-f0-9]{64}$",
+        description="The SHA-256 hash of the raw scratchpad text generated in this branch.",
+    )
+    prm_score: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="The logical validity score assigned to this branch by the Process Reward Model.",
+    )
+
+
+class LatentScratchpadTrace(CoreasonBaseModel):
+    trace_id: str = Field(min_length=1, description="Unique identifier for this entire test-time compute session.")
+    explored_branches: list[ThoughtBranch] = Field(description="All logical paths the agent attempted.")
+    discarded_branches: list[str] = Field(
+        description="A list of branch_ids that were explicitly pruned due to logical dead-ends."
+    )
+    resolution_branch_id: str | None = Field(
+        default=None,
+        description="The branch_id that successfully resolved the uncertainty and led to the final output.",
+    )
+    total_latent_tokens: int = Field(
+        ge=0, description="The total compute expenditure (in tokens) spent purely on internal reasoning."
+    )
+
+    @model_validator(mode="after")
+    def verify_referential_integrity(self) -> "LatentScratchpadTrace":
+        explored_branch_ids = {branch.branch_id for branch in self.explored_branches}
+
+        if self.resolution_branch_id is not None and self.resolution_branch_id not in explored_branch_ids:
+            raise ValueError(f"resolution_branch_id '{self.resolution_branch_id}' not found in explored_branches.")
+
+        for discarded_id in self.discarded_branches:
+            if discarded_id not in explored_branch_ids:
+                raise ValueError(f"discarded branch '{discarded_id}' not found in explored_branches.")
+
+        return self

--- a/src/coreason_manifest/state/scratchpad.py
+++ b/src/coreason_manifest/state/scratchpad.py
@@ -5,6 +5,8 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from typing import Self
+
 from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
@@ -42,7 +44,7 @@ class LatentScratchpadTrace(CoreasonBaseModel):
     )
 
     @model_validator(mode="after")
-    def verify_referential_integrity(self) -> "LatentScratchpadTrace":
+    def verify_referential_integrity(self) -> Self:
         explored_branch_ids = {branch.branch_id for branch in self.explored_branches}
 
         if self.resolution_branch_id is not None and self.resolution_branch_id not in explored_branch_ids:

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Annotated, Literal
 from pydantic import Field
 
 from coreason_manifest.compute.profiles import RoutingFrontier
+from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.oversight.dlp import SecureSubSession
 from coreason_manifest.state.cognition import CognitiveStateProfile
@@ -113,6 +114,12 @@ class AgentNode(BaseNode):
     )
     correction_policy: SelfCorrectionPolicy | None = Field(
         default=None, description="The policy governing self-correction loops."
+    )
+    escalation_policy: EscalationContract | None = Field(
+        default=None, description="The mathematical boundary authorizing the agent to spin up Test-Time Compute."
+    )
+    prm_policy: ProcessRewardContract | None = Field(
+        default=None, description="The ruleset governing how intermediate thoughts are scored and pruned."
     )
 
 

--- a/tests/domains/test_state_scratchpad.py
+++ b/tests/domains/test_state_scratchpad.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.state.scratchpad import LatentScratchpadTrace, ThoughtBranch
+
+
+def test_latent_scratchpad_trace_valid() -> None:
+    branch1 = ThoughtBranch(
+        branch_id="b1",
+        latent_content_hash="a" * 64,
+        prm_score=0.9,
+    )
+    branch2 = ThoughtBranch(
+        branch_id="b2",
+        parent_branch_id="b1",
+        latent_content_hash="b" * 64,
+        prm_score=0.4,
+    )
+
+    trace = LatentScratchpadTrace(
+        trace_id="t1",
+        explored_branches=[branch1, branch2],
+        discarded_branches=["b2"],
+        resolution_branch_id="b1",
+        total_latent_tokens=150,
+    )
+
+    assert trace.trace_id == "t1"
+    assert trace.resolution_branch_id == "b1"
+
+
+def test_latent_scratchpad_trace_invalid_resolution_branch() -> None:
+    branch1 = ThoughtBranch(
+        branch_id="b1",
+        latent_content_hash="a" * 64,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        LatentScratchpadTrace(
+            trace_id="t1",
+            explored_branches=[branch1],
+            discarded_branches=[],
+            resolution_branch_id="ghost_b",
+            total_latent_tokens=150,
+        )
+
+    assert "resolution_branch_id 'ghost_b' not found in explored_branches." in str(exc.value)
+
+
+def test_latent_scratchpad_trace_invalid_discarded_branch() -> None:
+    branch1 = ThoughtBranch(
+        branch_id="b1",
+        latent_content_hash="a" * 64,
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        LatentScratchpadTrace(
+            trace_id="t1",
+            explored_branches=[branch1],
+            discarded_branches=["ghost_b"],
+            resolution_branch_id="b1",
+            total_latent_tokens=150,
+        )
+
+    assert "discarded branch 'ghost_b' not found in explored_branches." in str(exc.value)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -52,6 +52,68 @@ from coreason_manifest.workflow.topologies import AnyTopology, StateContract
 
 
 @st.composite
+def draw_escalation_contract(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "uncertainty_escalation_threshold": st.floats(min_value=0.0, max_value=1.0),
+                "max_latent_tokens_budget": st.integers(min_value=1),
+                "max_test_time_compute_ms": st.integers(min_value=1),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_process_reward_contract(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "pruning_threshold": st.floats(min_value=0.0, max_value=1.0),
+                "max_backtracks_allowed": st.integers(min_value=0),
+                "evaluator_model_name": st.one_of(st.none(), st.text()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_thought_branch(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "branch_id": st.text(min_size=1),
+                "parent_branch_id": st.one_of(st.none(), st.text()),
+                "latent_content_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+                "prm_score": st.one_of(st.none(), st.floats(min_value=0.0, max_value=1.0)),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_latent_scratchpad_trace(draw: Any) -> dict[str, Any]:
+    explored_branches = draw(st.lists(draw_thought_branch(), min_size=1, max_size=5))
+    explored_branch_ids = [branch["branch_id"] for branch in explored_branches]
+
+    # ensure resolution_branch_id and discarded_branches are valid if generated
+    resolution_branch_id = draw(st.one_of(st.none(), st.sampled_from(explored_branch_ids)))
+    discarded_branches = draw(st.lists(st.sampled_from(explored_branch_ids), max_size=len(explored_branch_ids)))
+
+    res: dict[str, Any] = {
+        "trace_id": draw(st.text(min_size=1)),
+        "explored_branches": explored_branches,
+        "discarded_branches": discarded_branches,
+        "resolution_branch_id": resolution_branch_id,
+        "total_latent_tokens": draw(st.integers(min_value=0)),
+    }
+    return res
+
+
+@st.composite
 def draw_reflex_policy(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
@@ -238,6 +300,10 @@ def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
         payload["baseline_cognitive_state"] = draw(draw_cognitive_state_profile())
     if draw(st.booleans()):
         payload["correction_policy"] = draw(draw_correction_policy())
+    if draw(st.booleans()):
+        payload["escalation_policy"] = draw(draw_escalation_contract())
+    if draw(st.booleans()):
+        payload["prm_policy"] = draw(draw_process_reward_contract())
     return payload
 
 
@@ -682,6 +748,8 @@ def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
             payload["sensory_trigger"] = draw(draw_embodied_sensory_vector())
         if event_type == "belief_update" and draw(st.booleans()):
             payload["uncertainty_profile"] = draw(draw_cognitive_uncertainty_profile())
+        if event_type == "belief_update" and draw(st.booleans()):
+            payload["scratchpad_trace"] = draw(draw_latent_scratchpad_trace())
     return payload
 
 


### PR DESCRIPTION
Added test-time compute modeling schemas (`LatentScratchpadTrace`, `ProcessRewardContract`, `EscalationContract`) to `coreason_manifest` along with requisite field updates in `BeliefUpdateEvent` and `AgentNode`. Provided necessary fuzzing setup and referential integrity validations to pass rigorous CI checks.

---
*PR created automatically by Jules for task [9848922371424260732](https://jules.google.com/task/9848922371424260732) started by @gowthamrao*