### PR TITLE
feat: Implement Phase 3 Abductive Reasoning schemas

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -32,6 +32,55 @@
       "title": "ActionSpace",
       "type": "object"
     },
+    "ActiveInferenceContract": {
+      "additionalProperties": false,
+      "properties": {
+        "task_id": {
+          "description": "Unique identifier for this active inference execution.",
+          "minLength": 1,
+          "title": "Task Id",
+          "type": "string"
+        },
+        "target_hypothesis_id": {
+          "description": "The HypothesisGenerationEvent this task is attempting to falsify.",
+          "title": "Target Hypothesis Id",
+          "type": "string"
+        },
+        "target_condition_id": {
+          "description": "The specific FalsificationCondition being tested.",
+          "title": "Target Condition Id",
+          "type": "string"
+        },
+        "selected_tool_name": {
+          "description": "The exact tool from the ActionSpace allocated for this experiment.",
+          "title": "Selected Tool Name",
+          "type": "string"
+        },
+        "expected_information_gain": {
+          "description": "The mathematically estimated reduction in Epistemic Uncertainty (entropy) this tool call will yield.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Expected Information Gain",
+          "type": "number"
+        },
+        "execution_cost_budget_cents": {
+          "description": "The maximum economic expenditure authorized to run this specific scientific test.",
+          "minimum": 0,
+          "title": "Execution Cost Budget Cents",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "task_id",
+        "target_hypothesis_id",
+        "target_condition_id",
+        "selected_tool_name",
+        "expected_information_gain",
+        "execution_cost_budget_cents"
+      ],
+      "title": "ActiveInferenceContract",
+      "type": "object"
+    },
     "AdjudicationRubric": {
       "additionalProperties": false,
       "description": "Rubric defining multiple criteria and passing threshold for algorithmic adjudication.",
@@ -342,6 +391,18 @@
           ],
           "default": null,
           "description": "The ruleset governing how intermediate thoughts are scored and pruned."
+        },
+        "active_inference_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActiveInferenceContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal contract demanding mathematical proof of Expected Information Gain before authorizing tool execution."
         }
       },
       "required": [
@@ -437,6 +498,7 @@
       "discriminator": {
         "mapping": {
           "belief_update": "#/$defs/BeliefUpdateEvent",
+          "hypothesis": "#/$defs/HypothesisGenerationEvent",
           "observation": "#/$defs/ObservationEvent",
           "system_fault": "#/$defs/SystemFaultEvent"
         },
@@ -451,6 +513,9 @@
         },
         {
           "$ref": "#/$defs/SystemFaultEvent"
+        },
+        {
+          "$ref": "#/$defs/HypothesisGenerationEvent"
         }
       ]
     },
@@ -2282,6 +2347,47 @@
       "title": "FallbackTrigger",
       "type": "object"
     },
+    "FalsificationCondition": {
+      "additionalProperties": false,
+      "properties": {
+        "condition_id": {
+          "description": "Unique identifier for this falsification test.",
+          "minLength": 1,
+          "title": "Condition Id",
+          "type": "string"
+        },
+        "description": {
+          "description": "Semantic description of what observation would prove the parent hypothesis is false.",
+          "title": "Description",
+          "type": "string"
+        },
+        "required_tool_name": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific ActionSpace tool required to test this condition (e.g., 'sql_query_db').",
+          "title": "Required Tool Name"
+        },
+        "falsifying_observation_signature": {
+          "description": "The expected data schema or regex pattern that, if returned by the tool, kills the hypothesis.",
+          "title": "Falsifying Observation Signature",
+          "type": "string"
+        }
+      },
+      "required": [
+        "condition_id",
+        "description",
+        "falsifying_observation_signature"
+      ],
+      "title": "FalsificationCondition",
+      "type": "object"
+    },
     "FaultInjectionProfile": {
       "additionalProperties": false,
       "properties": {
@@ -2604,6 +2710,76 @@
         "description"
       ],
       "title": "HumanNode",
+      "type": "object"
+    },
+    "HypothesisGenerationEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_id": {
+          "description": "A unique identifier for the event.",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "The timestamp when the event occurred.",
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "hypothesis",
+          "default": "hypothesis",
+          "description": "Discriminator for a hypothesis generation event.",
+          "title": "Type",
+          "type": "string"
+        },
+        "hypothesis_id": {
+          "description": "Unique identifier for this abductive leap.",
+          "minLength": 1,
+          "title": "Hypothesis Id",
+          "type": "string"
+        },
+        "premise_text": {
+          "description": "The natural language explanation of the abductive theory.",
+          "title": "Premise Text",
+          "type": "string"
+        },
+        "bayesian_prior": {
+          "description": "The agent's initial probabilistic belief in this hypothesis before testing.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Bayesian Prior",
+          "type": "number"
+        },
+        "falsification_conditions": {
+          "description": "The list of strict conditions that the orchestrator must test to attempt to disprove this premise.",
+          "items": {
+            "$ref": "#/$defs/FalsificationCondition"
+          },
+          "minItems": 1,
+          "title": "Falsification Conditions",
+          "type": "array"
+        },
+        "status": {
+          "default": "active",
+          "description": "The current validity state of this hypothesis in the EpistemicLedger.",
+          "enum": [
+            "active",
+            "falsified",
+            "verified"
+          ],
+          "title": "Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "event_id",
+        "timestamp",
+        "hypothesis_id",
+        "premise_text",
+        "bayesian_prior",
+        "falsification_conditions"
+      ],
+      "title": "HypothesisGenerationEvent",
       "type": "object"
     },
     "InformationFlowPolicy": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -5,6 +5,7 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from coreason_manifest.compute.inference import ActiveInferenceContract
 from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID, SemanticVersion
@@ -16,6 +17,7 @@ from coreason_manifest.workflow.nodes import AnyNode
 from coreason_manifest.workflow.topologies import AnyTopology
 
 __all__ = [
+    "ActiveInferenceContract",
     "AnyNode",
     "AnyTopology",
     "CognitiveStateProfile",

--- a/src/coreason_manifest/compute/__init__.py
+++ b/src/coreason_manifest/compute/__init__.py
@@ -5,6 +5,7 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from coreason_manifest.compute.inference import ActiveInferenceContract
 from coreason_manifest.compute.profiles import (
     ComputeProvisioningRequest,
     ModelProfile,
@@ -22,6 +23,7 @@ from coreason_manifest.compute.stochastic import (
 )
 
 __all__ = [
+    "ActiveInferenceContract",
     "ComputeProvisioningRequest",
     "CrossoverStrategy",
     "CrossoverType",

--- a/src/coreason_manifest/compute/inference.py
+++ b/src/coreason_manifest/compute/inference.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class ActiveInferenceContract(CoreasonBaseModel):
+    task_id: str = Field(min_length=1, description="Unique identifier for this active inference execution.")
+    target_hypothesis_id: str = Field(description="The HypothesisGenerationEvent this task is attempting to falsify.")
+    target_condition_id: str = Field(description="The specific FalsificationCondition being tested.")
+    selected_tool_name: str = Field(description="The exact tool from the ActionSpace allocated for this experiment.")
+    expected_information_gain: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The mathematically estimated reduction in Epistemic Uncertainty "
+        "(entropy) this tool call will yield.",
+    )
+    execution_cost_budget_cents: int = Field(
+        ge=0,
+        description="The maximum economic expenditure authorized to run this specific scientific test.",
+    )

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -124,7 +124,42 @@ class SystemFaultEvent(BaseStateEvent):
     )
 
 
+class FalsificationCondition(CoreasonBaseModel):
+    condition_id: str = Field(min_length=1, description="Unique identifier for this falsification test.")
+    description: str = Field(
+        description="Semantic description of what observation would prove the parent hypothesis is false."
+    )
+    required_tool_name: str | None = Field(
+        default=None,
+        description="The specific ActionSpace tool required to test this condition (e.g., 'sql_query_db').",
+    )
+    falsifying_observation_signature: str = Field(
+        description="The expected data schema or regex pattern that, if returned by the tool, kills the hypothesis."
+    )
+
+
+class HypothesisGenerationEvent(BaseStateEvent):
+    type: Literal["hypothesis"] = Field(
+        default="hypothesis", description="Discriminator for a hypothesis generation event."
+    )
+    hypothesis_id: str = Field(min_length=1, description="Unique identifier for this abductive leap.")
+    premise_text: str = Field(description="The natural language explanation of the abductive theory.")
+    bayesian_prior: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The agent's initial probabilistic belief in this hypothesis before testing.",
+    )
+    falsification_conditions: list[FalsificationCondition] = Field(
+        min_length=1,
+        description="The list of strict conditions that the orchestrator must test to attempt to "
+        "disprove this premise.",
+    )
+    status: Literal["active", "falsified", "verified"] = Field(
+        default="active", description="The current validity state of this hypothesis in the EpistemicLedger."
+    )
+
+
 type AnyStateEvent = Annotated[
-    ObservationEvent | BeliefUpdateEvent | SystemFaultEvent,
+    ObservationEvent | BeliefUpdateEvent | SystemFaultEvent | HypothesisGenerationEvent,
     Field(discriminator="type", description="A discriminated union of state events."),
 ]

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Annotated, Literal
 
 from pydantic import Field
 
+from coreason_manifest.compute.inference import ActiveInferenceContract
 from coreason_manifest.compute.profiles import RoutingFrontier
 from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
 from coreason_manifest.core.base import CoreasonBaseModel
@@ -120,6 +121,11 @@ class AgentNode(BaseNode):
     )
     prm_policy: ProcessRewardContract | None = Field(
         default=None, description="The ruleset governing how intermediate thoughts are scored and pruned."
+    )
+    active_inference_policy: ActiveInferenceContract | None = Field(
+        default=None,
+        description="The formal contract demanding mathematical proof of Expected Information Gain "
+        "before authorizing tool execution.",
     )
 
 

--- a/tests/domains/test_state_hypothesis.py
+++ b/tests/domains/test_state_hypothesis.py
@@ -1,0 +1,91 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.compute.inference import ActiveInferenceContract
+from coreason_manifest.state.events import FalsificationCondition, HypothesisGenerationEvent
+
+
+def test_hypothesis_generation_event_valid() -> None:
+    condition = FalsificationCondition(
+        condition_id="cond-1",
+        description="Must observe HTTP 404.",
+        required_tool_name="http_client",
+        falsifying_observation_signature="HTTP 404 Not Found",
+    )
+
+    hypothesis = HypothesisGenerationEvent(
+        event_id="evt-1",
+        timestamp=123.456,
+        hypothesis_id="hyp-1",
+        premise_text="The server is down.",
+        bayesian_prior=0.75,
+        falsification_conditions=[condition],
+        status="active",
+    )
+
+    assert hypothesis.type == "hypothesis"
+    assert hypothesis.hypothesis_id == "hyp-1"
+    assert hypothesis.bayesian_prior == 0.75
+    assert len(hypothesis.falsification_conditions) == 1
+    assert hypothesis.falsification_conditions[0].condition_id == "cond-1"
+
+
+def test_hypothesis_bayesian_prior_bounds() -> None:
+    condition = FalsificationCondition(
+        condition_id="cond-1",
+        description="test",
+        falsifying_observation_signature="test",
+    )
+
+    with pytest.raises(ValidationError) as exc:
+        HypothesisGenerationEvent(
+            event_id="evt-1",
+            timestamp=123.456,
+            hypothesis_id="hyp-1",
+            premise_text="Premise",
+            bayesian_prior=-0.1,  # Invalid
+            falsification_conditions=[condition],
+        )
+    assert "Input should be greater than or equal to 0" in str(exc.value)
+
+    with pytest.raises(ValidationError) as exc:
+        HypothesisGenerationEvent(
+            event_id="evt-1",
+            timestamp=123.456,
+            hypothesis_id="hyp-1",
+            premise_text="Premise",
+            bayesian_prior=1.1,  # Invalid
+            falsification_conditions=[condition],
+        )
+    assert "Input should be less than or equal to 1" in str(exc.value)
+
+
+def test_active_inference_contract_expected_information_gain_bounds() -> None:
+    with pytest.raises(ValidationError) as exc:
+        ActiveInferenceContract(
+            task_id="task-1",
+            target_hypothesis_id="hyp-1",
+            target_condition_id="cond-1",
+            selected_tool_name="tool-1",
+            expected_information_gain=-0.1,  # Invalid
+            execution_cost_budget_cents=100,
+        )
+    assert "Input should be greater than or equal to 0" in str(exc.value)
+
+    with pytest.raises(ValidationError) as exc:
+        ActiveInferenceContract(
+            task_id="task-1",
+            target_hypothesis_id="hyp-1",
+            target_condition_id="cond-1",
+            selected_tool_name="tool-1",
+            expected_information_gain=1.1,  # Invalid
+            execution_cost_budget_cents=100,
+        )
+    assert "Input should be less than or equal to 1" in str(exc.value)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -37,7 +37,13 @@ from coreason_manifest.presentation.intents import (
 )
 from coreason_manifest.presentation.scivis import AnyPanel, GrammarPanel, InsightCard
 from coreason_manifest.state.argumentation import ArgumentGraph
-from coreason_manifest.state.events import AnyStateEvent, BeliefUpdateEvent, ObservationEvent, SystemFaultEvent
+from coreason_manifest.state.events import (
+    AnyStateEvent,
+    BeliefUpdateEvent,
+    HypothesisGenerationEvent,
+    ObservationEvent,
+    SystemFaultEvent,
+)
 from coreason_manifest.state.memory import EpistemicLedger
 from coreason_manifest.state.semantic import SemanticEdge, SemanticNode
 from coreason_manifest.telemetry.custody import CustodyRecord
@@ -120,6 +126,61 @@ def draw_reflex_policy(draw: Any) -> dict[str, Any]:
             {
                 "confidence_threshold": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
                 "allowed_read_only_tools": st.lists(st.text(), max_size=100),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_falsification_condition(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "condition_id": st.text(min_size=1),
+                "description": st.text(),
+                "required_tool_name": st.one_of(st.none(), st.text()),
+                "falsifying_observation_signature": st.text(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_hypothesis_generation_event(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("hypothesis"),
+                "hypothesis_id": st.text(min_size=1),
+                "premise_text": st.text(),
+                "bayesian_prior": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+                "falsification_conditions": st.lists(
+                    draw_falsification_condition(), min_size=1, max_size=10, unique_by=lambda x: x["condition_id"]
+                ),
+                "status": st.sampled_from(["active", "falsified", "verified"]),
+                "event_id": st.text(min_size=1),
+                "timestamp": st.floats(allow_nan=False, allow_infinity=False),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_active_inference_contract(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "task_id": st.text(min_size=1),
+                "target_hypothesis_id": st.text(),
+                "target_condition_id": st.text(),
+                "selected_tool_name": st.text(),
+                "expected_information_gain": st.floats(
+                    min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                ),
+                "execution_cost_budget_cents": st.integers(min_value=0),
             }
         )
     )
@@ -304,6 +365,8 @@ def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
         payload["escalation_policy"] = draw(draw_escalation_contract())
     if draw(st.booleans()):
         payload["prm_policy"] = draw(draw_process_reward_contract())
+    if draw(st.booleans()):
+        payload["active_inference_policy"] = draw(draw_active_inference_contract())
     return payload
 
 
@@ -712,7 +775,12 @@ def draw_any_toolchain_state() -> st.SearchStrategy[dict[str, Any]]:
 
 @st.composite
 def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
-    event_type = draw(st.sampled_from(["observation", "belief_update", "system_fault"]))
+    event_type = draw(st.sampled_from(["observation", "belief_update", "system_fault", "hypothesis"]))
+
+    if event_type == "hypothesis":
+        res: dict[str, Any] = draw(draw_hypothesis_generation_event())
+        return res
+
     payload: dict[str, Any] = {
         "type": event_type,
         "event_id": draw(st.text()),
@@ -763,11 +831,13 @@ def test_anystateevent_routing(payload: dict[str, Any]) -> None:
         assert isinstance(parsed, BeliefUpdateEvent)
     elif event_type == "system_fault":
         assert isinstance(parsed, SystemFaultEvent)
+    elif event_type == "hypothesis":
+        assert isinstance(parsed, HypothesisGenerationEvent)
 
 
 @given(st.text())
 def test_anystateevent_invalid(invalid_type: str) -> None:
-    if invalid_type in ["observation", "belief_update", "system_fault"]:
+    if invalid_type in ["observation", "belief_update", "system_fault", "hypothesis"]:
         return
     payload = {"type": invalid_type, "event_id": "test", "timestamp": 123.0}
     with pytest.raises(ValidationError):


### PR DESCRIPTION
Implemented Phase 3 Abductive Reasoning schemas (`FalsificationCondition`, `HypothesisGenerationEvent`, `ActiveInferenceContract`), integrated them into the orchestrator topologies, wrote strict tests and fuzzing strategies, and exported the regenerated coreason ontology schema.

---
*PR created automatically by Jules for task [17592586526695053476](https://jules.google.com/task/17592586526695053476) started by @gowthamrao*