### PR TITLE
Fix logical flaw in scratchpad fuzzer by enforcing unique branch ids

### DIFF
--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -102,7 +102,9 @@ def draw_thought_branch(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_latent_scratchpad_trace(draw: Any) -> dict[str, Any]:
-    explored_branches = draw(st.lists(draw_thought_branch(), min_size=1, max_size=5))
+    explored_branches = draw(
+        st.lists(draw_thought_branch(), min_size=1, max_size=5, unique_by=lambda b: b["branch_id"])
+    )
     explored_branch_ids = [branch["branch_id"] for branch in explored_branches]
 
     # ensure resolution_branch_id and discarded_branches are valid if generated


### PR DESCRIPTION
Modified `draw_latent_scratchpad_trace` in `tests/test_fuzzing.py` to use `unique_by=lambda b: b["branch_id"]` when generating `explored_branches`. This ensures that generated `ThoughtBranch` items have mathematically unique IDs in the non-monotonic Tree of Thoughts, preventing invalid trees and corrupted referential integrity during testing.

---
*PR created automatically by Jules for task [7600723903656494020](https://jules.google.com/task/7600723903656494020) started by @gowthamrao*