### PR TITLE
feat: Add Phase 4 neuromodulation and deep MoE execution layer

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -32,6 +32,50 @@
       "title": "ActionSpace",
       "type": "object"
     },
+    "ActivationSteeringContract": {
+      "additionalProperties": false,
+      "description": "Hardware-level contract for Representation Engineering via activation injection/ablation.",
+      "properties": {
+        "steering_vector_hash": {
+          "description": "The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Steering Vector Hash",
+          "type": "string"
+        },
+        "injection_layers": {
+          "description": "The specific transformer layer indices where this vector must be applied.",
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 1,
+          "title": "Injection Layers",
+          "type": "array"
+        },
+        "scaling_factor": {
+          "description": "The mathematical magnitude/strength of the injection (can be negative for ablation).",
+          "title": "Scaling Factor",
+          "type": "number"
+        },
+        "vector_modality": {
+          "description": "The tensor operation to perform: add the vector, subtract it, or clamp activations to its bounds.",
+          "enum": [
+            "additive",
+            "ablation",
+            "clamping"
+          ],
+          "title": "Vector Modality",
+          "type": "string"
+        }
+      },
+      "required": [
+        "steering_vector_hash",
+        "injection_layers",
+        "scaling_factor",
+        "vector_modality"
+      ],
+      "title": "ActivationSteeringContract",
+      "type": "object"
+    },
     "ActiveInferenceContract": {
       "additionalProperties": false,
       "properties": {
@@ -1114,6 +1158,44 @@
       "title": "CircuitBreakerTrip",
       "type": "object"
     },
+    "CognitiveRoutingDirective": {
+      "additionalProperties": false,
+      "description": "Hardware-level contract overriding MoE routing to enforce functional/specialist paths.",
+      "properties": {
+        "dynamic_top_k": {
+          "description": "The exact number of functional experts the router must activate per token. High values simulate deep cognitive strain.",
+          "minimum": 1,
+          "title": "Dynamic Top K",
+          "type": "integer"
+        },
+        "routing_temperature": {
+          "description": "The temperature applied to the router's softmax gate, controlling how deterministically it picks experts.",
+          "minimum": 0.0,
+          "title": "Routing Temperature",
+          "type": "number"
+        },
+        "expert_logit_biases": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Explicit tensor biases applied to the router gate. Keys are expert IDs (e.g., 'expert_falsifier'), values are logit modifiers.",
+          "title": "Expert Logit Biases",
+          "type": "object"
+        },
+        "enforce_functional_isolation": {
+          "default": false,
+          "description": "If True, the orchestrator applies a hard mask (-inf) to any expert not explicitly boosted in expert_logit_biases.",
+          "title": "Enforce Functional Isolation",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "dynamic_top_k",
+        "routing_temperature"
+      ],
+      "title": "CognitiveRoutingDirective",
+      "type": "object"
+    },
     "CognitiveStateProfile": {
       "additionalProperties": false,
       "properties": {
@@ -1138,19 +1220,29 @@
           "title": "Divergence Tolerance",
           "type": "number"
         },
-        "active_steering_vector_hash": {
+        "activation_steering": {
           "anyOf": [
             {
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
+              "$ref": "#/$defs/ActivationSteeringContract"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The SHA-256 hash of the specific Representation Engineering control vector applied to the residual stream.",
-          "title": "Active Steering Vector Hash"
+          "description": "The precise mathematical contract for altering the LLM's residual stream to enforce this mood."
+        },
+        "moe_routing_directive": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CognitiveRoutingDirective"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The physical hardware mandate overriding default MoE token routing to enforce this cognitive state."
         }
       },
       "required": [
@@ -3405,6 +3497,14 @@
         "rate_card": {
           "$ref": "#/$defs/RateCard",
           "description": "The economic cost definition associated with the model."
+        },
+        "supported_functional_experts": {
+          "description": "A declarative list of specialized functional expert clusters (e.g., 'falsifier', 'synthesizer') physically present in this model's architecture.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Supported Functional Experts",
+          "type": "array"
         }
       },
       "required": [

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -6,6 +6,7 @@
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
 from coreason_manifest.compute.inference import ActiveInferenceContract
+from coreason_manifest.compute.neuromodulation import ActivationSteeringContract, CognitiveRoutingDirective
 from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID, SemanticVersion
@@ -17,9 +18,11 @@ from coreason_manifest.workflow.nodes import AnyNode
 from coreason_manifest.workflow.topologies import AnyTopology
 
 __all__ = [
+    "ActivationSteeringContract",
     "ActiveInferenceContract",
     "AnyNode",
     "AnyTopology",
+    "CognitiveRoutingDirective",
     "CognitiveStateProfile",
     "CognitiveUncertaintyProfile",
     "CoreasonBaseModel",

--- a/src/coreason_manifest/compute/__init__.py
+++ b/src/coreason_manifest/compute/__init__.py
@@ -6,6 +6,7 @@
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
 from coreason_manifest.compute.inference import ActiveInferenceContract
+from coreason_manifest.compute.neuromodulation import ActivationSteeringContract, CognitiveRoutingDirective
 from coreason_manifest.compute.profiles import (
     ComputeProvisioningRequest,
     ModelProfile,
@@ -23,7 +24,9 @@ from coreason_manifest.compute.stochastic import (
 )
 
 __all__ = [
+    "ActivationSteeringContract",
     "ActiveInferenceContract",
+    "CognitiveRoutingDirective",
     "ComputeProvisioningRequest",
     "CrossoverStrategy",
     "CrossoverType",

--- a/src/coreason_manifest/compute/neuromodulation.py
+++ b/src/coreason_manifest/compute/neuromodulation.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Literal
+
+from pydantic import Field
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class ActivationSteeringContract(CoreasonBaseModel):
+    """
+    Hardware-level contract for Representation Engineering via activation injection/ablation.
+    """
+
+    steering_vector_hash: str = Field(
+        pattern=r"^[a-f0-9]{64}$",
+        description="The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
+    )
+    injection_layers: list[int] = Field(
+        min_length=1,
+        description="The specific transformer layer indices where this vector must be applied.",
+    )
+    scaling_factor: float = Field(
+        description="The mathematical magnitude/strength of the injection (can be negative for ablation).",
+    )
+    vector_modality: Literal["additive", "ablation", "clamping"] = Field(
+        description="The tensor operation to perform: add the vector, subtract it, or clamp activations to its bounds.",
+    )
+
+
+class CognitiveRoutingDirective(CoreasonBaseModel):
+    """
+    Hardware-level contract overriding MoE routing to enforce functional/specialist paths.
+    """
+
+    dynamic_top_k: int = Field(
+        ge=1,
+        description="The exact number of functional experts the router must activate per token. "
+        "High values simulate deep cognitive strain.",
+    )
+    routing_temperature: float = Field(
+        ge=0.0,
+        description="The temperature applied to the router's softmax gate, "
+        "controlling how deterministically it picks experts.",
+    )
+    expert_logit_biases: dict[str, float] = Field(
+        default_factory=dict,
+        description="Explicit tensor biases applied to the router gate. "
+        "Keys are expert IDs (e.g., 'expert_falsifier'), values are logit modifiers.",
+    )
+    enforce_functional_isolation: bool = Field(
+        default=False,
+        description="If True, the orchestrator applies a hard mask (-inf) "
+        "to any expert not explicitly boosted in expert_logit_biases.",
+    )

--- a/src/coreason_manifest/compute/profiles.py
+++ b/src/coreason_manifest/compute/profiles.py
@@ -57,6 +57,11 @@ class ModelProfile(CoreasonBaseModel):
     context_window_size: int = Field(description="The maximum context window size in tokens.")
     capabilities: list[str] = Field(description="A list of supported capabilities by the model.")
     rate_card: RateCard = Field(description="The economic cost definition associated with the model.")
+    supported_functional_experts: list[str] = Field(
+        default_factory=list,
+        description="A declarative list of specialized functional expert clusters (e.g., 'falsifier', 'synthesizer') "
+        "physically present in this model's architecture.",
+    )
 
 
 class ComputeProvisioningRequest(CoreasonBaseModel):

--- a/src/coreason_manifest/state/cognition.py
+++ b/src/coreason_manifest/state/cognition.py
@@ -7,6 +7,7 @@
 
 from pydantic import Field
 
+from coreason_manifest.compute.neuromodulation import ActivationSteeringContract, CognitiveRoutingDirective
 from coreason_manifest.core.base import CoreasonBaseModel
 
 
@@ -38,9 +39,12 @@ class CognitiveStateProfile(CoreasonBaseModel):
         description="The 'curiosity' metric; dictates how far the MoE router is allowed to stray "
         "from high-probability distributions.",
     )
-    active_steering_vector_hash: str | None = Field(
+    activation_steering: ActivationSteeringContract | None = Field(
         default=None,
-        pattern=r"^[a-f0-9]{64}$",
-        description="The SHA-256 hash of the specific Representation Engineering control vector "
-        "applied to the residual stream.",
+        description="The precise mathematical contract for altering the LLM's residual stream to enforce this mood.",
+    )
+    moe_routing_directive: CognitiveRoutingDirective | None = Field(
+        default=None,
+        description="The physical hardware mandate overriding default MoE token routing to "
+        "enforce this cognitive state.",
     )

--- a/tests/domains/test_compute_neuromodulation.py
+++ b/tests/domains/test_compute_neuromodulation.py
@@ -1,0 +1,81 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.compute.neuromodulation import ActivationSteeringContract, CognitiveRoutingDirective
+
+
+def test_activation_steering_contract_valid() -> None:
+    contract = ActivationSteeringContract(
+        steering_vector_hash="a" * 64,
+        injection_layers=[1, 2, 3],
+        scaling_factor=1.5,
+        vector_modality="additive",
+    )
+    assert contract.scaling_factor == 1.5
+
+
+def test_activation_steering_contract_invalid_hash() -> None:
+    with pytest.raises(ValidationError):
+        ActivationSteeringContract(
+            steering_vector_hash="invalid_hash",
+            injection_layers=[1, 2, 3],
+            scaling_factor=1.5,
+            vector_modality="additive",
+        )
+
+
+def test_activation_steering_contract_invalid_layers() -> None:
+    with pytest.raises(ValidationError):
+        ActivationSteeringContract(
+            steering_vector_hash="a" * 64,
+            injection_layers=[],
+            scaling_factor=1.5,
+            vector_modality="additive",
+        )
+
+
+def test_activation_steering_contract_invalid_modality() -> None:
+    with pytest.raises(ValidationError):
+        ActivationSteeringContract(
+            steering_vector_hash="a" * 64,
+            injection_layers=[1, 2, 3],
+            scaling_factor=1.5,
+            vector_modality="invalid_modality",  # type: ignore[arg-type]
+        )
+
+
+def test_cognitive_routing_directive_valid() -> None:
+    directive = CognitiveRoutingDirective(
+        dynamic_top_k=2,
+        routing_temperature=0.5,
+        expert_logit_biases={"falsifier": 2.0},
+        enforce_functional_isolation=True,
+    )
+    assert directive.dynamic_top_k == 2
+
+
+def test_cognitive_routing_directive_invalid_top_k() -> None:
+    with pytest.raises(ValidationError):
+        CognitiveRoutingDirective(
+            dynamic_top_k=0,
+            routing_temperature=0.5,
+            expert_logit_biases={"falsifier": 2.0},
+            enforce_functional_isolation=True,
+        )
+
+
+def test_cognitive_routing_directive_invalid_temperature() -> None:
+    with pytest.raises(ValidationError):
+        CognitiveRoutingDirective(
+            dynamic_top_k=2,
+            routing_temperature=-0.1,
+            expert_logit_biases={"falsifier": 2.0},
+            enforce_functional_isolation=True,
+        )

--- a/tests/domains/test_state_cognition.py
+++ b/tests/domains/test_state_cognition.py
@@ -10,6 +10,7 @@ from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
+from coreason_manifest.compute.neuromodulation import ActivationSteeringContract, CognitiveRoutingDirective
 from coreason_manifest.state.cognition import CognitiveStateProfile, CognitiveUncertaintyProfile
 
 
@@ -35,20 +36,46 @@ def test_cognitive_uncertainty_profile_fuzzing(
     assert profile.epistemic_uncertainty == epistemic_uncertainty
 
 
+@st.composite
+def draw_activation_steering_contract(draw: st.DrawFn) -> ActivationSteeringContract:
+    return ActivationSteeringContract(
+        steering_vector_hash=draw(st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True)),
+        injection_layers=draw(st.lists(st.integers(), min_size=1)),
+        scaling_factor=draw(st.floats(allow_nan=False, allow_infinity=False)),
+        vector_modality=draw(st.sampled_from(["additive", "ablation", "clamping"])),
+    )
+
+
+@st.composite
+def draw_cognitive_routing_directive(draw: st.DrawFn) -> CognitiveRoutingDirective:
+    return CognitiveRoutingDirective(
+        dynamic_top_k=draw(st.integers(min_value=1)),
+        routing_temperature=draw(st.floats(min_value=0.0, allow_nan=False, allow_infinity=False)),
+        expert_logit_biases=draw(st.dictionaries(st.text(), st.floats(allow_nan=False, allow_infinity=False))),
+        enforce_functional_isolation=draw(st.booleans()),
+    )
+
+
 @given(
     urgency_index=st.floats(min_value=0.0, max_value=1.0),
     caution_index=st.floats(min_value=0.0, max_value=1.0),
     divergence_tolerance=st.floats(min_value=0.0, max_value=1.0),
-    active_steering_vector_hash=st.one_of(st.none(), st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True)),
+    activation_steering=st.one_of(st.none(), draw_activation_steering_contract()),
+    moe_routing_directive=st.one_of(st.none(), draw_cognitive_routing_directive()),
 )
 def test_cognitive_state_profile_fuzzing(
-    urgency_index: float, caution_index: float, divergence_tolerance: float, active_steering_vector_hash: str | None
+    urgency_index: float,
+    caution_index: float,
+    divergence_tolerance: float,
+    activation_steering: ActivationSteeringContract | None,
+    moe_routing_directive: CognitiveRoutingDirective | None,
 ) -> None:
     profile = CognitiveStateProfile(
         urgency_index=urgency_index,
         caution_index=caution_index,
         divergence_tolerance=divergence_tolerance,
-        active_steering_vector_hash=active_steering_vector_hash,
+        activation_steering=activation_steering,
+        moe_routing_directive=moe_routing_directive,
     )
     assert profile.urgency_index == urgency_index
 
@@ -72,10 +99,10 @@ def test_invalid_bounds_rejected() -> None:
             requires_abductive_escalation=False,
         )
 
-    # Test invalid SHA-256 hash
+    # Test invalid steering contract values indirectly
     with pytest.raises(ValidationError):
-        CognitiveStateProfile(
-            urgency_index=0.5, caution_index=0.5, divergence_tolerance=0.5, active_steering_vector_hash="invalidhash"
+        ActivationSteeringContract(
+            steering_vector_hash="invalidhash", injection_layers=[1], scaling_factor=1.0, vector_modality="additive"
         )
 
 
@@ -102,15 +129,31 @@ def test_canonical_hashing_determinism() -> None:
     assert profile1.model_dump_canonical() == profile2.model_dump_canonical()
     assert hash(profile1) == hash(profile2)
 
+    steering_dict = {
+        "steering_vector_hash": "a" * 64,
+        "injection_layers": [1],
+        "scaling_factor": 1.0,
+        "vector_modality": "additive",
+    }
+
+    routing_dict = {
+        "dynamic_top_k": 2,
+        "routing_temperature": 0.5,
+        "expert_logit_biases": {},
+        "enforce_functional_isolation": False,
+    }
+
     kwargs3: dict[str, Any] = {
         "urgency_index": 0.5,
         "caution_index": 0.5,
         "divergence_tolerance": 0.5,
-        "active_steering_vector_hash": "a" * 64,
+        "activation_steering": steering_dict,
+        "moe_routing_directive": routing_dict,
     }
 
     kwargs4: dict[str, Any] = {
-        "active_steering_vector_hash": "a" * 64,
+        "moe_routing_directive": routing_dict,
+        "activation_steering": steering_dict,
         "divergence_tolerance": 0.5,
         "caution_index": 0.5,
         "urgency_index": 0.5,

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -190,6 +190,38 @@ def draw_active_inference_contract(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_activation_steering_contract(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "steering_vector_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+                "injection_layers": st.lists(st.integers(min_value=0), min_size=1, max_size=10),
+                "scaling_factor": st.floats(allow_nan=False, allow_infinity=False),
+                "vector_modality": st.sampled_from(["additive", "ablation", "clamping"]),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_cognitive_routing_directive(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "dynamic_top_k": st.integers(min_value=1, max_value=100),
+                "routing_temperature": st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
+                "expert_logit_biases": st.dictionaries(
+                    st.text(min_size=1), st.floats(allow_nan=False, allow_infinity=False), max_size=10
+                ),
+                "enforce_functional_isolation": st.booleans(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_cognitive_state_profile(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
@@ -197,7 +229,8 @@ def draw_cognitive_state_profile(draw: Any) -> dict[str, Any]:
                 "urgency_index": st.floats(min_value=0.0, max_value=1.0),
                 "caution_index": st.floats(min_value=0.0, max_value=1.0),
                 "divergence_tolerance": st.floats(min_value=0.0, max_value=1.0),
-                "active_steering_vector_hash": st.one_of(st.none(), st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True)),
+                "activation_steering": st.one_of(st.none(), draw_activation_steering_contract()),
+                "moe_routing_directive": st.one_of(st.none(), draw_cognitive_routing_directive()),
             }
         )
     )


### PR DESCRIPTION
Implemented Phase 4: Neuromodulation & Deep MoE Control as requested.
- Created `ActivationSteeringContract` and `CognitiveRoutingDirective` in `src/coreason_manifest/compute/neuromodulation.py`.
- Updated `CognitiveStateProfile` in `src/coreason_manifest/state/cognition.py` to use these new contracts instead of `active_steering_vector_hash`.
- Updated `ModelProfile` in `src/coreason_manifest/compute/profiles.py` with `supported_functional_experts`.
- Added robust fuzzer strategies in `tests/test_fuzzing.py` and `tests/domains/test_state_cognition.py`.
- Wrote isolated bounds/validation tests in `tests/domains/test_compute_neuromodulation.py`.
- Added new models to `__init__.py` files and exported the JSON schema via `uv run coreason-export`.
- Code passed `ruff format`, `ruff check`, `mypy`, and `pytest --cov`.

---
*PR created automatically by Jules for task [4760615289819611555](https://jules.google.com/task/4760615289819611555) started by @gowthamrao*