### PR TITLE
feat: implement Pearlian SCMs and Interventional do-calculus

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -460,6 +460,18 @@
           "default": null,
           "description": "The formal contract forcing the agent to execute cross-domain lateral thinking."
         },
+        "interventional_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InterventionalCausalTask"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal contract authorizing the agent to mutate variables to prove Pearlian causation."
+        },
         "symbolic_handoff_policy": {
           "anyOf": [
             {
@@ -1155,6 +1167,41 @@
         "influence_weight"
       ],
       "title": "CausalAttribution",
+      "type": "object"
+    },
+    "CausalDirectedEdge": {
+      "additionalProperties": false,
+      "properties": {
+        "source_variable": {
+          "description": "The independent variable $X$.",
+          "minLength": 1,
+          "title": "Source Variable",
+          "type": "string"
+        },
+        "target_variable": {
+          "description": "The dependent variable $Y$.",
+          "minLength": 1,
+          "title": "Target Variable",
+          "type": "string"
+        },
+        "edge_type": {
+          "description": "The specific Pearlian topological relationship between the two variables.",
+          "enum": [
+            "direct_cause",
+            "confounder",
+            "collider",
+            "mediator"
+          ],
+          "title": "Edge Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_variable",
+        "target_variable",
+        "edge_type"
+      ],
+      "title": "CausalDirectedEdge",
       "type": "object"
     },
     "CausalInterval": {
@@ -2993,6 +3040,18 @@
           ],
           "title": "Status",
           "type": "string"
+        },
+        "causal_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StructuralCausalModel"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal DAG representing the agent's structural assumptions about the environment."
         }
       },
       "required": [
@@ -3225,6 +3284,55 @@
         "feedback"
       ],
       "title": "InterventionVerdict",
+      "type": "object"
+    },
+    "InterventionalCausalTask": {
+      "additionalProperties": false,
+      "properties": {
+        "task_id": {
+          "description": "Unique identifier for this causal intervention.",
+          "minLength": 1,
+          "title": "Task Id",
+          "type": "string"
+        },
+        "target_hypothesis_id": {
+          "description": "The hypothesis containing the SCM being tested.",
+          "title": "Target Hypothesis Id",
+          "type": "string"
+        },
+        "intervention_variable": {
+          "description": "The specific node $X$ in the SCM the agent is forcing to a specific state.",
+          "title": "Intervention Variable",
+          "type": "string"
+        },
+        "do_operator_state": {
+          "description": "The exact value or condition forced upon the intervention_variable, isolating it from its historical causes.",
+          "title": "Do Operator State",
+          "type": "string"
+        },
+        "expected_causal_information_gain": {
+          "description": "The mathematical proof of entropy reduction yielded specifically by breaking the confounding back-doors.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Expected Causal Information Gain",
+          "type": "number"
+        },
+        "execution_cost_budget_cents": {
+          "description": "The maximum economic expenditure authorized to run this specific causal intervention.",
+          "minimum": 0,
+          "title": "Execution Cost Budget Cents",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "task_id",
+        "target_hypothesis_id",
+        "intervention_variable",
+        "do_operator_state",
+        "expected_causal_information_gain",
+        "execution_cost_budget_cents"
+      ],
+      "title": "InterventionalCausalTask",
       "type": "object"
     },
     "LatentScratchpadTrace": {
@@ -4577,6 +4685,18 @@
           ],
           "default": null,
           "description": "The time window during which this relationship holds true."
+        },
+        "causal_relationship": {
+          "default": "undirected",
+          "description": "The Pearlian directionality of the semantic relationship.",
+          "enum": [
+            "causes",
+            "confounds",
+            "correlates_with",
+            "undirected"
+          ],
+          "title": "Causal Relationship",
+          "type": "string"
         }
       },
       "required": [
@@ -5064,6 +5184,42 @@
         "max_loops_allowed"
       ],
       "title": "SteadyStateHypothesis",
+      "type": "object"
+    },
+    "StructuralCausalModel": {
+      "additionalProperties": false,
+      "properties": {
+        "observed_variables": {
+          "description": "The nodes in the DAG that the agent can passively measure.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Observed Variables",
+          "type": "array"
+        },
+        "latent_variables": {
+          "description": "The unobserved confounders the agent suspects exist.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Latent Variables",
+          "type": "array"
+        },
+        "causal_edges": {
+          "description": "The declared topological mapping of causality.",
+          "items": {
+            "$ref": "#/$defs/CausalDirectedEdge"
+          },
+          "title": "Causal Edges",
+          "type": "array"
+        }
+      },
+      "required": [
+        "observed_variables",
+        "latent_variables",
+        "causal_edges"
+      ],
+      "title": "StructuralCausalModel",
       "type": "object"
     },
     "SuspenseEnvelope": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -5,7 +5,7 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from coreason_manifest.compute.inference import ActiveInferenceContract, AnalogicalMappingTask
+from coreason_manifest.compute.inference import ActiveInferenceContract, AnalogicalMappingTask, InterventionalCausalTask
 from coreason_manifest.compute.neuromodulation import ActivationSteeringContract, CognitiveRoutingDirective
 from coreason_manifest.compute.symbolic import NeuroSymbolicHandoff
 from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
@@ -14,6 +14,7 @@ from coreason_manifest.core.primitives import NodeID, SemanticVersion
 from coreason_manifest.state.cognition import CognitiveStateProfile, CognitiveUncertaintyProfile
 from coreason_manifest.state.differentials import DefeasibleCascade, TruthMaintenancePolicy
 from coreason_manifest.state.embodied import EmbodiedSensoryVector
+from coreason_manifest.state.events import CausalDirectedEdge, StructuralCausalModel
 from coreason_manifest.state.scratchpad import LatentScratchpadTrace, ThoughtBranch
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AnyNode
@@ -25,6 +26,7 @@ __all__ = [
     "AnalogicalMappingTask",
     "AnyNode",
     "AnyTopology",
+    "CausalDirectedEdge",
     "CognitiveRoutingDirective",
     "CognitiveStateProfile",
     "CognitiveUncertaintyProfile",
@@ -32,11 +34,13 @@ __all__ = [
     "DefeasibleCascade",
     "EmbodiedSensoryVector",
     "EscalationContract",
+    "InterventionalCausalTask",
     "LatentScratchpadTrace",
     "NeuroSymbolicHandoff",
     "NodeID",
     "ProcessRewardContract",
     "SemanticVersion",
+    "StructuralCausalModel",
     "ThoughtBranch",
     "TruthMaintenancePolicy",
     "WorkflowEnvelope",

--- a/src/coreason_manifest/compute/inference.py
+++ b/src/coreason_manifest/compute/inference.py
@@ -26,6 +26,27 @@ class AnalogicalMappingTask(CoreasonBaseModel):
     )
 
 
+class InterventionalCausalTask(CoreasonBaseModel):
+    task_id: str = Field(min_length=1, description="Unique identifier for this causal intervention.")
+    target_hypothesis_id: str = Field(description="The hypothesis containing the SCM being tested.")
+    intervention_variable: str = Field(
+        description="The specific node $X$ in the SCM the agent is forcing to a specific state."
+    )
+    do_operator_state: str = Field(
+        description="The exact value or condition forced upon the intervention_variable, "
+        "isolating it from its historical causes."
+    )
+    expected_causal_information_gain: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The mathematical proof of entropy reduction yielded specifically by "
+        "breaking the confounding back-doors.",
+    )
+    execution_cost_budget_cents: int = Field(
+        ge=0, description="The maximum economic expenditure authorized to run this specific causal intervention."
+    )
+
+
 class ActiveInferenceContract(CoreasonBaseModel):
     task_id: str = Field(min_length=1, description="Unique identifier for this active inference execution.")
     target_hypothesis_id: str = Field(description="The HypothesisGenerationEvent this task is attempting to falsify.")

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -124,6 +124,20 @@ class SystemFaultEvent(BaseStateEvent):
     )
 
 
+class CausalDirectedEdge(CoreasonBaseModel):
+    source_variable: str = Field(min_length=1, description="The independent variable $X$.")
+    target_variable: str = Field(min_length=1, description="The dependent variable $Y$.")
+    edge_type: Literal["direct_cause", "confounder", "collider", "mediator"] = Field(
+        description="The specific Pearlian topological relationship between the two variables."
+    )
+
+
+class StructuralCausalModel(CoreasonBaseModel):
+    observed_variables: list[str] = Field(description="The nodes in the DAG that the agent can passively measure.")
+    latent_variables: list[str] = Field(description="The unobserved confounders the agent suspects exist.")
+    causal_edges: list[CausalDirectedEdge] = Field(description="The declared topological mapping of causality.")
+
+
 class FalsificationCondition(CoreasonBaseModel):
     condition_id: str = Field(min_length=1, description="Unique identifier for this falsification test.")
     description: str = Field(
@@ -156,6 +170,10 @@ class HypothesisGenerationEvent(BaseStateEvent):
     )
     status: Literal["active", "falsified", "verified"] = Field(
         default="active", description="The current validity state of this hypothesis in the EpistemicLedger."
+    )
+    causal_model: StructuralCausalModel | None = Field(
+        default=None,
+        description="The formal DAG representing the agent's structural assumptions about the environment.",
     )
 
 

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -151,3 +151,6 @@ class SemanticEdge(CoreasonBaseModel):
     temporal_bounds: TemporalBounds | None = Field(
         default=None, description="The time window during which this relationship holds true."
     )
+    causal_relationship: Literal["causes", "confounds", "correlates_with", "undirected"] = Field(
+        default="undirected", description="The Pearlian directionality of the semantic relationship."
+    )

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Annotated, Literal
 
 from pydantic import Field
 
-from coreason_manifest.compute.inference import ActiveInferenceContract, AnalogicalMappingTask
+from coreason_manifest.compute.inference import ActiveInferenceContract, AnalogicalMappingTask, InterventionalCausalTask
 from coreason_manifest.compute.profiles import RoutingFrontier
 from coreason_manifest.compute.symbolic import NeuroSymbolicHandoff
 from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
@@ -130,6 +130,10 @@ class AgentNode(BaseNode):
     )
     analogical_policy: AnalogicalMappingTask | None = Field(
         default=None, description="The formal contract forcing the agent to execute cross-domain lateral thinking."
+    )
+    interventional_policy: InterventionalCausalTask | None = Field(
+        default=None,
+        description="The formal contract authorizing the agent to mutate variables to prove Pearlian causation.",
     )
     symbolic_handoff_policy: NeuroSymbolicHandoff | None = Field(
         default=None,

--- a/tests/domains/test_compute_inference.py
+++ b/tests/domains/test_compute_inference.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest.compute.inference import AnalogicalMappingTask
+from coreason_manifest.compute.inference import AnalogicalMappingTask, InterventionalCausalTask
 
 
 def test_analogical_mapping_task_valid() -> None:
@@ -35,6 +35,30 @@ def test_analogical_mapping_task_invalid_temperature() -> None:
             required_isomorphisms=3,
             divergence_temperature_override=-0.5,
         )
+
+
+def test_interventional_causal_task_bounds() -> None:
+    with pytest.raises(ValidationError) as exc:
+        InterventionalCausalTask(
+            task_id="task-1",
+            target_hypothesis_id="hyp-1",
+            intervention_variable="X",
+            do_operator_state="1",
+            expected_causal_information_gain=-0.1,  # Invalid
+            execution_cost_budget_cents=100,
+        )
+    assert "Input should be greater than or equal to 0" in str(exc.value)
+
+    with pytest.raises(ValidationError) as exc:
+        InterventionalCausalTask(
+            task_id="task-1",
+            target_hypothesis_id="hyp-1",
+            intervention_variable="X",
+            do_operator_state="1",
+            expected_causal_information_gain=1.1,  # Invalid
+            execution_cost_budget_cents=100,
+        )
+    assert "Input should be less than or equal to 1" in str(exc.value)
 
 
 def test_analogical_mapping_task_invalid_id() -> None:

--- a/tests/domains/test_state_hypothesis.py
+++ b/tests/domains/test_state_hypothesis.py
@@ -9,7 +9,12 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.compute.inference import ActiveInferenceContract
-from coreason_manifest.state.events import FalsificationCondition, HypothesisGenerationEvent
+from coreason_manifest.state.events import (
+    CausalDirectedEdge,
+    FalsificationCondition,
+    HypothesisGenerationEvent,
+    StructuralCausalModel,
+)
 
 
 def test_hypothesis_generation_event_valid() -> None:
@@ -35,6 +40,39 @@ def test_hypothesis_generation_event_valid() -> None:
     assert hypothesis.bayesian_prior == 0.75
     assert len(hypothesis.falsification_conditions) == 1
     assert hypothesis.falsification_conditions[0].condition_id == "cond-1"
+
+
+def test_hypothesis_causal_model() -> None:
+    causal_edge = CausalDirectedEdge(
+        source_variable="smoking",
+        target_variable="cancer",
+        edge_type="direct_cause",
+    )
+    scm = StructuralCausalModel(
+        observed_variables=["smoking", "cancer"],
+        latent_variables=["genetics"],
+        causal_edges=[causal_edge],
+    )
+    hypothesis = HypothesisGenerationEvent(
+        event_id="evt-2",
+        timestamp=123.456,
+        hypothesis_id="hyp-2",
+        premise_text="Smoking causes cancer.",
+        bayesian_prior=0.9,
+        falsification_conditions=[
+            FalsificationCondition(
+                condition_id="cond-2",
+                description="Must not observe correlation.",
+                falsifying_observation_signature="No correlation",
+            )
+        ],
+        status="active",
+        causal_model=scm,
+    )
+
+    assert hypothesis.causal_model is not None
+    assert len(hypothesis.causal_model.causal_edges) == 1
+    assert hypothesis.causal_model.causal_edges[0].edge_type == "direct_cause"
 
 
 def test_hypothesis_bayesian_prior_bounds() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -135,6 +135,34 @@ def draw_reflex_policy(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_causal_directed_edge(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "source_variable": st.text(min_size=1),
+                "target_variable": st.text(min_size=1),
+                "edge_type": st.sampled_from(["direct_cause", "confounder", "collider", "mediator"]),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_structural_causal_model(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "observed_variables": st.lists(st.text(), max_size=100),
+                "latent_variables": st.lists(st.text(), max_size=100),
+                "causal_edges": st.lists(draw_causal_directed_edge(), max_size=100),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_falsification_condition(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
@@ -164,6 +192,26 @@ def draw_hypothesis_generation_event(draw: Any) -> dict[str, Any]:
                 "status": st.sampled_from(["active", "falsified", "verified"]),
                 "event_id": st.text(min_size=1),
                 "timestamp": st.floats(allow_nan=False, allow_infinity=False),
+                "causal_model": st.one_of(st.none(), draw_structural_causal_model()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_interventional_causal_task(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "task_id": st.text(min_size=1),
+                "target_hypothesis_id": st.text(),
+                "intervention_variable": st.text(),
+                "do_operator_state": st.text(),
+                "expected_causal_information_gain": st.floats(
+                    min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                ),
+                "execution_cost_budget_cents": st.integers(min_value=0),
             }
         )
     )
@@ -406,6 +454,8 @@ def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
         payload["analogical_policy"] = draw(draw_analogical_mapping_task())
     if draw(st.booleans()):
         payload["symbolic_handoff_policy"] = draw(draw_neuro_symbolic_handoff())
+    if draw(st.booleans()):
+        payload["interventional_policy"] = draw(draw_interventional_causal_task())
     return payload
 
 
@@ -1272,6 +1322,7 @@ def test_semanticnode_fuzzing(payload: dict[str, Any]) -> None:
                 ),
             ),
             "temporal_bounds": st.one_of(st.none(), draw_temporal_bounds()),
+            "causal_relationship": st.sampled_from(["causes", "confounds", "correlates_with", "undirected"]),
         }
     )
 )


### PR DESCRIPTION
Implemented Epic 2: Pearlian Interventions (Causal Graphing) by adding Structural Causal Models (SCMs), interventional tasks, and updating the semantic graph to track causal directionality. Extended data schemas in `coreason-manifest` with strict Pydantic rules without writing any runtime logic. Updates included global fuzzing tests to ensure compatibility and re-generating the JSON schema map.

---
*PR created automatically by Jules for task [7975483678146885312](https://jules.google.com/task/7975483678146885312) started by @gowthamrao*