### PR TITLE
Implement Ontological Alignment Policy and Handshake Records

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1687,6 +1687,18 @@
           ],
           "default": null,
           "description": "The explicit ruleset governing how the council resolves disagreements."
+        },
+        "ontological_alignment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologicalAlignmentPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
         }
       },
       "required": [
@@ -1974,6 +1986,41 @@
         "quarantined_event_ids"
       ],
       "title": "DefeasibleCascade",
+      "type": "object"
+    },
+    "DimensionalProjectionContract": {
+      "additionalProperties": false,
+      "properties": {
+        "source_model_name": {
+          "description": "The native embedding model of the origin agent.",
+          "title": "Source Model Name",
+          "type": "string"
+        },
+        "target_model_name": {
+          "description": "The native embedding model of the destination agent.",
+          "title": "Target Model Name",
+          "type": "string"
+        },
+        "projection_matrix_hash": {
+          "description": "The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions.",
+          "title": "Projection Matrix Hash",
+          "type": "string"
+        },
+        "isometry_preservation_score": {
+          "description": "Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Isometry Preservation Score",
+          "type": "number"
+        }
+      },
+      "required": [
+        "source_model_name",
+        "target_model_name",
+        "projection_matrix_hash",
+        "isometry_preservation_score"
+      ],
+      "title": "DimensionalProjectionContract",
       "type": "object"
     },
     "DistributionProfile": {
@@ -4102,6 +4149,99 @@
       "title": "ObservationEvent",
       "type": "object"
     },
+    "OntologicalAlignmentPolicy": {
+      "additionalProperties": false,
+      "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics.",
+      "properties": {
+        "min_cosine_similarity": {
+          "description": "The absolute minimum latent vector similarity required to allow swarm communication.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Min Cosine Similarity",
+          "type": "number"
+        },
+        "require_isometry_proof": {
+          "description": "If True, the orchestrator must reject dimensional projections that fall below a safe isometry preservation score.",
+          "title": "Require Isometry Proof",
+          "type": "boolean"
+        },
+        "fallback_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rigid external JSON schema to force agents to use if their latent vector geometries are hopelessly incommensurable."
+        }
+      },
+      "required": [
+        "min_cosine_similarity",
+        "require_isometry_proof"
+      ],
+      "title": "OntologicalAlignmentPolicy",
+      "type": "object"
+    },
+    "OntologicalHandshake": {
+      "additionalProperties": false,
+      "properties": {
+        "handshake_id": {
+          "minLength": 1,
+          "title": "Handshake Id",
+          "type": "string"
+        },
+        "participant_node_ids": {
+          "description": "The agents establishing semantic alignment.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 2,
+          "title": "Participant Node Ids",
+          "type": "array"
+        },
+        "measured_cosine_similarity": {
+          "description": "The calculated geometric alignment of the agents' core definitions.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Measured Cosine Similarity",
+          "type": "number"
+        },
+        "alignment_status": {
+          "description": "The final verdict of the handshake protocol.",
+          "enum": [
+            "aligned",
+            "projected",
+            "fallback_triggered",
+            "incommensurable"
+          ],
+          "title": "Alignment Status",
+          "type": "string"
+        },
+        "applied_projection": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DimensionalProjectionContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The projection applied if the agents natively used different embedding dimensionalities."
+        }
+      },
+      "required": [
+        "handshake_id",
+        "participant_node_ids",
+        "measured_cosine_similarity",
+        "alignment_status"
+      ],
+      "title": "OntologicalHandshake",
+      "type": "object"
+    },
     "OptimizationDirection": {
       "enum": [
         "maximize",
@@ -4623,6 +4763,18 @@
           "minItems": 2,
           "title": "Participant Node Ids",
           "type": "array"
+        },
+        "ontological_alignment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologicalAlignmentPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
         }
       },
       "required": [

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -4189,6 +4189,7 @@
       "additionalProperties": false,
       "properties": {
         "handshake_id": {
+          "description": "The unique identifier for the handshake.",
           "minLength": 1,
           "title": "Handshake Id",
           "type": "string"

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -23,9 +23,10 @@ from coreason_manifest.state.events import (
     ZeroKnowledgeProof,
 )
 from coreason_manifest.state.scratchpad import LatentScratchpadTrace, ThoughtBranch
+from coreason_manifest.state.semantic import DimensionalProjectionContract, OntologicalHandshake
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AnyNode
-from coreason_manifest.workflow.topologies import AnyTopology
+from coreason_manifest.workflow.topologies import AnyTopology, OntologicalAlignmentPolicy
 
 __all__ = [
     "ActivationSteeringContract",
@@ -39,6 +40,7 @@ __all__ = [
     "CognitiveUncertaintyProfile",
     "CoreasonBaseModel",
     "DefeasibleCascade",
+    "DimensionalProjectionContract",
     "EmbodiedSensoryVector",
     "EscalationContract",
     "InterventionalCausalTask",
@@ -47,6 +49,8 @@ __all__ = [
     "NeuralAuditAttestation",
     "NeuroSymbolicHandoff",
     "NodeID",
+    "OntologicalAlignmentPolicy",
+    "OntologicalHandshake",
     "ProcessRewardContract",
     "SaeFeatureActivation",
     "SemanticVersion",

--- a/src/coreason_manifest/state/__init__.py
+++ b/src/coreason_manifest/state/__init__.py
@@ -46,8 +46,10 @@ from coreason_manifest.state.memory import (
 )
 from coreason_manifest.state.semantic import (
     CausalInterval,
+    DimensionalProjectionContract,
     MemoryProvenance,
     MemoryTier,
+    OntologicalHandshake,
     SalienceProfile,
     SemanticEdge,
     SemanticNode,
@@ -75,6 +77,7 @@ __all__ = [
     "CognitiveUncertaintyProfile",
     "DefeasibleAttack",
     "DefeasibleCascade",
+    "DimensionalProjectionContract",
     "EmbodiedSensoryVector",
     "EpistemicLedger",
     "EvidentiaryWarrant",
@@ -83,6 +86,7 @@ __all__ = [
     "MemoryTier",
     "NeuralAuditAttestation",
     "ObservationEvent",
+    "OntologicalHandshake",
     "PatchOperation",
     "RollbackRequest",
     "SaeFeatureActivation",

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -32,20 +32,20 @@ class DimensionalProjectionContract(CoreasonBaseModel):
     source_model_name: str = Field(description="The native embedding model of the origin agent.")
     target_model_name: str = Field(description="The native embedding model of the destination agent.")
     projection_matrix_hash: str = Field(
-        description="The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions."
+        description="The SHA-256 hash of the exact mathematical matrix used to "
+        "compress or translate the latent dimensions."
     )
     isometry_preservation_score: float = Field(
         ge=0.0,
         le=1.0,
-        description="Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
+        description="Mathematical proof (e.g., Earth Mover's Distance preservation) of "
+        "how accurately relative semantic distances were maintained during projection.",
     )
 
 
 class OntologicalHandshake(CoreasonBaseModel):
     handshake_id: str = Field(min_length=1, description="The unique identifier for the handshake.")
-    participant_node_ids: list[str] = Field(
-        min_length=2, description="The agents establishing semantic alignment."
-    )
+    participant_node_ids: list[str] = Field(min_length=2, description="The agents establishing semantic alignment.")
     measured_cosine_similarity: float = Field(
         ge=-1.0,
         le=1.0,

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -28,6 +28,38 @@ class SpatialAnchor(CoreasonBaseModel):
 type CausalInterval = Literal["strictly_precedes", "overlaps", "contains", "causes", "mitigates"]
 
 
+class DimensionalProjectionContract(CoreasonBaseModel):
+    source_model_name: str = Field(description="The native embedding model of the origin agent.")
+    target_model_name: str = Field(description="The native embedding model of the destination agent.")
+    projection_matrix_hash: str = Field(
+        description="The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions."
+    )
+    isometry_preservation_score: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
+    )
+
+
+class OntologicalHandshake(CoreasonBaseModel):
+    handshake_id: str = Field(min_length=1, description="The unique identifier for the handshake.")
+    participant_node_ids: list[str] = Field(
+        min_length=2, description="The agents establishing semantic alignment."
+    )
+    measured_cosine_similarity: float = Field(
+        ge=-1.0,
+        le=1.0,
+        description="The calculated geometric alignment of the agents' core definitions.",
+    )
+    alignment_status: Literal["aligned", "projected", "fallback_triggered", "incommensurable"] = Field(
+        description="The final verdict of the handshake protocol."
+    )
+    applied_projection: DimensionalProjectionContract | None = Field(
+        default=None,
+        description="The projection applied if the agents natively used different embedding dimensionalities.",
+    )
+
+
 class VectorEmbedding(CoreasonBaseModel):
     vector: list[float] = Field(description="The raw high-dimensional floating-point array.")
     dimensionality: int = Field(description="The size of the vector array.")

--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -32,6 +32,7 @@ from coreason_manifest.workflow.topologies import (
     DAGTopology,
     DiversityConstraint,
     EvolutionaryTopology,
+    OntologicalAlignmentPolicy,
     StateContract,
     SwarmTopology,
 )
@@ -54,6 +55,7 @@ __all__ = [
     "EpistemicScanner",
     "EvolutionaryTopology",
     "HumanNode",
+    "OntologicalAlignmentPolicy",
     "SelfCorrectionPolicy",
     "StateContract",
     "SwarmTopology",

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -49,6 +49,25 @@ class DiversityConstraint(CoreasonBaseModel):
     )
 
 
+class OntologicalAlignmentPolicy(CoreasonBaseModel):
+    """
+    The pre-flight execution gate forcing agents to mathematically align their latent semantics.
+    """
+
+    min_cosine_similarity: float = Field(
+        ge=-1.0,
+        le=1.0,
+        description="The absolute minimum latent vector similarity required to allow swarm communication.",
+    )
+    require_isometry_proof: bool = Field(
+        description="If True, the orchestrator must reject dimensional projections that fall below a safe isometry preservation score."
+    )
+    fallback_state_contract: StateContract | None = Field(
+        default=None,
+        description="The rigid external JSON schema to force agents to use if their latent vector geometries are hopelessly incommensurable.",
+    )
+
+
 class BackpressurePolicy(CoreasonBaseModel):
     """
     Declarative backpressure constraints.
@@ -163,6 +182,10 @@ class CouncilTopology(BaseTopology):
     consensus_policy: ConsensusPolicy | None = Field(
         default=None, description="The explicit ruleset governing how the council resolves disagreements."
     )
+    ontological_alignment: OntologicalAlignmentPolicy | None = Field(
+        default=None,
+        description="The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology.",
+    )
 
     @model_validator(mode="after")
     def check_adjudicator_id(self) -> Self:
@@ -235,6 +258,10 @@ class SMPCTopology(BaseTopology):
     participant_node_ids: list[str] = Field(
         min_length=2,
         description="The strict ordered list of NodeIDs participating in the Secure Multi-Party Computation ring.",
+    )
+    ontological_alignment: OntologicalAlignmentPolicy | None = Field(
+        default=None,
+        description="The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology.",
     )
 
 

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -60,11 +60,13 @@ class OntologicalAlignmentPolicy(CoreasonBaseModel):
         description="The absolute minimum latent vector similarity required to allow swarm communication.",
     )
     require_isometry_proof: bool = Field(
-        description="If True, the orchestrator must reject dimensional projections that fall below a safe isometry preservation score."
+        description="If True, the orchestrator must reject dimensional projections that fall below "
+        "a safe isometry preservation score."
     )
     fallback_state_contract: StateContract | None = Field(
         default=None,
-        description="The rigid external JSON schema to force agents to use if their latent vector geometries are hopelessly incommensurable.",
+        description="The rigid external JSON schema to force agents to use if their "
+        "latent vector geometries are hopelessly incommensurable.",
     )
 
 
@@ -184,7 +186,8 @@ class CouncilTopology(BaseTopology):
     )
     ontological_alignment: OntologicalAlignmentPolicy | None = Field(
         default=None,
-        description="The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology.",
+        description="The pre-flight execution gate forcing agents to mathematically align their latent "
+        "semantics before participating in the topology.",
     )
 
     @model_validator(mode="after")
@@ -261,7 +264,8 @@ class SMPCTopology(BaseTopology):
     )
     ontological_alignment: OntologicalAlignmentPolicy | None = Field(
         default=None,
-        description="The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology.",
+        description="The pre-flight execution gate forcing agents to mathematically align their latent "
+        "semantics before participating in the topology.",
     )
 
 

--- a/tests/domains/test_state_semantic.py
+++ b/tests/domains/test_state_semantic.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from coreason_manifest.state.semantic import DimensionalProjectionContract
+
+
+@given(isometry_preservation_score=st.floats(max_value=-0.000001) | st.floats(min_value=1.000001))
+def test_dimensional_projection_contract_mathematical_bounds(isometry_preservation_score: float) -> None:
+    """Test: Prove DimensionalProjectionContract decisively rejects values outside [0.0, 1.0]."""
+    with pytest.raises(ValidationError):
+        DimensionalProjectionContract(
+            source_model_name="source",
+            target_model_name="target",
+            projection_matrix_hash="hash",
+            isometry_preservation_score=isometry_preservation_score,
+        )

--- a/tests/domains/test_workflow_topology.py
+++ b/tests/domains/test_workflow_topology.py
@@ -15,7 +15,7 @@ from coreason_manifest.workflow.nodes import (
     System1Reflex,
     SystemNode,
 )
-from coreason_manifest.workflow.topologies import CouncilTopology, DAGTopology
+from coreason_manifest.workflow.topologies import CouncilTopology, DAGTopology, OntologicalAlignmentPolicy
 
 # Strategy for valid NodeIDs (alphanumeric, underscores, hyphens)
 # Also must have a minimum length of 1 based on core primitives.
@@ -122,6 +122,13 @@ def test_system1_reflex_mathematical_bounds(confidence_threshold: float) -> None
     """Test 3: Prove System1Reflex decisively rejects values outside [0.0, 1.0]."""
     with pytest.raises(ValidationError):
         System1Reflex(confidence_threshold=confidence_threshold, allowed_read_only_tools=["tool_a"])
+
+
+@given(min_cosine_similarity=st.floats(max_value=-1.000001) | st.floats(min_value=1.000001))
+def test_ontological_alignment_policy_mathematical_bounds(min_cosine_similarity: float) -> None:
+    """Test: Prove OntologicalAlignmentPolicy decisively rejects values outside [-1.0, 1.0]."""
+    with pytest.raises(ValidationError):
+        OntologicalAlignmentPolicy(min_cosine_similarity=min_cosine_similarity, require_isometry_proof=True)
 
 
 @given(dissonance_threshold=st.floats(max_value=-0.000001) | st.floats(min_value=1.000001))

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -45,7 +45,12 @@ from coreason_manifest.state.events import (
     SystemFaultEvent,
 )
 from coreason_manifest.state.memory import EpistemicLedger
-from coreason_manifest.state.semantic import SemanticEdge, SemanticNode
+from coreason_manifest.state.semantic import (
+    DimensionalProjectionContract,
+    OntologicalHandshake,
+    SemanticEdge,
+    SemanticNode,
+)
 from coreason_manifest.telemetry.custody import CustodyRecord
 from coreason_manifest.telemetry.schemas import TraceExportBatch
 from coreason_manifest.testing.chaos import ChaosExperiment
@@ -54,7 +59,7 @@ from coreason_manifest.tooling import ActionSpace, ToolDefinition
 from coreason_manifest.workflow.auctions import AuctionState, TaskAward
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, CompositeNode, HumanNode, SystemNode
-from coreason_manifest.workflow.topologies import AnyTopology, StateContract
+from coreason_manifest.workflow.topologies import AnyTopology, OntologicalAlignmentPolicy, StateContract
 
 
 @st.composite
@@ -492,6 +497,57 @@ def draw_output_mapping(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_dimensional_projection_contract(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "source_model_name": st.text(min_size=1),
+                "target_model_name": st.text(min_size=1),
+                "projection_matrix_hash": st.text(min_size=10),
+                "isometry_preservation_score": st.floats(
+                    min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                ),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_ontological_handshake(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "handshake_id": st.text(min_size=1),
+                "participant_node_ids": st.lists(st.text(min_size=1), min_size=2, max_size=5),
+                "measured_cosine_similarity": st.floats(
+                    min_value=-1.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                ),
+                "alignment_status": st.sampled_from(["aligned", "projected", "fallback_triggered", "incommensurable"]),
+                "applied_projection": st.one_of(st.none(), draw_dimensional_projection_contract()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_ontological_alignment_policy(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "min_cosine_similarity": st.floats(
+                    min_value=-1.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                ),
+                "require_isometry_proof": st.booleans(),
+                "fallback_state_contract": st.none(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_consensus_policy(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
@@ -568,6 +624,7 @@ def draw_topology_payload(nodes_strategy: st.SearchStrategy[dict[str, Any]]) -> 
             ),
             "diversity_policy": st.none(),
             "consensus_policy": st.one_of(st.none(), draw_consensus_policy()),
+            "ontological_alignment": st.one_of(st.none(), draw_ontological_alignment_policy()),
         }
     ).map(_council_mapper)
 
@@ -590,6 +647,7 @@ def draw_topology_payload(nodes_strategy: st.SearchStrategy[dict[str, Any]]) -> 
                 min_size=2,
                 max_size=5,
             ),
+            "ontological_alignment": st.one_of(st.none(), draw_ontological_alignment_policy()),
         }
     )
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -46,8 +46,6 @@ from coreason_manifest.state.events import (
 )
 from coreason_manifest.state.memory import EpistemicLedger
 from coreason_manifest.state.semantic import (
-    DimensionalProjectionContract,
-    OntologicalHandshake,
     SemanticEdge,
     SemanticNode,
 )
@@ -59,7 +57,7 @@ from coreason_manifest.tooling import ActionSpace, ToolDefinition
 from coreason_manifest.workflow.auctions import AuctionState, TaskAward
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, CompositeNode, HumanNode, SystemNode
-from coreason_manifest.workflow.topologies import AnyTopology, OntologicalAlignmentPolicy, StateContract
+from coreason_manifest.workflow.topologies import AnyTopology, StateContract
 
 
 @st.composite


### PR DESCRIPTION
This pull request introduces the `OntologicalAlignmentPolicy`, `OntologicalHandshake`, and `DimensionalProjectionContract` schemas to enforce dimensional geometry alignment and semantic commensurability before agents enter swarm topologies. It successfully adds `@st.composite` generator logic into `test_fuzzing.py` and implements bounded float domain testing for Isometry Preservation and Cosine Similarities. The `coreason_ontology.schema.json` has also been regenerated to reflect these updates.

---
*PR created automatically by Jules for task [6322035914861059656](https://jules.google.com/task/6322035914861059656) started by @gowthamrao*