### PR TITLE
feat: Implement Algorithmic Consensus (Swarm Prediction Markets)

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1520,7 +1520,8 @@
           "enum": [
             "unanimous",
             "majority",
-            "debate_rounds"
+            "debate_rounds",
+            "prediction_market"
           ],
           "title": "Strategy",
           "type": "string"
@@ -1549,6 +1550,18 @@
           "default": null,
           "description": "The maximum number of argument/rebuttal cycles permitted before forced adjudication.",
           "title": "Max Debate Rounds"
+        },
+        "prediction_market_rules": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/PredictionMarketPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strict algorithmic mechanism rules required if the strategy is prediction_market."
         }
       },
       "required": [
@@ -3136,6 +3149,45 @@
       "title": "HypothesisGenerationEvent",
       "type": "object"
     },
+    "HypothesisStake": {
+      "additionalProperties": false,
+      "description": "The mathematical record of an agent taking a financial/compute position on a specific causal hypothesis.",
+      "properties": {
+        "agent_id": {
+          "description": "The ID of the agent placing the stake.",
+          "minLength": 1,
+          "title": "Agent Id",
+          "type": "string"
+        },
+        "target_hypothesis_id": {
+          "description": "The exact HypothesisGenerationEvent the agent is betting on.",
+          "minLength": 1,
+          "title": "Target Hypothesis Id",
+          "type": "string"
+        },
+        "staked_cents": {
+          "description": "The volume of capital or compute budget committed to this position.",
+          "exclusiveMinimum": 0,
+          "title": "Staked Cents",
+          "type": "integer"
+        },
+        "implied_probability": {
+          "description": "The agent's calculated internal confidence score.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Implied Probability",
+          "type": "number"
+        }
+      },
+      "required": [
+        "agent_id",
+        "target_hypothesis_id",
+        "staked_cents",
+        "implied_probability"
+      ],
+      "title": "HypothesisStake",
+      "type": "object"
+    },
     "InformationFlowPolicy": {
       "additionalProperties": false,
       "description": "Mathematical Data Loss Prevention (DLP) contract that bounds the graph.",
@@ -3666,6 +3718,47 @@
         "http"
       ],
       "type": "string"
+    },
+    "MarketResolution": {
+      "additionalProperties": false,
+      "description": "The resolution state of an algorithmic prediction market.",
+      "properties": {
+        "market_id": {
+          "description": "The ID of the prediction market.",
+          "minLength": 1,
+          "title": "Market Id",
+          "type": "string"
+        },
+        "winning_hypothesis_id": {
+          "description": "The hypothesis ID that was verified.",
+          "title": "Winning Hypothesis Id",
+          "type": "string"
+        },
+        "falsified_hypothesis_ids": {
+          "description": "The hypothesis IDs that were falsified.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Falsified Hypothesis Ids",
+          "type": "array"
+        },
+        "payout_distribution": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "The deterministic mapping of agent IDs to their earned compute budget/cents based on Brier scoring.",
+          "title": "Payout Distribution",
+          "type": "object"
+        }
+      },
+      "required": [
+        "market_id",
+        "winning_hypothesis_id",
+        "falsified_hypothesis_ids",
+        "payout_distribution"
+      ],
+      "title": "MarketResolution",
+      "type": "object"
     },
     "MechanisticAuditContract": {
       "additionalProperties": false,
@@ -4427,6 +4520,89 @@
         "pq_signature_blob"
       ],
       "title": "PostQuantumSignature",
+      "type": "object"
+    },
+    "PredictionMarketPolicy": {
+      "additionalProperties": false,
+      "description": "The ruleset governing the market. It enforces Sybil resistance\n(via quadratic staking) and dictates when the market stops trading.",
+      "properties": {
+        "staking_function": {
+          "description": "The mathematical curve applied to stakes. Quadratic enforces Sybil resistance.",
+          "enum": [
+            "linear",
+            "quadratic"
+          ],
+          "title": "Staking Function",
+          "type": "string"
+        },
+        "min_liquidity_cents": {
+          "description": "Minimum liquidity required.",
+          "minimum": 0,
+          "title": "Min Liquidity Cents",
+          "type": "integer"
+        },
+        "convergence_delta_threshold": {
+          "description": "The threshold indicating the market price has stabilized enough to trigger the resolution oracle.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Convergence Delta Threshold",
+          "type": "number"
+        }
+      },
+      "required": [
+        "staking_function",
+        "min_liquidity_cents",
+        "convergence_delta_threshold"
+      ],
+      "title": "PredictionMarketPolicy",
+      "type": "object"
+    },
+    "PredictionMarketState": {
+      "additionalProperties": false,
+      "description": "The state of the Automated Market Maker (AMM) using Robin Hanson's\nLogarithmic Market Scoring Rule (LMSR) to ensure infinite liquidity.",
+      "properties": {
+        "market_id": {
+          "description": "The ID of the prediction market.",
+          "minLength": 1,
+          "title": "Market Id",
+          "type": "string"
+        },
+        "resolution_oracle_condition_id": {
+          "description": "The specific FalsificationCondition ID whose execution will trigger the market payout.",
+          "title": "Resolution Oracle Condition Id",
+          "type": "string"
+        },
+        "lmsr_b_parameter": {
+          "description": "The liquidity parameter defining the market depth and max loss for the AMM.",
+          "exclusiveMinimum": 0.0,
+          "title": "Lmsr B Parameter",
+          "type": "number"
+        },
+        "order_book": {
+          "description": "The immutable ledger of all stakes placed by the swarm.",
+          "items": {
+            "$ref": "#/$defs/HypothesisStake"
+          },
+          "title": "Order Book",
+          "type": "array"
+        },
+        "current_market_probabilities": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "Mapping of hypothesis IDs to their current LMSR-calculated market price (probability).",
+          "title": "Current Market Probabilities",
+          "type": "object"
+        }
+      },
+      "required": [
+        "market_id",
+        "resolution_oracle_condition_id",
+        "lmsr_b_parameter",
+        "order_book",
+        "current_market_probabilities"
+      ],
+      "title": "PredictionMarketState",
       "type": "object"
     },
     "ProcessRewardContract": {
@@ -5617,6 +5793,22 @@
           ],
           "default": null,
           "description": "The mathematical policy governing task decentralization via Spot Markets."
+        },
+        "active_prediction_markets": {
+          "description": "The live algorithmic betting markets resolving swarm consensus.",
+          "items": {
+            "$ref": "#/$defs/PredictionMarketState"
+          },
+          "title": "Active Prediction Markets",
+          "type": "array"
+        },
+        "resolved_markets": {
+          "description": "The immutable records of finalized markets and reputation capital distributions.",
+          "items": {
+            "$ref": "#/$defs/MarketResolution"
+          },
+          "title": "Resolved Markets",
+          "type": "array"
         }
       },
       "required": [

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -25,6 +25,7 @@ from coreason_manifest.state.events import (
 from coreason_manifest.state.scratchpad import LatentScratchpadTrace, ThoughtBranch
 from coreason_manifest.state.semantic import DimensionalProjectionContract, OntologicalHandshake
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
+from coreason_manifest.workflow.markets import HypothesisStake, MarketResolution, PredictionMarketState
 from coreason_manifest.workflow.nodes import AnyNode
 from coreason_manifest.workflow.topologies import AnyTopology, OntologicalAlignmentPolicy
 
@@ -43,14 +44,17 @@ __all__ = [
     "DimensionalProjectionContract",
     "EmbodiedSensoryVector",
     "EscalationContract",
+    "HypothesisStake",
     "InterventionalCausalTask",
     "LatentScratchpadTrace",
+    "MarketResolution",
     "MechanisticAuditContract",
     "NeuralAuditAttestation",
     "NeuroSymbolicHandoff",
     "NodeID",
     "OntologicalAlignmentPolicy",
     "OntologicalHandshake",
+    "PredictionMarketState",
     "ProcessRewardContract",
     "SaeFeatureActivation",
     "SemanticVersion",

--- a/src/coreason_manifest/oversight/__init__.py
+++ b/src/coreason_manifest/oversight/__init__.py
@@ -8,7 +8,7 @@
 from .adjudication import AdjudicationRubric, AdjudicationVerdict, GradingCriteria
 from .audit import MechanisticAuditContract
 from .dlp import DataClassification, InformationFlowPolicy, RedactionRule, SanitizationAction, SecureSubSession
-from .governance import ConsensusPolicy, ConstitutionalRule, GlobalGovernance, GovernancePolicy
+from .governance import ConsensusPolicy, ConstitutionalRule, GlobalGovernance, GovernancePolicy, PredictionMarketPolicy
 from .intervention import (
     AnyInterventionPayload,
     BoundedInterventionScope,
@@ -43,6 +43,7 @@ __all__ = [
     "LifecycleTrigger",
     "MechanisticAuditContract",
     "OverrideIntent",
+    "PredictionMarketPolicy",
     "QuarantineOrder",
     "RedactionRule",
     "SanitizationAction",

--- a/src/coreason_manifest/oversight/governance.py
+++ b/src/coreason_manifest/oversight/governance.py
@@ -38,12 +38,29 @@ class GovernancePolicy(CoreasonBaseModel):
     rules: list[ConstitutionalRule] = Field(description="List of constitutional rules included in this policy.")
 
 
+class PredictionMarketPolicy(CoreasonBaseModel):
+    """
+    The ruleset governing the market. It enforces Sybil resistance
+    (via quadratic staking) and dictates when the market stops trading.
+    """
+
+    staking_function: Literal["linear", "quadratic"] = Field(
+        description="The mathematical curve applied to stakes. Quadratic enforces Sybil resistance."
+    )
+    min_liquidity_cents: int = Field(ge=0, description="Minimum liquidity required.")
+    convergence_delta_threshold: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The threshold indicating the market price has stabilized enough to trigger the resolution oracle.",
+    )
+
+
 class ConsensusPolicy(CoreasonBaseModel):
     """
     Explicit ruleset governing how a council resolves disagreements.
     """
 
-    strategy: Literal["unanimous", "majority", "debate_rounds"] = Field(
+    strategy: Literal["unanimous", "majority", "debate_rounds", "prediction_market"] = Field(
         description="The mathematical rule for reaching agreement."
     )
     tie_breaker_node_id: NodeID | None = Field(
@@ -52,6 +69,10 @@ class ConsensusPolicy(CoreasonBaseModel):
     max_debate_rounds: int | None = Field(
         default=None,
         description="The maximum number of argument/rebuttal cycles permitted before forced adjudication.",
+    )
+    prediction_market_rules: PredictionMarketPolicy | None = Field(
+        default=None,
+        description="The strict algorithmic mechanism rules required if the strategy is prediction_market.",
     )
 
 

--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -15,6 +15,7 @@ from coreason_manifest.workflow.auctions import (
     TieBreaker,
 )
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
+from coreason_manifest.workflow.markets import HypothesisStake, MarketResolution, PredictionMarketState
 from coreason_manifest.workflow.nodes import (
     AgentNode,
     AnyNode,
@@ -55,7 +56,10 @@ __all__ = [
     "EpistemicScanner",
     "EvolutionaryTopology",
     "HumanNode",
+    "HypothesisStake",
+    "MarketResolution",
     "OntologicalAlignmentPolicy",
+    "PredictionMarketState",
     "SelfCorrectionPolicy",
     "StateContract",
     "SwarmTopology",

--- a/src/coreason_manifest/workflow/markets.py
+++ b/src/coreason_manifest/workflow/markets.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+from typing import Annotated
+
+from pydantic import Field, StringConstraints
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class HypothesisStake(CoreasonBaseModel):
+    """
+    The mathematical record of an agent taking a financial/compute position on a specific causal hypothesis.
+    """
+
+    agent_id: Annotated[str, StringConstraints(min_length=1)] = Field(
+        description="The ID of the agent placing the stake."
+    )
+    target_hypothesis_id: Annotated[str, StringConstraints(min_length=1)] = Field(
+        description="The exact HypothesisGenerationEvent the agent is betting on."
+    )
+    staked_cents: int = Field(gt=0, description="The volume of capital or compute budget committed to this position.")
+    implied_probability: float = Field(ge=0.0, le=1.0, description="The agent's calculated internal confidence score.")
+
+
+class PredictionMarketState(CoreasonBaseModel):
+    """
+    The state of the Automated Market Maker (AMM) using Robin Hanson's
+    Logarithmic Market Scoring Rule (LMSR) to ensure infinite liquidity.
+    """
+
+    market_id: Annotated[str, StringConstraints(min_length=1)] = Field(description="The ID of the prediction market.")
+    resolution_oracle_condition_id: str = Field(
+        description="The specific FalsificationCondition ID whose execution will trigger the market payout."
+    )
+    lmsr_b_parameter: float = Field(
+        gt=0.0, description="The liquidity parameter defining the market depth and max loss for the AMM."
+    )
+    order_book: list[HypothesisStake] = Field(description="The immutable ledger of all stakes placed by the swarm.")
+    current_market_probabilities: dict[str, float] = Field(
+        description="Mapping of hypothesis IDs to their current LMSR-calculated market price (probability)."
+    )
+
+
+class MarketResolution(CoreasonBaseModel):
+    """
+    The resolution state of an algorithmic prediction market.
+    """
+
+    market_id: Annotated[str, StringConstraints(min_length=1)] = Field(description="The ID of the prediction market.")
+    winning_hypothesis_id: str = Field(description="The hypothesis ID that was verified.")
+    falsified_hypothesis_ids: list[str] = Field(description="The hypothesis IDs that were falsified.")
+    payout_distribution: dict[str, int] = Field(
+        description="The deterministic mapping of agent IDs to their earned compute budget/cents "
+        "based on Brier scoring."
+    )

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -16,6 +16,7 @@ from coreason_manifest.oversight.dlp import InformationFlowPolicy
 from coreason_manifest.oversight.governance import ConsensusPolicy
 from coreason_manifest.telemetry.schemas import ObservabilityPolicy
 from coreason_manifest.workflow.auctions import AuctionPolicy
+from coreason_manifest.workflow.markets import MarketResolution, PredictionMarketState
 from coreason_manifest.workflow.nodes import AnyNode
 
 
@@ -212,6 +213,13 @@ class SwarmTopology(BaseTopology):
     )
     auction_policy: AuctionPolicy | None = Field(
         default=None, description="The mathematical policy governing task decentralization via Spot Markets."
+    )
+    active_prediction_markets: list[PredictionMarketState] = Field(
+        default_factory=list, description="The live algorithmic betting markets resolving swarm consensus."
+    )
+    resolved_markets: list[MarketResolution] = Field(
+        default_factory=list,
+        description="The immutable records of finalized markets and reputation capital distributions.",
     )
 
     @model_validator(mode="after")

--- a/tests/domains/test_oversight_governance.py
+++ b/tests/domains/test_oversight_governance.py
@@ -4,7 +4,7 @@ from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from coreason_manifest.oversight.adjudication import AdjudicationRubric, GradingCriteria
-from coreason_manifest.oversight.governance import ConstitutionalRule
+from coreason_manifest.oversight.governance import ConstitutionalRule, PredictionMarketPolicy
 from coreason_manifest.oversight.intervention import BoundedInterventionScope, FallbackSLA, InterventionRequest
 
 
@@ -70,6 +70,28 @@ def test_constitutional_rule_deduplicates_or_rejects_duplicate_strings(forbidden
         assert len(rule.forbidden_intents) < len(forbidden_intents)
     except ValidationError:
         pass  # Also acceptable if it rejects lists with duplicates (depending on strict mode)
+
+
+def test_prediction_market_policy_bounds() -> None:
+    # Test valid bounds
+    policy = PredictionMarketPolicy(
+        staking_function="quadratic", min_liquidity_cents=0, convergence_delta_threshold=0.5
+    )
+    assert policy.staking_function == "quadratic"
+
+    # Test invalid min_liquidity_cents
+    with pytest.raises(ValidationError) as exc_info:
+        PredictionMarketPolicy(staking_function="quadratic", min_liquidity_cents=-1, convergence_delta_threshold=0.5)
+    assert "ge" in str(exc_info.value) or "greater than or equal" in str(exc_info.value)
+
+    # Test invalid convergence_delta_threshold
+    with pytest.raises(ValidationError) as exc_info2:
+        PredictionMarketPolicy(staking_function="linear", min_liquidity_cents=100, convergence_delta_threshold=-0.1)
+    assert "ge" in str(exc_info2.value) or "greater than or equal" in str(exc_info2.value)
+
+    with pytest.raises(ValidationError) as exc_info3:
+        PredictionMarketPolicy(staking_function="linear", min_liquidity_cents=100, convergence_delta_threshold=1.1)
+    assert "le" in str(exc_info3.value) or "less than or equal" in str(exc_info3.value)
 
 
 @given(

--- a/tests/domains/test_workflow_markets.py
+++ b/tests/domains/test_workflow_markets.py
@@ -1,0 +1,62 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.workflow.markets import HypothesisStake, PredictionMarketState
+
+
+def test_hypothesis_stake_rejects_zero_or_negative_cents() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        HypothesisStake(agent_id="agent-1", target_hypothesis_id="hyp-1", staked_cents=0, implied_probability=0.5)
+    assert "gt" in str(exc_info.value) or "greater than" in str(exc_info.value)
+
+    with pytest.raises(ValidationError) as exc_info2:
+        HypothesisStake(agent_id="agent-1", target_hypothesis_id="hyp-1", staked_cents=-10, implied_probability=0.5)
+    assert "gt" in str(exc_info2.value) or "greater than" in str(exc_info2.value)
+
+
+def test_hypothesis_stake_valid() -> None:
+    stake = HypothesisStake(
+        agent_id="agent-1", target_hypothesis_id="hyp-1", staked_cents=100, implied_probability=0.75
+    )
+    assert stake.staked_cents == 100
+    assert stake.implied_probability == 0.75
+
+
+def test_prediction_market_state_rejects_invalid_lmsr_b_parameter() -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        PredictionMarketState(
+            market_id="mkt-1",
+            resolution_oracle_condition_id="cond-1",
+            lmsr_b_parameter=0.0,
+            order_book=[],
+            current_market_probabilities={"hyp-1": 0.5},
+        )
+    assert "gt" in str(exc_info.value) or "greater than" in str(exc_info.value)
+
+    with pytest.raises(ValidationError) as exc_info2:
+        PredictionMarketState(
+            market_id="mkt-1",
+            resolution_oracle_condition_id="cond-1",
+            lmsr_b_parameter=-1.5,
+            order_book=[],
+            current_market_probabilities={"hyp-1": 0.5},
+        )
+    assert "gt" in str(exc_info2.value) or "greater than" in str(exc_info2.value)
+
+
+def test_prediction_market_state_valid() -> None:
+    state = PredictionMarketState(
+        market_id="mkt-1",
+        resolution_oracle_condition_id="cond-1",
+        lmsr_b_parameter=100.0,
+        order_book=[],
+        current_market_probabilities={"hyp-1": 0.5},
+    )
+    assert state.lmsr_b_parameter == 100.0

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -546,16 +546,79 @@ def draw_ontological_alignment_policy(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_prediction_market_policy(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "staking_function": st.sampled_from(["linear", "quadratic"]),
+                "min_liquidity_cents": st.integers(min_value=0),
+                "convergence_delta_threshold": st.floats(
+                    min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                ),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_consensus_policy(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
-                "strategy": st.sampled_from(["unanimous", "majority", "debate_rounds"]),
+                "strategy": st.sampled_from(["unanimous", "majority", "debate_rounds", "prediction_market"]),
                 "tie_breaker_node_id": st.one_of(
                     st.none(),
                     st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"),
                 ),
                 "max_debate_rounds": st.one_of(st.none(), st.integers(min_value=1, max_value=100)),
+                "prediction_market_rules": st.one_of(st.none(), draw_prediction_market_policy()),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_hypothesis_stake(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "agent_id": st.text(min_size=1),
+                "target_hypothesis_id": st.text(min_size=1),
+                "staked_cents": st.integers(min_value=1),
+                "implied_probability": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_prediction_market_state(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "market_id": st.text(min_size=1),
+                "resolution_oracle_condition_id": st.text(),
+                "lmsr_b_parameter": st.floats(min_value=0.01, allow_nan=False, allow_infinity=False),
+                "order_book": st.lists(draw_hypothesis_stake(), max_size=10),
+                "current_market_probabilities": st.dictionaries(st.text(), st.floats(), max_size=10),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_market_resolution(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "market_id": st.text(min_size=1),
+                "winning_hypothesis_id": st.text(),
+                "falsified_hypothesis_ids": st.lists(st.text(), max_size=10),
+                "payout_distribution": st.dictionaries(st.text(), st.integers(), max_size=10),
             }
         )
     )
@@ -626,6 +689,25 @@ def draw_topology_payload(nodes_strategy: st.SearchStrategy[dict[str, Any]]) -> 
         }
     ).map(_council_mapper)
 
+    swarm_strategy = st.fixed_dictionaries(
+        {
+            "type": st.just("swarm"),
+            "nodes": st.dictionaries(
+                st.text(min_size=1, alphabet="abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"),
+                nodes_strategy,
+                max_size=5,
+            ),
+            "shared_state_contract": st.none(),
+            "information_flow": st.none(),
+            "observability": st.none(),
+            "spawning_threshold": st.integers(min_value=1, max_value=10),
+            "max_concurrent_agents": st.integers(min_value=10, max_value=100),
+            "auction_policy": st.none(),
+            "active_prediction_markets": st.lists(draw_prediction_market_state(), max_size=10),
+            "resolved_markets": st.lists(draw_market_resolution(), max_size=10),
+        }
+    )
+
     smpc_strategy = st.fixed_dictionaries(
         {
             "type": st.just("smpc"),
@@ -649,7 +731,7 @@ def draw_topology_payload(nodes_strategy: st.SearchStrategy[dict[str, Any]]) -> 
         }
     )
 
-    return st.one_of(dag_strategy, council_strategy, smpc_strategy)
+    return st.one_of(dag_strategy, council_strategy, swarm_strategy, smpc_strategy)
 
 
 def draw_composite_node_payload(


### PR DESCRIPTION
Implemented Epic 5: Algorithmic Consensus (Swarm Prediction Markets) by adding Automated Market Maker schemas to `coreason-manifest`. Added rigorous `PredictionMarketPolicy` to govern sybil resistance mechanisms, exported endpoints via init files, generated schemas, and validated strictly typed pydantic models over 100% boundary testing to respect no-execution laws.

---
*PR created automatically by Jules for task [11082911693836245180](https://jules.google.com/task/11082911693836245180) started by @gowthamrao*