### PR TITLE
Epic 67: SAE Latent Constraints & Firewalls

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -3402,6 +3402,14 @@
           ],
           "default": null,
           "description": "The active cognitive defense perimeter against adversarial control-flow overrides."
+        },
+        "latent_firewalls": {
+          "description": "The list of tensor-level mechanistic firewalls monitoring the forward pass for adversarial intent.",
+          "items": {
+            "$ref": "#/$defs/SaeLatentFirewall"
+          },
+          "title": "Latent Firewalls",
+          "type": "array"
         }
       },
       "required": [
@@ -5080,6 +5088,71 @@
         "activation_magnitude"
       ],
       "title": "SaeFeatureActivation",
+      "type": "object"
+    },
+    "SaeLatentFirewall": {
+      "additionalProperties": false,
+      "description": "A real-time mechanistic interpretability boundary that monitors and controls specific neural circuits.",
+      "properties": {
+        "target_feature_index": {
+          "description": "The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
+          "minimum": 0,
+          "title": "Target Feature Index",
+          "type": "integer"
+        },
+        "monitored_layers": {
+          "description": "The specific transformer layer indices where this feature activation must be monitored.",
+          "items": {
+            "type": "integer"
+          },
+          "minItems": 1,
+          "title": "Monitored Layers",
+          "type": "array"
+        },
+        "max_activation_threshold": {
+          "description": "The mathematical magnitude limit. If the feature activates beyond this, the firewall trips.",
+          "minimum": 0.0,
+          "title": "Max Activation Threshold",
+          "type": "number"
+        },
+        "violation_action": {
+          "description": "The tensor-level remediation applied when the threshold is breached.",
+          "enum": [
+            "clamp",
+            "halt",
+            "quarantine"
+          ],
+          "title": "Violation Action",
+          "type": "string"
+        },
+        "clamp_value": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If violation_action is 'clamp', the physical value to which the activation tensor is forced.",
+          "title": "Clamp Value"
+        },
+        "sae_dictionary_hash": {
+          "description": "The SHA-256 hash of the exact SAE projection matrix required to decode this feature.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Sae Dictionary Hash",
+          "type": "string"
+        }
+      },
+      "required": [
+        "target_feature_index",
+        "monitored_layers",
+        "max_activation_threshold",
+        "violation_action",
+        "sae_dictionary_hash"
+      ],
+      "title": "SaeLatentFirewall",
       "type": "object"
     },
     "SalienceProfile": {

--- a/src/coreason_manifest/compute/neuromodulation.py
+++ b/src/coreason_manifest/compute/neuromodulation.py
@@ -33,6 +33,34 @@ class ActivationSteeringContract(CoreasonBaseModel):
     )
 
 
+class SaeLatentFirewall(CoreasonBaseModel):
+    """A real-time mechanistic interpretability boundary that monitors and controls specific neural circuits."""
+
+    target_feature_index: int = Field(
+        ge=0,
+        description="The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
+    )
+    monitored_layers: list[int] = Field(
+        min_length=1,
+        description="The specific transformer layer indices where this feature activation must be monitored.",
+    )
+    max_activation_threshold: float = Field(
+        ge=0.0,
+        description="The mathematical magnitude limit. If the feature activates beyond this, the firewall trips.",
+    )
+    violation_action: Literal["clamp", "halt", "quarantine"] = Field(
+        description="The tensor-level remediation applied when the threshold is breached.",
+    )
+    clamp_value: float | None = Field(
+        default=None,
+        description="If violation_action is 'clamp', the physical value to which the activation tensor is forced.",
+    )
+    sae_dictionary_hash: str = Field(
+        pattern=r"^[a-f0-9]{64}$",
+        description="The SHA-256 hash of the exact SAE projection matrix required to decode this feature.",
+    )
+
+
 class CognitiveRoutingDirective(CoreasonBaseModel):
     """
     Hardware-level contract overriding MoE routing to enforce functional/specialist paths.

--- a/src/coreason_manifest/oversight/dlp.py
+++ b/src/coreason_manifest/oversight/dlp.py
@@ -9,6 +9,7 @@ from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
+from coreason_manifest.compute.neuromodulation import SaeLatentFirewall
 from coreason_manifest.core.base import CoreasonBaseModel
 
 type DataClassification = Literal["phi", "pii", "pci", "confidential", "public"]
@@ -73,6 +74,12 @@ class InformationFlowPolicy(CoreasonBaseModel):
     semantic_firewall: SemanticFirewallPolicy | None = Field(
         default=None,
         description="The active cognitive defense perimeter against adversarial control-flow overrides.",
+    )
+    latent_firewalls: list[SaeLatentFirewall] = Field(
+        default_factory=list,
+        description=(
+            "The list of tensor-level mechanistic firewalls monitoring the forward pass for adversarial intent."
+        ),
     )
 
     @model_validator(mode="after")

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1764,6 +1764,23 @@ def draw_semantic_firewall_policy(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_sae_latent_firewall(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "target_feature_index": st.integers(min_value=0),
+                "monitored_layers": st.lists(st.integers(min_value=0), min_size=1, max_size=10),
+                "max_activation_threshold": st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
+                "violation_action": st.sampled_from(["clamp", "halt", "quarantine"]),
+                "clamp_value": st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
+                "sae_dictionary_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_information_flow_policy(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
@@ -1772,6 +1789,7 @@ def draw_information_flow_policy(draw: Any) -> dict[str, Any]:
                 "active": st.booleans(),
                 "rules": st.lists(draw_redaction_rule(), max_size=100),
                 "semantic_firewall": st.one_of(st.none(), draw_semantic_firewall_policy()),
+                "latent_firewalls": st.lists(draw_sae_latent_firewall(), max_size=10),
             }
         )
     )


### PR DESCRIPTION
Define the passive JSON boundaries for Sparse Autoencoder (SAE) feature monitoring. This change introduces the `SaeLatentFirewall` declarative Pydantic schema to define pre-token interception boundaries without importing any active ML libraries. The firewall is integrated into the Data Loss Prevention (DLP) mechanism's `InformationFlowPolicy`. Fuzzing generators have been updated in-place to ensure correctness and prevent merge conflicts with parallel workflows.

---
*PR created automatically by Jules for task [7887086130543041010](https://jules.google.com/task/7887086130543041010) started by @gowthamrao*