### PR TITLE
feat(tooling): Add spatial kinematics schemas for GUI automation

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1221,6 +1221,48 @@
       "title": "BoundedInterventionScope",
       "type": "object"
     },
+    "BoundingBox": {
+      "additionalProperties": false,
+      "description": "A resolution-independent spatial region.",
+      "properties": {
+        "x_min": {
+          "description": "The left boundary.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "X Min",
+          "type": "number"
+        },
+        "y_min": {
+          "description": "The top boundary.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Y Min",
+          "type": "number"
+        },
+        "x_max": {
+          "description": "The right boundary.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "X Max",
+          "type": "number"
+        },
+        "y_max": {
+          "description": "The bottom boundary.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Y Max",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x_min",
+        "y_min",
+        "x_max",
+        "y_max"
+      ],
+      "title": "BoundingBox",
+      "type": "object"
+    },
     "BrowserDOMState": {
       "additionalProperties": false,
       "properties": {
@@ -4228,6 +4270,32 @@
       "title": "NeuroSymbolicHandoff",
       "type": "object"
     },
+    "NormalizedCoordinate": {
+      "additionalProperties": false,
+      "description": "A resolution-independent 2D spatial vector.",
+      "properties": {
+        "x": {
+          "description": "The normalized X-axis coordinate (0.0 = left, 1.0 = right).",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "description": "The normalized Y-axis coordinate (0.0 = top, 1.0 = bottom).",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Y",
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y"
+      ],
+      "title": "NormalizedCoordinate",
+      "type": "object"
+    },
     "ObservabilityPolicy": {
       "additionalProperties": false,
       "properties": {
@@ -5613,6 +5681,77 @@
         }
       },
       "title": "SpatialAnchor",
+      "type": "object"
+    },
+    "SpatialKinematicAction": {
+      "additionalProperties": false,
+      "description": "A mathematical declaration of an OS-level pointer or interaction trajectory.",
+      "properties": {
+        "action_type": {
+          "description": "The specific kinematic interaction paradigm.",
+          "enum": [
+            "click",
+            "double_click",
+            "drag_and_drop",
+            "scroll",
+            "hover",
+            "keystroke"
+          ],
+          "title": "Action Type",
+          "type": "string"
+        },
+        "target_coordinate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NormalizedCoordinate"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The primary spatial terminus for clicks or hovers."
+        },
+        "trajectory_duration_ms": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The exact temporal duration of the movement, simulating human kinematics.",
+          "title": "Trajectory Duration Ms"
+        },
+        "bezier_control_points": {
+          "description": "Waypoints for constructing non-linear, bot-evasive movement curves.",
+          "items": {
+            "$ref": "#/$defs/NormalizedCoordinate"
+          },
+          "title": "Bezier Control Points",
+          "type": "array"
+        },
+        "expected_visual_concept": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The visual anchor (e.g., 'Submit Button'). The orchestrator must verify this semantic concept exists at the target_coordinate before executing the macro, preventing blind clicks.",
+          "title": "Expected Visual Concept"
+        }
+      },
+      "required": [
+        "action_type"
+      ],
+      "title": "SpatialKinematicAction",
       "type": "object"
     },
     "StateContract": {

--- a/src/coreason_manifest/tooling/__init__.py
+++ b/src/coreason_manifest/tooling/__init__.py
@@ -15,12 +15,16 @@ from .schemas import (
     SideEffectProfile,
     ToolDefinition,
 )
+from .spatial import BoundingBox, NormalizedCoordinate, SpatialKinematicAction
 
 __all__ = [
     "ActionSpace",
+    "BoundingBox",
     "ExecutionSLA",
     "MCPClientBinding",
+    "NormalizedCoordinate",
     "PermissionBoundary",
     "SideEffectProfile",
+    "SpatialKinematicAction",
     "ToolDefinition",
 ]

--- a/src/coreason_manifest/tooling/spatial.py
+++ b/src/coreason_manifest/tooling/spatial.py
@@ -1,0 +1,51 @@
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+class NormalizedCoordinate(CoreasonBaseModel):
+    """A resolution-independent 2D spatial vector."""
+
+    x: float = Field(ge=0.0, le=1.0, description="The normalized X-axis coordinate (0.0 = left, 1.0 = right).")
+    y: float = Field(ge=0.0, le=1.0, description="The normalized Y-axis coordinate (0.0 = top, 1.0 = bottom).")
+
+
+class BoundingBox(CoreasonBaseModel):
+    """A resolution-independent spatial region."""
+
+    x_min: float = Field(ge=0.0, le=1.0, description="The left boundary.")
+    y_min: float = Field(ge=0.0, le=1.0, description="The top boundary.")
+    x_max: float = Field(ge=0.0, le=1.0, description="The right boundary.")
+    y_max: float = Field(ge=0.0, le=1.0, description="The bottom boundary.")
+
+    @model_validator(mode="after")
+    def validate_geometry(self) -> Self:
+        if self.x_min > self.x_max:
+            raise ValueError("x_min cannot be strictly greater than x_max.")
+        if self.y_min > self.y_max:
+            raise ValueError("y_min cannot be strictly greater than y_max.")
+        return self
+
+
+class SpatialKinematicAction(CoreasonBaseModel):
+    """A mathematical declaration of an OS-level pointer or interaction trajectory."""
+
+    action_type: Literal["click", "double_click", "drag_and_drop", "scroll", "hover", "keystroke"] = Field(
+        description="The specific kinematic interaction paradigm."
+    )
+    target_coordinate: NormalizedCoordinate | None = Field(
+        default=None, description="The primary spatial terminus for clicks or hovers."
+    )
+    trajectory_duration_ms: int | None = Field(
+        default=None, gt=0, description="The exact temporal duration of the movement, simulating human kinematics."
+    )
+    bezier_control_points: list[NormalizedCoordinate] = Field(
+        default_factory=list, description="Waypoints for constructing non-linear, bot-evasive movement curves."
+    )
+    expected_visual_concept: str | None = Field(
+        default=None,
+        description="The visual anchor (e.g., 'Submit Button'). The orchestrator must verify this "
+        "semantic concept exists at the target_coordinate before executing the macro, preventing blind clicks.",
+    )

--- a/tests/domains/test_tooling_spatial.py
+++ b/tests/domains/test_tooling_spatial.py
@@ -1,0 +1,64 @@
+from typing import Any
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import TypeAdapter, ValidationError
+
+from coreason_manifest.tooling.spatial import BoundingBox, SpatialKinematicAction
+
+
+@st.composite
+def draw_normalized_coordinate(draw: Any) -> dict[str, Any]:
+    return {
+        "x": draw(st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)),
+        "y": draw(st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)),
+    }
+
+
+@st.composite
+def draw_bounding_box(draw: Any) -> dict[str, Any]:
+    x1 = draw(st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False))
+    x2 = draw(st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False))
+    y1 = draw(st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False))
+    y2 = draw(st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False))
+
+    return {
+        "x_min": min(x1, x2),
+        "x_max": max(x1, x2),
+        "y_min": min(y1, y2),
+        "y_max": max(y1, y2),
+    }
+
+
+@st.composite
+def draw_spatial_kinematic_action(draw: Any) -> dict[str, Any]:
+    return {
+        "action_type": draw(
+            st.sampled_from(["click", "double_click", "drag_and_drop", "scroll", "hover", "keystroke"])
+        ),
+        "target_coordinate": draw(st.one_of(st.none(), draw_normalized_coordinate())),
+        "trajectory_duration_ms": draw(st.one_of(st.none(), st.integers(min_value=1))),
+        "bezier_control_points": draw(st.lists(draw_normalized_coordinate(), max_size=5)),
+        "expected_visual_concept": draw(st.one_of(st.none(), st.text(min_size=1))),
+    }
+
+
+@given(draw_bounding_box())
+def test_bounding_box_valid(payload: dict[str, Any]) -> None:
+    TypeAdapter(BoundingBox).validate_python(payload)
+
+
+def test_bounding_box_invalid_geometry() -> None:
+    with pytest.raises(ValidationError):
+        TypeAdapter(BoundingBox).validate_python({"x_min": 0.8, "x_max": 0.2, "y_min": 0.0, "y_max": 1.0})
+
+
+def test_bounding_box_invalid_geometry_y() -> None:
+    with pytest.raises(ValidationError):
+        TypeAdapter(BoundingBox).validate_python({"x_min": 0.0, "x_max": 1.0, "y_min": 0.8, "y_max": 0.2})
+
+
+@given(draw_spatial_kinematic_action())
+def test_spatial_kinematic_action_routing(payload: dict[str, Any]) -> None:
+    TypeAdapter(SpatialKinematicAction).validate_python(payload)


### PR DESCRIPTION
# Epic 66: Spatial Kinematics for GUI Automation

This pull request introduces the passive, mathematically rigorous schemas required for agents (VLMs) to interact with GUI environments via resolution-independent coordinates and kinematic actions. 

**Key Changes:**
* Added `NormalizedCoordinate` and `BoundingBox` to strictly type spatial representations between `0.0` and `1.0`.
* Added `SpatialKinematicAction` to mathematically declare OS-level pointer interactions, including bezier control points for bot-evasive trajectories.
* Exposed models in `src/coreason_manifest/tooling/__init__.py`.
* Added Hypothesis property-based testing in `tests/domains/test_tooling_spatial.py` to continuously mathematically prove geometric boundaries.
* Adhered strictly to the "Hollow Data Plane" rule, using zero active GUI execution logic libraries.

---
*PR created automatically by Jules for task [4607769535004872117](https://jules.google.com/task/4607769535004872117) started by @gowthamrao*