### PR TITLE
feat(compute): implement temporally-smoothed dynamic latent clamping

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -3835,6 +3835,47 @@
       "title": "LatentScratchpadTrace",
       "type": "object"
     },
+    "LatentSmoothingProfile": {
+      "additionalProperties": false,
+      "description": "The mathematical curve used to gently taper an adversarial activation to prevent logit collapse.",
+      "properties": {
+        "decay_function": {
+          "description": "The trigonometric or algebraic function governing the attenuation curve.",
+          "enum": [
+            "linear",
+            "exponential",
+            "cosine_annealing"
+          ],
+          "title": "Decay Function",
+          "type": "string"
+        },
+        "transition_window_tokens": {
+          "description": "The exact number of forward-pass generation steps over which the decay is applied.",
+          "exclusiveMinimum": 0,
+          "title": "Transition Window Tokens",
+          "type": "integer"
+        },
+        "decay_rate_param": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The optional tuning parameter (e.g., half-life lambda for exponential decay).",
+          "title": "Decay Rate Param"
+        }
+      },
+      "required": [
+        "decay_function",
+        "transition_window_tokens"
+      ],
+      "title": "LatentSmoothingProfile",
+      "type": "object"
+    },
     "LifecycleTrigger": {
       "enum": [
         "on_start",
@@ -5400,7 +5441,8 @@
           "enum": [
             "clamp",
             "halt",
-            "quarantine"
+            "quarantine",
+            "smooth_decay"
           ],
           "title": "Violation Action",
           "type": "string"
@@ -5423,6 +5465,18 @@
           "pattern": "^[a-f0-9]{64}$",
           "title": "Sae Dictionary Hash",
           "type": "string"
+        },
+        "smoothing_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LatentSmoothingProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The geometric parameters for continuous attenuation if violation_action is 'smooth_decay'."
         }
       },
       "required": [

--- a/src/coreason_manifest/compute/__init__.py
+++ b/src/coreason_manifest/compute/__init__.py
@@ -13,6 +13,7 @@ from .inference import (
 from .neuromodulation import (
     ActivationSteeringContract,
     CognitiveRoutingDirective,
+    LatentSmoothingProfile,
 )
 from .peft import PeftAdapterContract
 from .profiles import (
@@ -47,6 +48,7 @@ __all__ = [
     "EscalationContract",
     "FitnessObjective",
     "InterventionalCausalTask",
+    "LatentSmoothingProfile",
     "ModelProfile",
     "MutationPolicy",
     "NeuroSymbolicHandoff",

--- a/src/coreason_manifest/compute/neuromodulation.py
+++ b/src/coreason_manifest/compute/neuromodulation.py
@@ -5,9 +5,9 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from typing import Literal
+from typing import Literal, Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 
@@ -33,6 +33,22 @@ class ActivationSteeringContract(CoreasonBaseModel):
     )
 
 
+class LatentSmoothingProfile(CoreasonBaseModel):
+    """The mathematical curve used to gently taper an adversarial activation to prevent logit collapse."""
+
+    decay_function: Literal["linear", "exponential", "cosine_annealing"] = Field(
+        description="The trigonometric or algebraic function governing the attenuation curve."
+    )
+    transition_window_tokens: int = Field(
+        gt=0,
+        description="The exact number of forward-pass generation steps over which the decay is applied.",
+    )
+    decay_rate_param: float | None = Field(
+        default=None,
+        description="The optional tuning parameter (e.g., half-life lambda for exponential decay).",
+    )
+
+
 class SaeLatentFirewall(CoreasonBaseModel):
     """A real-time mechanistic interpretability boundary that monitors and controls specific neural circuits."""
 
@@ -48,7 +64,7 @@ class SaeLatentFirewall(CoreasonBaseModel):
         ge=0.0,
         description="The mathematical magnitude limit. If the feature activates beyond this, the firewall trips.",
     )
-    violation_action: Literal["clamp", "halt", "quarantine"] = Field(
+    violation_action: Literal["clamp", "halt", "quarantine", "smooth_decay"] = Field(
         description="The tensor-level remediation applied when the threshold is breached.",
     )
     clamp_value: float | None = Field(
@@ -59,6 +75,21 @@ class SaeLatentFirewall(CoreasonBaseModel):
         pattern=r"^[a-f0-9]{64}$",
         description="The SHA-256 hash of the exact SAE projection matrix required to decode this feature.",
     )
+    smoothing_profile: LatentSmoothingProfile | None = Field(
+        default=None,
+        description="The geometric parameters for continuous attenuation if violation_action is 'smooth_decay'.",
+    )
+
+    @model_validator(mode="after")
+    def validate_smooth_decay(self) -> Self:
+        if self.violation_action == "smooth_decay":
+            if self.smoothing_profile is None:
+                raise ValueError("smoothing_profile must be provided when violation_action is 'smooth_decay'.")
+            if self.clamp_value is None:
+                raise ValueError(
+                    "clamp_value must be provided as the target asymptote when violation_action is 'smooth_decay'."
+                )
+        return self
 
 
 class CognitiveRoutingDirective(CoreasonBaseModel):

--- a/tests/domains/test_compute_neuromodulation.py
+++ b/tests/domains/test_compute_neuromodulation.py
@@ -8,7 +8,56 @@
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest.compute.neuromodulation import ActivationSteeringContract, CognitiveRoutingDirective
+from coreason_manifest.compute.neuromodulation import (
+    ActivationSteeringContract,
+    CognitiveRoutingDirective,
+    LatentSmoothingProfile,
+    SaeLatentFirewall,
+)
+
+
+def test_sae_latent_firewall_smooth_decay_missing_profile() -> None:
+    with pytest.raises(ValidationError, match="smoothing_profile must be provided"):
+        SaeLatentFirewall(
+            target_feature_index=1,
+            monitored_layers=[1, 2],
+            max_activation_threshold=1.5,
+            violation_action="smooth_decay",
+            clamp_value=0.5,
+            sae_dictionary_hash="a" * 64,
+            smoothing_profile=None,
+        )
+
+
+def test_sae_latent_firewall_smooth_decay_missing_clamp() -> None:
+    prof = LatentSmoothingProfile(decay_function="linear", transition_window_tokens=5)
+    with pytest.raises(ValidationError, match="clamp_value must be provided"):
+        SaeLatentFirewall(
+            target_feature_index=1,
+            monitored_layers=[1, 2],
+            max_activation_threshold=1.5,
+            violation_action="smooth_decay",
+            clamp_value=None,
+            sae_dictionary_hash="a" * 64,
+            smoothing_profile=prof,
+        )
+
+
+def test_sae_latent_firewall_smooth_decay_valid() -> None:
+    prof = LatentSmoothingProfile(decay_function="linear", transition_window_tokens=5)
+    fw = SaeLatentFirewall(
+        target_feature_index=1,
+        monitored_layers=[1, 2],
+        max_activation_threshold=1.5,
+        violation_action="smooth_decay",
+        clamp_value=0.5,
+        sae_dictionary_hash="a" * 64,
+        smoothing_profile=prof,
+    )
+    assert fw.violation_action == "smooth_decay"
+    assert fw.clamp_value == 0.5
+    assert fw.smoothing_profile is not None
+    assert fw.smoothing_profile.decay_function == "linear"
 
 
 def test_activation_steering_contract_valid() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1818,20 +1818,36 @@ def draw_semantic_firewall_policy(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_latent_smoothing_profile(draw: Any) -> dict[str, Any]:
+    return {
+        "decay_function": draw(st.sampled_from(["linear", "exponential", "cosine_annealing"])),
+        "transition_window_tokens": draw(st.integers(min_value=1)),
+        "decay_rate_param": draw(st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False))),
+    }
+
+
+@st.composite
 def draw_sae_latent_firewall(draw: Any) -> dict[str, Any]:
-    res: dict[str, Any] = draw(
-        st.fixed_dictionaries(
-            {
-                "target_feature_index": st.integers(min_value=0),
-                "monitored_layers": st.lists(st.integers(min_value=0), min_size=1, max_size=10),
-                "max_activation_threshold": st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
-                "violation_action": st.sampled_from(["clamp", "halt", "quarantine"]),
-                "clamp_value": st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)),
-                "sae_dictionary_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
-            }
-        )
-    )
-    return res
+    action = draw(st.sampled_from(["clamp", "halt", "quarantine", "smooth_decay"]))
+    clamp_val = draw(st.one_of(st.none(), st.floats(allow_nan=False, allow_infinity=False)))
+    smooth_prof = draw(st.one_of(st.none(), draw_latent_smoothing_profile()))
+
+    # Satisfy the strict validation lock
+    if action == "smooth_decay":
+        if clamp_val is None:
+            clamp_val = draw(st.floats(allow_nan=False, allow_infinity=False))
+        if smooth_prof is None:
+            smooth_prof = draw(draw_latent_smoothing_profile())
+
+    return {
+        "target_feature_index": draw(st.integers(min_value=0)),
+        "monitored_layers": draw(st.lists(st.integers(min_value=0), min_size=1, max_size=10)),
+        "max_activation_threshold": draw(st.floats(min_value=0.0, allow_nan=False, allow_infinity=False)),
+        "violation_action": action,
+        "clamp_value": clamp_val,
+        "sae_dictionary_hash": draw(st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True)),
+        "smoothing_profile": smooth_prof,
+    }
 
 
 @st.composite


### PR DESCRIPTION
This PR introduces support for Temporally-Smoothed Dynamic Latent Clamping to prevent logit collapse when attenuating Sparse Autoencoder (SAE) features.

It defines a passive mathematical schema `LatentSmoothingProfile` and introduces the `"smooth_decay"` remediation action into the `SaeLatentFirewall`. A strict Pydantic model validator ensures that instances utilizing `smooth_decay` consistently carry both a geometric decay curve definition and a target clamp asymptote. The hypothesis test generators are properly refactored to explore this dependency without raising validation errors during tests.

Resolves Epic 69.

---
*PR created automatically by Jules for task [16829900437543984458](https://jules.google.com/task/16829900437543984458) started by @gowthamrao*