### PR TITLE
feat: implement DynamicConvergenceSLA for Epic 70

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2403,6 +2403,37 @@
       "title": "DiversityConstraint",
       "type": "object"
     },
+    "DynamicConvergenceSLA": {
+      "additionalProperties": false,
+      "description": "Service Level Agreement defining the mathematical conditions for early termination of a reasoning search.",
+      "properties": {
+        "convergence_delta_epsilon": {
+          "description": "The minimal required PRM score improvement across the lookback window to justify continued compute.",
+          "minimum": 0.0,
+          "title": "Convergence Delta Epsilon",
+          "type": "number"
+        },
+        "lookback_window_steps": {
+          "description": "The N-step temporal window over which the PRM gradient is calculated.",
+          "exclusiveMinimum": 0,
+          "title": "Lookback Window Steps",
+          "type": "integer"
+        },
+        "minimum_reasoning_steps": {
+          "description": "The mandatory 'burn-in' period. The orchestrator cannot terminate the search before this structural depth is reached, preventing premature collapse.",
+          "exclusiveMinimum": 0,
+          "title": "Minimum Reasoning Steps",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "convergence_delta_epsilon",
+        "lookback_window_steps",
+        "minimum_reasoning_steps"
+      ],
+      "title": "DynamicConvergenceSLA",
+      "type": "object"
+    },
     "EmbodiedSensoryVector": {
       "additionalProperties": false,
       "properties": {
@@ -5001,6 +5032,18 @@
     "ProcessRewardContract": {
       "additionalProperties": false,
       "properties": {
+        "convergence_sla": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DynamicConvergenceSLA"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic circuit breaker that halts the search when PRM variance converges, preventing VRAM waste."
+        },
         "pruning_threshold": {
           "description": "If a ThoughtBranch's prm_score falls below this threshold, the orchestrator MUST halt its generation.",
           "maximum": 1.0,

--- a/src/coreason_manifest/compute/__init__.py
+++ b/src/coreason_manifest/compute/__init__.py
@@ -33,6 +33,7 @@ from .symbolic import (
     NeuroSymbolicHandoff,
 )
 from .test_time import (
+    DynamicConvergenceSLA,
     EscalationContract,
     ProcessRewardContract,
 )
@@ -45,6 +46,7 @@ __all__ = [
     "ComputeProvisioningRequest",
     "CrossoverStrategy",
     "DistributionProfile",
+    "DynamicConvergenceSLA",
     "EscalationContract",
     "FitnessObjective",
     "InterventionalCausalTask",

--- a/src/coreason_manifest/compute/test_time.py
+++ b/src/coreason_manifest/compute/test_time.py
@@ -10,7 +10,30 @@ from pydantic import Field
 from coreason_manifest.core.base import CoreasonBaseModel
 
 
+class DynamicConvergenceSLA(CoreasonBaseModel):
+    """Service Level Agreement defining the mathematical conditions for early termination of a reasoning search."""
+
+    convergence_delta_epsilon: float = Field(
+        ge=0.0,
+        description="The minimal required PRM score improvement across the lookback "
+        "window to justify continued compute.",
+    )
+    lookback_window_steps: int = Field(
+        gt=0, description="The N-step temporal window over which the PRM gradient is calculated."
+    )
+    minimum_reasoning_steps: int = Field(
+        gt=0,
+        description="The mandatory 'burn-in' period. The orchestrator cannot terminate the search "
+        "before this structural depth is reached, preventing premature collapse.",
+    )
+
+
 class ProcessRewardContract(CoreasonBaseModel):
+    convergence_sla: DynamicConvergenceSLA | None = Field(
+        default=None,
+        description="The dynamic circuit breaker that halts the search when PRM variance converges, "
+        "preventing VRAM waste.",
+    )
     pruning_threshold: float = Field(
         ge=0.0,
         le=1.0,

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -100,7 +100,7 @@ def draw_escalation_contract(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_dynamic_convergence_sla(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "convergence_delta_epsilon": st.floats(
@@ -111,6 +111,7 @@ def draw_dynamic_convergence_sla(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -99,6 +99,21 @@ def draw_escalation_contract(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_dynamic_convergence_sla(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "convergence_delta_epsilon": st.floats(
+                    min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                ),
+                "lookback_window_steps": st.integers(min_value=1, max_value=100),
+                "minimum_reasoning_steps": st.integers(min_value=1, max_value=100),
+            }
+        )
+    )
+
+
+@st.composite
 def draw_process_reward_contract(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(
         st.fixed_dictionaries(
@@ -106,6 +121,7 @@ def draw_process_reward_contract(draw: Any) -> dict[str, Any]:
                 "pruning_threshold": st.floats(min_value=0.0, max_value=1.0),
                 "max_backtracks_allowed": st.integers(min_value=0),
                 "evaluator_model_name": st.one_of(st.none(), st.text()),
+                "convergence_sla": st.one_of(st.none(), draw_dynamic_convergence_sla()),
             }
         )
     )


### PR DESCRIPTION
Introduces `DynamicConvergenceSLA` schema to define mathematical boundaries for early termination of reasoning searches when PRM scores converge. Attaches the SLA to `ProcessRewardContract` and updates relevant fuzzer generation strategies in `tests/test_fuzzing.py` without introducing new external ML framework dependencies.

---
*PR created automatically by Jules for task [13569006948427949239](https://jules.google.com/task/13569006948427949239) started by @gowthamrao*