### PR TITLE
feat(governance): implement pBFT mathematical quorum for swarm consensus

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1802,7 +1802,8 @@
             "unanimous",
             "majority",
             "debate_rounds",
-            "prediction_market"
+            "prediction_market",
+            "pbft"
           ],
           "title": "Strategy",
           "type": "string"
@@ -1846,6 +1847,18 @@
           ],
           "default": null,
           "description": "The strict algorithmic mechanism rules required if the strategy is prediction_market."
+        },
+        "quorum_rules": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/QuorumPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strict Byzantine fault tolerance limits required if the strategy is 'pbft'."
         }
       },
       "required": [
@@ -5073,6 +5086,52 @@
         "reason"
       ],
       "title": "QuarantineOrder",
+      "type": "object"
+    },
+    "QuorumPolicy": {
+      "additionalProperties": false,
+      "description": "The mathematical boundaries required to survive Byzantine failures in a decentralized swarm.",
+      "properties": {
+        "max_tolerable_faults": {
+          "description": "The maximum number of actively malicious, hallucinating, or degraded nodes (f) the swarm must survive.",
+          "minimum": 0,
+          "title": "Max Tolerable Faults",
+          "type": "integer"
+        },
+        "min_quorum_size": {
+          "description": "The minimum number of participating agents (N) required to form consensus.",
+          "exclusiveMinimum": 0,
+          "title": "Min Quorum Size",
+          "type": "integer"
+        },
+        "state_validation_metric": {
+          "description": "The cryptographic material the agents must sign to submit a valid vote.",
+          "enum": [
+            "ledger_hash",
+            "zk_proof",
+            "semantic_embedding"
+          ],
+          "title": "State Validation Metric",
+          "type": "string"
+        },
+        "byzantine_action": {
+          "description": "The deterministic punishment executed by the orchestrator against nodes that violate the consensus quorum.",
+          "enum": [
+            "quarantine",
+            "slash_escrow",
+            "ignore"
+          ],
+          "title": "Byzantine Action",
+          "type": "string"
+        }
+      },
+      "required": [
+        "max_tolerable_faults",
+        "min_quorum_size",
+        "state_validation_metric",
+        "byzantine_action"
+      ],
+      "title": "QuorumPolicy",
       "type": "object"
     },
     "RateCard": {

--- a/src/coreason_manifest/oversight/governance.py
+++ b/src/coreason_manifest/oversight/governance.py
@@ -5,9 +5,9 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from typing import Annotated, Literal
+from typing import Annotated, Literal, Self
 
-from pydantic import Field, StringConstraints
+from pydantic import Field, StringConstraints, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID, SemanticVersion
@@ -55,12 +55,41 @@ class PredictionMarketPolicy(CoreasonBaseModel):
     )
 
 
+class QuorumPolicy(CoreasonBaseModel):
+    """The mathematical boundaries required to survive Byzantine failures in a decentralized swarm."""
+
+    max_tolerable_faults: int = Field(
+        ge=0,
+        description=(
+            "The maximum number of actively malicious, hallucinating, or degraded nodes (f) the swarm must survive."
+        ),
+    )
+    min_quorum_size: int = Field(
+        gt=0, description="The minimum number of participating agents (N) required to form consensus."
+    )
+    state_validation_metric: Literal["ledger_hash", "zk_proof", "semantic_embedding"] = Field(
+        description="The cryptographic material the agents must sign to submit a valid vote."
+    )
+    byzantine_action: Literal["quarantine", "slash_escrow", "ignore"] = Field(
+        description=(
+            "The deterministic punishment executed by the orchestrator against nodes that violate the consensus quorum."
+        )
+    )
+
+    @model_validator(mode="after")
+    def enforce_bft_math(self) -> Self:
+        """Mathematically guarantees the network can reach Byzantine agreement."""
+        if self.min_quorum_size < (3 * self.max_tolerable_faults) + 1:
+            raise ValueError("Byzantine Fault Tolerance requires min_quorum_size (N) >= 3f + 1.")
+        return self
+
+
 class ConsensusPolicy(CoreasonBaseModel):
     """
     Explicit ruleset governing how a council resolves disagreements.
     """
 
-    strategy: Literal["unanimous", "majority", "debate_rounds", "prediction_market"] = Field(
+    strategy: Literal["unanimous", "majority", "debate_rounds", "prediction_market", "pbft"] = Field(
         description="The mathematical rule for reaching agreement."
     )
     tie_breaker_node_id: NodeID | None = Field(
@@ -74,6 +103,15 @@ class ConsensusPolicy(CoreasonBaseModel):
         default=None,
         description="The strict algorithmic mechanism rules required if the strategy is prediction_market.",
     )
+    quorum_rules: QuorumPolicy | None = Field(
+        default=None, description="The strict Byzantine fault tolerance limits required if the strategy is 'pbft'."
+    )
+
+    @model_validator(mode="after")
+    def validate_pbft_requirements(self) -> Self:
+        if self.strategy == "pbft" and self.quorum_rules is None:
+            raise ValueError("quorum_rules must be provided when strategy is 'pbft'.")
+        return self
 
 
 class FormalVerificationContract(CoreasonBaseModel):

--- a/tests/domains/test_oversight_governance.py
+++ b/tests/domains/test_oversight_governance.py
@@ -4,7 +4,12 @@ from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from coreason_manifest.oversight.adjudication import AdjudicationRubric, GradingCriteria
-from coreason_manifest.oversight.governance import ConstitutionalRule, PredictionMarketPolicy
+from coreason_manifest.oversight.governance import (
+    ConsensusPolicy,
+    ConstitutionalRule,
+    PredictionMarketPolicy,
+    QuorumPolicy,
+)
 from coreason_manifest.oversight.intervention import BoundedInterventionScope, FallbackSLA, InterventionRequest
 
 
@@ -92,6 +97,49 @@ def test_prediction_market_policy_bounds() -> None:
     with pytest.raises(ValidationError) as exc_info3:
         PredictionMarketPolicy(staking_function="linear", min_liquidity_cents=100, convergence_delta_threshold=1.1)
     assert "le" in str(exc_info3.value) or "less than or equal" in str(exc_info3.value)
+
+
+def test_quorum_policy_enforce_bft_math() -> None:
+    # Valid quorum
+    QuorumPolicy(
+        max_tolerable_faults=1,
+        min_quorum_size=4,
+        state_validation_metric="ledger_hash",
+        byzantine_action="quarantine",
+    )
+
+    # Invalid quorum: 3 * 1 + 1 = 4, but min_quorum_size is 3
+    with pytest.raises(
+        ValidationError,
+        match=r"Byzantine Fault Tolerance requires min_quorum_size \(N\) >= 3f \+ 1\.",
+    ):
+        QuorumPolicy(
+            max_tolerable_faults=1,
+            min_quorum_size=3,
+            state_validation_metric="ledger_hash",
+            byzantine_action="quarantine",
+        )
+
+
+def test_consensus_policy_validate_pbft_requirements() -> None:
+    # Valid consensus policy with pbft
+    quorum = QuorumPolicy(
+        max_tolerable_faults=1,
+        min_quorum_size=4,
+        state_validation_metric="ledger_hash",
+        byzantine_action="quarantine",
+    )
+    ConsensusPolicy(
+        strategy="pbft",
+        quorum_rules=quorum,
+    )
+
+    # Invalid consensus policy with pbft but missing quorum_rules
+    with pytest.raises(ValidationError, match=r"quorum_rules must be provided when strategy is 'pbft'\."):
+        ConsensusPolicy(
+            strategy="pbft",
+            quorum_rules=None,
+        )
 
 
 @given(

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -588,21 +588,33 @@ def draw_prediction_market_policy(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_quorum_policy(draw: Any) -> dict[str, Any]:
+    f = draw(st.integers(min_value=0, max_value=10))
+    n = draw(st.integers(min_value=(3 * f) + 1, max_value=100))
+    return {
+        "max_tolerable_faults": f,
+        "min_quorum_size": n,
+        "state_validation_metric": draw(st.sampled_from(["ledger_hash", "zk_proof", "semantic_embedding"])),
+        "byzantine_action": draw(st.sampled_from(["quarantine", "slash_escrow", "ignore"])),
+    }
+
+
+@st.composite
 def draw_consensus_policy(draw: Any) -> dict[str, Any]:
-    res: dict[str, Any] = draw(
-        st.fixed_dictionaries(
-            {
-                "strategy": st.sampled_from(["unanimous", "majority", "debate_rounds", "prediction_market"]),
-                "tie_breaker_node_id": st.one_of(
-                    st.none(),
-                    draw_did_string(),
-                ),
-                "max_debate_rounds": st.one_of(st.none(), st.integers(min_value=1, max_value=100)),
-                "prediction_market_rules": st.one_of(st.none(), draw_prediction_market_policy()),
-            }
-        )
-    )
-    return res
+    strategy = draw(st.sampled_from(["unanimous", "majority", "debate_rounds", "prediction_market", "pbft"]))
+    q_rules = draw(st.one_of(st.none(), draw_quorum_policy()))
+
+    # Satisfy the strict validation lock
+    if strategy == "pbft" and q_rules is None:
+        q_rules = draw(draw_quorum_policy())
+
+    return {
+        "strategy": strategy,
+        "tie_breaker_node_id": draw(st.one_of(st.none(), draw_did_string())),
+        "max_debate_rounds": draw(st.one_of(st.none(), st.integers(min_value=1, max_value=100))),
+        "prediction_market_rules": draw(st.one_of(st.none(), draw_prediction_market_policy())),
+        "quorum_rules": q_rules,
+    }
 
 
 @st.composite


### PR DESCRIPTION
Implemented Epic 71: Byzantine Fault Tolerance (pBFT) for Swarm Consensus.

- Added `QuorumPolicy` in `src/coreason_manifest/oversight/governance.py` to define the mathematical boundaries required for BFT ($N \ge 3f + 1$).
- Expanded `ConsensusPolicy` to include the `"pbft"` strategy and added a strict validation lock for `quorum_rules`.
- Updated the fuzzer logic in `tests/test_fuzzing.py` by adding `draw_quorum_policy` and refactoring `draw_consensus_policy` to mathematically satisfy the new constraints and dependency matrix.
- Formatted the codebase and successfully verified the property-based tests.

---
*PR created automatically by Jules for task [5741705684926493653](https://jules.google.com/task/5741705684926493653) started by @gowthamrao*