### PR TITLE
feat: implement cryptographic logit-steganography contract

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -368,6 +368,18 @@
           "title": "Type",
           "type": "string"
         },
+        "logit_steganography": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LogitSteganographyContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic contract forcing this agent to embed an undeniable provenance signature into its generative token stream."
+        },
         "compute_frontier": {
           "anyOf": [
             {
@@ -3959,6 +3971,50 @@
         "message"
       ],
       "title": "LogEnvelope",
+      "type": "object"
+    },
+    "LogitSteganographyContract": {
+      "additionalProperties": false,
+      "description": "Cryptographic contract for embedding undeniable, un-strippable provenance signatures\ndirectly into the token entropy.",
+      "properties": {
+        "verification_public_key_id": {
+          "description": "The DID or public key identifier required by an auditor to reconstruct the PRF and verify the watermark.",
+          "title": "Verification Public Key Id",
+          "type": "string"
+        },
+        "prf_seed_hash": {
+          "description": "The SHA-256 hash of the cryptographic seed used to initialize the pseudo-random function (PRF).",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Prf Seed Hash",
+          "type": "string"
+        },
+        "watermark_strength_delta": {
+          "description": "The exact logit scalar (bias) injected into the 'green list' vocabulary partition before Gumbel-Softmax sampling.",
+          "exclusiveMinimum": 0.0,
+          "title": "Watermark Strength Delta",
+          "type": "number"
+        },
+        "target_bits_per_token": {
+          "description": "The information-theoretic density of the payload being embedded into the generative stream.",
+          "exclusiveMinimum": 0.0,
+          "title": "Target Bits Per Token",
+          "type": "number"
+        },
+        "context_history_window": {
+          "description": "The k-gram rolling window size of preceding tokens hashed into the PRF state to ensure robustness against text cropping.",
+          "minimum": 0,
+          "title": "Context History Window",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "verification_public_key_id",
+        "prf_seed_hash",
+        "watermark_strength_delta",
+        "target_bits_per_token",
+        "context_history_window"
+      ],
+      "title": "LogitSteganographyContract",
       "type": "object"
     },
     "MCPCapabilityWhitelist": {

--- a/src/coreason_manifest/compute/__init__.py
+++ b/src/coreason_manifest/compute/__init__.py
@@ -26,6 +26,7 @@ from .stochastic import (
     CrossoverStrategy,
     DistributionProfile,
     FitnessObjective,
+    LogitSteganographyContract,
     MutationPolicy,
     VerifiableEntropy,
 )
@@ -49,6 +50,7 @@ __all__ = [
     "FitnessObjective",
     "InterventionalCausalTask",
     "LatentSmoothingProfile",
+    "LogitSteganographyContract",
     "ModelProfile",
     "MutationPolicy",
     "NeuroSymbolicHandoff",

--- a/src/coreason_manifest/compute/stochastic.py
+++ b/src/coreason_manifest/compute/stochastic.py
@@ -60,10 +60,12 @@ class VerifiableEntropy(CoreasonBaseModel):
 
 
 class LogitSteganographyContract(CoreasonBaseModel):
-    """Cryptographic contract for embedding undeniable, un-strippable provenance signatures directly into the token entropy."""
+    """Cryptographic contract for embedding undeniable, un-strippable provenance signatures
+    directly into the token entropy."""
 
     verification_public_key_id: str = Field(
-        description="The DID or public key identifier required by an auditor to reconstruct the PRF and verify the watermark."
+        description="The DID or public key identifier required by an auditor to reconstruct the PRF "
+        "and verify the watermark."
     )
     prf_seed_hash: str = Field(
         pattern=r"^[a-f0-9]{64}$",
@@ -71,7 +73,8 @@ class LogitSteganographyContract(CoreasonBaseModel):
     )
     watermark_strength_delta: float = Field(
         gt=0.0,
-        description="The exact logit scalar (bias) injected into the 'green list' vocabulary partition before Gumbel-Softmax sampling.",
+        description="The exact logit scalar (bias) injected into the 'green list' vocabulary partition "
+        "before Gumbel-Softmax sampling.",
     )
     target_bits_per_token: float = Field(
         gt=0.0,
@@ -79,7 +82,8 @@ class LogitSteganographyContract(CoreasonBaseModel):
     )
     context_history_window: int = Field(
         ge=0,
-        description="The k-gram rolling window size of preceding tokens hashed into the PRF state to ensure robustness against text cropping.",
+        description="The k-gram rolling window size of preceding tokens hashed into the PRF state "
+        "to ensure robustness against text cropping.",
     )
 
 

--- a/src/coreason_manifest/compute/stochastic.py
+++ b/src/coreason_manifest/compute/stochastic.py
@@ -59,6 +59,30 @@ class VerifiableEntropy(CoreasonBaseModel):
     seed_hash: str = Field(min_length=10, description="The SHA-256 hash of the origin seed used to initialize the VRF.")
 
 
+class LogitSteganographyContract(CoreasonBaseModel):
+    """Cryptographic contract for embedding undeniable, un-strippable provenance signatures directly into the token entropy."""
+
+    verification_public_key_id: str = Field(
+        description="The DID or public key identifier required by an auditor to reconstruct the PRF and verify the watermark."
+    )
+    prf_seed_hash: str = Field(
+        pattern=r"^[a-f0-9]{64}$",
+        description="The SHA-256 hash of the cryptographic seed used to initialize the pseudo-random function (PRF).",
+    )
+    watermark_strength_delta: float = Field(
+        gt=0.0,
+        description="The exact logit scalar (bias) injected into the 'green list' vocabulary partition before Gumbel-Softmax sampling.",
+    )
+    target_bits_per_token: float = Field(
+        gt=0.0,
+        description="The information-theoretic density of the payload being embedded into the generative stream.",
+    )
+    context_history_window: int = Field(
+        ge=0,
+        description="The k-gram rolling window size of preceding tokens hashed into the PRF state to ensure robustness against text cropping.",
+    )
+
+
 class MutationPolicy(CoreasonBaseModel):
     """Constraints governing random heuristic mutations."""
 

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -12,6 +12,7 @@ from pydantic import Field
 from coreason_manifest.compute.inference import ActiveInferenceContract, AnalogicalMappingTask, InterventionalCausalTask
 from coreason_manifest.compute.peft import PeftAdapterContract
 from coreason_manifest.compute.profiles import RoutingFrontier
+from coreason_manifest.compute.stochastic import LogitSteganographyContract
 from coreason_manifest.compute.symbolic import NeuroSymbolicHandoff
 from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
 from coreason_manifest.core.base import CoreasonBaseModel
@@ -98,6 +99,10 @@ class AgentNode(BaseNode):
     """
 
     type: Literal["agent"] = Field(default="agent", description="Discriminator for an Agent node.")
+    logit_steganography: LogitSteganographyContract | None = Field(
+        default=None,
+        description="The cryptographic contract forcing this agent to embed an undeniable provenance signature into its generative token stream.",
+    )
     compute_frontier: RoutingFrontier | None = Field(
         default=None, description="The dynamic spot-market compute requirements for this agent."
     )

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -101,7 +101,8 @@ class AgentNode(BaseNode):
     type: Literal["agent"] = Field(default="agent", description="Discriminator for an Agent node.")
     logit_steganography: LogitSteganographyContract | None = Field(
         default=None,
-        description="The cryptographic contract forcing this agent to embed an undeniable provenance signature into its generative token stream.",
+        description="The cryptographic contract forcing this agent to embed an undeniable provenance signature "
+        "into its generative token stream.",
     )
     compute_frontier: RoutingFrontier | None = Field(
         default=None, description="The dynamic spot-market compute requirements for this agent."

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -468,8 +468,28 @@ def draw_routing_frontier(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_logit_steganography_contract(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "verification_public_key_id": draw_did_string(),
+                "prf_seed_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+                "watermark_strength_delta": st.floats(
+                    min_value=0.1, max_value=10.0, allow_nan=False, allow_infinity=False
+                ),
+                "target_bits_per_token": st.floats(min_value=0.1, max_value=5.0, allow_nan=False, allow_infinity=False),
+                "context_history_window": st.integers(min_value=0, max_value=100),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"type": "agent", "description": draw(st.text())}
+    if draw(st.booleans()):
+        payload["logit_steganography"] = draw(draw_logit_steganography_contract())
     if draw(st.booleans()):
         payload["compute_frontier"] = draw(draw_routing_frontier())
     if draw(st.booleans()):


### PR DESCRIPTION
Closes Epic 72: Cryptographic Logit-Steganography.

Added `LogitSteganographyContract` to `src/coreason_manifest/compute/stochastic.py` and exposed it via `__init__.py`. 
Integrated this contract as an optional field into `AgentNode` in `src/coreason_manifest/workflow/nodes.py`. 
Updated `tests/test_fuzzing.py` in-place to generate valid fuzzer payloads for the new field without causing AST conflicts. 
All types use Python 3.14 native type hints as required. Tests and type checking (`ruff`, `pytest`, `mypy`) all pass successfully.

---
*PR created automatically by Jules for task [6835706226073230880](https://jules.google.com/task/6835706226073230880) started by @gowthamrao*