### PR TITLE
feat(state): Add CounterfactualRegretEvent for self-correction simulation

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -679,6 +679,7 @@
         "mapping": {
           "barge_in": "#/$defs/BargeInInterruptEvent",
           "belief_update": "#/$defs/BeliefUpdateEvent",
+          "counterfactual_regret": "#/$defs/CounterfactualRegretEvent",
           "hypothesis": "#/$defs/HypothesisGenerationEvent",
           "observation": "#/$defs/ObservationEvent",
           "system_fault": "#/$defs/SystemFaultEvent"
@@ -700,6 +701,9 @@
         },
         {
           "$ref": "#/$defs/BargeInInterruptEvent"
+        },
+        {
+          "$ref": "#/$defs/CounterfactualRegretEvent"
         }
       ]
     },
@@ -2033,6 +2037,73 @@
         "adjudicator_id"
       ],
       "title": "CouncilTopology",
+      "type": "object"
+    },
+    "CounterfactualRegretEvent": {
+      "additionalProperties": false,
+      "description": "A cryptographic record of an agent simulating an alternative timeline to calculate epistemic regret\nand update its policy.",
+      "properties": {
+        "event_id": {
+          "description": "A unique identifier for the event.",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "The timestamp when the event occurred.",
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "counterfactual_regret",
+          "default": "counterfactual_regret",
+          "description": "Discriminator type for a counterfactual regret event.",
+          "title": "Type",
+          "type": "string"
+        },
+        "historical_event_id": {
+          "description": "The specific historical state node where the agent mathematically diverged to simulate an alternative path.",
+          "title": "Historical Event Id",
+          "type": "string"
+        },
+        "counterfactual_intervention": {
+          "description": "The specific alternative action or do-calculus intervention applied in the simulation.",
+          "title": "Counterfactual Intervention",
+          "type": "string"
+        },
+        "expected_utility_actual": {
+          "description": "The computed utility of the trajectory that was actually executed.",
+          "title": "Expected Utility Actual",
+          "type": "number"
+        },
+        "expected_utility_simulated": {
+          "description": "The computed utility of the simulated counterfactual trajectory.",
+          "title": "Expected Utility Simulated",
+          "type": "number"
+        },
+        "epistemic_regret": {
+          "description": "The mathematical variance (simulated - actual) representing the opportunity cost of the historical decision.",
+          "title": "Epistemic Regret",
+          "type": "number"
+        },
+        "policy_update_gradients": {
+          "additionalProperties": {
+            "type": "number"
+          },
+          "description": "The stateless routing gradient adjustments derived from the calculated regret, used to self-correct future routing.",
+          "title": "Policy Update Gradients",
+          "type": "object"
+        }
+      },
+      "required": [
+        "event_id",
+        "timestamp",
+        "historical_event_id",
+        "counterfactual_intervention",
+        "expected_utility_actual",
+        "expected_utility_simulated",
+        "epistemic_regret"
+      ],
+      "title": "CounterfactualRegretEvent",
       "type": "object"
     },
     "CrossoverStrategy": {

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -252,7 +252,43 @@ class BargeInInterruptEvent(BaseStateEvent):
     )
 
 
+class CounterfactualRegretEvent(BaseStateEvent):
+    """A cryptographic record of an agent simulating an alternative timeline to calculate epistemic regret
+    and update its policy."""
+
+    type: Literal["counterfactual_regret"] = Field(
+        default="counterfactual_regret", description="Discriminator type for a counterfactual regret event."
+    )
+    historical_event_id: str = Field(
+        description="The specific historical state node where the agent mathematically diverged "
+        "to simulate an alternative path."
+    )
+    counterfactual_intervention: str = Field(
+        description="The specific alternative action or do-calculus intervention applied in the simulation."
+    )
+    expected_utility_actual: float = Field(
+        description="The computed utility of the trajectory that was actually executed."
+    )
+    expected_utility_simulated: float = Field(
+        description="The computed utility of the simulated counterfactual trajectory."
+    )
+    epistemic_regret: float = Field(
+        description="The mathematical variance (simulated - actual) representing the opportunity "
+        "cost of the historical decision."
+    )
+    policy_update_gradients: dict[str, float] = Field(
+        default_factory=dict,
+        description="The stateless routing gradient adjustments derived from the calculated regret, "
+        "used to self-correct future routing.",
+    )
+
+
 type AnyStateEvent = Annotated[
-    ObservationEvent | BeliefUpdateEvent | SystemFaultEvent | HypothesisGenerationEvent | BargeInInterruptEvent,
+    ObservationEvent
+    | BeliefUpdateEvent
+    | SystemFaultEvent
+    | HypothesisGenerationEvent
+    | BargeInInterruptEvent
+    | CounterfactualRegretEvent,
     Field(discriminator="type", description="A discriminated union of state events."),
 ]

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1150,7 +1150,7 @@ def draw_barge_in_interrupt_event(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_counterfactual_regret_event(draw: Any) -> dict[str, Any]:
-    return draw(
+    res: dict[str, Any] = draw(
         st.fixed_dictionaries(
             {
                 "type": st.just("counterfactual_regret"),
@@ -1165,6 +1165,7 @@ def draw_counterfactual_regret_event(draw: Any) -> dict[str, Any]:
             }
         )
     )
+    return res
 
 
 @st.composite
@@ -1184,7 +1185,8 @@ def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
         return res
 
     if event_type == "counterfactual_regret":
-        return draw(draw_counterfactual_regret_event())
+        cf_res: dict[str, Any] = draw(draw_counterfactual_regret_event())
+        return cf_res
 
     payload: dict[str, Any] = {
         "type": event_type,

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1149,8 +1149,31 @@ def draw_barge_in_interrupt_event(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_counterfactual_regret_event(draw: Any) -> dict[str, Any]:
+    return draw(
+        st.fixed_dictionaries(
+            {
+                "type": st.just("counterfactual_regret"),
+                "event_id": st.text(min_size=1),
+                "timestamp": st.floats(allow_nan=False, allow_infinity=False),
+                "historical_event_id": st.text(min_size=1),
+                "counterfactual_intervention": st.text(min_size=1),
+                "expected_utility_actual": st.floats(allow_nan=False, allow_infinity=False),
+                "expected_utility_simulated": st.floats(allow_nan=False, allow_infinity=False),
+                "epistemic_regret": st.floats(allow_nan=False, allow_infinity=False),
+                "policy_update_gradients": st.dictionaries(st.text(), st.floats(allow_nan=False, allow_infinity=False)),
+            }
+        )
+    )
+
+
+@st.composite
 def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
-    event_type = draw(st.sampled_from(["observation", "belief_update", "system_fault", "hypothesis", "barge_in"]))
+    event_type = draw(
+        st.sampled_from(
+            ["observation", "belief_update", "system_fault", "hypothesis", "barge_in", "counterfactual_regret"]
+        )
+    )
 
     if event_type == "barge_in":
         barge_in_res: dict[str, Any] = draw(draw_barge_in_interrupt_event())
@@ -1159,6 +1182,9 @@ def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
     if event_type == "hypothesis":
         res: dict[str, Any] = draw(draw_hypothesis_generation_event())
         return res
+
+    if event_type == "counterfactual_regret":
+        return draw(draw_counterfactual_regret_event())
 
     payload: dict[str, Any] = {
         "type": event_type,
@@ -1214,11 +1240,22 @@ def test_anystateevent_routing(payload: dict[str, Any]) -> None:
         from coreason_manifest.state.events import BargeInInterruptEvent
 
         assert isinstance(parsed, BargeInInterruptEvent)
+    elif event_type == "counterfactual_regret":
+        from coreason_manifest.state.events import CounterfactualRegretEvent
+
+        assert isinstance(parsed, CounterfactualRegretEvent)
 
 
 @given(st.text())
 def test_anystateevent_invalid(invalid_type: str) -> None:
-    if invalid_type in ["observation", "belief_update", "system_fault", "hypothesis", "barge_in"]:
+    if invalid_type in [
+        "observation",
+        "belief_update",
+        "system_fault",
+        "hypothesis",
+        "barge_in",
+        "counterfactual_regret",
+    ]:
         return
     payload = {"type": invalid_type, "event_id": "test", "timestamp": 123.0}
     with pytest.raises(ValidationError):


### PR DESCRIPTION
Implements Epic 73: Counterfactual Regret Simulation. This PR enables unsupervised self-correction within the Epistemic Ledger by defining a declarative event schema for documenting the calculation of epistemic regret, bypassing the need for human-labeled preference data. The implementation strictly adheres to the "Hollow Data Plane" rule.

---
*PR created automatically by Jules for task [16820828729633854115](https://jules.google.com/task/16820828729633854115) started by @gowthamrao*