### PR TITLE
refactor(mcp): implement O(1) boot-time cache for schema discovery

### DIFF
--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -5,7 +5,7 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from typing import Any
+from typing import Any, cast
 
 from mcp.server.fastmcp import FastMCP
 from pydantic import TypeAdapter
@@ -23,18 +23,18 @@ for _name in coreason_manifest.__all__:
     # Skip None and the abstract base class itself
     if _obj is None or _obj is CoreasonBaseModel:
         continue
-    try:
-        TypeAdapter(_obj)  # Verifies Pydantic can compile it
-        _AVAILABLE_SCHEMAS[_name] = _obj
-    except Exception:  # noqa: S110
-        # Ignore strings, simple enums, or un-adaptable objects
-        pass
+    import contextlib
+
+    with contextlib.suppress(Exception):
+        _AVAILABLE_SCHEMAS[_name] = TypeAdapter(_obj).json_schema()
+
+_SCHEMA_NAMES = sorted(_AVAILABLE_SCHEMAS.keys())
 
 
 @mcp.tool()
 def list_schemas() -> list[str]:
     """Returns a list of all available schema names exported in the root __init__.py."""
-    return sorted(_AVAILABLE_SCHEMAS.keys())
+    return _SCHEMA_NAMES
 
 
 @mcp.tool()
@@ -47,8 +47,7 @@ def get_schema(schema_name: str) -> dict[str, Any]:
     if schema_name not in _AVAILABLE_SCHEMAS:
         raise ValueError(f"Schema '{schema_name}' not found in the manifest.")
 
-    # Generate JSON schema using Pydantic
-    return TypeAdapter(_AVAILABLE_SCHEMAS[schema_name]).json_schema()
+    return cast("dict[str, Any]", _AVAILABLE_SCHEMAS[schema_name])
 
 
 def _global_error_handler_shield() -> None:

--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -8,50 +8,33 @@
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from pydantic import TypeAdapter
 
 import coreason_manifest
+from coreason_manifest.core import CoreasonBaseModel
 
 # Create an MCP server
 mcp = FastMCP("coreason-manifest-schema-service")
+
+_AVAILABLE_SCHEMAS: dict[str, Any] = {}
+
+for _name in coreason_manifest.__all__:
+    _obj = getattr(coreason_manifest, _name, None)
+    # Skip None and the abstract base class itself
+    if _obj is None or _obj is CoreasonBaseModel:
+        continue
+    try:
+        TypeAdapter(_obj)  # Verifies Pydantic can compile it
+        _AVAILABLE_SCHEMAS[_name] = _obj
+    except Exception:  # noqa: S110
+        # Ignore strings, simple enums, or un-adaptable objects
+        pass
 
 
 @mcp.tool()
 def list_schemas() -> list[str]:
     """Returns a list of all available schema names exported in the root __init__.py."""
-    schemas = []
-
-    # Check if the model is exported and is a CoreasonBaseModel
-    import importlib
-
-    from coreason_manifest.core import CoreasonBaseModel
-
-    domains = [
-        "coreason_manifest.core",
-        "coreason_manifest.oversight",
-        "coreason_manifest.state",
-        "coreason_manifest.testing",
-        "coreason_manifest.tooling",
-        "coreason_manifest.workflow",
-        "coreason_manifest.telemetry",
-        "coreason_manifest.compute",
-    ]
-
-    for domain in domains:
-        try:
-            mod = importlib.import_module(domain)
-            for name in getattr(mod, "__all__", []):
-                obj = getattr(mod, name)
-                if isinstance(obj, type) and issubclass(obj, CoreasonBaseModel) and obj is not CoreasonBaseModel:
-                    schemas.append(name)
-        except ImportError:
-            pass
-
-    for name in getattr(coreason_manifest, "__all__", []):
-        obj = getattr(coreason_manifest, name)
-        if isinstance(obj, type) and issubclass(obj, CoreasonBaseModel) and obj is not CoreasonBaseModel:
-            schemas.append(name)
-
-    return sorted(set(schemas))
+    return sorted(_AVAILABLE_SCHEMAS.keys())
 
 
 @mcp.tool()
@@ -61,42 +44,11 @@ def get_schema(schema_name: str) -> dict[str, Any]:
     Args:
         schema_name: The name of the schema to fetch (e.g., WorkingMemorySnapshot)
     """
-    import importlib
-
-    from coreason_manifest.core import CoreasonBaseModel
-
-    domains = [
-        "coreason_manifest.core",
-        "coreason_manifest.oversight",
-        "coreason_manifest.state",
-        "coreason_manifest.testing",
-        "coreason_manifest.tooling",
-        "coreason_manifest.workflow",
-        "coreason_manifest.telemetry",
-        "coreason_manifest.compute",
-    ]
-
-    obj = None
-    for domain in domains:
-        try:
-            mod = importlib.import_module(domain)
-            if schema_name in getattr(mod, "__all__", []):
-                obj = getattr(mod, schema_name)
-                break
-        except ImportError:
-            pass
-
-    if obj is None and schema_name in getattr(coreason_manifest, "__all__", []):
-        obj = getattr(coreason_manifest, schema_name)
-
-    if obj is None:
+    if schema_name not in _AVAILABLE_SCHEMAS:
         raise ValueError(f"Schema '{schema_name}' not found in the manifest.")
 
-    if not isinstance(obj, type) or not issubclass(obj, CoreasonBaseModel):
-        raise ValueError(f"'{schema_name}' is not a valid schema model.")
-
     # Generate JSON schema using Pydantic
-    return obj.model_json_schema()
+    return TypeAdapter(_AVAILABLE_SCHEMAS[schema_name]).json_schema()
 
 
 def _global_error_handler_shield() -> None:

--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -5,6 +5,7 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+import contextlib
 from typing import Any, cast
 
 from mcp.server.fastmcp import FastMCP
@@ -23,7 +24,6 @@ for _name in coreason_manifest.__all__:
     # Skip None and the abstract base class itself
     if _obj is None or _obj is CoreasonBaseModel:
         continue
-    import contextlib
 
     with contextlib.suppress(Exception):
         _AVAILABLE_SCHEMAS[_name] = TypeAdapter(_obj).json_schema()

--- a/tests/domains/test_mcp_boundary.py
+++ b/tests/domains/test_mcp_boundary.py
@@ -125,21 +125,6 @@ def test_mcp_server_tool_schemas() -> None:
     with pytest.raises(ValueError, match="not found in the manifest"):
         get_schema("DoesNotExistSchema")
 
-    # Passing something that is NOT a subclass of CoreasonBaseModel, if exposed.
-    # Otherwise the DoesNotExistSchema gives enough coverage of the first ValueError.
-    # To get coverage on the second value error ("is not a valid schema model"),
-    # we can inject a dummy object into the namespace temporarily.
-    import coreason_manifest
-
-    coreason_manifest.DummyInvalid = object  # type: ignore[attr-defined]
-    coreason_manifest.__all__.append("DummyInvalid")
-    try:
-        with pytest.raises(ValueError, match="is not a valid schema model"):
-            get_schema("DummyInvalid")
-    finally:
-        coreason_manifest.__all__.remove("DummyInvalid")
-        del coreason_manifest.DummyInvalid  # type: ignore[attr-defined]
-
 
 @pytest.mark.anyio
 async def test_mcp_stdio_server_happy_path() -> None:


### PR DESCRIPTION
Implements Sub-Epic 2: The MCP Server Cache (O(1) Discovery) for the `coreason-manifest` repository. Refactors `list_schemas` and `get_schema` in `src/coreason_manifest/cli/mcp_server.py` to use a global dictionary `_AVAILABLE_SCHEMAS` populated once at boot-time with `TypeAdapter` verified schemas, optimizing MCP tool endpoints for zero-latency execution. Also updates the relevant MCP boundary tests to reflect this change.

---
*PR created automatically by Jules for task [6677490846309369618](https://jules.google.com/task/6677490846309369618) started by @gowthamrao*