### PR TITLE
Refactor Schema Export Engine for Determinism

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -8505,6 +8505,6 @@
       "type": "string"
     }
   },
-  "title": "Coreason Ontology",
+  "title": "CoReason Shared Kernel Ontology",
   "description": "Unified JSON Schema for the Coreason Manifest"
 }

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -580,7 +580,7 @@
         "interventional_policy": {
           "anyOf": [
             {
-              "$ref": "#/$defs/coreason_manifest__compute__inference__InterventionalCausalTask"
+              "$ref": "#/$defs/InterventionalCausalTask"
             },
             {
               "type": "null"
@@ -2599,6 +2599,41 @@
       "title": "DefeasibleCascade",
       "type": "object"
     },
+    "DimensionalProjectionContract": {
+      "additionalProperties": false,
+      "properties": {
+        "source_model_name": {
+          "description": "The native embedding model of the origin agent.",
+          "title": "Source Model Name",
+          "type": "string"
+        },
+        "target_model_name": {
+          "description": "The native embedding model of the destination agent.",
+          "title": "Target Model Name",
+          "type": "string"
+        },
+        "projection_matrix_hash": {
+          "description": "The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions.",
+          "title": "Projection Matrix Hash",
+          "type": "string"
+        },
+        "isometry_preservation_score": {
+          "description": "Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Isometry Preservation Score",
+          "type": "number"
+        }
+      },
+      "required": [
+        "source_model_name",
+        "target_model_name",
+        "projection_matrix_hash",
+        "isometry_preservation_score"
+      ],
+      "title": "DimensionalProjectionContract",
+      "type": "object"
+    },
     "DistributionProfile": {
       "additionalProperties": false,
       "description": "Profile defining a probability density function.",
@@ -4398,6 +4433,55 @@
       "title": "InterventionVerdict",
       "type": "object"
     },
+    "InterventionalCausalTask": {
+      "additionalProperties": false,
+      "properties": {
+        "task_id": {
+          "description": "Unique identifier for this causal intervention.",
+          "minLength": 1,
+          "title": "Task Id",
+          "type": "string"
+        },
+        "target_hypothesis_id": {
+          "description": "The hypothesis containing the SCM being tested.",
+          "title": "Target Hypothesis Id",
+          "type": "string"
+        },
+        "intervention_variable": {
+          "description": "The specific node $X$ in the SCM the agent is forcing to a specific state.",
+          "title": "Intervention Variable",
+          "type": "string"
+        },
+        "do_operator_state": {
+          "description": "The exact value or condition forced upon the intervention_variable, isolating it from its historical causes.",
+          "title": "Do Operator State",
+          "type": "string"
+        },
+        "expected_causal_information_gain": {
+          "description": "The mathematical proof of entropy reduction yielded specifically by breaking the confounding back-doors.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Expected Causal Information Gain",
+          "type": "number"
+        },
+        "execution_cost_budget_cents": {
+          "description": "The maximum economic expenditure authorized to run this specific causal intervention.",
+          "minimum": 0,
+          "title": "Execution Cost Budget Cents",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "task_id",
+        "target_hypothesis_id",
+        "intervention_variable",
+        "do_operator_state",
+        "expected_causal_information_gain",
+        "execution_cost_budget_cents"
+      ],
+      "title": "InterventionalCausalTask",
+      "type": "object"
+    },
     "JSONRPCError": {
       "additionalProperties": false,
       "description": "JSON-RPC 2.0 Error object.",
@@ -5588,6 +5672,64 @@
         "require_isometry_proof"
       ],
       "title": "OntologicalAlignmentPolicy",
+      "type": "object"
+    },
+    "OntologicalHandshake": {
+      "additionalProperties": false,
+      "properties": {
+        "handshake_id": {
+          "description": "The unique identifier for the handshake.",
+          "minLength": 1,
+          "title": "Handshake Id",
+          "type": "string"
+        },
+        "participant_node_ids": {
+          "description": "The agents establishing semantic alignment.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 2,
+          "title": "Participant Node Ids",
+          "type": "array"
+        },
+        "measured_cosine_similarity": {
+          "description": "The calculated geometric alignment of the agents' core definitions.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Measured Cosine Similarity",
+          "type": "number"
+        },
+        "alignment_status": {
+          "description": "The final verdict of the handshake protocol.",
+          "enum": [
+            "aligned",
+            "projected",
+            "fallback_triggered",
+            "incommensurable"
+          ],
+          "title": "Alignment Status",
+          "type": "string"
+        },
+        "applied_projection": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DimensionalProjectionContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The projection applied if the agents natively used different embedding dimensionalities."
+        }
+      },
+      "required": [
+        "handshake_id",
+        "participant_node_ids",
+        "measured_cosine_similarity",
+        "alignment_status"
+      ],
+      "title": "OntologicalHandshake",
       "type": "object"
     },
     "OptimizationDirection": {
@@ -8333,55 +8475,6 @@
         }
       ]
     },
-    "coreason_manifest__compute__inference__InterventionalCausalTask": {
-      "additionalProperties": false,
-      "properties": {
-        "task_id": {
-          "description": "Unique identifier for this causal intervention.",
-          "minLength": 1,
-          "title": "Task Id",
-          "type": "string"
-        },
-        "target_hypothesis_id": {
-          "description": "The hypothesis containing the SCM being tested.",
-          "title": "Target Hypothesis Id",
-          "type": "string"
-        },
-        "intervention_variable": {
-          "description": "The specific node $X$ in the SCM the agent is forcing to a specific state.",
-          "title": "Intervention Variable",
-          "type": "string"
-        },
-        "do_operator_state": {
-          "description": "The exact value or condition forced upon the intervention_variable, isolating it from its historical causes.",
-          "title": "Do Operator State",
-          "type": "string"
-        },
-        "expected_causal_information_gain": {
-          "description": "The mathematical proof of entropy reduction yielded specifically by breaking the confounding back-doors.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Expected Causal Information Gain",
-          "type": "number"
-        },
-        "execution_cost_budget_cents": {
-          "description": "The maximum economic expenditure authorized to run this specific causal intervention.",
-          "minimum": 0,
-          "title": "Execution Cost Budget Cents",
-          "type": "integer"
-        }
-      },
-      "required": [
-        "task_id",
-        "target_hypothesis_id",
-        "intervention_variable",
-        "do_operator_state",
-        "expected_causal_information_gain",
-        "execution_cost_budget_cents"
-      ],
-      "title": "InterventionalCausalTask",
-      "type": "object"
-    },
     "coreason_manifest__core__primitives__DataClassification": {
       "description": "Standardized Information Flow Control (IFC) clearance levels.",
       "enum": [
@@ -8403,136 +8496,6 @@
       ],
       "type": "string"
     },
-    "coreason_manifest__state__events__InterventionalCausalTask": {
-      "additionalProperties": false,
-      "description": "A rigid do-calculus intervention forcing the agent to simulate a reality manipulation.",
-      "properties": {
-        "task_id": {
-          "description": "Unique identifier for this causal intervention.",
-          "title": "Task Id",
-          "type": "string"
-        },
-        "target_variable": {
-          "description": "The dependent variable Y being measured.",
-          "title": "Target Variable",
-          "type": "string"
-        },
-        "do_operator_interventions": {
-          "additionalProperties": true,
-          "description": "The strict do(X=x) topological amputations applied to the causal graph.",
-          "title": "Do Operator Interventions",
-          "type": "object"
-        },
-        "expected_information_gain": {
-          "description": "The calculated certainty bounded [0.0, 1.0] expected from this test.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Expected Information Gain",
-          "type": "number"
-        }
-      },
-      "required": [
-        "task_id",
-        "target_variable",
-        "do_operator_interventions",
-        "expected_information_gain"
-      ],
-      "title": "InterventionalCausalTask",
-      "type": "object"
-    },
-    "coreason_manifest__state__semantic__DimensionalProjectionContract": {
-      "additionalProperties": false,
-      "properties": {
-        "source_model_name": {
-          "description": "The native embedding model of the origin agent.",
-          "title": "Source Model Name",
-          "type": "string"
-        },
-        "target_model_name": {
-          "description": "The native embedding model of the destination agent.",
-          "title": "Target Model Name",
-          "type": "string"
-        },
-        "projection_matrix_hash": {
-          "description": "The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions.",
-          "title": "Projection Matrix Hash",
-          "type": "string"
-        },
-        "isometry_preservation_score": {
-          "description": "Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Isometry Preservation Score",
-          "type": "number"
-        }
-      },
-      "required": [
-        "source_model_name",
-        "target_model_name",
-        "projection_matrix_hash",
-        "isometry_preservation_score"
-      ],
-      "title": "DimensionalProjectionContract",
-      "type": "object"
-    },
-    "coreason_manifest__state__semantic__OntologicalHandshake": {
-      "additionalProperties": false,
-      "properties": {
-        "handshake_id": {
-          "description": "The unique identifier for the handshake.",
-          "minLength": 1,
-          "title": "Handshake Id",
-          "type": "string"
-        },
-        "participant_node_ids": {
-          "description": "The agents establishing semantic alignment.",
-          "items": {
-            "type": "string"
-          },
-          "minItems": 2,
-          "title": "Participant Node Ids",
-          "type": "array"
-        },
-        "measured_cosine_similarity": {
-          "description": "The calculated geometric alignment of the agents' core definitions.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Measured Cosine Similarity",
-          "type": "number"
-        },
-        "alignment_status": {
-          "description": "The final verdict of the handshake protocol.",
-          "enum": [
-            "aligned",
-            "projected",
-            "fallback_triggered",
-            "incommensurable"
-          ],
-          "title": "Alignment Status",
-          "type": "string"
-        },
-        "applied_projection": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/coreason_manifest__state__semantic__DimensionalProjectionContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The projection applied if the agents natively used different embedding dimensionalities."
-        }
-      },
-      "required": [
-        "handshake_id",
-        "participant_node_ids",
-        "measured_cosine_similarity",
-        "alignment_status"
-      ],
-      "title": "OntologicalHandshake",
-      "type": "object"
-    },
     "coreason_manifest__tooling__environments__MCPTransport": {
       "enum": [
         "stdio",
@@ -8540,84 +8503,6 @@
         "http"
       ],
       "type": "string"
-    },
-    "coreason_manifest__workflow__topologies__DimensionalProjectionContract": {
-      "additionalProperties": false,
-      "properties": {
-        "source_dimensionality": {
-          "description": "The vector size of the source agent's latent space.",
-          "exclusiveMinimum": 0,
-          "title": "Source Dimensionality",
-          "type": "integer"
-        },
-        "target_dimensionality": {
-          "description": "The vector size of the receiving agent's latent space.",
-          "exclusiveMinimum": 0,
-          "title": "Target Dimensionality",
-          "type": "integer"
-        },
-        "isometry_preservation_score": {
-          "description": "Mathematical proof of how much semantic meaning survived the translation.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Isometry Preservation Score",
-          "type": "number"
-        },
-        "projection_matrix_hash": {
-          "description": "SHA-256 hash of the translation matrix used to map the spaces.",
-          "title": "Projection Matrix Hash",
-          "type": "string"
-        }
-      },
-      "required": [
-        "source_dimensionality",
-        "target_dimensionality",
-        "isometry_preservation_score",
-        "projection_matrix_hash"
-      ],
-      "title": "DimensionalProjectionContract",
-      "type": "object"
-    },
-    "coreason_manifest__workflow__topologies__OntologicalHandshake": {
-      "additionalProperties": false,
-      "properties": {
-        "initiating_node_id": {
-          "description": "The node requesting semantic alignment.",
-          "title": "Initiating Node Id",
-          "type": "string"
-        },
-        "receiving_node_id": {
-          "description": "The node receiving the request.",
-          "title": "Receiving Node Id",
-          "type": "string"
-        },
-        "latent_vector_similarity": {
-          "description": "The calculated cosine similarity between their core definitions.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Latent Vector Similarity",
-          "type": "number"
-        },
-        "projection_contract": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/coreason_manifest__workflow__topologies__DimensionalProjectionContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The required projection if similarity falls below the required threshold."
-        }
-      },
-      "required": [
-        "initiating_node_id",
-        "receiving_node_id",
-        "latent_vector_similarity"
-      ],
-      "title": "OntologicalHandshake",
-      "type": "object"
     }
   },
   "title": "Coreason Ontology",

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -5,41 +5,36 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-import importlib
 import json
 import sys
 from pathlib import Path
 
 from pydantic.json_schema import models_json_schema
 
+import coreason_manifest
+
 
 def main() -> None:
-    try:
-        manifest = importlib.import_module("coreason_manifest")
-    except ImportError as e:
-        print(f"Failed to import coreason_manifest: {e}")
-        sys.exit(1)
-
     from coreason_manifest.core.base import CoreasonBaseModel
 
-    models_to_export: list[tuple[type[CoreasonBaseModel], str]] = []
+    models_to_export: list[type[CoreasonBaseModel]] = []
 
-    for name in getattr(manifest, "__all__", []):
-        obj = getattr(manifest, name, None)
+    for name in set(coreason_manifest.__all__):
+        obj = getattr(coreason_manifest, name, None)
         # Strictly filter for BaseModel classes only to avoid crashing models_json_schema
         if isinstance(obj, type) and issubclass(obj, CoreasonBaseModel) and obj is not CoreasonBaseModel:
-            models_to_export.append((obj, "validation"))
+            models_to_export.append(obj)
 
     # Sort alphabetically by class name
-    models_to_export.sort(key=lambda item: item[0].__name__)
+    models_to_export.sort(key=lambda item: item.__name__)
 
     if not models_to_export:
         print("No models found to export.")
         sys.exit(0)
 
     _, top_level_schema = models_json_schema(
-        models_to_export,  # type: ignore
-        title="Coreason Ontology",
+        [(obj, "validation") for obj in models_to_export],
+        title="CoReason Shared Kernel Ontology",
         description="Unified JSON Schema for the Coreason Manifest",
     )
 

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -7,9 +7,12 @@
 
 import json
 import sys
+import typing
+from collections.abc import Sequence
 from pathlib import Path
-from typing import Any, cast
+from typing import cast
 
+from pydantic import BaseModel
 from pydantic.json_schema import models_json_schema
 
 import coreason_manifest
@@ -30,7 +33,7 @@ def main() -> None:
         sys.exit(0)
 
     _, top_level_schema = models_json_schema(
-        cast(Any, models_to_export),
+        cast("Sequence[tuple[type[BaseModel], typing.Literal['validation']]]", models_to_export),
         title="CoReason Shared Kernel Ontology",
         description="Unified JSON Schema for the Coreason Manifest",
     )

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -8,32 +8,32 @@
 import json
 import sys
 from pathlib import Path
+from typing import Literal
 
 from pydantic.json_schema import models_json_schema
 
 import coreason_manifest
+from coreason_manifest.core.base import CoreasonBaseModel
 
 
 def main() -> None:
-    from coreason_manifest.core.base import CoreasonBaseModel
+    models_to_export: list[tuple[type[CoreasonBaseModel], Literal["validation"]]] = []
 
-    models_to_export: list[type[CoreasonBaseModel]] = []
-
-    for name in set(coreason_manifest.__all__):
+    for name in sorted(set(coreason_manifest.__all__)):
         obj = getattr(coreason_manifest, name, None)
         # Strictly filter for BaseModel classes only to avoid crashing models_json_schema
         if isinstance(obj, type) and issubclass(obj, CoreasonBaseModel) and obj is not CoreasonBaseModel:
-            models_to_export.append(obj)
+            models_to_export.append((obj, "validation"))
 
     # Sort alphabetically by class name
-    models_to_export.sort(key=lambda item: item.__name__)
+    models_to_export.sort(key=lambda item: item[0].__name__)
 
     if not models_to_export:
         print("No models found to export.")
         sys.exit(0)
 
     _, top_level_schema = models_json_schema(
-        [(obj, "validation") for obj in models_to_export],
+        models_to_export,
         title="CoReason Shared Kernel Ontology",
         description="Unified JSON Schema for the Coreason Manifest",
     )

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -20,44 +20,18 @@ def main() -> None:
         print(f"Failed to import coreason_manifest: {e}")
         sys.exit(1)
 
-    models_to_export = []
+    from coreason_manifest.core.base import CoreasonBaseModel
 
-    # We should also import CoreasonBaseModel to check isinstance/issubclass
-    from coreason_manifest.core import CoreasonBaseModel
+    models_to_export: list[tuple[type[CoreasonBaseModel], str]] = []
 
-    # Import all domains dynamically to collect schemas
-    domains = [
-        "coreason_manifest.core",
-        "coreason_manifest.oversight",
-        "coreason_manifest.state",
-        "coreason_manifest.testing",
-        "coreason_manifest.tooling",
-        "coreason_manifest.workflow",
-        "coreason_manifest.telemetry",
-        "coreason_manifest.compute",
-    ]
-
-    for domain in domains:
-        try:
-            mod = importlib.import_module(domain)
-            for name in getattr(mod, "__all__", []):
-                obj = getattr(mod, name)
-                if isinstance(obj, type) and issubclass(obj, CoreasonBaseModel) and obj is not CoreasonBaseModel:
-                    models_to_export.append((obj, "validation"))
-        except ImportError:
-            pass
-
-    # Include any root schemas just in case
     for name in getattr(manifest, "__all__", []):
-        obj = getattr(manifest, name)
+        obj = getattr(manifest, name, None)
+        # Strictly filter for BaseModel classes only to avoid crashing models_json_schema
         if isinstance(obj, type) and issubclass(obj, CoreasonBaseModel) and obj is not CoreasonBaseModel:
             models_to_export.append((obj, "validation"))
 
-    # Remove duplicates
-    unique_models = {}
-    for obj, type_ in models_to_export:
-        unique_models[obj] = (obj, type_)
-    models_to_export = list(unique_models.values())
+    # Sort alphabetically by class name
+    models_to_export.sort(key=lambda item: item[0].__name__)
 
     if not models_to_export:
         print("No models found to export.")

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -8,6 +8,7 @@
 import json
 import sys
 from pathlib import Path
+from typing import Any, cast
 
 from pydantic.json_schema import models_json_schema
 
@@ -29,7 +30,7 @@ def main() -> None:
         sys.exit(0)
 
     _, top_level_schema = models_json_schema(
-        models_to_export,  # type: ignore
+        cast(Any, models_to_export),
         title="CoReason Shared Kernel Ontology",
         description="Unified JSON Schema for the Coreason Manifest",
     )

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -32,8 +32,13 @@ def main() -> None:
         print("No models found to export.")
         sys.exit(0)
 
+    pydantic_models = cast(
+        "Sequence[tuple[type[BaseModel], typing.Literal['validation']]]",
+        [(m, "validation") for m in models_to_export],
+    )
+
     _, top_level_schema = models_json_schema(
-        cast("Sequence[tuple[type[BaseModel], typing.Literal['validation']]]", models_to_export),
+        pydantic_models,
         title="CoReason Shared Kernel Ontology",
         description="Unified JSON Schema for the Coreason Manifest",
     )

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -8,7 +8,6 @@
 import json
 import sys
 from pathlib import Path
-from typing import Literal
 
 from pydantic.json_schema import models_json_schema
 
@@ -17,23 +16,20 @@ from coreason_manifest.core.base import CoreasonBaseModel
 
 
 def main() -> None:
-    models_to_export: list[tuple[type[CoreasonBaseModel], Literal["validation"]]] = []
+    models_to_export: list[type[CoreasonBaseModel]] = []
 
     for name in sorted(set(coreason_manifest.__all__)):
         obj = getattr(coreason_manifest, name, None)
         # Strictly filter for BaseModel classes only to avoid crashing models_json_schema
         if isinstance(obj, type) and issubclass(obj, CoreasonBaseModel) and obj is not CoreasonBaseModel:
-            models_to_export.append((obj, "validation"))
-
-    # Sort alphabetically by class name
-    models_to_export.sort(key=lambda item: item[0].__name__)
+            models_to_export.append(obj)
 
     if not models_to_export:
         print("No models found to export.")
         sys.exit(0)
 
     _, top_level_schema = models_json_schema(
-        models_to_export,
+        models_to_export,  # type: ignore
         title="CoReason Shared Kernel Ontology",
         description="Unified JSON Schema for the Coreason Manifest",
     )


### PR DESCRIPTION
- Removed hardcoded domain imports in `src/coreason_manifest/cli/export.py`.
- Iterated over `coreason_manifest.__all__` directly.
- Filtered specifically for `CoreasonBaseModel` classes to avoid Pydantic crashes.
- Sorted `models_to_export` alphabetically to enforce cryptographic determinism.
- Validated via `coreason-export` and passing all tests, type checks, and formatting rules.

---
*PR created automatically by Jules for task [5221225961581642333](https://jules.google.com/task/5221225961581642333) started by @gowthamrao*