### PR TITLE
refactor: Purge scattered model_rebuild calls

### DIFF
--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -55,10 +55,6 @@ from .topologies import (
     SwarmTopology,
 )
 
-CompositeNode.model_rebuild()
-WorkflowEnvelope.model_rebuild()
-
-
 __all__ = [
     "AgentAttestation",
     "AgentBid",


### PR DESCRIPTION
As per Sub-Epic 2.1 Directive, removed all scattered `.model_rebuild()` calls within the `src/coreason_manifest/` directory to prevent circular import issues and prepare for centralized schema resolution.

---
*PR created automatically by Jules for task [14587017330079271699](https://jules.google.com/task/14587017330079271699) started by @gowthamrao*