### PR TITLE
chore: Inject Cognitive Tripwires above critical Discriminated Unions

### DIFF
--- a/src/coreason_manifest/oversight/intervention.py
+++ b/src/coreason_manifest/oversight/intervention.py
@@ -119,6 +119,13 @@ class OverrideIntent(CoreasonBaseModel):
     )
 
 
+# =========================================================================
+# AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
+# If you create a new class above, you MUST append it to the AnyInterventionPayload union below.
+# Failure to do so will result in a fatal Pydantic discriminator crash at runtime,
+# creating a 'Dangling Class' that the orchestrator cannot deserialize.
+# =========================================================================
+
 type AnyInterventionPayload = Annotated[
     InterventionRequest | InterventionVerdict | OverrideIntent, Field(discriminator="type")
 ]

--- a/src/coreason_manifest/oversight/resilience.py
+++ b/src/coreason_manifest/oversight/resilience.py
@@ -52,6 +52,13 @@ class FallbackTrigger(CoreasonBaseModel):
     fallback_node_id: NodeID = Field(description="The ID of the node to use as a fallback.")
 
 
+# =========================================================================
+# AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
+# If you create a new class above, you MUST append it to the AnyResiliencePayload union below.
+# Failure to do so will result in a fatal Pydantic discriminator crash at runtime,
+# creating a 'Dangling Class' that the orchestrator cannot deserialize.
+# =========================================================================
+
 type AnyResiliencePayload = Annotated[
     QuarantineOrder | CircuitBreakerTrip | FallbackTrigger, Field(discriminator="type")
 ]

--- a/src/coreason_manifest/presentation/intents.py
+++ b/src/coreason_manifest/presentation/intents.py
@@ -84,6 +84,13 @@ class EscalationIntent(CoreasonBaseModel):
     )
 
 
+# =========================================================================
+# AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
+# If you create a new class above, you MUST append it to the AnyPresentationIntent union below.
+# Failure to do so will result in a fatal Pydantic discriminator crash at runtime,
+# creating a 'Dangling Class' that the orchestrator cannot deserialize.
+# =========================================================================
+
 type AnyPresentationIntent = Annotated[
     InformationalIntent | DraftingIntent | AdjudicationIntent | EscalationIntent, Field(discriminator="type")
 ]

--- a/src/coreason_manifest/presentation/scivis.py
+++ b/src/coreason_manifest/presentation/scivis.py
@@ -107,6 +107,13 @@ class InsightCard(CoreasonBaseModel):
         return v
 
 
+# =========================================================================
+# AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
+# If you create a new class above, you MUST append it to the AnyPanel union below.
+# Failure to do so will result in a fatal Pydantic discriminator crash at runtime,
+# creating a 'Dangling Class' that the orchestrator cannot deserialize.
+# =========================================================================
+
 type AnyPanel = Annotated[
     GrammarPanel | InsightCard,
     Field(discriminator="type", description="A discriminated union of presentation UI panels."),

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -288,6 +288,13 @@ class CounterfactualRegretEvent(BaseStateEvent):
     )
 
 
+# =========================================================================
+# AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
+# If you create a new class above, you MUST append it to the AnyStateEvent union below.
+# Failure to do so will result in a fatal Pydantic discriminator crash at runtime,
+# creating a 'Dangling Class' that the orchestrator cannot deserialize.
+# =========================================================================
+
 type AnyStateEvent = Annotated[
     ObservationEvent
     | BeliefUpdateEvent

--- a/src/coreason_manifest/state/toolchains.py
+++ b/src/coreason_manifest/state/toolchains.py
@@ -38,6 +38,13 @@ class TerminalBufferState(CoreasonBaseModel):
     env_variables_hash: str = Field(description="The SHA-256 hash of the active environment variables matrix.")
 
 
+# =========================================================================
+# AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
+# If you create a new class above, you MUST append it to the AnyToolchainState union below.
+# Failure to do so will result in a fatal Pydantic discriminator crash at runtime,
+# creating a 'Dangling Class' that the orchestrator cannot deserialize.
+# =========================================================================
+
 AnyToolchainState = Annotated[
     BrowserDOMState | TerminalBufferState,
     Field(discriminator="type", description="A discriminated union of immutable external toolchain states."),

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -197,6 +197,13 @@ class CompositeNode(BaseNode):
     output_mappings: list[OutputMapping] = Field(default_factory=list, description="Explicit state projection outputs.")
 
 
+# =========================================================================
+# AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
+# If you create a new class above, you MUST append it to the AnyNode union below.
+# Failure to do so will result in a fatal Pydantic discriminator crash at runtime,
+# creating a 'Dangling Class' that the orchestrator cannot deserialize.
+# =========================================================================
+
 type AnyNode = Annotated[
     AgentNode | HumanNode | SystemNode | CompositeNode,
     Field(

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -308,6 +308,13 @@ class SMPCTopology(BaseTopology):
     )
 
 
+# =========================================================================
+# AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
+# If you create a new class above, you MUST append it to the AnyTopology union below.
+# Failure to do so will result in a fatal Pydantic discriminator crash at runtime,
+# creating a 'Dangling Class' that the orchestrator cannot deserialize.
+# =========================================================================
+
 type AnyTopology = Annotated[
     DAGTopology | CouncilTopology | SwarmTopology | EvolutionaryTopology | SMPCTopology,
     Field(discriminator="type", description="A discriminated union of workflow topologies."),


### PR DESCRIPTION
Injects an ASCII-bounded warning comment block above the 8 most critical Discriminated Unions in the coreason-manifest repository to mitigate the 'Locality Bias' vulnerability. This ensures future agents are visually prompted to register new Pydantic classes to prevent runtime DiscriminatorErrors.

---
*PR created automatically by Jules for task [1812889963132645431](https://jules.google.com/task/1812889963132645431) started by @gowthamrao*