### PR TITLE
feat: implement MkDocs infrastructure and automated generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Deptry Check
         run: uv run deptry src/
 
+      - name: Docs Audit
+        run: uv run mkdocs build --strict
+
   schema-contracts:
     name: Schema Contracts (Semantic Backward-Compatibility)
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,3 +58,6 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Deploy Docs (Mike Multi-Versioning)
+        run: uv run mike deploy ${{ github.ref_name }} latest --update-aliases --push

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,2 @@
+# CoReason Manifest
+::: coreason_manifest

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,28 @@
+site_name: CoReason Manifest
+
+theme:
+  name: material
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.tabs
+    - toc.integrate
+    - search.suggest
+    - search.highlight
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          paths: [src/]
+          options:
+            docstring_style: null
+  - mike
+  - minify
+  - git-revision-date-localized
+
+markdown_extensions:
+  - pymdownx.superfences
+  - pymdownx.tabbed
+  - pymdownx.snippets


### PR DESCRIPTION
Implements Epic 1: MkDocs Infrastructure & Automated Generation.

Key changes:
- Adds `mkdocs.yml` with the material theme, strict mkdocstrings settings, and multi-versioning via mike.
- Scaffolds `docs/index.md` containing only the `::: coreason_manifest` mkdocstrings directive to automatically extract schemas from the Python AST.
- Integrates `uv run mkdocs build --strict` into the `.github/workflows/ci.yml` lint-and-audit job to ensure CI fails on any unresolved references.
- Appends `uv run mike deploy` into `.github/workflows/release.yml` for immutable multi-versioning upon release tags.

---
*PR created automatically by Jules for task [16997540964714141728](https://jules.google.com/task/16997540964714141728) started by @gowthamrao*