### PR TITLE
Fix CI deployment and enhance MkDocs metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install uv
         uses: astral-sh/setup-uv@v5
@@ -58,6 +60,11 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+      - name: Configure Git Author
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
       - name: Deploy Docs (Mike Multi-Versioning)
         run: uv run mike deploy ${{ github.ref_name }} latest --update-aliases --push

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,7 @@
 site_name: CoReason Manifest
+site_url: https://coreason-ai.github.io/coreason_manifest/
+repo_name: CoReason-AI/coreason_manifest
+repo_url: https://github.com/CoReason-AI/coreason_manifest
 
 theme:
   name: material
@@ -18,6 +21,9 @@ plugins:
           paths: [src/]
           options:
             docstring_style: null
+            show_root_heading: true
+            show_bases: true
+            show_signature_annotations: true
   - mike
   - minify
   - git-revision-date-localized


### PR DESCRIPTION
Applied critical deployment hotfixes and SOTA polish to MkDocs infrastructure.

Fixes:
- `mike` Deployment Mechanics in `.github/workflows/release.yml` by doing a full fetch and configuring Git Author identity
- AST Rendering & Metadata in `mkdocs.yml` by injecting Canonical Metadata and Enhancing `mkdocstrings` options to enforce strict object hierarchy visualization.

---
*PR created automatically by Jules for task [13223511618184410938](https://jules.google.com/task/13223511618184410938) started by @gowthamrao*