### PR TITLE
feat: add strictly bounded domain extensions to base node schema

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -402,6 +402,20 @@
           "title": "Intervention Policies",
           "type": "array"
         },
+        "domain_extensions": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
+          "title": "Domain Extensions"
+        },
         "type": {
           "const": "agent",
           "default": "agent",
@@ -1147,6 +1161,20 @@
           },
           "title": "Intervention Policies",
           "type": "array"
+        },
+        "domain_extensions": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
+          "title": "Domain Extensions"
         }
       },
       "required": [
@@ -1956,6 +1984,20 @@
           },
           "title": "Intervention Policies",
           "type": "array"
+        },
+        "domain_extensions": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
+          "title": "Domain Extensions"
         },
         "type": {
           "const": "composite",
@@ -3976,6 +4018,20 @@
           },
           "title": "Intervention Policies",
           "type": "array"
+        },
+        "domain_extensions": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
+          "title": "Domain Extensions"
         },
         "type": {
           "const": "human",
@@ -7668,6 +7724,20 @@
           },
           "title": "Intervention Policies",
           "type": "array"
+        },
+        "domain_extensions": {
+          "anyOf": [
+            {
+              "additionalProperties": true,
+              "type": "object"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
+          "title": "Domain Extensions"
         },
         "type": {
           "const": "system",

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -10,9 +10,9 @@ These schemas dictate the multi-agent graph geometry and decentralized routing m
 execution code or synchronous blocking loops. Think purely in terms of graph theory, Byzantine fault tolerance, and
 multi-agent market dynamics."""
 
-from typing import TYPE_CHECKING, Annotated, Literal
+from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from coreason_manifest.compute.inference import ActiveInferenceContract, AnalogicalMappingTask, InterventionalCausalTask
 from coreason_manifest.compute.peft import PeftAdapterContract
@@ -43,6 +43,36 @@ class BaseNode(CoreasonBaseModel):
         default_factory=list,
         description="A declarative list of proactive oversight hooks bound to this node's lifecycle.",
     )
+    domain_extensions: dict[str, Any] | None = Field(
+        default=None,
+        description="Passive, untyped extension point for vertical domain context. "
+        "Strictly bounded to prevent JSON-bomb memory leaks.",
+    )
+
+    @field_validator("domain_extensions", mode="before")
+    @classmethod
+    def validate_domain_extensions_depth(cls, v: Any) -> Any:
+        if v is None:
+            return v
+        if not isinstance(v, dict):
+            raise ValueError("domain_extensions must be a dictionary")
+
+        def _check_depth(obj: Any, depth: int) -> None:
+            if depth > 5:
+                raise ValueError("domain_extensions exceeds maximum allowed depth of 5")
+            if isinstance(obj, dict):
+                for key, val in obj.items():
+                    if not isinstance(key, str):
+                        raise ValueError("domain_extensions keys must be strings")
+                    if len(key) > 255:
+                        raise ValueError("domain_extensions key exceeds maximum length of 255 characters")
+                    _check_depth(val, depth + 1)
+            elif isinstance(obj, list):
+                for item in obj:
+                    _check_depth(item, depth + 1)
+
+        _check_depth(v, 0)
+        return v
 
 
 class System1Reflex(CoreasonBaseModel):

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -70,6 +70,10 @@ class BaseNode(CoreasonBaseModel):
             elif isinstance(obj, list):
                 for item in obj:
                     _check_depth(item, depth + 1)
+            else:
+                # EXPLICIT LEAF NODE ENFORCEMENT: Prevent JSON serialization crashes
+                if obj is not None and not isinstance(obj, (str, int, float, bool)):
+                    raise ValueError(f"domain_extensions leaf values must be JSON primitives, got {type(obj).__name__}")
 
         _check_depth(v, 0)
         return v

--- a/tests/domains/test_workflow_nodes.py
+++ b/tests/domains/test_workflow_nodes.py
@@ -1,0 +1,51 @@
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.workflow.nodes import SystemNode
+
+
+def test_domain_extensions_rejects_deep_nesting() -> None:
+    # Create depth 6 payload
+    nested_payload: dict[str, Any] = {}
+    current = nested_payload
+    for _ in range(6):
+        current["child"] = {}
+        current = current["child"]
+
+    with pytest.raises(ValidationError, match="exceeds maximum allowed depth of 5"):
+        SystemNode(description="Test", domain_extensions=nested_payload)
+
+
+def test_domain_extensions_rejects_long_keys() -> None:
+    toxic_key = "a" * 256
+    with pytest.raises(ValidationError, match="exceeds maximum length of 255 characters"):
+        SystemNode(description="Test", domain_extensions={toxic_key: "value"})
+
+
+def test_domain_extensions_rejects_non_json_primitives() -> None:
+    class ToxicObject:
+        pass
+
+    with pytest.raises(ValidationError, match="leaf values must be JSON primitives"):
+        SystemNode(description="Test", domain_extensions={"key": ToxicObject()})
+
+
+def test_domain_extensions_rejects_non_string_keys() -> None:
+    with pytest.raises(ValidationError, match="keys must be strings"):
+        SystemNode(description="Test", domain_extensions={123: "value"})  # type: ignore
+
+
+def test_domain_extensions_rejects_non_dict() -> None:
+    with pytest.raises(ValidationError, match="must be a dictionary"):
+        SystemNode(description="Test", domain_extensions="not a dict")  # type: ignore
+
+
+def test_domain_extensions_list_recursion() -> None:
+    # Adding a list with a non-json primitive to exercise list traversal code path
+    class ToxicObject:
+        pass
+
+    with pytest.raises(ValidationError, match="leaf values must be JSON primitives"):
+        SystemNode(description="Test", domain_extensions={"list": [1, 2, ToxicObject()]})

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -504,11 +504,28 @@ def draw_logit_steganography_contract(draw: Any) -> dict[str, Any]:
 
 @st.composite
 def draw_domain_extensions(draw: Any) -> dict[str, Any]:
+    # Base JSON primitives
+    json_primitives = st.one_of(
+        st.text(max_size=50), st.integers(), st.floats(allow_nan=False, allow_infinity=False), st.booleans(), st.none()
+    )
+
+    # Generate recursive structures bounded to depth 5 (max_leaves controls scale)
+    base_dict = st.dictionaries(st.text(max_size=255), json_primitives, max_size=5)
+
     res: dict[str, Any] = draw(
-        st.dictionaries(
-            st.text(max_size=255),
-            st.one_of(st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False), st.booleans()),
-            max_size=5,
+        st.one_of(
+            base_dict,
+            st.dictionaries(
+                st.text(max_size=255),
+                st.recursive(
+                    base_dict,
+                    lambda children: st.one_of(
+                        st.lists(children, max_size=3), st.dictionaries(st.text(max_size=255), children, max_size=3)
+                    ),
+                    max_leaves=3,
+                ),
+                max_size=5,
+            ),
         )
     )
     return res

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -503,6 +503,18 @@ def draw_logit_steganography_contract(draw: Any) -> dict[str, Any]:
 
 
 @st.composite
+def draw_domain_extensions(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.dictionaries(
+            st.text(max_size=255),
+            st.one_of(st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False), st.booleans()),
+            max_size=5,
+        )
+    )
+    return res
+
+
+@st.composite
 def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"type": "agent", "description": draw(st.text())}
     if draw(st.booleans()):
@@ -525,6 +537,8 @@ def draw_agent_node_payload(draw: Any) -> dict[str, Any]:
         payload["epistemic_policy"] = draw(draw_epistemic_policy())
     if draw(st.booleans()):
         payload["correction_policy"] = draw(draw_correction_policy())
+    if draw(st.booleans()):
+        payload["domain_extensions"] = draw(draw_domain_extensions())
     return payload
 
 
@@ -533,6 +547,8 @@ def draw_human_node_payload(draw: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"type": "human", "description": draw(st.text())}
     if draw(st.booleans()):
         payload["intervention_policies"] = draw(st.lists(draw_intervention_policy(), max_size=100))
+    if draw(st.booleans()):
+        payload["domain_extensions"] = draw(draw_domain_extensions())
     return payload
 
 
@@ -541,6 +557,8 @@ def draw_system_node_payload(draw: Any) -> dict[str, Any]:
     payload: dict[str, Any] = {"type": "system", "description": draw(st.text())}
     if draw(st.booleans()):
         payload["intervention_policies"] = draw(st.lists(draw_intervention_policy(), max_size=100))
+    if draw(st.booleans()):
+        payload["domain_extensions"] = draw(draw_domain_extensions())
     return payload
 
 
@@ -821,6 +839,7 @@ def draw_composite_node_payload(
             "topology": topology_strategy,
             "input_mappings": st.lists(draw_input_mapping(), max_size=5),
             "output_mappings": st.lists(draw_output_mapping(), max_size=5),
+            "domain_extensions": st.one_of(st.none(), draw_domain_extensions()),
         }
     )
 


### PR DESCRIPTION
Inject a strictly bounded, untyped extension point into the base node schema for domain context attachments.

---
*PR created automatically by Jules for task [3645759196788725636](https://jules.google.com/task/3645759196788725636) started by @gowthamrao*