### PR TITLE
feat(workflow): implement Digital Twin topology and Convergence SLA schemas

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -866,6 +866,7 @@
         "mapping": {
           "council": "#/$defs/CouncilTopology",
           "dag": "#/$defs/DAGTopology",
+          "digital_twin": "#/$defs/DigitalTwinTopology",
           "evaluator_optimizer": "#/$defs/EvaluatorOptimizerTopology",
           "evolutionary": "#/$defs/EvolutionaryTopology",
           "smpc": "#/$defs/SMPCTopology",
@@ -891,6 +892,9 @@
         },
         {
           "$ref": "#/$defs/EvaluatorOptimizerTopology"
+        },
+        {
+          "$ref": "#/$defs/DigitalTwinTopology"
         }
       ]
     },
@@ -2673,6 +2677,88 @@
         "quarantined_event_ids"
       ],
       "title": "DefeasibleCascade",
+      "type": "object"
+    },
+    "DigitalTwinTopology": {
+      "additionalProperties": false,
+      "description": "An isolated sandbox graph representing a Digital Twin.",
+      "properties": {
+        "nodes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AnyNode"
+          },
+          "description": "Flat registry of all nodes in this topology.",
+          "propertyNames": {
+            "$ref": "#/$defs/NodeID"
+          },
+          "title": "Nodes",
+          "type": "object"
+        },
+        "shared_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The schema-on-write contract governing the internal state of this topology."
+        },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Data Loss Prevention (DLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
+        "type": {
+          "const": "digital_twin",
+          "default": "digital_twin",
+          "description": "Discriminator for a Digital Twin topology.",
+          "title": "Type",
+          "type": "string"
+        },
+        "target_topology_id": {
+          "description": "The identifier (expected to be a W3C DID) pointing to the real-world topology it is cloning.",
+          "title": "Target Topology Id",
+          "type": "string"
+        },
+        "convergence_sla": {
+          "$ref": "#/$defs/SimulationConvergenceSLA",
+          "description": "The strict mathematical boundaries for the simulation."
+        },
+        "enforce_no_side_effects": {
+          "default": true,
+          "description": "A declarative flag that instructs the runtime to mathematically sever all external write access.",
+          "title": "Enforce No Side Effects",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "nodes",
+        "target_topology_id",
+        "convergence_sla"
+      ],
+      "title": "DigitalTwinTopology",
       "type": "object"
     },
     "DimensionalProjectionContract": {
@@ -7203,6 +7289,31 @@
         "mutates_state"
       ],
       "title": "SideEffectProfile",
+      "type": "object"
+    },
+    "SimulationConvergenceSLA": {
+      "additionalProperties": false,
+      "description": "The statistical limits of the sandbox simulation.",
+      "properties": {
+        "max_monte_carlo_rollouts": {
+          "description": "The absolute physical limit on how many alternate futures the system is allowed to render.",
+          "exclusiveMinimum": 0,
+          "title": "Max Monte Carlo Rollouts",
+          "type": "integer"
+        },
+        "variance_tolerance": {
+          "description": "The statistical confidence required to collapse the probability wave early and save GPU VRAM.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Variance Tolerance",
+          "type": "number"
+        }
+      },
+      "required": [
+        "max_monte_carlo_rollouts",
+        "variance_tolerance"
+      ],
+      "title": "SimulationConvergenceSLA",
       "type": "object"
     },
     "SpanEvent": {

--- a/src/coreason_manifest/workflow/topologies.py
+++ b/src/coreason_manifest/workflow/topologies.py
@@ -308,6 +308,42 @@ class SMPCTopology(BaseTopology):
     )
 
 
+class SimulationConvergenceSLA(CoreasonBaseModel):
+    """
+    The statistical limits of the sandbox simulation.
+    """
+
+    max_monte_carlo_rollouts: int = Field(
+        gt=0,
+        description="The absolute physical limit on how many alternate futures the system is allowed to render.",
+    )
+    variance_tolerance: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The statistical confidence required to collapse the probability wave early and save GPU VRAM.",
+    )
+
+
+class DigitalTwinTopology(BaseTopology):
+    """
+    An isolated sandbox graph representing a Digital Twin.
+    """
+
+    type: Literal["digital_twin"] = Field(
+        default="digital_twin", description="Discriminator for a Digital Twin topology."
+    )
+    target_topology_id: str = Field(
+        description="The identifier (expected to be a W3C DID) pointing to the real-world topology it is cloning."
+    )
+    convergence_sla: SimulationConvergenceSLA = Field(
+        description="The strict mathematical boundaries for the simulation."
+    )
+    enforce_no_side_effects: bool = Field(
+        default=True,
+        description="A declarative flag that instructs the runtime to mathematically sever all external write access.",
+    )
+
+
 class EvaluatorOptimizerTopology(BaseTopology):
     """
     A formalized Actor-Critic micro-topology enforcing strict, finite generation-evaluation-revision cycles.
@@ -342,6 +378,12 @@ class EvaluatorOptimizerTopology(BaseTopology):
 # =========================================================================
 
 type AnyTopology = Annotated[
-    DAGTopology | CouncilTopology | SwarmTopology | EvolutionaryTopology | SMPCTopology | EvaluatorOptimizerTopology,
+    DAGTopology
+    | CouncilTopology
+    | SwarmTopology
+    | EvolutionaryTopology
+    | SMPCTopology
+    | EvaluatorOptimizerTopology
+    | DigitalTwinTopology,
     Field(discriminator="type", description="A discriminated union of workflow topologies."),
 ]

--- a/tests/domains/test_workflow_topology.py
+++ b/tests/domains/test_workflow_topology.py
@@ -5,7 +5,7 @@ import pytest
 from hypothesis import assume, given
 from hypothesis import strategies as st
 from hypothesis.strategies import DataObject
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
 from coreason_manifest.workflow.nodes import (
     AgentNode,
@@ -16,10 +16,13 @@ from coreason_manifest.workflow.nodes import (
     SystemNode,
 )
 from coreason_manifest.workflow.topologies import (
+    AnyTopology,
     CouncilTopology,
     DAGTopology,
+    DigitalTwinTopology,
     EvaluatorOptimizerTopology,
     OntologicalAlignmentPolicy,
+    SimulationConvergenceSLA,
 )
 
 # Strategy for valid NodeIDs (alphanumeric, underscores, hyphens)
@@ -191,3 +194,41 @@ def test_system1_reflex_toxic_floats(confidence_threshold: float) -> None:
     """Prove System1Reflex decisively rejects toxic floats (NaN, Inf, -Inf)."""
     with pytest.raises(ValidationError):
         System1Reflex(confidence_threshold=confidence_threshold, allowed_read_only_tools=["tool_a"])
+
+
+@given(max_monte_carlo_rollouts=st.integers(max_value=0))
+def test_simulation_convergence_sla_rejects_zero_or_negative_rollouts(max_monte_carlo_rollouts: int) -> None:
+    """Prove SimulationConvergenceSLA strictly rejects max_monte_carlo_rollouts equal to or less than 0."""
+    with pytest.raises(ValidationError):
+        SimulationConvergenceSLA(max_monte_carlo_rollouts=max_monte_carlo_rollouts, variance_tolerance=0.5)
+
+
+@given(variance_tolerance=st.floats(max_value=-0.000001) | st.floats(min_value=1.000001))
+def test_simulation_convergence_sla_rejects_out_of_bounds_variance_tolerance(variance_tolerance: float) -> None:
+    """Prove SimulationConvergenceSLA strictly rejects a variance_tolerance outside the [0.0, 1.0] bound."""
+    with pytest.raises(ValidationError):
+        SimulationConvergenceSLA(max_monte_carlo_rollouts=100, variance_tolerance=variance_tolerance)
+
+
+def test_digital_twin_topology_routes_through_discriminator() -> None:
+    """Prove DigitalTwinTopology correctly routes through the AnyTopology discriminator."""
+    payload = {
+        "type": "digital_twin",
+        "target_topology_id": "did:web:target_topology_123",
+        "nodes": {"did:web:node_1": {"type": "system", "description": "Test node"}},
+        "convergence_sla": {
+            "max_monte_carlo_rollouts": 100,
+            "variance_tolerance": 0.5,
+        },
+        "enforce_no_side_effects": True,
+    }
+
+    adapter = TypeAdapter(AnyTopology)
+    topology = adapter.validate_python(payload)
+
+    assert isinstance(topology, DigitalTwinTopology)
+    assert topology.type == "digital_twin"
+    assert topology.target_topology_id == "did:web:target_topology_123"
+    assert topology.convergence_sla.max_monte_carlo_rollouts == 100
+    assert topology.convergence_sla.variance_tolerance == 0.5
+    assert topology.enforce_no_side_effects is True

--- a/tests/domains/test_workflow_topology.py
+++ b/tests/domains/test_workflow_topology.py
@@ -223,7 +223,7 @@ def test_digital_twin_topology_routes_through_discriminator() -> None:
         "enforce_no_side_effects": True,
     }
 
-    adapter = TypeAdapter(AnyTopology)
+    adapter: TypeAdapter[AnyTopology] = TypeAdapter(AnyTopology)
     topology = adapter.validate_python(payload)
 
     assert isinstance(topology, DigitalTwinTopology)


### PR DESCRIPTION
Implements declarative schemas representing the Digital Twin topological sandbox bounds for Epic 2.

- Adds `SimulationConvergenceSLA` enforcing `max_monte_carlo_rollouts > 0` and `variance_tolerance` within [0.0, 1.0].
- Adds `DigitalTwinTopology` with a `"digital_twin"` discriminator and `enforce_no_side_effects` set to True.
- Modifies `AnyTopology` union in `topologies.py` to route the new topology.
- Adds test coverage using `hypothesis` and `pytest` for robust validation of structural parameters.

---
*PR created automatically by Jules for task [16895188290773630773](https://jules.google.com/task/16895188290773630773) started by @gowthamrao*