### PR TITLE
feat: Implement Epistemic Crystallization (Memory Promotion)

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -815,6 +815,7 @@
           "barge_in": "#/$defs/BargeInInterruptEvent",
           "belief_update": "#/$defs/BeliefUpdateEvent",
           "counterfactual_regret": "#/$defs/CounterfactualRegretEvent",
+          "epistemic_promotion": "#/$defs/EpistemicPromotionEvent",
           "hypothesis": "#/$defs/HypothesisGenerationEvent",
           "observation": "#/$defs/ObservationEvent",
           "system_fault": "#/$defs/SystemFaultEvent",
@@ -843,6 +844,9 @@
         },
         {
           "$ref": "#/$defs/ToolInvocationEvent"
+        },
+        {
+          "$ref": "#/$defs/EpistemicPromotionEvent"
         }
       ]
     },
@@ -2504,6 +2508,39 @@
       ],
       "type": "string"
     },
+    "CrystallizationPolicy": {
+      "additionalProperties": false,
+      "properties": {
+        "min_observations_required": {
+          "description": "The minimum number of episodic logs needed to statistically prove a crystallized rule.",
+          "minimum": 10,
+          "title": "Min Observations Required",
+          "type": "integer"
+        },
+        "aleatoric_entropy_threshold": {
+          "description": "The entropy variance must fall below this mathematical threshold to prove absolute certainty before compression is authorized.",
+          "maximum": 0.1,
+          "title": "Aleatoric Entropy Threshold",
+          "type": "number"
+        },
+        "target_memory_tier": {
+          "description": "The destination tier where the compressed rule will be stored.",
+          "enum": [
+            "semantic",
+            "working"
+          ],
+          "title": "Target Memory Tier",
+          "type": "string"
+        }
+      },
+      "required": [
+        "min_observations_required",
+        "aleatoric_entropy_threshold",
+        "target_memory_tier"
+      ],
+      "title": "CrystallizationPolicy",
+      "type": "object"
+    },
     "CustodyRecord": {
       "additionalProperties": false,
       "description": "Cryptographic state of an agent to ensure full traceability and provenance.",
@@ -3161,12 +3198,73 @@
           },
           "title": "Active Cascades",
           "type": "array"
+        },
+        "crystallization_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CrystallizationPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical threshold required to compress episodic observations into semantic rules."
         }
       },
       "required": [
         "history"
       ],
       "title": "EpistemicLedger",
+      "type": "object"
+    },
+    "EpistemicPromotionEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark linking this node to the Merkle-DAG.",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "epistemic_promotion",
+          "default": "epistemic_promotion",
+          "description": "Discriminator type for an epistemic promotion event.",
+          "title": "Type",
+          "type": "string"
+        },
+        "source_episodic_event_ids": {
+          "description": "A list of CIDs (Content Identifiers) representing the raw logs being compressed and archived.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Source Episodic Event Ids",
+          "type": "array"
+        },
+        "crystallized_semantic_node_id": {
+          "description": "The resulting permanent W3C DID / CID of the newly minted knowledge node.",
+          "title": "Crystallized Semantic Node Id",
+          "type": "string"
+        },
+        "compression_ratio": {
+          "description": "A mathematical proof of the token savings achieved (e.g., old_token_count / new_token_count).",
+          "title": "Compression Ratio",
+          "type": "number"
+        }
+      },
+      "required": [
+        "event_id",
+        "timestamp",
+        "source_episodic_event_ids",
+        "crystallized_semantic_node_id",
+        "compression_ratio"
+      ],
+      "title": "EpistemicPromotionEvent",
       "type": "object"
     },
     "EpistemicScanner": {

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -337,6 +337,21 @@ class CounterfactualRegretEvent(BaseStateEvent):
     )
 
 
+class EpistemicPromotionEvent(BaseStateEvent):
+    type: Literal["epistemic_promotion"] = Field(
+        default="epistemic_promotion", description="Discriminator type for an epistemic promotion event."
+    )
+    source_episodic_event_ids: list[str] = Field(
+        description="A list of CIDs (Content Identifiers) representing the raw logs being compressed and archived."
+    )
+    crystallized_semantic_node_id: str = Field(
+        description="The resulting permanent W3C DID / CID of the newly minted knowledge node."
+    )
+    compression_ratio: float = Field(
+        description="A mathematical proof of the token savings achieved (e.g., old_token_count / new_token_count)."
+    )
+
+
 # =========================================================================
 # AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
 # If you create a new class above, you MUST append it to the AnyStateEvent union below.
@@ -351,6 +366,7 @@ type AnyStateEvent = Annotated[
     | HypothesisGenerationEvent
     | BargeInInterruptEvent
     | CounterfactualRegretEvent
-    | ToolInvocationEvent,
+    | ToolInvocationEvent
+    | EpistemicPromotionEvent,
     Field(discriminator="type", description="A discriminated union of state events."),
 ]

--- a/src/coreason_manifest/state/memory.py
+++ b/src/coreason_manifest/state/memory.py
@@ -33,7 +33,8 @@ class CrystallizationPolicy(CoreasonBaseModel):
     )
     aleatoric_entropy_threshold: float = Field(
         le=0.1,
-        description="The entropy variance must fall below this mathematical threshold to prove absolute certainty before compression is authorized.",
+        description="The entropy variance must fall below this mathematical threshold "
+        "to prove absolute certainty before compression is authorized.",
     )
     target_memory_tier: Literal["semantic", "working"] = Field(
         description="The destination tier where the compressed rule will be stored."

--- a/src/coreason_manifest/state/memory.py
+++ b/src/coreason_manifest/state/memory.py
@@ -27,6 +27,19 @@ from coreason_manifest.state.differentials import (
 from coreason_manifest.state.events import AnyStateEvent
 
 
+class CrystallizationPolicy(CoreasonBaseModel):
+    min_observations_required: int = Field(
+        ge=10, description="The minimum number of episodic logs needed to statistically prove a crystallized rule."
+    )
+    aleatoric_entropy_threshold: float = Field(
+        le=0.1,
+        description="The entropy variance must fall below this mathematical threshold to prove absolute certainty before compression is authorized.",
+    )
+    target_memory_tier: Literal["semantic", "working"] = Field(
+        description="The destination tier where the compressed rule will be stored."
+    )
+
+
 class EvictionPolicy(CoreasonBaseModel):
     strategy: Literal["fifo", "salience_decay", "summarize"] = Field(
         description="The mathematical heuristic used to select which semantic memories are retracted or compressed."
@@ -70,6 +83,10 @@ class EpistemicLedger(CoreasonBaseModel):
     active_cascades: list[DefeasibleCascade] = Field(
         default_factory=list,
         description="The active state-differential payload muting specific causal subgraphs due to falsification.",
+    )
+    crystallization_policy: CrystallizationPolicy | None = Field(
+        default=None,
+        description="The mathematical threshold required to compress episodic observations into semantic rules.",
     )
 
     @model_validator(mode="after")

--- a/tests/domains/test_state_events.py
+++ b/tests/domains/test_state_events.py
@@ -70,7 +70,7 @@ def test_epistemic_promotion_event_routing() -> None:
         "compression_ratio": 5.0,
     }
 
-    adapter = TypeAdapter(AnyStateEvent)
+    adapter: TypeAdapter[AnyStateEvent] = TypeAdapter(AnyStateEvent)
     parsed_event = adapter.validate_python(event_data)
 
     assert isinstance(parsed_event, EpistemicPromotionEvent)

--- a/tests/domains/test_state_events.py
+++ b/tests/domains/test_state_events.py
@@ -6,9 +6,14 @@
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
 import pytest
-from pydantic import ValidationError
+from pydantic import TypeAdapter, ValidationError
 
-from coreason_manifest.state.events import NeuralAuditAttestation, SaeFeatureActivation
+from coreason_manifest.state.events import (
+    AnyStateEvent,
+    EpistemicPromotionEvent,
+    NeuralAuditAttestation,
+    SaeFeatureActivation,
+)
 
 
 def test_sae_feature_activation_valid() -> None:
@@ -53,3 +58,23 @@ def test_neural_audit_attestation_invalid_empty_id() -> None:
             audit_id="",
             layer_activations={},
         )
+
+
+def test_epistemic_promotion_event_routing() -> None:
+    event_data = {
+        "type": "epistemic_promotion",
+        "event_id": "promo_123",
+        "timestamp": 1234567890.0,
+        "source_episodic_event_ids": ["obs_1", "obs_2", "obs_3"],
+        "crystallized_semantic_node_id": "sem_node_42",
+        "compression_ratio": 5.0,
+    }
+
+    adapter = TypeAdapter(AnyStateEvent)
+    parsed_event = adapter.validate_python(event_data)
+
+    assert isinstance(parsed_event, EpistemicPromotionEvent)
+    assert parsed_event.event_id == "promo_123"
+    assert parsed_event.source_episodic_event_ids == ["obs_1", "obs_2", "obs_3"]
+    assert parsed_event.crystallized_semantic_node_id == "sem_node_42"
+    assert parsed_event.compression_ratio == 5.0

--- a/tests/domains/test_state_memory.py
+++ b/tests/domains/test_state_memory.py
@@ -43,7 +43,7 @@ def test_crystallization_policy_entropy_threshold() -> None:
     )
 
     # Invalid
-    with pytest.raises(ValidationError, match="Input should be less than or equal to 0.1"):
+    with pytest.raises(ValidationError, match=r"Input should be less than or equal to 0\.1"):
         CrystallizationPolicy(
             min_observations_required=10,
             aleatoric_entropy_threshold=0.11,

--- a/tests/domains/test_state_memory.py
+++ b/tests/domains/test_state_memory.py
@@ -1,5 +1,7 @@
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+from pydantic import ValidationError
 
 from coreason_manifest.state.events import (
     AnyStateEvent,
@@ -8,10 +10,45 @@ from coreason_manifest.state.events import (
     SystemFaultEvent,
 )
 from coreason_manifest.state.memory import (
+    CrystallizationPolicy,
     EpistemicLedger,
     TheoryOfMindSnapshot,
     WorkingMemorySnapshot,
 )
+
+
+def test_crystallization_policy_min_observations() -> None:
+    # Valid
+    CrystallizationPolicy(
+        min_observations_required=10,
+        aleatoric_entropy_threshold=0.1,
+        target_memory_tier="semantic",
+    )
+
+    # Invalid
+    with pytest.raises(ValidationError, match="Input should be greater than or equal to 10"):
+        CrystallizationPolicy(
+            min_observations_required=9,
+            aleatoric_entropy_threshold=0.1,
+            target_memory_tier="semantic",
+        )
+
+
+def test_crystallization_policy_entropy_threshold() -> None:
+    # Valid
+    CrystallizationPolicy(
+        min_observations_required=10,
+        aleatoric_entropy_threshold=0.05,
+        target_memory_tier="semantic",
+    )
+
+    # Invalid
+    with pytest.raises(ValidationError, match="Input should be less than or equal to 0.1"):
+        CrystallizationPolicy(
+            min_observations_required=10,
+            aleatoric_entropy_threshold=0.11,
+            target_memory_tier="semantic",
+        )
 
 
 @st.composite


### PR DESCRIPTION
This PR introduces declarative schemas for Epic 3: Epistemic Crystallization, a SOTA memory promotion framework.

- Added `CrystallizationPolicy` to mathematically enforce minimum episodic log observation and acceptable entropy thresholds for semantic compression.
- Expanded `EpistemicLedger` to accept the new crystallization policy.
- Introduced `EpistemicPromotionEvent` to record the promotion process in the append-only cognitive ledger.
- Surgically updated the `AnyStateEvent` discriminated union to map the new event type, ensuring the global polymorphic router operates smoothly.
- Increased test coverage verifying policy bounds via Pydantic ValidationErrors and validating the strict type routing of the new event type. All unit tests, linters, and type-checks pass according to the Shared Kernel architectural mandates.

---
*PR created automatically by Jules for task [7783710167164819978](https://jules.google.com/task/7783710167164819978) started by @gowthamrao*