### PR TITLE
chore: overhaul epistemic ledger docstrings and schemas

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -847,7 +847,7 @@
       ]
     },
     "AnyToolchainState": {
-      "description": "A discriminated union of immutable external toolchain states.",
+      "description": "A discriminated union of Causal Actuators defining strict perimeters for Exogenous Perturbations to the causal graph.",
       "discriminator": {
         "mapping": {
           "browser": "#/$defs/BrowserDOMState",
@@ -911,7 +911,7 @@
           "type": "string"
         },
         "proponent_id": {
-          "description": "The NodeID of the agent or system that advanced this claim.",
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the agent or system that advanced this claim.",
           "title": "Proponent Id",
           "type": "string"
         },
@@ -940,12 +940,13 @@
     },
     "ArgumentGraph": {
       "additionalProperties": false,
+      "description": "A Truth Maintenance System (TMS) calculating dialectical justification for non-monotonic belief retraction.",
       "properties": {
         "claims": {
           "additionalProperties": {
             "$ref": "#/$defs/ArgumentClaim"
           },
-          "description": "A registry of all active claims, keyed by claim_id.",
+          "description": "Components of an Abstract Argumentation Framework.",
           "maxProperties": 10000,
           "title": "Claims",
           "type": "object"
@@ -954,7 +955,7 @@
           "additionalProperties": {
             "$ref": "#/$defs/DefeasibleAttack"
           },
-          "description": "A registry of all directed attack edges, keyed by attack_id.",
+          "description": "Geometric matrices of undercutting defeaters.",
           "maxProperties": 10000,
           "title": "Attacks",
           "type": "object"
@@ -1672,17 +1673,17 @@
         "type": {
           "const": "browser",
           "default": "browser",
-          "description": "Discriminator for browser state snapshots.",
+          "description": "Discriminator for Causal Actuators representing structural shifts.",
           "title": "Type",
           "type": "string"
         },
         "current_url": {
-          "description": "The exact URI the headless browser was positioned at.",
+          "description": "Spatial Execution Bounds where the agent interacts.",
           "title": "Current Url",
           "type": "string"
         },
         "viewport_size": {
-          "description": "The [width, height] dimensions of the rendered viewport.",
+          "description": "Capability Perimeters detailing bounding coordinates.",
           "maxItems": 2,
           "minItems": 2,
           "prefixItems": [
@@ -1697,12 +1698,12 @@
           "type": "array"
         },
         "dom_hash": {
-          "description": "The SHA-256 hash of the complete, rendered HTML Document Object Model.",
+          "description": "The SHA-256 hash acting as the structural manifestation vector.",
           "title": "Dom Hash",
           "type": "string"
         },
         "accessibility_tree_hash": {
-          "description": "The SHA-256 hash of the parsed Chrome/Firefox Accessibility Tree.",
+          "description": "The SHA-256 hash of the accessibility tree defining Exogenous Perturbations to the state space.",
           "title": "Accessibility Tree Hash",
           "type": "string"
         },
@@ -1716,7 +1717,7 @@
             }
           ],
           "default": null,
-          "description": "The Content Identifier (CID) or URI pointing to the visual snapshot in cold storage.",
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the snapshot representation.",
           "title": "Screenshot Cid"
         }
       },
@@ -1937,9 +1938,10 @@
     },
     "CognitiveStateProfile": {
       "additionalProperties": false,
+      "description": "Causal Directed Acyclic Graphs (cDAGs) and constraints for state progression.",
       "properties": {
         "urgency_index": {
-          "description": "Drives latency requirements; high urgency forces fast, heuristic System 1 routing.",
+          "description": "Drives structural constraints; high urgency forces fast heuristic routing.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Urgency Index",
@@ -1953,7 +1955,7 @@
           "type": "number"
         },
         "divergence_tolerance": {
-          "description": "The 'curiosity' metric; dictates how far the MoE router is allowed to stray from high-probability distributions.",
+          "description": "The 'curiosity' metric; dictates how far the router is allowed to stray from high-probability distributions.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Divergence Tolerance",
@@ -1969,7 +1971,7 @@
             }
           ],
           "default": null,
-          "description": "The precise mathematical contract for altering the LLM's residual stream to enforce this mood."
+          "description": "The precise mathematical contract for altering the residual stream to enforce this constraint."
         },
         "moe_routing_directive": {
           "anyOf": [
@@ -1981,7 +1983,7 @@
             }
           ],
           "default": null,
-          "description": "The physical hardware mandate overriding default MoE token routing to enforce this cognitive state."
+          "description": "The structural mandate overriding default token routing to enforce this cognitive state."
         }
       },
       "required": [
@@ -1994,30 +1996,31 @@
     },
     "CognitiveUncertaintyProfile": {
       "additionalProperties": false,
+      "description": "Structural Causal Models (SCMs) for active epistemic bounding.",
       "properties": {
         "aleatoric_entropy": {
-          "description": "Irreducible ambiguity detected in the input task or environment.",
+          "description": "Irreducible ambiguity detected in the observational fields (P(y|x)).",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Aleatoric Entropy",
           "type": "number"
         },
         "epistemic_uncertainty": {
-          "description": "The model's internal lack of knowledge, calculated via semantic disagreement.",
+          "description": "The causal gap demanding Do-Calculus Interventions (P(y|do(x))).",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Epistemic Uncertainty",
           "type": "number"
         },
         "semantic_consistency_score": {
-          "description": "The degree to which multiple sampled latent thoughts align on the same conclusion.",
+          "description": "Counterfactual Geometries representing alternative timeline vectors.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Semantic Consistency Score",
           "type": "number"
         },
         "requires_abductive_escalation": {
-          "description": "True if epistemic_uncertainty breaches the safety threshold, requiring System 2 test-time compute.",
+          "description": "True if epistemic_uncertainty breaches the safety threshold, requiring structural mandate escalation.",
           "title": "Requires Abductive Escalation",
           "type": "boolean"
         }
@@ -2672,18 +2675,18 @@
           "type": "string"
         },
         "source_claim_id": {
-          "description": "The Content Identifier (CID) of the claim mounting the attack.",
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the claim mounting the attack.",
           "title": "Source Claim Id",
           "type": "string"
         },
         "target_claim_id": {
-          "description": "The Content Identifier (CID) of the claim being attacked.",
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the claim being attacked.",
           "title": "Target Claim Id",
           "type": "string"
         },
         "attack_vector": {
           "$ref": "#/$defs/AttackVector",
-          "description": "The specific defeasible logic vector (e.g., attacking the premise, the link, or the conclusion)."
+          "description": "Geometric matrices of undercutting defeaters."
         }
       },
       "required": [
@@ -3056,7 +3059,7 @@
       "additionalProperties": false,
       "properties": {
         "sensory_modality": {
-          "description": "The continuous data stream being monitored.",
+          "description": "Multimodal Sensor Fusion and Spatial-Temporal Bindings representing Proprioceptive State and Exteroceptive Vectors.",
           "enum": [
             "video",
             "audio",
@@ -3066,13 +3069,13 @@
           "type": "string"
         },
         "bayesian_surprise_score": {
-          "description": "The calculated KL divergence between the agent's prior belief and the incoming sensory evidence.",
+          "description": "The calculated KL divergence between the prior belief and the incoming structural evidence.",
           "minimum": 0.0,
           "title": "Bayesian Surprise Score",
           "type": "number"
         },
         "temporal_duration_ms": {
-          "description": "The exact length of the continuous stream segment encapsulated by this observation.",
+          "description": "The exact length of the timeline encapsulated by this observation.",
           "exclusiveMinimum": 0,
           "maximum": 86400000,
           "title": "Temporal Duration Ms",
@@ -3080,7 +3083,7 @@
         },
         "salience_threshold_breached": {
           "default": true,
-          "description": "Mathematical proof that the anomaly was severe enough to warrant a memory snapshot.",
+          "description": "Continuous-to-Discrete Crystallization threshold being crossed.",
           "title": "Salience Threshold Breached",
           "type": "boolean"
         }
@@ -3433,7 +3436,7 @@
             }
           ],
           "default": null,
-          "description": "A link to a specific observation in the EpistemicLedger.",
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for a specific observation in the EpistemicLedger.",
           "title": "Source Event Id"
         },
         "source_semantic_node_id": {
@@ -3446,7 +3449,7 @@
             }
           ],
           "default": null,
-          "description": "A link to a specific concept in the Semantic Knowledge Graph.",
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for a specific concept in the Semantic Knowledge Graph.",
           "title": "Source Semantic Node Id"
         },
         "justification": {
@@ -8267,27 +8270,27 @@
         "type": {
           "const": "terminal",
           "default": "terminal",
-          "description": "Discriminator for terminal state snapshots.",
+          "description": "Discriminator for Causal Actuators on structural buffers.",
           "title": "Type",
           "type": "string"
         },
         "working_directory": {
-          "description": "The absolute path of the active shell context.",
+          "description": "Capability Perimeters defining context bounds.",
           "title": "Working Directory",
           "type": "string"
         },
         "stdout_hash": {
-          "description": "The SHA-256 hash of the standard output buffer at the moment of observation.",
+          "description": "The SHA-256 hash of the Exogenous Perturbations captured.",
           "title": "Stdout Hash",
           "type": "string"
         },
         "stderr_hash": {
-          "description": "The SHA-256 hash of the standard error buffer.",
+          "description": "The SHA-256 hash tracking structural deviation anomalies.",
           "title": "Stderr Hash",
           "type": "string"
         },
         "env_variables_hash": {
-          "description": "The SHA-256 hash of the active environment variables matrix.",
+          "description": "The SHA-256 hash of the state-space context matrix.",
           "title": "Env Variables Hash",
           "type": "string"
         }

--- a/src/coreason_manifest/state/argumentation.py
+++ b/src/coreason_manifest/state/argumentation.py
@@ -7,8 +7,8 @@
 
 """AGENT INSTRUCTION: This file maps the immutable argumentation schemas. This is a STRICTLY EPISTEMIC BOUNDARY.
 These schemas represent the append-only cognitive ledger of the swarm. YOU ARE EXPLICITLY FORBIDDEN from introducing
-mutable state loops, standard CRUD database paradigms, or downstream business logic. Focus purely on cryptographic
-event sourcing, hardware attestations, and non-monotonic belief updates."""
+monotonic logic, standard CRUD database paradigms, or kinetic execution parameters. These models represent computable
+geometric graphs of cognition and causal inference."""
 
 from typing import Literal
 
@@ -21,10 +21,14 @@ type AttackVector = Literal["rebuttal", "undercutter", "underminer"]
 
 class EvidentiaryWarrant(CoreasonBaseModel):
     source_event_id: str | None = Field(
-        default=None, description="A link to a specific observation in the EpistemicLedger."
+        default=None,
+        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark for a specific "
+        "observation in the EpistemicLedger.",
     )
     source_semantic_node_id: str | None = Field(
-        default=None, description="A link to a specific concept in the Semantic Knowledge Graph."
+        default=None,
+        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark for a specific "
+        "concept in the Semantic Knowledge Graph.",
     )
     justification: str = Field(description="The logical premise explaining why this evidence supports the claim.")
 
@@ -36,7 +40,10 @@ class ArgumentClaim(CoreasonBaseModel):
             "specific logical proposition."
         )
     )
-    proponent_id: str = Field(description="The NodeID of the agent or system that advanced this claim.")
+    proponent_id: str = Field(
+        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the agent or "
+        "system that advanced this claim."
+    )
     text_chunk: str = Field(max_length=50000, description="The natural language representation of the proposition.")
     warrants: list[EvidentiaryWarrant] = Field(
         default_factory=list, description="The foundational premises supporting this claim."
@@ -49,19 +56,27 @@ class DefeasibleAttack(CoreasonBaseModel):
             "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for this directed attack edge."
         )
     )
-    source_claim_id: str = Field(description="The Content Identifier (CID) of the claim mounting the attack.")
-    target_claim_id: str = Field(description="The Content Identifier (CID) of the claim being attacked.")
+    source_claim_id: str = Field(
+        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the claim "
+        "mounting the attack."
+    )
+    target_claim_id: str = Field(
+        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the claim "
+        "being attacked."
+    )
     attack_vector: AttackVector = Field(
-        description="The specific defeasible logic vector (e.g., attacking the premise, the link, or the conclusion)."
+        description="Geometric matrices of undercutting defeaters."
     )
 
 
 class ArgumentGraph(CoreasonBaseModel):
+    """A Truth Maintenance System (TMS) calculating dialectical justification for non-monotonic belief retraction."""
+
     claims: dict[str, ArgumentClaim] = Field(
-        max_length=10000, description="A registry of all active claims, keyed by claim_id."
+        max_length=10000, description="Components of an Abstract Argumentation Framework."
     )
     attacks: dict[str, DefeasibleAttack] = Field(
         default_factory=dict,
         max_length=10000,
-        description="A registry of all directed attack edges, keyed by attack_id.",
+        description="Geometric matrices of undercutting defeaters.",
     )

--- a/src/coreason_manifest/state/argumentation.py
+++ b/src/coreason_manifest/state/argumentation.py
@@ -64,9 +64,7 @@ class DefeasibleAttack(CoreasonBaseModel):
         description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the claim "
         "being attacked."
     )
-    attack_vector: AttackVector = Field(
-        description="Geometric matrices of undercutting defeaters."
-    )
+    attack_vector: AttackVector = Field(description="Geometric matrices of undercutting defeaters.")
 
 
 class ArgumentGraph(CoreasonBaseModel):

--- a/src/coreason_manifest/state/cognition.py
+++ b/src/coreason_manifest/state/cognition.py
@@ -7,8 +7,8 @@
 
 """AGENT INSTRUCTION: This file maps the immutable cognitive schemas. This is a STRICTLY EPISTEMIC BOUNDARY.
 These schemas represent the append-only cognitive ledger of the swarm. YOU ARE EXPLICITLY FORBIDDEN from introducing
-mutable state loops, standard CRUD database paradigms, or downstream business logic. Focus purely on cryptographic
-event sourcing, hardware attestations, and non-monotonic belief updates."""
+monotonic logic, standard CRUD database paradigms, or kinetic execution parameters. These models represent computable
+geometric graphs of cognition and causal inference."""
 
 from pydantic import Field
 
@@ -17,23 +17,26 @@ from coreason_manifest.core.base import CoreasonBaseModel
 
 
 class CognitiveUncertaintyProfile(CoreasonBaseModel):
+    """Structural Causal Models (SCMs) for active epistemic bounding."""
     aleatoric_entropy: float = Field(
-        ge=0.0, le=1.0, description="Irreducible ambiguity detected in the input task or environment."
+        ge=0.0, le=1.0, description="Irreducible ambiguity detected in the observational fields (P(y|x))."
     )
     epistemic_uncertainty: float = Field(
-        ge=0.0, le=1.0, description="The model's internal lack of knowledge, calculated via semantic disagreement."
+        ge=0.0, le=1.0, description="The causal gap demanding Do-Calculus Interventions (P(y|do(x)))."
     )
     semantic_consistency_score: float = Field(
-        ge=0.0, le=1.0, description="The degree to which multiple sampled latent thoughts align on the same conclusion."
+        ge=0.0, le=1.0, description="Counterfactual Geometries representing alternative timeline vectors."
     )
     requires_abductive_escalation: bool = Field(
-        description="True if epistemic_uncertainty breaches the safety threshold, requiring System 2 test-time compute."
+        description="True if epistemic_uncertainty breaches the safety threshold, requiring structural mandate "
+        "escalation."
     )
 
 
 class CognitiveStateProfile(CoreasonBaseModel):
+    """Causal Directed Acyclic Graphs (cDAGs) and constraints for state progression."""
     urgency_index: float = Field(
-        ge=0.0, le=1.0, description="Drives latency requirements; high urgency forces fast, heuristic System 1 routing."
+        ge=0.0, le=1.0, description="Drives structural constraints; high urgency forces fast heuristic routing."
     )
     caution_index: float = Field(
         ge=0.0, le=1.0, description="Drives precision; high caution injects analytical/falsification steering vectors."
@@ -41,15 +44,15 @@ class CognitiveStateProfile(CoreasonBaseModel):
     divergence_tolerance: float = Field(
         ge=0.0,
         le=1.0,
-        description="The 'curiosity' metric; dictates how far the MoE router is allowed to stray "
+        description="The 'curiosity' metric; dictates how far the router is allowed to stray "
         "from high-probability distributions.",
     )
     activation_steering: ActivationSteeringContract | None = Field(
         default=None,
-        description="The precise mathematical contract for altering the LLM's residual stream to enforce this mood.",
+        description="The precise mathematical contract for altering the residual stream to enforce this constraint.",
     )
     moe_routing_directive: CognitiveRoutingDirective | None = Field(
         default=None,
-        description="The physical hardware mandate overriding default MoE token routing to "
+        description="The structural mandate overriding default token routing to "
         "enforce this cognitive state.",
     )

--- a/src/coreason_manifest/state/cognition.py
+++ b/src/coreason_manifest/state/cognition.py
@@ -18,6 +18,7 @@ from coreason_manifest.core.base import CoreasonBaseModel
 
 class CognitiveUncertaintyProfile(CoreasonBaseModel):
     """Structural Causal Models (SCMs) for active epistemic bounding."""
+
     aleatoric_entropy: float = Field(
         ge=0.0, le=1.0, description="Irreducible ambiguity detected in the observational fields (P(y|x))."
     )
@@ -35,6 +36,7 @@ class CognitiveUncertaintyProfile(CoreasonBaseModel):
 
 class CognitiveStateProfile(CoreasonBaseModel):
     """Causal Directed Acyclic Graphs (cDAGs) and constraints for state progression."""
+
     urgency_index: float = Field(
         ge=0.0, le=1.0, description="Drives structural constraints; high urgency forces fast heuristic routing."
     )
@@ -53,6 +55,5 @@ class CognitiveStateProfile(CoreasonBaseModel):
     )
     moe_routing_directive: CognitiveRoutingDirective | None = Field(
         default=None,
-        description="The structural mandate overriding default token routing to "
-        "enforce this cognitive state.",
+        description="The structural mandate overriding default token routing to enforce this cognitive state.",
     )

--- a/src/coreason_manifest/state/embodied.py
+++ b/src/coreason_manifest/state/embodied.py
@@ -7,8 +7,8 @@
 
 """AGENT INSTRUCTION: This file maps the immutable embodied state schemas. This is a STRICTLY EPISTEMIC BOUNDARY.
 These schemas represent the append-only cognitive ledger of the swarm. YOU ARE EXPLICITLY FORBIDDEN from introducing
-mutable state loops, standard CRUD database paradigms, or downstream business logic. Focus purely on cryptographic
-event sourcing, hardware attestations, and non-monotonic belief updates."""
+monotonic logic, standard CRUD database paradigms, or kinetic execution parameters. These models represent computable
+geometric graphs of cognition and causal inference."""
 
 from typing import Literal
 
@@ -19,17 +19,18 @@ from coreason_manifest.core.base import CoreasonBaseModel
 
 class EmbodiedSensoryVector(CoreasonBaseModel):
     sensory_modality: Literal["video", "audio", "spatial_telemetry"] = Field(
-        description="The continuous data stream being monitored."
+        description="Multimodal Sensor Fusion and Spatial-Temporal Bindings representing Proprioceptive State and "
+        "Exteroceptive Vectors."
     )
     bayesian_surprise_score: float = Field(
         ge=0.0,
-        description="The calculated KL divergence between the agent's prior belief and the incoming sensory evidence.",
+        description="The calculated KL divergence between the prior belief and the incoming structural evidence.",
     )
     temporal_duration_ms: int = Field(
         gt=0,
         le=86400000,
-        description="The exact length of the continuous stream segment encapsulated by this observation.",
+        description="The exact length of the timeline encapsulated by this observation.",
     )
     salience_threshold_breached: bool = Field(
-        default=True, description="Mathematical proof that the anomaly was severe enough to warrant a memory snapshot."
+        default=True, description="Continuous-to-Discrete Crystallization threshold being crossed."
     )

--- a/src/coreason_manifest/state/toolchains.py
+++ b/src/coreason_manifest/state/toolchains.py
@@ -7,8 +7,8 @@
 
 """AGENT INSTRUCTION: This file maps the immutable toolchain schemas. This is a STRICTLY EPISTEMIC BOUNDARY.
 These schemas represent the append-only cognitive ledger of the swarm. YOU ARE EXPLICITLY FORBIDDEN from introducing
-mutable state loops, standard CRUD database paradigms, or downstream business logic. Focus purely on cryptographic
-event sourcing, hardware attestations, and non-monotonic belief updates."""
+monotonic logic, standard CRUD database paradigms, or kinetic execution parameters. These models represent computable
+geometric graphs of cognition and causal inference."""
 
 from typing import Annotated, Literal
 
@@ -18,24 +18,30 @@ from coreason_manifest.core.base import CoreasonBaseModel
 
 
 class BrowserDOMState(CoreasonBaseModel):
-    type: Literal["browser"] = Field(default="browser", description="Discriminator for browser state snapshots.")
-    current_url: str = Field(description="The exact URI the headless browser was positioned at.")
-    viewport_size: tuple[int, int] = Field(description="The [width, height] dimensions of the rendered viewport.")
-    dom_hash: str = Field(description="The SHA-256 hash of the complete, rendered HTML Document Object Model.")
+    type: Literal["browser"] = Field(
+        default="browser", description="Discriminator for Causal Actuators representing structural shifts."
+    )
+    current_url: str = Field(description="Spatial Execution Bounds where the agent interacts.")
+    viewport_size: tuple[int, int] = Field(description="Capability Perimeters detailing bounding coordinates.")
+    dom_hash: str = Field(description="The SHA-256 hash acting as the structural manifestation vector.")
     accessibility_tree_hash: str = Field(
-        description="The SHA-256 hash of the parsed Chrome/Firefox Accessibility Tree."
+        description="The SHA-256 hash of the accessibility tree defining Exogenous Perturbations to the state space."
     )
     screenshot_cid: str | None = Field(
-        default=None, description="The Content Identifier (CID) or URI pointing to the visual snapshot in cold storage."
+        default=None,
+        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the snapshot "
+        "representation.",
     )
 
 
 class TerminalBufferState(CoreasonBaseModel):
-    type: Literal["terminal"] = Field(default="terminal", description="Discriminator for terminal state snapshots.")
-    working_directory: str = Field(description="The absolute path of the active shell context.")
-    stdout_hash: str = Field(description="The SHA-256 hash of the standard output buffer at the moment of observation.")
-    stderr_hash: str = Field(description="The SHA-256 hash of the standard error buffer.")
-    env_variables_hash: str = Field(description="The SHA-256 hash of the active environment variables matrix.")
+    type: Literal["terminal"] = Field(
+        default="terminal", description="Discriminator for Causal Actuators on structural buffers."
+    )
+    working_directory: str = Field(description="Capability Perimeters defining context bounds.")
+    stdout_hash: str = Field(description="The SHA-256 hash of the Exogenous Perturbations captured.")
+    stderr_hash: str = Field(description="The SHA-256 hash tracking structural deviation anomalies.")
+    env_variables_hash: str = Field(description="The SHA-256 hash of the state-space context matrix.")
 
 
 # =========================================================================
@@ -47,5 +53,9 @@ class TerminalBufferState(CoreasonBaseModel):
 
 type AnyToolchainState = Annotated[
     BrowserDOMState | TerminalBufferState,
-    Field(discriminator="type", description="A discriminated union of immutable external toolchain states."),
+    Field(
+        discriminator="type",
+        description="A discriminated union of Causal Actuators defining "
+        "strict perimeters for Exogenous Perturbations to the causal graph.",
+    ),
 ]


### PR DESCRIPTION
This PR updates the final four files of the Epistemic Ledger to reflect the required mathematical and causal framing:
- **`argumentation.py`**: Eradicated standard debate terms; introduced "Abstract Argumentation Framework", "geometric matrices of undercutting defeaters".
- **`cognition.py`**: Removed standard knowledge-graph terms; framed around SCMs, cDAGs, and Do-Calculus Interventions.
- **`embodied.py`**: Eradicated legacy software sensor terms in favor of "Multimodal Sensor Fusion", "Proprioceptive State", and "Continuous-to-Discrete Crystallization".
- **`toolchains.py`**: Reframed tools as "Causal Actuators" with "Spatial Execution Bounds" and "Capability Perimeters", eliminating kinetic execution terminology.

Additionally, the PR adheres to all hard constraint rules:
1. Replaced all legacy "ID" language with "Content Identifier (CID)..."
2. Strict use of formatting rules (like trailing space in concatenated multiline strings).
3. Maintained 100% Pydantic `Field` metadata coverage.
4. Fully passed strict linting, type-checking, and tests constraints locally as required by `AGENTS.md`.

---
*PR created automatically by Jules for task [10921328439477049440](https://jules.google.com/task/10921328439477049440) started by @gowthamrao*