### PR TITLE
feat(vision): Universal Visual Modality Extraction Contracts

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -304,6 +304,44 @@
       "title": "AdversarialSimulationProfile",
       "type": "object"
     },
+    "AffineTransformMatrix": {
+      "additionalProperties": false,
+      "properties": {
+        "pixel_min": {
+          "description": "The absolute minimal visual coordinate on this axis.",
+          "title": "Pixel Min",
+          "type": "number"
+        },
+        "pixel_max": {
+          "description": "The absolute maximal visual coordinate on this axis.",
+          "title": "Pixel Max",
+          "type": "number"
+        },
+        "domain_min": {
+          "description": "The semantic/data value corresponding to pixel_min.",
+          "title": "Domain Min",
+          "type": "number"
+        },
+        "domain_max": {
+          "description": "The semantic/data value corresponding to pixel_max.",
+          "title": "Domain Max",
+          "type": "number"
+        },
+        "scale_type": {
+          "$ref": "#/$defs/ChartAxisScale",
+          "description": "The mathematical progression between min and max."
+        }
+      },
+      "required": [
+        "pixel_min",
+        "pixel_max",
+        "domain_min",
+        "domain_max",
+        "scale_type"
+      ],
+      "title": "AffineTransformMatrix",
+      "type": "object"
+    },
     "AgentAttestation": {
       "additionalProperties": false,
       "description": "Cryptographic identity passport and AI-BOM for the agent.",
@@ -1878,6 +1916,15 @@
       "title": "ChaosExperiment",
       "type": "object"
     },
+    "ChartAxisScale": {
+      "enum": [
+        "linear",
+        "log",
+        "categorical",
+        "datetime"
+      ],
+      "type": "string"
+    },
     "CircuitBreakerTrip": {
       "additionalProperties": false,
       "description": "Indicates that a circuit breaker has been tripped for a target node.",
@@ -3055,6 +3102,78 @@
         "model_variance_required"
       ],
       "title": "DiversityConstraint",
+      "type": "object"
+    },
+    "DocumentLayoutAnalysis": {
+      "additionalProperties": false,
+      "properties": {
+        "blocks": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DocumentLayoutBlock"
+          },
+          "description": "Dictionary mapping block_ids to their strict spatial definitions.",
+          "title": "Blocks",
+          "type": "object"
+        },
+        "reading_order_edges": {
+          "description": "Directed edges defining the topological sort (chronological flow) of the document.",
+          "items": {
+            "maxItems": 2,
+            "minItems": 2,
+            "prefixItems": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string"
+              }
+            ],
+            "type": "array"
+          },
+          "title": "Reading Order Edges",
+          "type": "array"
+        }
+      },
+      "required": [
+        "blocks"
+      ],
+      "title": "DocumentLayoutAnalysis",
+      "type": "object"
+    },
+    "DocumentLayoutBlock": {
+      "additionalProperties": false,
+      "properties": {
+        "block_id": {
+          "description": "Unique structural identifier for this geometric region.",
+          "minLength": 1,
+          "title": "Block Id",
+          "type": "string"
+        },
+        "block_type": {
+          "description": "The taxonomic classification of the layout region.",
+          "enum": [
+            "header",
+            "paragraph",
+            "figure",
+            "table",
+            "footnote",
+            "caption",
+            "equation"
+          ],
+          "title": "Block Type",
+          "type": "string"
+        },
+        "anchor": {
+          "$ref": "#/$defs/MultimodalTokenAnchor",
+          "description": "The strict visual and token coordinate bindings for this block."
+        }
+      },
+      "required": [
+        "block_id",
+        "block_type",
+        "anchor"
+      ],
+      "title": "DocumentLayoutBlock",
       "type": "object"
     },
     "DraftingIntent": {
@@ -5754,6 +5873,47 @@
       "title": "MarketResolution",
       "type": "object"
     },
+    "MathematicalNotationExtraction": {
+      "additionalProperties": false,
+      "properties": {
+        "math_type": {
+          "description": "The structural context of the equation.",
+          "enum": [
+            "inline",
+            "display"
+          ],
+          "title": "Math Type",
+          "type": "string"
+        },
+        "syntax": {
+          "description": "The strict symbolic compilation language.",
+          "enum": [
+            "latex",
+            "mathml"
+          ],
+          "title": "Syntax",
+          "type": "string"
+        },
+        "expression": {
+          "description": "The raw, unescaped mathematical syntax string.",
+          "minLength": 1,
+          "title": "Expression",
+          "type": "string"
+        },
+        "anchor": {
+          "$ref": "#/$defs/MultimodalTokenAnchor",
+          "description": "The strict visual and token coordinate bindings. Cannot be None."
+        }
+      },
+      "required": [
+        "math_type",
+        "syntax",
+        "expression",
+        "anchor"
+      ],
+      "title": "MathematicalNotationExtraction",
+      "type": "object"
+    },
     "MechanisticAuditContract": {
       "additionalProperties": false,
       "properties": {
@@ -8171,6 +8331,43 @@
       "title": "StatePatch",
       "type": "object"
     },
+    "StatisticalChartExtraction": {
+      "additionalProperties": false,
+      "properties": {
+        "axes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AffineTransformMatrix"
+          },
+          "description": "Named axes (e.g., 'x', 'y') defining the affine transformation boundaries.",
+          "title": "Axes",
+          "type": "object"
+        },
+        "data_series": {
+          "description": "The discrete semantic tuples extracted from the chart markers.",
+          "items": {
+            "additionalProperties": {
+              "anyOf": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string"
+                }
+              ]
+            },
+            "type": "object"
+          },
+          "title": "Data Series",
+          "type": "array"
+        }
+      },
+      "required": [
+        "axes",
+        "data_series"
+      ],
+      "title": "StatisticalChartExtraction",
+      "type": "object"
+    },
     "StdioTransportConfig": {
       "additionalProperties": false,
       "description": "Configuration for local Stdio-based MCP transport.",
@@ -8495,6 +8692,72 @@
         "description"
       ],
       "title": "SystemNode",
+      "type": "object"
+    },
+    "TableCell": {
+      "additionalProperties": false,
+      "properties": {
+        "row_index": {
+          "description": "The zero-indexed absolute matrix row.",
+          "minimum": 0,
+          "title": "Row Index",
+          "type": "integer"
+        },
+        "col_index": {
+          "description": "The zero-indexed absolute matrix column.",
+          "minimum": 0,
+          "title": "Col Index",
+          "type": "integer"
+        },
+        "row_span": {
+          "default": 1,
+          "description": "The vertical height of the cell.",
+          "minimum": 1,
+          "title": "Row Span",
+          "type": "integer"
+        },
+        "col_span": {
+          "default": 1,
+          "description": "The horizontal width of the cell.",
+          "minimum": 1,
+          "title": "Col Span",
+          "type": "integer"
+        },
+        "content": {
+          "description": "The normalized text value.",
+          "title": "Content",
+          "type": "string"
+        },
+        "anchor": {
+          "$ref": "#/$defs/MultimodalTokenAnchor",
+          "description": "The physical location of the cell within the image or document."
+        }
+      },
+      "required": [
+        "row_index",
+        "col_index",
+        "content",
+        "anchor"
+      ],
+      "title": "TableCell",
+      "type": "object"
+    },
+    "TabularDataExtraction": {
+      "additionalProperties": false,
+      "properties": {
+        "cells": {
+          "description": "The sparse tensor representing all populated cells.",
+          "items": {
+            "$ref": "#/$defs/TableCell"
+          },
+          "title": "Cells",
+          "type": "array"
+        }
+      },
+      "required": [
+        "cells"
+      ],
+      "title": "TabularDataExtraction",
       "type": "object"
     },
     "TaskAnnouncement": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -192,6 +192,15 @@ from coreason_manifest.state.semantic import (
     VectorEmbedding,
 )
 from coreason_manifest.state.toolchains import AnyToolchainState, BrowserDOMState, TerminalBufferState
+from coreason_manifest.state.vision import (
+    AffineTransformMatrix,
+    DocumentLayoutAnalysis,
+    DocumentLayoutBlock,
+    MathematicalNotationExtraction,
+    StatisticalChartExtraction,
+    TableCell,
+    TabularDataExtraction,
+)
 from coreason_manifest.telemetry.custody import CustodyRecord, ExecutionNode, TamperError
 from coreason_manifest.telemetry.schemas import (
     ExecutionSpan,
@@ -262,6 +271,7 @@ __all__ = [
     "AdjudicationRubric",
     "AdjudicationVerdict",
     "AdversarialSimulationProfile",
+    "AffineTransformMatrix",
     "AgentAttestation",
     "AgentBid",
     "AgentNode",
@@ -327,6 +337,8 @@ __all__ = [
     "DistributionProfile",
     "DistributionType",
     "DiversityConstraint",
+    "DocumentLayoutAnalysis",
+    "DocumentLayoutBlock",
     "DraftingIntent",
     "DynamicConvergenceSLA",
     "DynamicLayoutTemplate",
@@ -396,6 +408,7 @@ __all__ = [
     "MacroGrid",
     "MarkType",
     "MarketResolution",
+    "MathematicalNotationExtraction",
     "MechanisticAuditContract",
     "MemoryProvenance",
     "MemoryTier",
@@ -458,6 +471,7 @@ __all__ = [
     "StateContract",
     "StateDiff",
     "StatePatch",
+    "StatisticalChartExtraction",
     "StdioTransportConfig",
     "SteadyStateHypothesis",
     "StructuralCausalModel",
@@ -467,6 +481,8 @@ __all__ = [
     "SystemFaultEvent",
     "SystemNode",
     "SystemRole",
+    "TableCell",
+    "TabularDataExtraction",
     "TamperError",
     "TaskAnnouncement",
     "TaskAward",

--- a/src/coreason_manifest/state/__init__.py
+++ b/src/coreason_manifest/state/__init__.py
@@ -73,8 +73,18 @@ from .toolchains import (
     BrowserDOMState,
     TerminalBufferState,
 )
+from .vision import (
+    AffineTransformMatrix,
+    DocumentLayoutAnalysis,
+    DocumentLayoutBlock,
+    MathematicalNotationExtraction,
+    StatisticalChartExtraction,
+    TableCell,
+    TabularDataExtraction,
+)
 
 __all__ = [
+    "AffineTransformMatrix",
     "ArgumentClaim",
     "ArgumentGraph",
     "BaseStateEvent",
@@ -87,6 +97,8 @@ __all__ = [
     "DefeasibleAttack",
     "DefeasibleCascade",
     "DimensionalProjectionContract",
+    "DocumentLayoutAnalysis",
+    "DocumentLayoutBlock",
     "EmbodiedSensoryVector",
     "EpistemicLedger",
     "EvictionPolicy",
@@ -99,6 +111,7 @@ __all__ = [
     "InterventionalCausalTask",
     "LatentScratchpadTrace",
     "LineageWatermark",
+    "MathematicalNotationExtraction",
     "MemoryProvenance",
     "MigrationContract",
     "MultimodalArtifact",
@@ -113,8 +126,11 @@ __all__ = [
     "SemanticNode",
     "StateDiff",
     "StatePatch",
+    "StatisticalChartExtraction",
     "StructuralCausalModel",
     "SystemFaultEvent",
+    "TableCell",
+    "TabularDataExtraction",
     "TemporalBounds",
     "TemporalCheckpoint",
     "TerminalBufferState",

--- a/src/coreason_manifest/state/vision.py
+++ b/src/coreason_manifest/state/vision.py
@@ -1,0 +1,164 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+"""AGENT INSTRUCTION: This file maps the universal visual-semantic extraction schemas.
+This is a STRICTLY EPISTEMIC BOUNDARY. These schemas translate raw visual arrays into
+verified, geometric topologies. YOU ARE EXPLICITLY FORBIDDEN from introducing execution
+scripts or OCR parsing loops here. All validation must be pure mathematical geometry."""
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.state.semantic import MultimodalTokenAnchor
+
+# ==========================================
+# 1. Document Layout Analysis
+# ==========================================
+
+
+class DocumentLayoutBlock(CoreasonBaseModel):
+    block_id: str = Field(min_length=1, description="Unique structural identifier for this geometric region.")
+    block_type: Literal["header", "paragraph", "figure", "table", "footnote", "caption", "equation"] = Field(
+        description="The taxonomic classification of the layout region."
+    )
+    anchor: MultimodalTokenAnchor = Field(description="The strict visual and token coordinate bindings for this block.")
+
+
+class DocumentLayoutAnalysis(CoreasonBaseModel):
+    blocks: dict[str, DocumentLayoutBlock] = Field(
+        description="Dictionary mapping block_ids to their strict spatial definitions."
+    )
+    reading_order_edges: list[tuple[str, str]] = Field(
+        default_factory=list,
+        description="Directed edges defining the topological sort (chronological flow) of the document.",
+    )
+
+    @model_validator(mode="after")
+    def verify_dag_and_integrity(self) -> Self:
+        adj: dict[str, list[str]] = {node_id: [] for node_id in self.blocks}
+        for source, target in self.reading_order_edges:
+            if source not in self.blocks:
+                raise ValueError(f"Source block '{source}' does not exist.")
+            if target not in self.blocks:
+                raise ValueError(f"Target block '{target}' does not exist.")
+            adj[source].append(target)
+
+        # Detect cycles (DFS)
+        visited: set[str] = set()
+        recursion_stack: set[str] = set()
+
+        for start_node in self.blocks:
+            if start_node in visited:
+                continue
+
+            stack = [(start_node, iter(adj[start_node]))]
+            visited.add(start_node)
+            recursion_stack.add(start_node)
+
+            while stack:
+                curr, neighbors = stack[-1]
+                try:
+                    neighbor = next(neighbors)
+                    if neighbor not in visited:
+                        visited.add(neighbor)
+                        recursion_stack.add(neighbor)
+                        stack.append((neighbor, iter(adj[neighbor])))
+                    elif neighbor in recursion_stack:
+                        raise ValueError("Reading order contains a cyclical contradiction.")
+                except StopIteration:
+                    recursion_stack.remove(curr)
+                    stack.pop()
+        return self
+
+
+# ==========================================
+# 2. Mathematical Notation Normalization
+# ==========================================
+
+
+class MathematicalNotationExtraction(CoreasonBaseModel):
+    math_type: Literal["inline", "display"] = Field(description="The structural context of the equation.")
+    syntax: Literal["latex", "mathml"] = Field(description="The strict symbolic compilation language.")
+    expression: str = Field(min_length=1, description="The raw, unescaped mathematical syntax string.")
+    anchor: MultimodalTokenAnchor = Field(
+        description="The strict visual and token coordinate bindings. Cannot be None."
+    )
+
+    @model_validator(mode="after")
+    def verify_grounding(self) -> Self:
+        if self.anchor.token_span_start is None and self.anchor.bounding_box is None:
+            raise ValueError("Mathematical extractions must have a definitive visual or token bounding box.")
+        return self
+
+
+# ==========================================
+# 3. Visual-to-Numerical Statistical Data
+# ==========================================
+
+type ChartAxisScale = Literal["linear", "log", "categorical", "datetime"]
+
+
+class AffineTransformMatrix(CoreasonBaseModel):
+    pixel_min: float = Field(description="The absolute minimal visual coordinate on this axis.")
+    pixel_max: float = Field(description="The absolute maximal visual coordinate on this axis.")
+    domain_min: float = Field(description="The semantic/data value corresponding to pixel_min.")
+    domain_max: float = Field(description="The semantic/data value corresponding to pixel_max.")
+    scale_type: ChartAxisScale = Field(description="The mathematical progression between min and max.")
+
+
+class StatisticalChartExtraction(CoreasonBaseModel):
+    axes: dict[str, AffineTransformMatrix] = Field(
+        description="Named axes (e.g., 'x', 'y') defining the affine transformation boundaries."
+    )
+    data_series: list[dict[str, float | str]] = Field(
+        description="The discrete semantic tuples extracted from the chart markers."
+    )
+
+    @model_validator(mode="after")
+    def verify_dimensional_isometry(self) -> Self:
+        axis_keys = set(self.axes.keys())
+        for point in self.data_series:
+            point_keys = set(point.keys())
+            if not point_keys.issubset(axis_keys) and not axis_keys.issubset(point_keys):
+                # We allow extra keys for series names/labels, but it MUST contain all axis keys
+                missing = axis_keys - point_keys
+                if missing:
+                    raise ValueError(f"Data point missing required axis dimensions: {missing}")
+        return self
+
+
+# ==========================================
+# 4. Tabular Data Serialization
+# ==========================================
+
+
+class TableCell(CoreasonBaseModel):
+    row_index: int = Field(ge=0, description="The zero-indexed absolute matrix row.")
+    col_index: int = Field(ge=0, description="The zero-indexed absolute matrix column.")
+    row_span: int = Field(default=1, ge=1, description="The vertical height of the cell.")
+    col_span: int = Field(default=1, ge=1, description="The horizontal width of the cell.")
+    content: str = Field(description="The normalized text value.")
+    anchor: MultimodalTokenAnchor = Field(description="The physical location of the cell within the image or document.")
+
+
+class TabularDataExtraction(CoreasonBaseModel):
+    cells: list[TableCell] = Field(description="The sparse tensor representing all populated cells.")
+
+    @model_validator(mode="after")
+    def detect_geometric_collisions(self) -> Self:
+        occupied_coordinates: set[tuple[int, int]] = set()
+
+        for cell in self.cells:
+            for r in range(cell.row_index, cell.row_index + cell.row_span):
+                for c in range(cell.col_index, cell.col_index + cell.col_span):
+                    coord = (r, c)
+                    if coord in occupied_coordinates:
+                        raise ValueError(f"Geometric Collision Detected: Cell overlapping at coordinate {coord}.")
+                    occupied_coordinates.add(coord)
+        return self

--- a/tests/domains/test_state_vision.py
+++ b/tests/domains/test_state_vision.py
@@ -1,0 +1,37 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.state.semantic import MultimodalTokenAnchor
+from coreason_manifest.state.vision import (
+    DocumentLayoutAnalysis,
+    DocumentLayoutBlock,
+    MathematicalNotationExtraction,
+    TableCell,
+    TabularDataExtraction,
+)
+
+
+def test_layout_cycle_prevention() -> None:
+    anchor = MultimodalTokenAnchor(token_span_start=0, token_span_end=10)
+    block1 = DocumentLayoutBlock(block_id="b1", block_type="paragraph", anchor=anchor)
+    block2 = DocumentLayoutBlock(block_id="b2", block_type="paragraph", anchor=anchor)
+
+    with pytest.raises(ValidationError, match="cyclical contradiction"):
+        DocumentLayoutAnalysis(blocks={"b1": block1, "b2": block2}, reading_order_edges=[("b1", "b2"), ("b2", "b1")])
+
+
+def test_tabular_collision_prevention() -> None:
+    anchor = MultimodalTokenAnchor(token_span_start=0, token_span_end=10)
+    # Cell 1 spans (0,0), (0,1), (1,0), (1,1)
+    cell1 = TableCell(row_index=0, col_index=0, row_span=2, col_span=2, content="A", anchor=anchor)
+    # Cell 2 tries to occupy (1,1)
+    cell2 = TableCell(row_index=1, col_index=1, row_span=1, col_span=1, content="B", anchor=anchor)
+
+    with pytest.raises(ValidationError, match="Geometric Collision Detected"):
+        TabularDataExtraction(cells=[cell1, cell2])
+
+
+def test_mathematical_ungrounded_prevention() -> None:
+    empty_anchor = MultimodalTokenAnchor()  # Neither bounding_box nor token_span
+    with pytest.raises(ValidationError, match="definitive visual or token bounding box"):
+        MathematicalNotationExtraction(math_type="inline", syntax="latex", expression="E=mc^2", anchor=empty_anchor)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -51,6 +51,10 @@ from coreason_manifest.state.semantic import (
     SemanticEdge,
     SemanticNode,
 )
+from coreason_manifest.state.vision import (
+    DocumentLayoutAnalysis,
+    TabularDataExtraction,
+)
 from coreason_manifest.telemetry.custody import CustodyRecord
 from coreason_manifest.telemetry.schemas import TraceExportBatch
 from coreason_manifest.testing.chaos import ChaosExperiment
@@ -2973,3 +2977,91 @@ def test_mcp_server_config_http_routing(payload: dict[str, Any]) -> None:
     assert isinstance(parsed, MCPServerConfig)
     assert isinstance(parsed.transport, HTTPTransportConfig)
     assert parsed.transport.type == "http"
+
+
+@st.composite
+def draw_document_layout_block(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "block_id": st.text(min_size=1),
+                "block_type": st.sampled_from(
+                    ["header", "paragraph", "figure", "table", "footnote", "caption", "equation"]
+                ),
+                "anchor": draw_multimodal_token_anchor(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_document_layout_analysis(draw: Any) -> dict[str, Any]:
+    blocks = draw(st.lists(draw_document_layout_block(), min_size=1, max_size=5, unique_by=lambda b: b["block_id"]))
+    blocks_dict = {block["block_id"]: block for block in blocks}
+    block_ids = list(blocks_dict.keys())
+
+    # Generate acyclic edges by only allowing edges from lower index to higher index
+    edges = []
+    if len(block_ids) > 1:
+        num_edges = draw(st.integers(min_value=0, max_value=len(block_ids) - 1))
+        for _ in range(num_edges):
+            i = draw(st.integers(min_value=0, max_value=len(block_ids) - 2))
+            j = draw(st.integers(min_value=i + 1, max_value=len(block_ids) - 1))
+            edges.append((block_ids[i], block_ids[j]))
+
+    res: dict[str, Any] = {
+        "blocks": blocks_dict,
+        "reading_order_edges": edges,
+    }
+    return res
+
+
+document_layout_analysis_adapter: TypeAdapter[DocumentLayoutAnalysis] = TypeAdapter(DocumentLayoutAnalysis)
+
+
+@given(draw_document_layout_analysis())
+def test_document_layout_analysis_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = document_layout_analysis_adapter.validate_python(payload)
+    assert isinstance(parsed, DocumentLayoutAnalysis)
+
+
+@st.composite
+def draw_table_cell(draw: Any, r: int, c: int) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "row_index": st.just(r),
+                "col_index": st.just(c),
+                "row_span": st.just(1),
+                "col_span": st.just(1),
+                "content": st.text(),
+                "anchor": draw_multimodal_token_anchor(),
+            }
+        )
+    )
+    return res
+
+
+@st.composite
+def draw_tabular_data_extraction(draw: Any) -> dict[str, Any]:
+    max_r = draw(st.integers(min_value=1, max_value=3))
+    max_c = draw(st.integers(min_value=1, max_value=3))
+
+    cells: list[Any] = []
+    for r in range(max_r):
+        cells.extend(draw_table_cell(r=r, c=c) for c in range(max_c) if draw(st.booleans()))
+
+    res: dict[str, Any] = {
+        "cells": [draw(cell) for cell in cells],
+    }
+    return res
+
+
+tabular_data_extraction_adapter: TypeAdapter[TabularDataExtraction] = TypeAdapter(TabularDataExtraction)
+
+
+@given(draw_tabular_data_extraction())
+def test_tabular_data_extraction_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = tabular_data_extraction_adapter.validate_python(payload)
+    assert isinstance(parsed, TabularDataExtraction)


### PR DESCRIPTION
Implements the requested Universal Visual Modality Extraction Contracts to handle structural visual-semantic features like layouts, equations, charts, and tables using strict Pydantic schemas. Includes unit tests, hypothesis fuzzing strategies, and fully verified local execution.

---
*PR created automatically by Jules for task [8987358965993599520](https://jules.google.com/task/8987358965993599520) started by @gowthamrao*