### PR TITLE
feat(workflow): implement dynamic epistemic routing schemas

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1738,6 +1738,46 @@
       "title": "BrowserDOMState",
       "type": "object"
     },
+    "BypassReceipt": {
+      "additionalProperties": false,
+      "description": "The Merkle Null-Op preserving the topological chain of custody when an extraction node is intentionally\nskipped.",
+      "properties": {
+        "artifact_event_id": {
+          "description": "The exact genesis CID of the document, ensuring continuity.",
+          "minLength": 1,
+          "title": "Artifact Event Id",
+          "type": "string"
+        },
+        "bypassed_node_id": {
+          "$ref": "#/$defs/NodeID",
+          "description": "The exact extraction step in the DAG that was mathematically starved of compute."
+        },
+        "justification": {
+          "description": "The deterministic reason the orchestrator severed this execution branch.",
+          "enum": [
+            "modality_mismatch",
+            "budget_exhaustion",
+            "sla_timeout"
+          ],
+          "title": "Justification",
+          "type": "string"
+        },
+        "cryptographic_null_hash": {
+          "description": "The SHA-256 null-hash representing the skipped state to satisfy the Epistemic Ledger.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Cryptographic Null Hash",
+          "type": "string"
+        }
+      },
+      "required": [
+        "artifact_event_id",
+        "bypassed_node_id",
+        "justification",
+        "cryptographic_null_hash"
+      ],
+      "title": "BypassReceipt",
+      "type": "object"
+    },
     "CausalAttribution": {
       "additionalProperties": false,
       "properties": {
@@ -3144,6 +3184,60 @@
       "title": "DynamicLayoutTemplate",
       "type": "object"
     },
+    "DynamicRoutingManifest": {
+      "additionalProperties": false,
+      "description": "The Softmax Router Gate dictating the active execution topology and spot compute allocation.",
+      "properties": {
+        "manifest_id": {
+          "description": "The unique Content Identifier (CID) for this routing plan.",
+          "minLength": 1,
+          "title": "Manifest Id",
+          "type": "string"
+        },
+        "artifact_profile": {
+          "$ref": "#/$defs/GlobalSemanticProfile",
+          "description": "The semantic profile governing this route."
+        },
+        "active_subgraphs": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/$defs/NodeID"
+            },
+            "type": "array"
+          },
+          "description": "Mapping of specific modalities (e.g., 'tabular_grid') to the explicit lists of worker NodeIDs authorized to execute.",
+          "title": "Active Subgraphs",
+          "type": "object"
+        },
+        "bypassed_steps": {
+          "description": "The declarative list of steps the orchestrator is mandated to skip.",
+          "items": {
+            "$ref": "#/$defs/BypassReceipt"
+          },
+          "title": "Bypassed Steps",
+          "type": "array"
+        },
+        "branch_budgets_microcents": {
+          "additionalProperties": {
+            "type": "integer"
+          },
+          "description": "The strict economic allocation of compute budget bound to specific nodes.",
+          "propertyNames": {
+            "$ref": "#/$defs/NodeID"
+          },
+          "title": "Branch Budgets Microcents",
+          "type": "object"
+        }
+      },
+      "required": [
+        "manifest_id",
+        "artifact_profile",
+        "active_subgraphs",
+        "branch_budgets_microcents"
+      ],
+      "title": "DynamicRoutingManifest",
+      "type": "object"
+    },
     "EmbodiedSensoryVector": {
       "additionalProperties": false,
       "properties": {
@@ -4354,6 +4448,45 @@
         "global_timeout_seconds"
       ],
       "title": "GlobalGovernance",
+      "type": "object"
+    },
+    "GlobalSemanticProfile": {
+      "additionalProperties": false,
+      "description": "The immutable receipt of Step 1 ingestion acting as a static structural index of the artifact.",
+      "properties": {
+        "artifact_event_id": {
+          "description": "The exact genesis CID of the document entering the routing tier.",
+          "minLength": 1,
+          "title": "Artifact Event Id",
+          "type": "string"
+        },
+        "detected_modalities": {
+          "description": "The strictly typed enum list of physical modalities detected in the artifact.",
+          "items": {
+            "enum": [
+              "text",
+              "raster_image",
+              "vector_graphics",
+              "tabular_grid"
+            ],
+            "type": "string"
+          },
+          "title": "Detected Modalities",
+          "type": "array"
+        },
+        "token_density": {
+          "description": "The mathematical token density used for downstream compute budget allocation.",
+          "minimum": 0,
+          "title": "Token Density",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "artifact_event_id",
+        "detected_modalities",
+        "token_density"
+      ],
+      "title": "GlobalSemanticProfile",
       "type": "object"
     },
     "GovernancePolicy": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -237,6 +237,11 @@ from coreason_manifest.workflow.nodes import (
     System1Reflex,
     SystemNode,
 )
+from coreason_manifest.workflow.routing import (
+    BypassReceipt,
+    DynamicRoutingManifest,
+    GlobalSemanticProfile,
+)
 from coreason_manifest.workflow.topologies import (
     AnyTopology,
     BackpressurePolicy,
@@ -296,6 +301,7 @@ __all__ = [
     "BoundedJSONRPCRequest",
     "BoundingBox",
     "BrowserDOMState",
+    "BypassReceipt",
     "CausalAttribution",
     "CausalDirectedEdge",
     "CausalInterval",
@@ -330,6 +336,7 @@ __all__ = [
     "DraftingIntent",
     "DynamicConvergenceSLA",
     "DynamicLayoutTemplate",
+    "DynamicRoutingManifest",
     "EmbodiedSensoryVector",
     "EncodingChannel",
     "EpistemicCompressionSLA",
@@ -360,6 +367,7 @@ __all__ = [
     "FormalVerificationContract",
     "GitSHA",
     "GlobalGovernance",
+    "GlobalSemanticProfile",
     "GovernancePolicy",
     "GradingCriteria",
     "GrammarPanel",

--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -43,6 +43,11 @@ from .nodes import (
     System1Reflex,
     SystemNode,
 )
+from .routing import (
+    BypassReceipt,
+    DynamicRoutingManifest,
+    GlobalSemanticProfile,
+)
 from .topologies import (
     AnyTopology,
     BackpressurePolicy,
@@ -71,16 +76,19 @@ __all__ = [
     "BaseNode",
     "BaseTopology",
     "BilateralSLA",
+    "BypassReceipt",
     "CompositeNode",
     "CouncilTopology",
     "CrossSwarmHandshake",
     "DAGTopology",
     "DimensionalProjectionContract",
     "DiversityConstraint",
+    "DynamicRoutingManifest",
     "EpistemicScanner",
     "EscrowPolicy",
     "EvolutionaryTopology",
     "FederatedDiscoveryProtocol",
+    "GlobalSemanticProfile",
     "HumanNode",
     "HypothesisStake",
     "InputMapping",

--- a/src/coreason_manifest/workflow/routing.py
+++ b/src/coreason_manifest/workflow/routing.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+"""AGENT INSTRUCTION: This file maps the dynamic routing and bypass schemas. This is a STRICTLY TOPOLOGICAL BOUNDARY.
+These schemas act as a declarative Softmax Router Gate for the orchestrator. YOU ARE EXPLICITLY FORBIDDEN from
+introducing kinetic network dispatch code or mutable state loops here. Focus purely on structural DAG definitions
+and Merkle-DAG continuity receipts."""
+
+from typing import Literal, Self
+
+from pydantic import Field, model_validator
+
+from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.core.primitives import NodeID
+
+
+class GlobalSemanticProfile(CoreasonBaseModel):
+    """The immutable receipt of Step 1 ingestion acting as a static structural index of the artifact."""
+
+    artifact_event_id: str = Field(
+        min_length=1, description="The exact genesis CID of the document entering the routing tier."
+    )
+    detected_modalities: list[Literal["text", "raster_image", "vector_graphics", "tabular_grid"]] = Field(
+        description="The strictly typed enum list of physical modalities detected in the artifact."
+    )
+    token_density: int = Field(
+        ge=0, description="The mathematical token density used for downstream compute budget allocation."
+    )
+
+
+class BypassReceipt(CoreasonBaseModel):
+    """The Merkle Null-Op preserving the topological chain of custody when an extraction node is intentionally
+    skipped."""
+
+    artifact_event_id: str = Field(
+        min_length=1, description="The exact genesis CID of the document, ensuring continuity."
+    )
+    bypassed_node_id: NodeID = Field(
+        description="The exact extraction step in the DAG that was mathematically starved of compute."
+    )
+    justification: Literal["modality_mismatch", "budget_exhaustion", "sla_timeout"] = Field(
+        description="The deterministic reason the orchestrator severed this execution branch."
+    )
+    cryptographic_null_hash: str = Field(
+        pattern=r"^[a-f0-9]{64}$",
+        description="The SHA-256 null-hash representing the skipped state to satisfy the Epistemic Ledger.",
+    )
+
+
+class DynamicRoutingManifest(CoreasonBaseModel):
+    """The Softmax Router Gate dictating the active execution topology and spot compute allocation."""
+
+    manifest_id: str = Field(min_length=1, description="The unique Content Identifier (CID) for this routing plan.")
+    artifact_profile: GlobalSemanticProfile = Field(description="The semantic profile governing this route.")
+    active_subgraphs: dict[str, list[NodeID]] = Field(
+        description="Mapping of specific modalities (e.g., 'tabular_grid') to the explicit lists of worker NodeIDs "
+        "authorized to execute."
+    )
+    bypassed_steps: list[BypassReceipt] = Field(
+        default_factory=list, description="The declarative list of steps the orchestrator is mandated to skip."
+    )
+    branch_budgets_microcents: dict[NodeID, int] = Field(
+        description="The strict economic allocation of compute budget bound to specific nodes."
+    )
+
+    @model_validator(mode="after")
+    def validate_modality_alignment(self) -> Self:
+        """Mathematically proves that the router is not hallucinating graphs for non-existent modalities."""
+        for modality in self.active_subgraphs:
+            if modality not in self.artifact_profile.detected_modalities:
+                raise ValueError(
+                    f"Epistemic Violation: Cannot route to subgraph '{modality}' because it is missing from "
+                    "detected_modalities."
+                )
+        return self
+
+    @model_validator(mode="after")
+    def validate_conservation_of_custody(self) -> Self:
+        """Ensures bypass receipts do not contaminate cross-document boundaries."""
+        for bypass in self.bypassed_steps:
+            if bypass.artifact_event_id != self.artifact_profile.artifact_event_id:
+                raise ValueError(
+                    "Merkle Violation: BypassReceipt artifact_event_id does not match the root artifact_profile."
+                )
+        return self

--- a/tests/domains/test_workflow_routing.py
+++ b/tests/domains/test_workflow_routing.py
@@ -1,0 +1,44 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.workflow.routing import BypassReceipt, DynamicRoutingManifest, GlobalSemanticProfile
+
+
+def test_modality_alignment_raises_error() -> None:
+    profile = GlobalSemanticProfile(artifact_event_id="some-id", detected_modalities=["text"], token_density=100)
+
+    with pytest.raises(
+        ValidationError,
+        match=r"Cannot route to subgraph 'tabular_grid' because it is missing from detected_modalities.",
+    ):
+        DynamicRoutingManifest(
+            manifest_id="manifest-1",
+            artifact_profile=profile,
+            active_subgraphs={"tabular_grid": ["did:web:worker1"]},
+            bypassed_steps=[],
+            branch_budgets_microcents={},
+        )
+
+
+def test_conservation_of_custody_raises_error() -> None:
+    profile = GlobalSemanticProfile(
+        artifact_event_id="root-artifact-1", detected_modalities=["text"], token_density=100
+    )
+
+    bypass = BypassReceipt(
+        artifact_event_id="other-artifact-2",
+        bypassed_node_id="did:web:worker2",
+        justification="modality_mismatch",
+        cryptographic_null_hash="0" * 64,
+    )
+
+    with pytest.raises(
+        ValidationError, match=r"BypassReceipt artifact_event_id does not match the root artifact_profile."
+    ):
+        DynamicRoutingManifest(
+            manifest_id="manifest-1",
+            artifact_profile=profile,
+            active_subgraphs={"text": ["did:web:worker1"]},
+            bypassed_steps=[bypass],
+            branch_budgets_microcents={},
+        )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -59,6 +59,7 @@ from coreason_manifest.tooling import ActionSpace, ToolDefinition
 from coreason_manifest.workflow.auctions import AuctionState, TaskAward
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, CompositeNode, HumanNode, SystemNode
+from coreason_manifest.workflow.routing import DynamicRoutingManifest
 from coreason_manifest.workflow.topologies import AnyTopology, OntologicalHandshake, StateContract
 
 
@@ -2949,6 +2950,60 @@ def draw_neuro_symbolic_handoff(draw: Any) -> dict[str, Any]:
 
 
 mcp_server_config_adapter: TypeAdapter[MCPServerConfig] = TypeAdapter(MCPServerConfig)
+
+
+@st.composite
+def draw_global_semantic_profile(draw: Any) -> dict[str, Any]:
+    return {
+        "artifact_event_id": draw(st.text(min_size=1)),
+        "detected_modalities": draw(
+            st.lists(st.sampled_from(["text", "raster_image", "vector_graphics", "tabular_grid"]), unique=True)
+        ),
+        "token_density": draw(st.integers(min_value=0)),
+    }
+
+
+@st.composite
+def draw_bypass_receipt(draw: Any) -> dict[str, Any]:
+    return {
+        "artifact_event_id": draw(st.text(min_size=1)),
+        "bypassed_node_id": draw(draw_did_string()),
+        "justification": draw(st.sampled_from(["modality_mismatch", "budget_exhaustion", "sla_timeout"])),
+        "cryptographic_null_hash": draw(st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True)),
+    }
+
+
+@st.composite
+def draw_dynamic_routing_manifest(draw: Any) -> dict[str, Any]:
+    profile = draw(draw_global_semantic_profile())
+
+    # Bound the active subgraphs strictly to the detected modalities to pass validation
+    active_subgraphs = {}
+    for mod in profile["detected_modalities"]:
+        if draw(st.booleans()):
+            active_subgraphs[mod] = draw(st.lists(draw_did_string(), min_size=1, max_size=3))
+
+    # Bind the bypass receipt IDs to the profile ID to pass validation
+    bypassed_steps = draw(st.lists(draw_bypass_receipt(), max_size=3))
+    for bypass in bypassed_steps:
+        bypass["artifact_event_id"] = profile["artifact_event_id"]
+
+    return {
+        "manifest_id": draw(st.text(min_size=1)),
+        "artifact_profile": profile,
+        "active_subgraphs": active_subgraphs,
+        "bypassed_steps": bypassed_steps,
+        "branch_budgets_microcents": draw(st.dictionaries(draw_did_string(), st.integers(min_value=0), max_size=5)),
+    }
+
+
+routing_adapter: TypeAdapter[DynamicRoutingManifest] = TypeAdapter(DynamicRoutingManifest)
+
+
+@given(draw_dynamic_routing_manifest())
+def test_dynamic_routing_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = routing_adapter.validate_python(payload)
+    assert isinstance(parsed, DynamicRoutingManifest)
 
 
 @st.composite


### PR DESCRIPTION
Implements Dynamic Epistemic Routing schemas, fulfilling the constraints of the Coreason Shared Kernel Injection system directive. This includes pure Pydantic V2 definitions of `GlobalSemanticProfile`, `BypassReceipt`, and `DynamicRoutingManifest`, and strict immutability.

The schemas have been exported appropriately, deterministic fuzzing has been implemented using `hypothesis` strategies, and the required model validation checks and boundary tests have been written and run successfully. Code formatting and typing checks were executed locally.

---
*PR created automatically by Jules for task [3087314409329590323](https://jules.google.com/task/3087314409329590323) started by @gowthamrao*