### PR TITLE
feat: implement EphemeralNamespacePartition schema

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -24,6 +24,14 @@
           },
           "title": "Mcp Servers",
           "type": "array"
+        },
+        "ephemeral_partitions": {
+          "description": "Hermetically sealed memory boundaries for dynamically resolved scripts and PEFT adapters.",
+          "items": {
+            "$ref": "#/$defs/EphemeralNamespacePartition"
+          },
+          "title": "Ephemeral Partitions",
+          "type": "array"
         }
       },
       "required": [
@@ -3433,6 +3441,70 @@
         "temporal_duration_ms"
       ],
       "title": "EmbodiedSensoryVector",
+      "type": "object"
+    },
+    "EphemeralNamespacePartition": {
+      "additionalProperties": false,
+      "description": "A hermetically sealed, ephemeral execution partition for dynamic dependency resolution.",
+      "properties": {
+        "partition_id": {
+          "description": "Unique identifier for this ephemeral partition.",
+          "minLength": 1,
+          "title": "Partition Id",
+          "type": "string"
+        },
+        "execution_runtime": {
+          "description": "The strict virtual machine target mandated for dynamic execution.",
+          "enum": [
+            "wasm32-wasi",
+            "riscv32-zkvm",
+            "bpf"
+          ],
+          "title": "Execution Runtime",
+          "type": "string"
+        },
+        "authorized_bytecode_hashes": {
+          "description": "The explicit whitelist of SHA-256 hashes allowed to execute within this partition.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Authorized Bytecode Hashes",
+          "type": "array"
+        },
+        "max_ttl_seconds": {
+          "description": "The absolute temporal guillotine before the orchestrator drops the context.",
+          "exclusiveMinimum": 0,
+          "title": "Max Ttl Seconds",
+          "type": "integer"
+        },
+        "max_vram_mb": {
+          "description": "The strict physical VRAM ceiling allocated to this partition.",
+          "exclusiveMinimum": 0,
+          "title": "Max Vram Mb",
+          "type": "integer"
+        },
+        "allow_network_egress": {
+          "default": false,
+          "description": "Capability-based flag to allow or mathematically deny network sockets.",
+          "title": "Allow Network Egress",
+          "type": "boolean"
+        },
+        "allow_subprocess_spawning": {
+          "default": false,
+          "description": "Capability-based flag to allow or deny OS-level process spawning.",
+          "title": "Allow Subprocess Spawning",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "partition_id",
+        "execution_runtime",
+        "authorized_bytecode_hashes",
+        "max_ttl_seconds",
+        "max_vram_mb"
+      ],
+      "title": "EphemeralNamespacePartition",
       "type": "object"
     },
     "EpistemicCompressionSLA": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -225,6 +225,7 @@ from coreason_manifest.testing.chaos import ChaosExperiment, FaultInjectionProfi
 from coreason_manifest.testing.red_team import AdversarialSimulationProfile
 from coreason_manifest.tooling.environments import (
     ActionSpace,
+    EphemeralNamespacePartition,
     MCPClientBinding,
     MCPTransport,
     OntologicalSurfaceProjection,
@@ -367,6 +368,7 @@ __all__ = [
     "DynamicRoutingManifest",
     "EmbodiedSensoryVector",
     "EncodingChannel",
+    "EphemeralNamespacePartition",
     "EpistemicCompressionSLA",
     "EpistemicLedger",
     "EpistemicPromotionEvent",

--- a/src/coreason_manifest/tooling/__init__.py
+++ b/src/coreason_manifest/tooling/__init__.py
@@ -7,6 +7,7 @@
 
 from .environments import (
     ActionSpace,
+    EphemeralNamespacePartition,
     MCPClientBinding,
 )
 from .schemas import (
@@ -20,6 +21,7 @@ from .spatial import BoundingBox, NormalizedCoordinate, SpatialKinematicAction
 __all__ = [
     "ActionSpace",
     "BoundingBox",
+    "EphemeralNamespacePartition",
     "ExecutionSLA",
     "MCPClientBinding",
     "NormalizedCoordinate",

--- a/src/coreason_manifest/tooling/environments.py
+++ b/src/coreason_manifest/tooling/environments.py
@@ -10,6 +10,7 @@ These schemas govern how the agent mathematically interacts with external or emb
 FORBIDDEN from writing raw script executors here. All tool definitions must be bounded by strict JSON-RPC schemas,
 permission boundaries, and side-effect profiles."""
 
+import re
 from typing import Any, Literal, Self
 
 from pydantic import Field, model_validator
@@ -38,6 +39,37 @@ class MCPClientBinding(CoreasonBaseModel):
     )
 
 
+class EphemeralNamespacePartition(CoreasonBaseModel):
+    """
+    A hermetically sealed, ephemeral execution partition for dynamic dependency resolution.
+    """
+
+    partition_id: str = Field(min_length=1, description="Unique identifier for this ephemeral partition.")
+    execution_runtime: Literal["wasm32-wasi", "riscv32-zkvm", "bpf"] = Field(
+        description="The strict virtual machine target mandated for dynamic execution."
+    )
+    authorized_bytecode_hashes: list[str] = Field(
+        min_length=1, description="The explicit whitelist of SHA-256 hashes allowed to execute within this partition."
+    )
+    max_ttl_seconds: int = Field(
+        gt=0, description="The absolute temporal guillotine before the orchestrator drops the context."
+    )
+    max_vram_mb: int = Field(gt=0, description="The strict physical VRAM ceiling allocated to this partition.")
+    allow_network_egress: bool = Field(
+        default=False, description="Capability-based flag to allow or mathematically deny network sockets."
+    )
+    allow_subprocess_spawning: bool = Field(
+        default=False, description="Capability-based flag to allow or deny OS-level process spawning."
+    )
+
+    @model_validator(mode="after")
+    def validate_cryptographic_hashes(self) -> Self:
+        for h in self.authorized_bytecode_hashes:
+            if not re.match(r"^[a-f0-9]{64}$", h):
+                raise ValueError(f"Invalid SHA-256 hash in whitelist: {h}")
+        return self
+
+
 class ActionSpace(CoreasonBaseModel):
     """
     A curated environment of tools accessible to an agent or node.
@@ -50,6 +82,10 @@ class ActionSpace(CoreasonBaseModel):
     mcp_servers: list[MCPServerManifest] = Field(
         default_factory=list,
         description="The array of verified external Model Context Protocol servers mounted into this action space.",
+    )
+    ephemeral_partitions: list[EphemeralNamespacePartition] = Field(
+        default_factory=list,
+        description="Hermetically sealed memory boundaries for dynamically resolved scripts and PEFT adapters.",
     )
 
     @model_validator(mode="after")

--- a/tests/domains/test_tooling_environments.py
+++ b/tests/domains/test_tooling_environments.py
@@ -1,0 +1,26 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.tooling.environments import EphemeralNamespacePartition
+
+
+def test_ephemeral_partition_temporal_override_proof() -> None:
+    with pytest.raises(ValidationError, match="Input should be greater than 0"):
+        EphemeralNamespacePartition(
+            partition_id="part-1",
+            execution_runtime="wasm32-wasi",
+            authorized_bytecode_hashes=["a" * 64],
+            max_ttl_seconds=0,  # INVALID: Triggers guillotine override check
+            max_vram_mb=500,
+        )
+
+
+def test_ephemeral_partition_supply_chain_proof() -> None:
+    with pytest.raises(ValidationError, match="Invalid SHA-256 hash in whitelist"):
+        EphemeralNamespacePartition(
+            partition_id="part-1",
+            execution_runtime="wasm32-wasi",
+            authorized_bytecode_hashes=["a" * 64, "invalid-hash-string"],  # INVALID
+            max_ttl_seconds=300,
+            max_vram_mb=500,
+        )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1733,6 +1733,26 @@ def draw_mcp_server_manifest(draw: Any) -> dict[str, Any]:
     return res
 
 
+@st.composite
+def draw_ephemeral_namespace_partition(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "partition_id": st.text(min_size=1),
+                "execution_runtime": st.sampled_from(["wasm32-wasi", "riscv32-zkvm", "bpf"]),
+                "authorized_bytecode_hashes": st.lists(
+                    st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True), min_size=1, max_size=5
+                ),
+                "max_ttl_seconds": st.integers(min_value=1),
+                "max_vram_mb": st.integers(min_value=1),
+                "allow_network_egress": st.booleans(),
+                "allow_subprocess_spawning": st.booleans(),
+            }
+        )
+    )
+    return res
+
+
 @given(
     st.fixed_dictionaries(
         {
@@ -1778,6 +1798,7 @@ def draw_mcp_server_manifest(draw: Any) -> dict[str, Any]:
                 unique_by=lambda t: t["tool_name"] if isinstance(t, dict) and "tool_name" in t else str(t),
             ),
             "mcp_servers": st.lists(draw_mcp_server_manifest(), max_size=10),
+            "ephemeral_partitions": st.lists(draw_ephemeral_namespace_partition(), max_size=5),
         }
     )
 )


### PR DESCRIPTION
Implement Ephemeral Namespace Partitioning (FR-004) to enable tightly controlled, ephemeral execution capabilities bounded by hermetic parameters such as TTL, VRAM limits, and strictly allow-listed bytecode hashes.

---
*PR created automatically by Jules for task [4461374041280752886](https://jules.google.com/task/4461374041280752886) started by @gowthamrao*