### PR TITLE
Inject MCP Resource for Ontology Manifest

### DIFF
--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -6,6 +6,7 @@
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
 import contextlib
+import json
 from typing import Any, cast
 
 from mcp.server.fastmcp import FastMCP
@@ -48,6 +49,14 @@ def get_schema(schema_name: str) -> dict[str, Any]:
         raise ValueError(f"Schema '{schema_name}' not found in the manifest.")
 
     return cast("dict[str, Any]", _AVAILABLE_SCHEMAS[schema_name])
+
+
+@mcp.resource("schema://ontology/{schema_name}")
+def get_schema_resource(schema_name: str) -> str:
+    """Read-only resource exposing the exact JSON schema required for epistemic alignment."""
+    if schema_name not in _AVAILABLE_SCHEMAS:
+        raise ValueError(f"Schema '{schema_name}' not found in the manifest.")
+    return json.dumps(_AVAILABLE_SCHEMAS[schema_name], ensure_ascii=False)
 
 
 def _global_error_handler_shield() -> None:

--- a/tests/domains/test_mcp_boundary.py
+++ b/tests/domains/test_mcp_boundary.py
@@ -368,3 +368,19 @@ async def test_uptime_assertion_poison_pill() -> None:
     response_dict2 = sent_msg2.message.model_dump()
     assert response_dict2["jsonrpc"] == "2.0"
     assert response_dict2["error"]["code"] in (-32600, -32700)
+
+
+def test_mcp_server_resource_schemas() -> None:
+    """Test standard resource endpoints of mcp_server for branch coverage."""
+    import json
+
+    from coreason_manifest.cli.mcp_server import get_schema_resource
+
+    # Valid resource fetch
+    schema_str = get_schema_resource("AdjudicationRubric")
+    schema_dict = json.loads(schema_str)
+    assert schema_dict["title"] == "AdjudicationRubric"
+
+    # Invalid resource fetch
+    with pytest.raises(ValueError, match="not found in the manifest"):
+        get_schema_resource("GhostNodeSchema")


### PR DESCRIPTION
Adds a read-only Model Context Protocol (MCP) Resource into the `coreason-manifest` zero-trust ontology, per the Coreason Protocol directives.
- Uses `_AVAILABLE_SCHEMAS` map directly to avoid active execution loops.
- Adds appropriate test function mapping for validation.

---
*PR created automatically by Jules for task [2656016057509975117](https://jules.google.com/task/2656016057509975117) started by @gowthamrao*