### PR TITLE
Add coreason-validate CLI tool for structural linting

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
 [project.scripts]
 coreason-export = "coreason_manifest.cli.export:main"
 coreason-mcp = "coreason_manifest.cli.mcp_server:main"
+coreason-validate = "coreason_manifest.cli.validate:main"
 
 [project.urls]
 Homepage = "https://github.com/CoReason-AI/coreason_manifest"

--- a/src/coreason_manifest/cli/validate.py
+++ b/src/coreason_manifest/cli/validate.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+"""AGENT INSTRUCTION:
+This is a pure, side-effect-free POSIX CLI script for structural linting.
+It strictly adheres to the Hollow Data Plane constraint.
+NO runtime logging, NO network sockets, NO async loops.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from pydantic import TypeAdapter, ValidationError
+
+import coreason_manifest
+from coreason_manifest.core.base import CoreasonBaseModel
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Universal Structural Linter for CoReason Manifest.")
+    parser.add_argument("--schema", required=True, help="The exact name of the Pydantic schema class.")
+    parser.add_argument("payload_path", type=Path, help="Path to the JSON payload file.")
+
+    args = parser.parse_args()
+
+    schema_class = getattr(coreason_manifest, args.schema, None)
+    if schema_class is None or not (isinstance(schema_class, type) and issubclass(schema_class, CoreasonBaseModel)):
+        sys.stderr.write(
+            f"Error: Schema '{args.schema}' not found in coreason_manifest or is not a CoreasonBaseModel.\n"
+        )
+        sys.exit(1)
+
+    if not args.payload_path.exists():
+        sys.stderr.write(f"Error: Payload file '{args.payload_path}' does not exist.\n")
+        sys.exit(1)
+
+    raw_bytes = args.payload_path.read_bytes()
+
+    try:
+        TypeAdapter(schema_class).validate_json(raw_bytes)
+    except (ValidationError, ValueError) as e:
+        sys.stderr.write(str(e) + "\n")
+        sys.exit(1)
+
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,9 +1,11 @@
+import json
 from pathlib import Path
 
 import pytest
 
 from coreason_manifest.cli.export import main as export_main
 from coreason_manifest.cli.mcp_server import get_schema, list_schemas
+from coreason_manifest.cli.validate import main as validate_main
 
 
 def test_export_main(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -22,3 +24,68 @@ def test_mcp_server_schemas() -> None:
 
     with pytest.raises(ValueError, match="Schema 'NonExistentSchema' not found"):
         get_schema("NonExistentSchema")
+
+
+def test_validate_cli_success(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload = {"description": "A valid system node", "type": "system"}
+    payload_file = tmp_path / "valid.json"
+    payload_file.write_text(json.dumps(payload))
+
+    monkeypatch.setattr("sys.argv", ["coreason-validate", "--schema=SystemNode", str(payload_file)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_main()
+
+    assert exc_info.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err == ""
+
+
+def test_validate_cli_invalid_schema(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload_file = tmp_path / "dummy.json"
+    payload_file.write_text("{}")
+
+    monkeypatch.setattr("sys.argv", ["coreason-validate", "--schema=GhostSchema", str(payload_file)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "Error: Schema 'GhostSchema' not found" in captured.err
+
+
+def test_validate_cli_structural_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload = {"invalid_field": "This will fail SystemNode strict validation"}
+    payload_file = tmp_path / "invalid.json"
+    payload_file.write_text(json.dumps(payload))
+
+    monkeypatch.setattr("sys.argv", ["coreason-validate", "--schema=SystemNode", str(payload_file)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "validation error" in captured.err.lower()
+
+
+def test_validate_cli_missing_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing_file = tmp_path / "missing.json"
+    monkeypatch.setattr("sys.argv", ["coreason-validate", "--schema=SystemNode", str(missing_file)])
+
+    with pytest.raises(SystemExit) as exc_info:
+        validate_main()
+
+    assert exc_info.value.code == 1
+    captured = capsys.readouterr()
+    assert "does not exist" in captured.err


### PR DESCRIPTION
Adds `coreason-validate` CLI tool that reads a target file natively and parses it with `TypeAdapter().validate_json()` to avoid intermediate memory dicts. Tests fully pass.

---
*PR created automatically by Jules for task [9620188854724590895](https://jules.google.com/task/9620188854724590895) started by @gowthamrao*