### PR TITLE
feat(coreason-manifest): deterministic system 2 remediation translation

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -9120,6 +9120,45 @@
       "title": "System1Reflex",
       "type": "object"
     },
+    "System2RemediationPrompt": {
+      "additionalProperties": false,
+      "description": "A passive data envelope that deterministically maps a kinetic execution error\n(e.g., a Pydantic ValidationError) into a structurally rigid System 2 correction directive.",
+      "properties": {
+        "fault_id": {
+          "description": "A cryptographic Lineage Watermark (CID) tracking this specific dimensional collapse.",
+          "minLength": 1,
+          "title": "Fault Id",
+          "type": "string"
+        },
+        "target_node_id": {
+          "$ref": "#/$defs/NodeID",
+          "description": "The strict W3C DID of the agent that authored the invalid state, ensuring the fault is routed back to the exact memory partition."
+        },
+        "failing_pointers": {
+          "description": "A strictly typed array of RFC 6902 JSON Pointers isolating the exact topological coordinate of the hallucination.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Failing Pointers",
+          "type": "array"
+        },
+        "remediation_prompt": {
+          "description": "The deterministic, non-monotonic natural-language constraint the agent must satisfy.",
+          "minLength": 1,
+          "title": "Remediation Prompt",
+          "type": "string"
+        }
+      },
+      "required": [
+        "fault_id",
+        "target_node_id",
+        "failing_pointers",
+        "remediation_prompt"
+      ],
+      "title": "System2RemediationPrompt",
+      "type": "object"
+    },
     "SystemFaultEvent": {
       "additionalProperties": false,
       "properties": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -112,6 +112,7 @@ from coreason_manifest.presentation.intents import (
     InformationalIntent,
     PresentationEnvelope,
 )
+from coreason_manifest.presentation.remediation import System2RemediationPrompt
 from coreason_manifest.presentation.scivis import (
     AnyPanel,
     BasePanel,
@@ -512,6 +513,7 @@ __all__ = [
     "SwarmTopology",
     "SyntheticGenerationProfile",
     "System1Reflex",
+    "System2RemediationPrompt",
     "SystemFaultEvent",
     "SystemNode",
     "SystemRole",

--- a/src/coreason_manifest/presentation/__init__.py
+++ b/src/coreason_manifest/presentation/__init__.py
@@ -14,6 +14,10 @@ from .intents import (
     InformationalIntent,
     PresentationEnvelope,
 )
+from .remediation import (
+    System2RemediationPrompt,
+    generate_correction_prompt,
+)
 from .scivis import (
     BasePanel,
     ChannelEncoding,
@@ -43,4 +47,6 @@ __all__ = [
     "MacroGrid",
     "PresentationEnvelope",
     "ScaleDefinition",
+    "System2RemediationPrompt",
+    "generate_correction_prompt",
 ]

--- a/src/coreason_manifest/presentation/remediation.py
+++ b/src/coreason_manifest/presentation/remediation.py
@@ -35,7 +35,7 @@ class System2RemediationPrompt(CoreasonBaseModel):
     failing_pointers: list[str] = Field(
         min_length=1,
         description="A strictly typed array of RFC 6902 JSON Pointers isolating "
-        "the exact topological coordinate of the hallucination."
+        "the exact topological coordinate of the hallucination.",
     )
     remediation_prompt: str = Field(
         min_length=1, description="The deterministic, non-monotonic natural-language constraint the agent must satisfy."

--- a/src/coreason_manifest/presentation/remediation.py
+++ b/src/coreason_manifest/presentation/remediation.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
+"""AGENT INSTRUCTION:
+This file defines the System 2 Remediation Prompt schema and its deterministic adapter.
+This is a STRICTLY PASSIVE BOUNDARY. It is purely for translating Pythonic execution
+panics into LLM-legible geometric boundaries. DO NOT execute LLM calls or retry loops here.
+"""
+
+from typing import Self
+
+from pydantic import Field, ValidationError, model_validator
+
+from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.core.primitives import NodeID
+
+
+class System2RemediationPrompt(CoreasonBaseModel):
+    """
+    A passive data envelope that deterministically maps a kinetic execution error
+    (e.g., a Pydantic ValidationError) into a structurally rigid System 2 correction directive.
+    """
+
+    fault_id: str = Field(
+        min_length=1, description="A cryptographic Lineage Watermark (CID) tracking this specific dimensional collapse."
+    )
+    target_node_id: NodeID = Field(
+        description="The strict W3C DID of the agent that authored the invalid state, "
+        "ensuring the fault is routed back to the exact memory partition."
+    )
+    failing_pointers: list[str] = Field(
+        min_length=1,
+        description="A strictly typed array of RFC 6902 JSON Pointers isolating "
+        "the exact topological coordinate of the hallucination."
+    )
+    remediation_prompt: str = Field(
+        min_length=1, description="The deterministic, non-monotonic natural-language constraint the agent must satisfy."
+    )
+
+    @model_validator(mode="after")
+    def _sort_failing_pointers(self) -> Self:
+        """Mathematically sort pointers to guarantee deterministic canonical hashing."""
+        object.__setattr__(self, "failing_pointers", sorted(self.failing_pointers))
+        return self
+
+
+def generate_correction_prompt(error: ValidationError, target_node_id: str, fault_id: str) -> System2RemediationPrompt:
+    """
+    Pure functional adapter. Maps a raw Pythonic pydantic.ValidationError into a
+    language-model-legible System2RemediationPrompt without triggering runtime side effects.
+    """
+    failing_pointers: list[str] = []
+    error_messages: list[str] = []
+
+    for err in error.errors():
+        # Deterministically translate Pydantic 'loc' tuple to an RFC 6902 JSON Pointer
+        loc_path = "".join(f"/{item!s}" for item in err["loc"]) if err["loc"] else "/"
+        failing_pointers.append(loc_path)
+
+        # Project strict, deterministic error directives
+        err_type = err.get("type", "unknown")
+        if err_type == "missing":
+            error_messages.append(
+                f"The required semantic boundary at '{loc_path}' is completely missing. "
+                "You must project this missing dimension to satisfy the StateContract."
+            )
+        else:
+            msg = err.get("msg", "Invalid structural payload.")
+            error_messages.append(f"A structural boundary violation occurred at '{loc_path}': {msg}")
+
+    # Remove duplicates from pointers to prevent hash collision anomalies
+    failing_pointers = list(set(failing_pointers))
+
+    remediation_prompt = (
+        "CRITICAL CONTRACT BREACH: Your generated state representation violates the formal ontological boundaries "
+        "of the Shared Kernel. Review the following strict topological failures and correct your JSON projection:\n"
+        + "\n".join(f"- {msg}" for msg in error_messages)
+    )
+
+    return System2RemediationPrompt(
+        fault_id=fault_id,
+        target_node_id=target_node_id,
+        failing_pointers=failing_pointers,
+        remediation_prompt=remediation_prompt,
+    )

--- a/tests/domains/test_presentation_remediation.py
+++ b/tests/domains/test_presentation_remediation.py
@@ -10,6 +10,7 @@ class MockStrictSchema(BaseModel):
 
 
 def test_generate_correction_prompt_translation() -> None:
+    # Test invalid type (triggering the else branch "Invalid structural payload")
     try:
         MockStrictSchema(name="Bob", age="not_an_int")
         pytest.fail("Should have raised ValidationError")
@@ -27,3 +28,13 @@ def test_generate_correction_prompt_translation() -> None:
         assert "CRITICAL CONTRACT BREACH" in prompt.remediation_prompt
         assert "'/name'" in prompt.remediation_prompt
         assert "'/age'" in prompt.remediation_prompt
+
+    # Test missing field (triggering the "missing" branch)
+    try:
+        MockStrictSchema(name="Bob")
+        pytest.fail("Should have raised ValidationError")
+    except ValidationError as e:
+        prompt = generate_correction_prompt(error=e, target_node_id="did:web:node-1", fault_id="fault-002")
+
+        assert "/age" in prompt.failing_pointers
+        assert "is completely missing" in prompt.remediation_prompt

--- a/tests/domains/test_presentation_remediation.py
+++ b/tests/domains/test_presentation_remediation.py
@@ -31,7 +31,7 @@ def test_generate_correction_prompt_translation() -> None:
 
     # Test missing field (triggering the "missing" branch)
     try:
-        MockStrictSchema(name="Bob")
+        MockStrictSchema.model_validate({"name": "Bob"})
         pytest.fail("Should have raised ValidationError")
     except ValidationError as e:
         prompt = generate_correction_prompt(error=e, target_node_id="did:web:node-1", fault_id="fault-002")

--- a/tests/domains/test_presentation_remediation.py
+++ b/tests/domains/test_presentation_remediation.py
@@ -1,0 +1,29 @@
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from coreason_manifest.presentation.remediation import generate_correction_prompt
+
+
+class MockStrictSchema(BaseModel):
+    name: str = Field(min_length=5)
+    age: int
+
+
+def test_generate_correction_prompt_translation() -> None:
+    try:
+        MockStrictSchema(name="Bob", age="not_an_int")
+        pytest.fail("Should have raised ValidationError")
+    except ValidationError as e:
+        prompt = generate_correction_prompt(error=e, target_node_id="did:web:node-1", fault_id="fault-001")
+
+        assert prompt.fault_id == "fault-001"
+        assert prompt.target_node_id == "did:web:node-1"
+
+        # Both pointers should be mapped
+        assert "/name" in prompt.failing_pointers
+        assert "/age" in prompt.failing_pointers
+
+        # Verify deterministic error injection
+        assert "CRITICAL CONTRACT BREACH" in prompt.remediation_prompt
+        assert "'/name'" in prompt.remediation_prompt
+        assert "'/age'" in prompt.remediation_prompt

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -91,6 +91,27 @@ def test_workflow_envelope_determinism() -> None:
     assert hash(env1) == hash(env2)
 
 
+def test_system2_remediation_determinism() -> None:
+    from coreason_manifest.presentation.remediation import System2RemediationPrompt
+
+    # Prove that out-of-order failing_pointers are sorted mathematically
+    prompt1 = System2RemediationPrompt(
+        fault_id="fault-123",
+        target_node_id="did:web:agent-alpha",
+        failing_pointers=["/zeta", "/alpha", "/gamma"],
+        remediation_prompt="Fix it.",
+    )
+    prompt2 = System2RemediationPrompt(
+        fault_id="fault-123",
+        target_node_id="did:web:agent-alpha",
+        failing_pointers=["/gamma", "/zeta", "/alpha"],
+        remediation_prompt="Fix it.",
+    )
+
+    assert prompt1.model_dump_canonical() == prompt2.model_dump_canonical()
+    assert hash(prompt1) == hash(prompt2)
+
+
 def test_affordance_projection_determinism() -> None:
     from coreason_manifest.tooling.environments import ActionSpace, OntologicalSurfaceProjection
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -3275,3 +3275,29 @@ def test_synthetic_generation_profile_routing() -> None:
 
     parsed = adapter.validate_python(payload)
     assert isinstance(parsed, SyntheticGenerationProfile)
+
+
+@st.composite
+def draw_system2_remediation_prompt(draw: Any) -> dict[str, Any]:
+    return {
+        "fault_id": draw(st.text(min_size=1)),
+        "target_node_id": draw(draw_did_string()),
+        "failing_pointers": draw(st.lists(st.text(min_size=1), min_size=1, max_size=10)),
+        "remediation_prompt": draw(st.text(min_size=1)),
+    }
+
+
+def test_system2_remediation_prompt_fuzzing() -> None:
+    from coreason_manifest.presentation.remediation import System2RemediationPrompt
+
+    adapter = TypeAdapter(System2RemediationPrompt)
+
+    import hypothesis
+
+    @hypothesis.given(draw_system2_remediation_prompt())
+    @hypothesis.settings(max_examples=10)
+    def run_test(payload: dict[str, Any]) -> None:
+        parsed = adapter.validate_python(payload)
+        assert isinstance(parsed, System2RemediationPrompt)
+
+    run_test()


### PR DESCRIPTION
This commit introduces deterministic System 2 Remediation logic for Coreason Manifest, serving as a purely passive boundary.

It translates dynamic Pythonic `pydantic.ValidationError` panics into a deterministic, structurally rigid `System2RemediationPrompt` schema with sorted failing JSON pointers. This payload is meant for language models to remediate hallucinated topologies without executing active side effects.

Included are changes to support global exports in `__init__.py` files, logic for deterministic tests, and new fuzzing adapters. Code is strictly typed, and formatted correctly against the repository's strict standard tools (`ruff` and `mypy`).

---
*PR created automatically by Jules for task [8959336494557754553](https://jules.google.com/task/8959336494557754553) started by @gowthamrao*