### PR TITLE
feat: Execute Ticket 8 - Dynamic Capability Federation

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -5977,6 +5977,14 @@
           },
           "title": "Allowed Prompts",
           "type": "array"
+        },
+        "required_licenses": {
+          "description": "Explicit list of DUA/RBAC enterprise licenses mathematically required to perceive and mount this capability.",
+          "items": {
+            "type": "string"
+          },
+          "title": "Required Licenses",
+          "type": "array"
         }
       },
       "title": "MCPCapabilityWhitelist",

--- a/src/coreason_manifest/adapters/mcp/schemas.py
+++ b/src/coreason_manifest/adapters/mcp/schemas.py
@@ -38,7 +38,7 @@ class MCPCapabilityWhitelist(CoreasonBaseModel):
         description=(
             "Explicit list of DUA/RBAC enterprise licenses mathematically "
             "required to perceive and mount this capability."
-        )
+        ),
     )
 
 

--- a/src/coreason_manifest/adapters/mcp/schemas.py
+++ b/src/coreason_manifest/adapters/mcp/schemas.py
@@ -33,6 +33,10 @@ class MCPCapabilityWhitelist(CoreasonBaseModel):
     allowed_prompts: list[str] = Field(
         default_factory=list, description="The explicit whitelist of workflow templates the node is allowed to trigger."
     )
+    required_licenses: list[str] = Field(
+        default_factory=list,
+        description="Explicit list of DUA/RBAC enterprise licenses mathematically required to perceive and mount this capability.",
+    )
 
 
 class MCPServerManifest(CoreasonBaseModel):

--- a/src/coreason_manifest/adapters/mcp/schemas.py
+++ b/src/coreason_manifest/adapters/mcp/schemas.py
@@ -35,7 +35,10 @@ class MCPCapabilityWhitelist(CoreasonBaseModel):
     )
     required_licenses: list[str] = Field(
         default_factory=list,
-        description="Explicit list of DUA/RBAC enterprise licenses mathematically required to perceive and mount this capability.",
+        description=(
+            "Explicit list of DUA/RBAC enterprise licenses mathematically "
+            "required to perceive and mount this capability."
+        )
     )
 
 

--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -6,6 +6,7 @@
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
 import contextlib
+import os
 from typing import Any, cast
 
 from mcp.server.fastmcp import FastMCP
@@ -31,23 +32,47 @@ for _name in coreason_manifest.__all__:
 _SCHEMA_NAMES = sorted(_AVAILABLE_SCHEMAS.keys())
 
 
+def _get_granted_licenses() -> set[str]:
+    """Passively extracts the mathematically granted context from the environment."""
+    env_val = os.environ.get("COREASON_GRANTED_LICENSES", "")
+    if not env_val:
+        return set()
+    return {lic.strip() for lic in env_val.split(",") if lic.strip()}
+
+
+def _is_schema_allowed(schema_dict: dict[str, Any], granted_licenses: set[str]) -> bool:
+    """Calculates if the required license lattice is a strict subset of the granted lattice."""
+    required = schema_dict.get("x-required-licenses", [])
+    if not isinstance(required, list):
+        required = []
+    return set(required).issubset(granted_licenses)
+
+
 @mcp.tool()
 def list_schemas() -> list[str]:
-    """Returns a list of all available schema names exported in the root __init__.py."""
-    return _SCHEMA_NAMES
+    """Returns a list of all available schema names exported in the root __init__.py, filtered by RBAC context."""
+    granted = _get_granted_licenses()
+    allowed_schemas = []
+    for name in _SCHEMA_NAMES:
+        if _is_schema_allowed(_AVAILABLE_SCHEMAS[name], granted):
+            allowed_schemas.append(name)
+    return allowed_schemas
 
 
 @mcp.tool()
 def get_schema(schema_name: str) -> dict[str, Any]:
-    """Returns the strict Pydantic JSON schema for a specific requested model.
-
-    Args:
-        schema_name: The name of the schema to fetch (e.g., WorkingMemorySnapshot)
-    """
+    """Returns the strict Pydantic JSON schema for a specific requested model, governed by RBAC bounds."""
     if schema_name not in _AVAILABLE_SCHEMAS:
         raise ValueError(f"Schema '{schema_name}' not found in the manifest.")
 
-    return cast("dict[str, Any]", _AVAILABLE_SCHEMAS[schema_name])
+    granted = _get_granted_licenses()
+    schema_dict = cast("dict[str, Any]", _AVAILABLE_SCHEMAS[schema_name])
+
+    if not _is_schema_allowed(schema_dict, granted):
+        # Zero-Trust: If not allowed, it cryptographically does not exist for this client.
+        raise ValueError(f"Schema '{schema_name}' not found in the manifest.")
+
+    return schema_dict
 
 
 def _global_error_handler_shield() -> None:

--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -52,11 +52,7 @@ def _is_schema_allowed(schema_dict: dict[str, Any], granted_licenses: set[str]) 
 def list_schemas() -> list[str]:
     """Returns a list of all available schema names exported in the root __init__.py, filtered by RBAC context."""
     granted = _get_granted_licenses()
-    allowed_schemas = []
-    for name in _SCHEMA_NAMES:
-        if _is_schema_allowed(_AVAILABLE_SCHEMAS[name], granted):
-            allowed_schemas.append(name)
-    return allowed_schemas
+    return [name for name in _SCHEMA_NAMES if _is_schema_allowed(_AVAILABLE_SCHEMAS[name], granted)]
 
 
 @mcp.tool()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -92,3 +92,38 @@ def test_visualize_missing_file(capsys: pytest.CaptureFixture[str]) -> None:
 
     captured = capsys.readouterr()
     assert "not found" in captured.err
+
+
+def test_mcp_server_rbac_projection(monkeypatch: pytest.MonkeyPatch) -> None:
+    from coreason_manifest.cli.mcp_server import _AVAILABLE_SCHEMAS, get_schema, list_schemas
+
+    # Inject a mock proprietary schema
+    proprietary_name = "MockProprietarySchema"
+    _AVAILABLE_SCHEMAS[proprietary_name] = {"title": "MockProprietarySchema", "x-required-licenses": ["marketscan"]}
+    # We must append to _SCHEMA_NAMES to make it visible to list_schemas
+    from coreason_manifest.cli.mcp_server import _SCHEMA_NAMES
+
+    _SCHEMA_NAMES.append(proprietary_name)
+
+    try:
+        # TEST 1: Zero-Trust Default (No license)
+        monkeypatch.delenv("COREASON_GRANTED_LICENSES", raising=False)
+        schemas_denied = list_schemas()
+        assert proprietary_name not in schemas_denied
+
+        with pytest.raises(ValueError, match="not found in the manifest"):
+            get_schema(proprietary_name)
+
+        # TEST 2: Granted Context (Subset satisfied)
+        monkeypatch.setenv("COREASON_GRANTED_LICENSES", "rightfind, marketscan ")
+        schemas_allowed = list_schemas()
+        assert proprietary_name in schemas_allowed
+
+        schema = get_schema(proprietary_name)
+        assert schema["title"] == "MockProprietarySchema"
+
+    finally:
+        # Clean up
+        _AVAILABLE_SCHEMAS.pop(proprietary_name, None)
+        if proprietary_name in _SCHEMA_NAMES:
+            _SCHEMA_NAMES.remove(proprietary_name)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1702,6 +1702,7 @@ def draw_mcp_capability_whitelist(draw: Any) -> dict[str, Any]:
                 "allowed_tools": st.lists(st.text(), max_size=100),
                 "allowed_resources": st.lists(st.text(), max_size=100),
                 "allowed_prompts": st.lists(st.text(), max_size=100),
+                "required_licenses": st.lists(st.text(), max_size=10),
             }
         )
     )


### PR DESCRIPTION
Implemented the requested dynamic capability federation feature, enforcing Zero-Trust Information Flow Control (IFC) Lattice projection.

Specifically:
- Extended the `MCPCapabilityWhitelist` with a new `required_licenses` field.
- Replaced the `list_schemas` and `get_schema` in the `mcp_server` to implement an epistemic firewall that passively extracts licenses from the environment.
- Updated structural fuzzing tests to generate the new schema structure.
- Appended behavioral contract tests to test the Zero-Trust projection logic.

Ran all required verification protocols (ruff format, ruff check, mypy, pytest) successfully.

---
*PR created automatically by Jules for task [6568423875129175985](https://jules.google.com/task/6568423875129175985) started by @gowthamrao*