### PR TITLE
Unify MCP Resource Surface (Passive Discovery)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,11 @@ You are strictly forbidden from introducing "Active" or "Runtime" logic into thi
 * **Forbidden:** Dependencies on execution-layer libraries (e.g., `fastapi`, `starlette`, auth middleware, database drivers like `psycopg2`).
 * **Allowed:** Pure data dependencies (`pydantic`, `pyyaml`).
 
+### **Law 4: Passive Ontological Surface (The "No Kinematics" Rule)**
+* **Constraint:** The internal FastMCP server is strictly a passive projection of the Universal Ontology.
+* **Forbidden:** Registering active execution endpoints via `@mcp.tool()`.
+* **Allowed:** Exposing stateless schemas strictly via `@mcp.resource()` under `schema://` URIs.
+
 ---
 
 ## **2. Development Protocol**

--- a/src/coreason_manifest/cli/card.py
+++ b/src/coreason_manifest/cli/card.py
@@ -32,15 +32,19 @@ def project_envelope_to_markdown(envelope: WorkflowEnvelope) -> str:
         f"- **Type:** `{envelope.topology.type}`",
     ]
 
-    if envelope.topology.architectural_intent:
-        lines.append(f"- **Intent:** {envelope.topology.architectural_intent}")
-    if envelope.topology.justification:
-        lines.append(f"- **Justification:** *{envelope.topology.justification}*")
+    architectural_intent = getattr(envelope.topology, "architectural_intent", None)
+    if architectural_intent:
+        lines.append(f"- **Intent:** {architectural_intent}")
+
+    justification = getattr(envelope.topology, "justification", None)
+    if justification:
+        lines.append(f"- **Justification:** *{justification}*")
 
     lines.append("")
     lines.append("## Node Ledger & Personas")
 
-    for node_id, node in envelope.topology.nodes.items():
+    nodes = getattr(envelope.topology, "nodes", {})
+    for node_id, node in nodes.items():
         lines.append(f"### Node: `{node_id}`")
         lines.append(f"- **Type:** `{node.type}`")
         lines.append(f"- **Description:** {node.description}")
@@ -51,7 +55,7 @@ def project_envelope_to_markdown(envelope: WorkflowEnvelope) -> str:
             lines.append(f"- **Justification:** *{node.justification}*")
 
         if getattr(node, "agent_attestation", None) is not None:
-            attest = node.agent_attestation  # type: ignore
+            attest = getattr(node, "agent_attestation")
             if attest:
                 lines.append(f"- **Lineage Hash:** `{attest.training_lineage_hash}`")
         lines.append("")

--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -5,6 +5,8 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+"""AGENT INSTRUCTION: This MCP Server is strictly passive. DO NOT register @mcp.tool() endpoints. Use @mcp.resource() for all ontological projections."""  # noqa: E501
+
 import contextlib
 import os
 from typing import Any, cast
@@ -48,27 +50,55 @@ def _is_schema_allowed(schema_dict: dict[str, Any], granted_licenses: set[str]) 
     return set(required).issubset(granted_licenses)
 
 
-@mcp.tool()
-def list_schemas() -> list[str]:
-    """Returns a list of all available schema names exported in the root __init__.py, filtered by RBAC context."""
-    granted = _get_granted_licenses()
-    return [name for name in _SCHEMA_NAMES if _is_schema_allowed(_AVAILABLE_SCHEMAS[name], granted)]
+@mcp.resource("schema://epistemic/{name}")
+def get_epistemic_schema(name: str) -> str:
+    import json
 
-
-@mcp.tool()
-def get_schema(schema_name: str) -> dict[str, Any]:
-    """Returns the strict Pydantic JSON schema for a specific requested model, governed by RBAC bounds."""
-    if schema_name not in _AVAILABLE_SCHEMAS:
-        raise ValueError(f"Schema '{schema_name}' not found in the manifest.")
+    if name not in _AVAILABLE_SCHEMAS:
+        raise ValueError(f"Schema '{name}' not found.")
 
     granted = _get_granted_licenses()
-    schema_dict = cast("dict[str, Any]", _AVAILABLE_SCHEMAS[schema_name])
+    schema_dict = cast("dict[str, Any]", _AVAILABLE_SCHEMAS[name])
 
     if not _is_schema_allowed(schema_dict, granted):
-        # Zero-Trust: If not allowed, it cryptographically does not exist for this client.
-        raise ValueError(f"Schema '{schema_name}' not found in the manifest.")
+        raise ValueError(f"Schema '{name}' not found.")
 
-    return schema_dict
+    return json.dumps(schema_dict)
+
+
+@mcp.resource("schema://state/memoized/{hash}")
+def get_memoized_state_schema(hash: str) -> str:  # noqa: A002
+    import json
+    import re
+
+    if not re.fullmatch(r"^[a-f0-9]{64}$", hash):
+        raise ValueError("Invalid hash: must be a valid 64-character SHA-256 hex string.")
+
+    if "MemoizedNode" not in _AVAILABLE_SCHEMAS:
+        raise ValueError("Schema 'MemoizedNode' not found.")
+
+    schema_dict = cast("dict[str, Any]", _AVAILABLE_SCHEMAS["MemoizedNode"])
+    return json.dumps(schema_dict)
+
+
+@mcp.resource("schema://capabilities/{profile}")
+def get_capabilities_profile(profile: str) -> str:
+    import json
+
+    from coreason_manifest.compute.profiles import ComputeProvisioningRequest, ModelProfile, RateCard, RoutingFrontier
+
+    profiles = {
+        "ComputeProvisioningRequest": ComputeProvisioningRequest,
+        "ModelProfile": ModelProfile,
+        "RateCard": RateCard,
+        "RoutingFrontier": RoutingFrontier,
+    }
+
+    if profile not in profiles:
+        raise ValueError(f"Capability profile '{profile}' not found.")
+
+    cls = profiles[profile]
+    return json.dumps(list(cast("Any", cls).model_fields.keys()))
 
 
 def _global_error_handler_shield() -> None:

--- a/tests/domains/test_mcp_boundary.py
+++ b/tests/domains/test_mcp_boundary.py
@@ -110,20 +110,62 @@ def test_explicit_keys_and_list_limits() -> None:
     assert "params must be a dictionary" in str(exc.value)
 
 
-def test_mcp_server_tool_schemas() -> None:
-    """Test standard tool endpoints of mcp_server for branch coverage."""
-    from coreason_manifest.cli.mcp_server import get_schema, list_schemas
+@pytest.mark.anyio
+async def test_mcp_server_boundaries() -> None:
+    """Prove the passive nature of the MCP server and resource routing."""
+    import json
 
-    schemas = list_schemas()
-    assert len(schemas) > 0
-    # AdjudicationRubric is exported from coreason_manifest core
-    assert "AdjudicationRubric" in schemas
+    from coreason_manifest.cli.mcp_server import mcp
 
-    schema_dict = get_schema("AdjudicationRubric")
+    # Assert 0 tools
+    tools = await mcp.list_tools()
+    assert len(tools) == 0
+
+    # 1. Epistemic Caching Router
+    epistemic_res = await mcp.read_resource("schema://epistemic/AdjudicationRubric")
+
+    # Check if the result is a string, bytes, or if it is a list/tuple of resource objects
+    if isinstance(epistemic_res, list) and len(epistemic_res) > 0 and hasattr(epistemic_res[0], "content"):
+        epistemic_res = epistemic_res[0].content
+
+    if isinstance(epistemic_res, bytes):
+        epistemic_res = epistemic_res.decode("utf-8")
+
+    schema_dict = json.loads(str(epistemic_res))
     assert schema_dict["title"] == "AdjudicationRubric"
 
-    with pytest.raises(ValueError, match="not found in the manifest"):
-        get_schema("DoesNotExistSchema")
+    with pytest.raises(ValueError, match="not found"):
+        await mcp.read_resource("schema://epistemic/DoesNotExistSchema")
+
+    # 2. State Memoization Router
+    valid_hash = "a" * 64
+    memo_res = await mcp.read_resource(f"schema://state/memoized/{valid_hash}")
+
+    if isinstance(memo_res, list) and len(memo_res) > 0 and hasattr(memo_res[0], "content"):
+        memo_res = memo_res[0].content
+
+    if isinstance(memo_res, bytes):
+        memo_res = memo_res.decode("utf-8")
+    memo_dict = json.loads(str(memo_res))
+    assert memo_dict["title"] == "MemoizedNode"
+
+    with pytest.raises(ValueError, match="Invalid hash"):
+        await mcp.read_resource("schema://state/memoized/invalidhash")
+
+    # 3. Capability Discovery Router
+    cap_res = await mcp.read_resource("schema://capabilities/RoutingFrontier")
+
+    if isinstance(cap_res, list) and len(cap_res) > 0 and hasattr(cap_res[0], "content"):
+        cap_res = cap_res[0].content
+
+    if isinstance(cap_res, bytes):
+        cap_res = cap_res.decode("utf-8")
+    cap_list = json.loads(str(cap_res))
+    assert isinstance(cap_list, list)
+    assert "max_latency_ms" in cap_list
+
+    with pytest.raises(ValueError, match="not found"):
+        await mcp.read_resource("schema://capabilities/UnknownProfile")
 
 
 @pytest.mark.anyio

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,7 +5,6 @@ from unittest.mock import patch
 import pytest
 
 from coreason_manifest.cli.export import main as export_main
-from coreason_manifest.cli.mcp_server import get_schema, list_schemas
 from coreason_manifest.cli.visualize import main as visualize_main
 
 
@@ -13,18 +12,6 @@ def test_export_main(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.chdir(tmp_path)
     export_main()
     assert (tmp_path / "coreason_ontology.schema.json").exists()
-
-
-def test_mcp_server_schemas() -> None:
-    schemas = list_schemas()
-    assert len(schemas) > 0
-    assert "WorkflowEnvelope" in schemas
-
-    schema = get_schema("WorkflowEnvelope")
-    assert schema["title"] == "WorkflowEnvelope"
-
-    with pytest.raises(ValueError, match="Schema 'NonExistentSchema' not found"):
-        get_schema("NonExistentSchema")
 
 
 def test_visualize_valid_manifest(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
@@ -94,13 +81,14 @@ def test_visualize_missing_file(capsys: pytest.CaptureFixture[str]) -> None:
     assert "not found" in captured.err
 
 
-def test_mcp_server_rbac_projection(monkeypatch: pytest.MonkeyPatch) -> None:
-    from coreason_manifest.cli.mcp_server import _AVAILABLE_SCHEMAS, get_schema, list_schemas
+@pytest.mark.anyio
+async def test_mcp_server_rbac_projection(monkeypatch: pytest.MonkeyPatch) -> None:
+    from coreason_manifest.cli.mcp_server import _AVAILABLE_SCHEMAS, mcp
 
     # Inject a mock proprietary schema
     proprietary_name = "MockProprietarySchema"
     _AVAILABLE_SCHEMAS[proprietary_name] = {"title": "MockProprietarySchema", "x-required-licenses": ["marketscan"]}
-    # We must append to _SCHEMA_NAMES to make it visible to list_schemas
+    # We must append to _SCHEMA_NAMES to make it visible
     from coreason_manifest.cli.mcp_server import _SCHEMA_NAMES
 
     _SCHEMA_NAMES.append(proprietary_name)
@@ -108,18 +96,21 @@ def test_mcp_server_rbac_projection(monkeypatch: pytest.MonkeyPatch) -> None:
     try:
         # TEST 1: Zero-Trust Default (No license)
         monkeypatch.delenv("COREASON_GRANTED_LICENSES", raising=False)
-        schemas_denied = list_schemas()
-        assert proprietary_name not in schemas_denied
 
-        with pytest.raises(ValueError, match="not found in the manifest"):
-            get_schema(proprietary_name)
+        with pytest.raises(Exception, match="not found"):
+            await mcp.read_resource(f"schema://epistemic/{proprietary_name}")
 
         # TEST 2: Granted Context (Subset satisfied)
         monkeypatch.setenv("COREASON_GRANTED_LICENSES", "rightfind, marketscan ")
-        schemas_allowed = list_schemas()
-        assert proprietary_name in schemas_allowed
 
-        schema = get_schema(proprietary_name)
+        res = await mcp.read_resource(f"schema://epistemic/{proprietary_name}")
+
+        if isinstance(res, list) and len(res) > 0 and hasattr(res[0], 'content'):
+            res = res[0].content
+        if isinstance(res, bytes):
+            res = res.decode("utf-8")
+
+        schema = json.loads(str(res))
         assert schema["title"] == "MockProprietarySchema"
 
     finally:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -90,6 +90,19 @@ def draw_vc_presentation(draw: Any) -> dict[str, Any]:
     return res
 
 
+@pytest.mark.anyio
+@given(st.text(alphabet=st.characters(blacklist_categories=["Cs"]), min_size=1))
+@settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])
+async def test_malformed_mcp_resource_uris(uri: str) -> None:
+    """Ensure malformed schema URIs do not crash the server routing."""
+    import contextlib
+
+    from coreason_manifest.cli.mcp_server import mcp
+
+    with contextlib.suppress(ValueError, Exception):
+        await mcp.read_resource(f"schema://epistemic/{uri}")
+
+
 @st.composite
 def draw_escalation_contract(draw: Any) -> dict[str, Any]:
     res: dict[str, Any] = draw(


### PR DESCRIPTION
This submission addresses TICKET 9, "Unify MCP Resource Surface (Passive Discovery)", to strictly project the ontological surface of `coreason-manifest` via the `schema://` URI scheme using `@mcp.resource()`. The internal FastMCP server is strictly a passive component, without allowing dynamic `@mcp.tool()` executions. Active tooling logic, such as `list_schemas` and `get_schema`, has been eliminated. The testing and fuzzing boundaries have been updated.

---
*PR created automatically by Jules for task [16652707880108373790](https://jules.google.com/task/16652707880108373790) started by @gowthamrao*