### PR TITLE
feat: Add ActiveInferenceYield schema to state events

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -133,6 +133,62 @@
       "title": "ActiveInferenceContract",
       "type": "object"
     },
+    "ActiveInferenceYield": {
+      "additionalProperties": false,
+      "description": "AGENT INSTRUCTION: Terminal state node proving epistemic exhaustion.\nMust be emitted when internal probability distributions fall below safe execution thresholds.",
+      "properties": {
+        "event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark linking this node to the Merkle-DAG.",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "active_inference_yield",
+          "default": "active_inference_yield",
+          "description": "Discriminator type for an active inference yield event.",
+          "title": "Type",
+          "type": "string"
+        },
+        "target_variable_urn": {
+          "description": "Identifier of the missing structural parameter.",
+          "title": "Target Variable Urn",
+          "type": "string"
+        },
+        "epistemic_confidence_delta": {
+          "description": "Quantified gap between current state confidence and required execution threshold.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Epistemic Confidence Delta",
+          "type": "number"
+        },
+        "canonical_projection": {
+          "description": "Machine-to-human/oracle translation of the information deficit.",
+          "title": "Canonical Projection",
+          "type": "string"
+        },
+        "temporal_escalation_bound": {
+          "description": "TTL/timeout parameter before autonomous fallback or system failure.",
+          "exclusiveMinimum": 0,
+          "title": "Temporal Escalation Bound",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "event_id",
+        "timestamp",
+        "target_variable_urn",
+        "epistemic_confidence_delta",
+        "canonical_projection",
+        "temporal_escalation_bound"
+      ],
+      "title": "ActiveInferenceYield",
+      "type": "object"
+    },
     "AdjudicationIntent": {
       "additionalProperties": false,
       "properties": {
@@ -935,6 +991,7 @@
       "description": "A discriminated union of state events.",
       "discriminator": {
         "mapping": {
+          "active_inference_yield": "#/$defs/ActiveInferenceYield",
           "barge_in": "#/$defs/BargeInInterruptEvent",
           "belief_update": "#/$defs/BeliefUpdateEvent",
           "counterfactual_regret": "#/$defs/CounterfactualRegretEvent",
@@ -978,6 +1035,9 @@
         },
         {
           "$ref": "#/$defs/PersistenceCommitReceipt"
+        },
+        {
+          "$ref": "#/$defs/ActiveInferenceYield"
         }
       ]
     },

--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -383,6 +383,30 @@ class PersistenceCommitReceipt(BaseStateEvent):
     target_table_uri: str = Field(min_length=1, description="The specific table mutated.")
 
 
+class ActiveInferenceYield(BaseStateEvent):
+    """
+    AGENT INSTRUCTION: Terminal state node proving epistemic exhaustion.
+    Must be emitted when internal probability distributions fall below safe execution thresholds.
+    """
+
+    type: Literal["active_inference_yield"] = Field(
+        default="active_inference_yield", description="Discriminator type for an active inference yield event."
+    )
+    target_variable_urn: str = Field(..., description="Identifier of the missing structural parameter.")
+    epistemic_confidence_delta: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Quantified gap between current state confidence and required execution threshold.",
+    )
+    canonical_projection: str = Field(
+        ..., description="Machine-to-human/oracle translation of the information deficit."
+    )
+    temporal_escalation_bound: int = Field(
+        ..., gt=0, description="TTL/timeout parameter before autonomous fallback or system failure."
+    )
+
+
 # =========================================================================
 # AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER
 # If you create a new class above, you MUST append it to the AnyStateEvent union below.
@@ -400,6 +424,7 @@ type AnyStateEvent = Annotated[
     | ToolInvocationEvent
     | EpistemicPromotionEvent
     | NormativeDriftEvent
-    | PersistenceCommitReceipt,
+    | PersistenceCommitReceipt
+    | ActiveInferenceYield,
     Field(discriminator="type", description="A discriminated union of state events."),
 ]

--- a/tests/domains/test_state_events.py
+++ b/tests/domains/test_state_events.py
@@ -9,12 +9,53 @@ import pytest
 from pydantic import TypeAdapter, ValidationError
 
 from coreason_manifest.state.events import (
+    ActiveInferenceYield,
     AnyStateEvent,
     EpistemicPromotionEvent,
     NeuralAuditAttestation,
     NormativeDriftEvent,
     SaeFeatureActivation,
 )
+
+
+def test_active_inference_yield_valid() -> None:
+    """Prove baseline instantiation of epistemic exhaustion receipt."""
+    event = ActiveInferenceYield(
+        event_id="evt_123",
+        timestamp=1710000000.0,
+        target_variable_urn="urn:coreason:variable:user_intent",
+        epistemic_confidence_delta=0.85,
+        canonical_projection="Need user to clarify intent.",
+        temporal_escalation_bound=3600,
+    )
+    assert event.type == "active_inference_yield"
+    assert event.epistemic_confidence_delta == 0.85
+
+
+def test_active_inference_yield_invalid_confidence() -> None:
+    """Enforce mathematical bounds on epistemic confidence."""
+    with pytest.raises(ValidationError):
+        ActiveInferenceYield(
+            event_id="evt_123",
+            timestamp=1710000000.0,
+            target_variable_urn="urn:coreason:variable:user_intent",
+            epistemic_confidence_delta=1.5,  # Invalid: > 1.0
+            canonical_projection="Need user to clarify intent.",
+            temporal_escalation_bound=3600,
+        )
+
+
+def test_active_inference_yield_invalid_temporal() -> None:
+    """Enforce physical bounds on temporal escalation."""
+    with pytest.raises(ValidationError):
+        ActiveInferenceYield(
+            event_id="evt_123",
+            timestamp=1710000000.0,
+            target_variable_urn="urn:coreason:variable:user_intent",
+            epistemic_confidence_delta=0.5,
+            canonical_projection="Need user to clarify intent.",
+            temporal_escalation_bound=0,  # Invalid: <= 0
+        )
 
 
 def test_sae_feature_activation_valid() -> None:


### PR DESCRIPTION
This PR adds a new declarative schema event `ActiveInferenceYield` to the coreason-manifest zero-trust "Shared Kernel" ontology. The event is a terminal state node proving epistemic exhaustion and requires emitting internal probability distribution gaps (`epistemic_confidence_delta`).

It includes rigorous bounds testing for the schema fields (`target_variable_urn`, `epistemic_confidence_delta`, `canonical_projection`, `temporal_escalation_bound`) and is fully tested and verified against the existing immutable event schemas setup. All deterministic tests pass securely.

---
*PR created automatically by Jules for task [17820698384423390397](https://jules.google.com/task/17820698384423390397) started by @gowthamrao*