### PR TITLE
feat(workflow): Add KinematicDecompositionSpec mathematical contract

### DIFF
--- a/src/coreason_manifest/workflow/__init__.py
+++ b/src/coreason_manifest/workflow/__init__.py
@@ -39,6 +39,7 @@ from .nodes import (
     CompositeNode,
     EpistemicScanner,
     HumanNode,
+    KinematicDecompositionSpec,
     MemoizedNode,
     SelfCorrectionPolicy,
     System1Reflex,
@@ -94,6 +95,7 @@ __all__ = [
     "HumanNode",
     "HypothesisStake",
     "InputMapping",
+    "KinematicDecompositionSpec",
     "MarketResolution",
     "MemoizedNode",
     "OntologicalAlignmentPolicy",
@@ -112,3 +114,6 @@ __all__ = [
     "WorkflowEnvelope",
     "compute_topology_hash",
 ]
+
+# Rebuild topological forward references to avoid Circular Import Death Spirals
+KinematicDecompositionSpec.model_rebuild()

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -40,9 +40,10 @@ class KinematicDecompositionSpec(CoreasonBaseModel):
     AGENT INSTRUCTION: This is an immutable mathematical contract proving the fractal decomposition
     of a high-level objective vector into a bounded sub-topology. Active execution is STRICTLY FORBIDDEN.
     """
+
     parent_objective_vector: list[float] | str = Field(
         min_length=1,
-        description="The high-level intent or latent semantic embedding vector representing the parent objective."
+        description="The high-level intent or latent semantic embedding vector representing the parent objective.",
     )
     sub_topology: "AnyTopology" = Field(
         description="The expanded kinematic graph (allowing structural loops/recursion)."
@@ -50,7 +51,7 @@ class KinematicDecompositionSpec(CoreasonBaseModel):
     tractability_boundary_proof: float = Field(
         ge=0.0,
         le=1.0,
-        description="Mathematical proof bounding the conditional epistemic entropy for all terminal nodes."
+        description="Mathematical proof bounding the conditional epistemic entropy for all terminal nodes.",
     )
 
 

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -35,6 +35,25 @@ from coreason_manifest.oversight.intervention import InterventionPolicy
 from coreason_manifest.workflow.constraints import InputMapping, OutputMapping
 
 
+class KinematicDecompositionSpec(CoreasonBaseModel):
+    """
+    AGENT INSTRUCTION: This is an immutable mathematical contract proving the fractal decomposition
+    of a high-level objective vector into a bounded sub-topology. Active execution is STRICTLY FORBIDDEN.
+    """
+    parent_objective_vector: list[float] | str = Field(
+        min_length=1,
+        description="The high-level intent or latent semantic embedding vector representing the parent objective."
+    )
+    sub_topology: "AnyTopology" = Field(
+        description="The expanded kinematic graph (allowing structural loops/recursion)."
+    )
+    tractability_boundary_proof: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="Mathematical proof bounding the conditional epistemic entropy for all terminal nodes."
+    )
+
+
 class BaseNode(CoreasonBaseModel):
     """
     Base configuration for any execution node in a topology.

--- a/tests/domains/test_workflow_nodes.py
+++ b/tests/domains/test_workflow_nodes.py
@@ -56,9 +56,7 @@ def test_kinematic_decomposition_spec_invalid_tractability_low() -> None:
     valid_topology = DAGTopology(type="dag", lifecycle_phase="draft", nodes={}, edges=[], allow_cycles=False)
     with pytest.raises(ValidationError, match="Input should be greater than or equal to 0"):
         KinematicDecompositionSpec(
-            parent_objective_vector="test",
-            sub_topology=valid_topology,
-            tractability_boundary_proof=-0.01
+            parent_objective_vector="test", sub_topology=valid_topology, tractability_boundary_proof=-0.01
         )
 
 
@@ -66,9 +64,7 @@ def test_kinematic_decomposition_spec_invalid_tractability_high() -> None:
     valid_topology = DAGTopology(type="dag", lifecycle_phase="draft", nodes={}, edges=[], allow_cycles=False)
     with pytest.raises(ValidationError, match="Input should be less than or equal to 1"):
         KinematicDecompositionSpec(
-            parent_objective_vector="test",
-            sub_topology=valid_topology,
-            tractability_boundary_proof=1.01
+            parent_objective_vector="test", sub_topology=valid_topology, tractability_boundary_proof=1.01
         )
 
 
@@ -77,16 +73,12 @@ def test_kinematic_decomposition_spec_valid_vectors() -> None:
 
     # Test str
     spec1 = KinematicDecompositionSpec(
-        parent_objective_vector="test vector",
-        sub_topology=valid_topology,
-        tractability_boundary_proof=0.5
+        parent_objective_vector="test vector", sub_topology=valid_topology, tractability_boundary_proof=0.5
     )
     assert spec1.parent_objective_vector == "test vector"
 
     # Test list[float]
     spec2 = KinematicDecompositionSpec(
-        parent_objective_vector=[0.1, 0.2, 0.3],
-        sub_topology=valid_topology,
-        tractability_boundary_proof=0.5
+        parent_objective_vector=[0.1, 0.2, 0.3], sub_topology=valid_topology, tractability_boundary_proof=0.5
     )
     assert spec2.parent_objective_vector == [0.1, 0.2, 0.3]

--- a/tests/domains/test_workflow_nodes.py
+++ b/tests/domains/test_workflow_nodes.py
@@ -3,7 +3,8 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from coreason_manifest.workflow.nodes import SystemNode
+from coreason_manifest.workflow.nodes import KinematicDecompositionSpec, SystemNode
+from coreason_manifest.workflow.topologies import DAGTopology
 
 
 def test_domain_extensions_rejects_deep_nesting() -> None:
@@ -49,3 +50,43 @@ def test_domain_extensions_list_recursion() -> None:
 
     with pytest.raises(ValidationError, match="leaf values must be JSON primitives"):
         SystemNode(description="Test", domain_extensions={"list": [1, 2, ToxicObject()]})
+
+
+def test_kinematic_decomposition_spec_invalid_tractability_low() -> None:
+    valid_topology = DAGTopology(type="dag", lifecycle_phase="draft", nodes={}, edges=[], allow_cycles=False)
+    with pytest.raises(ValidationError, match="Input should be greater than or equal to 0"):
+        KinematicDecompositionSpec(
+            parent_objective_vector="test",
+            sub_topology=valid_topology,
+            tractability_boundary_proof=-0.01
+        )
+
+
+def test_kinematic_decomposition_spec_invalid_tractability_high() -> None:
+    valid_topology = DAGTopology(type="dag", lifecycle_phase="draft", nodes={}, edges=[], allow_cycles=False)
+    with pytest.raises(ValidationError, match="Input should be less than or equal to 1"):
+        KinematicDecompositionSpec(
+            parent_objective_vector="test",
+            sub_topology=valid_topology,
+            tractability_boundary_proof=1.01
+        )
+
+
+def test_kinematic_decomposition_spec_valid_vectors() -> None:
+    valid_topology = DAGTopology(type="dag", lifecycle_phase="draft", nodes={}, edges=[], allow_cycles=False)
+
+    # Test str
+    spec1 = KinematicDecompositionSpec(
+        parent_objective_vector="test vector",
+        sub_topology=valid_topology,
+        tractability_boundary_proof=0.5
+    )
+    assert spec1.parent_objective_vector == "test vector"
+
+    # Test list[float]
+    spec2 = KinematicDecompositionSpec(
+        parent_objective_vector=[0.1, 0.2, 0.3],
+        sub_topology=valid_topology,
+        tractability_boundary_proof=0.5
+    )
+    assert spec2.parent_objective_vector == [0.1, 0.2, 0.3]

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -628,8 +628,7 @@ def draw_kinematic_decomposition_spec_payload(draw: Any) -> dict[str, Any]:
         st.fixed_dictionaries(
             {
                 "parent_objective_vector": st.one_of(
-                    st.text(min_size=1),
-                    st.lists(st.floats(allow_nan=False, allow_infinity=False), min_size=1)
+                    st.text(min_size=1), st.lists(st.floats(allow_nan=False, allow_infinity=False), min_size=1)
                 ),
                 "sub_topology": draw_topology_payload(draw_any_node_recursive()),
                 "tractability_boundary_proof": st.floats(

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -62,7 +62,14 @@ from coreason_manifest.testing.red_team import AdversarialSimulationProfile
 from coreason_manifest.tooling import ActionSpace, ToolDefinition
 from coreason_manifest.workflow.auctions import AuctionState, TaskAward
 from coreason_manifest.workflow.envelope import WorkflowEnvelope
-from coreason_manifest.workflow.nodes import AgentNode, AnyNode, CompositeNode, HumanNode, SystemNode
+from coreason_manifest.workflow.nodes import (
+    AgentNode,
+    AnyNode,
+    CompositeNode,
+    HumanNode,
+    KinematicDecompositionSpec,
+    SystemNode,
+)
 from coreason_manifest.workflow.routing import DynamicRoutingManifest
 from coreason_manifest.workflow.topologies import AnyTopology, OntologicalHandshake, StateContract
 
@@ -613,6 +620,31 @@ def draw_system_node_payload(draw: Any) -> dict[str, Any]:
     if draw(st.booleans()):
         payload["domain_extensions"] = draw(draw_domain_extensions())
     return payload
+
+
+@st.composite
+def draw_kinematic_decomposition_spec_payload(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "parent_objective_vector": st.one_of(
+                    st.text(min_size=1),
+                    st.lists(st.floats(allow_nan=False, allow_infinity=False), min_size=1)
+                ),
+                "sub_topology": draw_topology_payload(draw_any_node_recursive()),
+                "tractability_boundary_proof": st.floats(
+                    min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                ),
+            }
+        )
+    )
+    return res
+
+
+@given(draw_kinematic_decomposition_spec_payload())
+def test_kinematic_decomposition_spec_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = TypeAdapter(KinematicDecompositionSpec).validate_python(payload)
+    assert isinstance(parsed, KinematicDecompositionSpec)
 
 
 @st.composite


### PR DESCRIPTION
This commit introduces the `KinematicDecompositionSpec` as defined by the "F3: Fractal Topological Isomorphism (Kinematic Decomposition)" specification within the `coreason-manifest` repository.

1. **Topology Schema Addition (`src/coreason_manifest/workflow/nodes.py`)**
   - Implemented `KinematicDecompositionSpec` inheriting from `CoreasonBaseModel`.
   - Strictly enforced static `Field` bounds, enforcing no dynamic execution and static analyzability.
   - Enforced type `parent_objective_vector: list[float] | str`
   - Bound `sub_topology` to `AnyTopology`.
   - Bound `tractability_boundary_proof` strictly between 0.0 and 1.0.

2. **Circular Reference Fix (`src/coreason_manifest/workflow/__init__.py`)**
   - Added `KinematicDecompositionSpec` import and `__all__` registration.
   - Handled Pydantic V2 recursive mapping explicitly by invoking `KinematicDecompositionSpec.model_rebuild()` at the end of module resolution.

3. **Hypothesis Fuzzing Update (`tests/test_fuzzing.py`)**
   - Added property-based generation strategy `draw_kinematic_decomposition_spec_payload`.
   - Prevented fuzzer infinite hangs by constraining the depth to 3 (`max_leaves=3`) utilizing the recursive strategy context payload generator.
   - Successfully validated payloads generated against `TypeAdapter(KinematicDecompositionSpec)`.

4. **Deterministic Unit Tests (`tests/domains/test_workflow_nodes.py`)**
   - Tested that providing `tractability_boundary_proof` `< 0.0` trips validation.
   - Tested that providing `tractability_boundary_proof` `> 1.0` trips validation.
   - Verified that both `str` and `list[float]` are smoothly digested by `parent_objective_vector`.

---
*PR created automatically by Jules for task [15422922520467618161](https://jules.google.com/task/15422922520467618161) started by @gowthamrao*