### PR TITLE
feat(compute): add test-time SubstrateEnvelope schema

### DIFF
--- a/src/coreason_manifest/compute/__init__.py
+++ b/src/coreason_manifest/compute/__init__.py
@@ -39,6 +39,7 @@ from .test_time import (
     DynamicConvergenceSLA,
     EscalationContract,
     ProcessRewardContract,
+    SubstrateEnvelope,
 )
 
 __all__ = [
@@ -64,5 +65,6 @@ __all__ = [
     "ProcessRewardContract",
     "RateCard",
     "RoutingFrontier",
+    "SubstrateEnvelope",
     "VerifiableEntropy",
 ]

--- a/src/coreason_manifest/compute/test_time.py
+++ b/src/coreason_manifest/compute/test_time.py
@@ -17,6 +17,21 @@ from pydantic import Field
 from coreason_manifest.core.base import CoreasonBaseModel
 
 
+class SubstrateEnvelope(CoreasonBaseModel):
+    """
+    AGENT INSTRUCTION: Declarative mathematical boundaries for hardware exhaustion.
+    Downstream orchestrators MUST abort routing if node capacity cannot satisfy these bounds.
+    """
+
+    algorithmic_token_budget: int = Field(..., gt=0, description="Maximum latent activations permitted.")
+    vram_frontier_bound: int = Field(..., gt=0, description="Peak memory footprint threshold in bytes.")
+    latency_sla_ms: int = Field(..., gt=0, description="Maximum allowable clock time before forced degradation.")
+    probabilistic_exhaustion_halt: bool = Field(
+        ...,
+        description="Flag to trigger early termination if trajectory models indicate inevitable breach of envelope.",
+    )
+
+
 class DynamicConvergenceSLA(CoreasonBaseModel):
     """Service Level Agreement defining the mathematical conditions for early termination of a reasoning search."""
 

--- a/tests/domains/test_compute_test_time.py
+++ b/tests/domains/test_compute_test_time.py
@@ -1,0 +1,13 @@
+from coreason_manifest.compute.test_time import SubstrateEnvelope
+
+
+def test_substrate_envelope_valid_instantiation() -> None:
+    """Assert the declarative schema accepts strictly positive economic bounds."""
+    envelope = SubstrateEnvelope(
+        algorithmic_token_budget=100000,
+        vram_frontier_bound=8589934592,  # 8GB
+        latency_sla_ms=5000,
+        probabilistic_exhaustion_halt=True,
+    )
+    assert envelope.algorithmic_token_budget == 100000
+    assert envelope.probabilistic_exhaustion_halt is True

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -13,6 +13,7 @@ from hypothesis import strategies as st
 from pydantic import TypeAdapter, ValidationError
 
 from coreason_manifest.adapters.mcp.schemas import HTTPTransportConfig, MCPServerConfig
+from coreason_manifest.compute.test_time import SubstrateEnvelope
 from coreason_manifest.core.primitives import DataClassification, RiskLevel
 from coreason_manifest.oversight.dlp import InformationFlowPolicy
 from coreason_manifest.oversight.governance import GlobalGovernance
@@ -65,6 +66,18 @@ from coreason_manifest.workflow.envelope import WorkflowEnvelope
 from coreason_manifest.workflow.nodes import AgentNode, AnyNode, CompositeNode, HumanNode, SystemNode
 from coreason_manifest.workflow.routing import DynamicRoutingManifest
 from coreason_manifest.workflow.topologies import AnyTopology, OntologicalHandshake, StateContract
+
+
+@given(st.integers(max_value=0), st.integers(max_value=0), st.integers(max_value=0), st.booleans())
+def test_substrate_envelope_rejects_byzantine_allocations(tokens: int, vram: int, latency: int, halt: bool) -> None:
+    """Ensure negative or zero bounds immediately trigger compile-time/instantiation failure."""
+    with pytest.raises(ValidationError):
+        SubstrateEnvelope(
+            algorithmic_token_budget=tokens,
+            vram_frontier_bound=vram,
+            latency_sla_ms=latency,
+            probabilistic_exhaustion_halt=halt,
+        )
 
 
 @st.composite


### PR DESCRIPTION
Implements the `SubstrateEnvelope` data schema to provide test-time compute bounding.

### Changes:
- **`src/coreason_manifest/compute/test_time.py`**: Added `SubstrateEnvelope` schema with Pydantic `gt=0` boundaries.
- **`src/coreason_manifest/compute/__init__.py`**: Exported `SubstrateEnvelope` to the global module interface.
- **`tests/test_fuzzing.py`**: Added `test_substrate_envelope_rejects_byzantine_allocations` to prove the schema mathematically rejects bounds <= 0.
- **`tests/domains/test_compute_test_time.py`**: Created explicit domain assertions for proper valid instantiation.

All tests and validation tools (`ruff format`, `ruff check`, `mypy`, `pytest`) passed successfully locally.

---
*PR created automatically by Jules for task [10534349417969848219](https://jules.google.com/task/10534349417969848219) started by @gowthamrao*