### PR TITLE
Add CyberneticControlLoop schema and tests

### DIFF
--- a/src/coreason_manifest/oversight/__init__.py
+++ b/src/coreason_manifest/oversight/__init__.py
@@ -13,6 +13,9 @@ from .adjudication import (
 from .audit import (
     MechanisticAuditContract,
 )
+from .cybernetics import (
+    CyberneticControlLoop,
+)
 from .dlp import (
     InformationFlowPolicy,
     RedactionRule,
@@ -48,6 +51,7 @@ __all__ = [
     "CircuitBreakerTrip",
     "ConsensusPolicy",
     "ConstitutionalRule",
+    "CyberneticControlLoop",
     "FallbackSLA",
     "FallbackTrigger",
     "FormalVerificationContract",

--- a/src/coreason_manifest/oversight/cybernetics.py
+++ b/src/coreason_manifest/oversight/cybernetics.py
@@ -1,0 +1,45 @@
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from coreason_manifest.oversight.intervention import AnyInterventionPayload
+from coreason_manifest.oversight.resilience import AnyResiliencePayload
+
+
+class CyberneticControlLoop(BaseModel):
+    """
+    AGENT INSTRUCTION: This struct represents a HOLOGRAPHIC RECEIPT of a cybernetic
+    control calculation (Sensor -> Controller -> Actuator). It is mathematically
+    flattened. Do NOT instantiate active monitoring loops. Downstream engines read
+    this state to execute physical interventions.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    homeostatic_deviation_vector: dict[str, int | float | str | bool] = Field(
+        ..., description="Deterministic JSON-primitive dictionary representing the topological or tensor drift."
+    )
+
+    adjudication_rationale: str = Field(
+        ..., description="The deterministic reasoning output of the Governor or rules-engine."
+    )
+
+    regulatory_intervention_action: AnyResiliencePayload | AnyInterventionPayload = Field(
+        ..., description="The declarative actuation boundary guaranteeing structurally legal interventions."
+    )
+
+    @model_validator(mode="after")
+    def _enforce_intervention_bounds(self) -> "CyberneticControlLoop":
+        # Mathematical constraint: Severe deviations must map to severe interventions.
+        deviation = self.homeostatic_deviation_vector
+        action = self.regulatory_intervention_action
+
+        if deviation.get("byzantine_fault_detected") is True:
+            # We enforce that the action must be a severe resilience payload,
+            # represented here by asserting the schema type or specific intent.
+            # (Assuming NetworkQuarantineIntent exists in AnyResiliencePayload)
+            action_type = getattr(action, "intent", None)
+            if action_type not in ("QUARANTINE", "SLASH_STAKE", "CIRCUIT_BREAK"):
+                raise ValueError(
+                    "ECONOMICS_VIOLATION: A Byzantine fault requires a severe regulatory intervention "
+                    "(QUARANTINE, SLASH_STAKE, or CIRCUIT_BREAK)."
+                )
+        return self

--- a/src/coreason_manifest/oversight/cybernetics.py
+++ b/src/coreason_manifest/oversight/cybernetics.py
@@ -33,13 +33,11 @@ class CyberneticControlLoop(BaseModel):
         action = self.regulatory_intervention_action
 
         if deviation.get("byzantine_fault_detected") is True:
-            # We enforce that the action must be a severe resilience payload,
-            # represented here by asserting the schema type or specific intent.
-            # (Assuming NetworkQuarantineIntent exists in AnyResiliencePayload)
-            action_type = getattr(action, "intent", None)
-            if action_type not in ("QUARANTINE", "SLASH_STAKE", "CIRCUIT_BREAK"):
+            # Enforce that the action must be a severe resilience payload based on the ontological 'type' field
+            action_type = getattr(action, "type", None)
+            if action_type not in ("quarantine", "slash_stake", "circuit_breaker"):
                 raise ValueError(
                     "ECONOMICS_VIOLATION: A Byzantine fault requires a severe regulatory intervention "
-                    "(QUARANTINE, SLASH_STAKE, or CIRCUIT_BREAK)."
+                    "(quarantine, slash_stake, or circuit_breaker)."
                 )
         return self

--- a/tests/domains/test_oversight_cybernetics.py
+++ b/tests/domains/test_oversight_cybernetics.py
@@ -1,0 +1,49 @@
+import pytest
+from pydantic import TypeAdapter
+
+from coreason_manifest.oversight.cybernetics import CyberneticControlLoop
+
+
+def test_cybernetic_control_loop_serialization_determinism() -> None:
+    payload = {
+        "homeostatic_deviation_vector": {"byzantine_fault_detected": False, "latency": 150},
+        "adjudication_rationale": "Latency within bounds.",
+        "regulatory_intervention_action": {
+            "type": "request",
+            "target_node_id": "did:web:node1",
+            "context_summary": "High latency",
+            "proposed_action": {"action": "scale_up"},
+            "adjudication_deadline": 1678886400.0,
+        },
+    }
+
+    adapter = TypeAdapter(CyberneticControlLoop)
+    obj = adapter.validate_python(payload)
+
+    # Assert deterministic serialization
+    serialized = adapter.dump_python(obj, mode="json")
+    assert serialized["homeostatic_deviation_vector"]["byzantine_fault_detected"] is False
+    assert serialized["homeostatic_deviation_vector"]["latency"] == 150
+    assert serialized["adjudication_rationale"] == "Latency within bounds."
+    assert serialized["regulatory_intervention_action"]["type"] == "request"
+    assert serialized["regulatory_intervention_action"]["target_node_id"] == "did:web:node1"
+
+
+def test_byzantine_fault_requires_severe_intervention() -> None:
+    payload = {
+        "homeostatic_deviation_vector": {"byzantine_fault_detected": True, "loss": 0.5},
+        "adjudication_rationale": "Byzantine fault detected in cluster.",
+        "regulatory_intervention_action": {
+            "type": "request",
+            "target_node_id": "did:web:node1",
+            "context_summary": "System anomaly",
+            "proposed_action": {"action": "log"},
+            "adjudication_deadline": 1678886400.0,
+        },
+    }
+
+    adapter = TypeAdapter(CyberneticControlLoop)
+    with pytest.raises(
+        ValueError, match="ECONOMICS_VIOLATION: A Byzantine fault requires a severe regulatory intervention"
+    ):
+        adapter.validate_python(payload)

--- a/tests/domains/test_oversight_cybernetics.py
+++ b/tests/domains/test_oversight_cybernetics.py
@@ -44,6 +44,28 @@ def test_byzantine_fault_requires_severe_intervention() -> None:
 
     adapter = TypeAdapter(CyberneticControlLoop)
     with pytest.raises(
-        ValueError, match="ECONOMICS_VIOLATION: A Byzantine fault requires a severe regulatory intervention"
+        ValueError,
+        match=r"ECONOMICS_VIOLATION: A Byzantine fault requires a severe regulatory intervention "
+        r"\(quarantine, slash_stake, or circuit_breaker\).",
     ):
         adapter.validate_python(payload)
+
+
+def test_byzantine_fault_accepts_severe_intervention() -> None:
+    payload = {
+        "homeostatic_deviation_vector": {"byzantine_fault_detected": True, "critical_drift": 0.99},
+        "adjudication_rationale": "Byzantine fault detected; severing malicious node.",
+        "regulatory_intervention_action": {
+            "type": "quarantine",
+            "target_node_id": "did:web:malicious-node",
+            "reason": "Cryptographic signature mismatch.",
+        },
+    }
+
+    adapter = TypeAdapter(CyberneticControlLoop)
+    # This must NOT raise a ValueError
+    obj = adapter.validate_python(payload)
+
+    # Assert structural integrity was maintained
+    assert obj.regulatory_intervention_action.type == "quarantine"
+    assert getattr(obj.regulatory_intervention_action, "target_node_id", None) == "did:web:malicious-node"

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -14,6 +14,7 @@ from pydantic import TypeAdapter, ValidationError
 
 from coreason_manifest.adapters.mcp.schemas import HTTPTransportConfig, MCPServerConfig
 from coreason_manifest.core.primitives import DataClassification, RiskLevel
+from coreason_manifest.oversight.cybernetics import CyberneticControlLoop
 from coreason_manifest.oversight.dlp import InformationFlowPolicy
 from coreason_manifest.oversight.governance import GlobalGovernance
 from coreason_manifest.oversight.intervention import (
@@ -2913,6 +2914,39 @@ def draw_any_intervention_payload() -> st.SearchStrategy[dict[str, Any]]:
     )
 
 
+def draw_any_resilience_payload() -> st.SearchStrategy[dict[str, Any]]:
+    return st.one_of(
+        st.fixed_dictionaries(
+            {"type": st.just("quarantine"), "target_node_id": draw_did_string(), "reason": st.text()}
+        ),
+        st.fixed_dictionaries(
+            {"type": st.just("circuit_breaker"), "target_node_id": draw_did_string(), "error_signature": st.text()}
+        ),
+        st.fixed_dictionaries(
+            {"type": st.just("fallback"), "target_node_id": draw_did_string(), "fallback_node_id": draw_did_string()}
+        ),
+    )
+
+
+@st.composite
+def draw_cybernetic_control_loop(draw: Any) -> dict[str, Any]:
+    # Prevent deterministic ValueErrors during fuzzing by avoiding byzantine_fault_detected=True
+    deviation_vector = draw(
+        st.dictionaries(
+            st.text(min_size=1),
+            st.one_of(st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False), st.booleans()),
+        ).filter(lambda d: d.get("byzantine_fault_detected") is not True)
+    )
+
+    return {
+        "homeostatic_deviation_vector": deviation_vector,
+        "adjudication_rationale": draw(st.text()),
+        "regulatory_intervention_action": draw(
+            st.one_of(draw_any_intervention_payload(), draw_any_resilience_payload())
+        ),
+    }
+
+
 intervention_payload_adapter: TypeAdapter[AnyInterventionPayload] = TypeAdapter(AnyInterventionPayload)
 
 
@@ -2930,6 +2964,15 @@ def test_anyinterventionpayload_routing(payload: dict[str, Any]) -> None:
         from coreason_manifest.oversight.intervention import ConstitutionalAmendmentProposal
 
         assert isinstance(parsed, ConstitutionalAmendmentProposal)
+
+
+cybernetic_control_loop_adapter: TypeAdapter[CyberneticControlLoop] = TypeAdapter(CyberneticControlLoop)
+
+
+@given(draw_cybernetic_control_loop())
+def test_cybernetic_control_loop_fuzzing(payload: dict[str, Any]) -> None:
+    parsed = cybernetic_control_loop_adapter.validate_python(payload)
+    assert isinstance(parsed, CyberneticControlLoop)
 
 
 workflow_envelope_adapter: TypeAdapter[WorkflowEnvelope] = TypeAdapter(WorkflowEnvelope)


### PR DESCRIPTION
Implements the `CyberneticControlLoop` struct in `src/coreason_manifest/oversight/cybernetics.py` as defined in the Universal Ontology. 

Modifies:
- `src/coreason_manifest/oversight/__init__.py` to expose the new struct.
- `tests/domains/test_oversight_cybernetics.py` to assert serialization determinism and the Byzantine fault validation logic.
- `tests/test_fuzzing.py` to include bounded random strategy generation for the new struct without tripping deterministic `ValueError`s.

Ran standard CI/CD checks (`ruff`, `mypy`, `pytest`) which succeeded.

---
*PR created automatically by Jules for task [13319794915882682287](https://jules.google.com/task/13319794915882682287) started by @gowthamrao*