### PR TITLE
feat: Add AlgorithmicPlasticityDelta and RFC6902Patch schemas to differentials

### DIFF
--- a/src/coreason_manifest/state/differentials.py
+++ b/src/coreason_manifest/state/differentials.py
@@ -12,7 +12,7 @@ event sourcing, hardware attestations, and non-monotonic belief updates."""
 
 from typing import Any, Literal, Self
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import TopologyHash
@@ -162,7 +162,7 @@ class TemporalCheckpoint(CoreasonBaseModel):
     )
 
 
-class RFC6902Patch(BaseModel):
+class RFC6902Patch(CoreasonBaseModel):
     """Deterministic, typed JSON patch for structural toolchain mutation."""
 
     op: Literal["add", "remove", "replace", "move", "copy", "test"]
@@ -170,7 +170,7 @@ class RFC6902Patch(BaseModel):
     value: Any | None = None
 
 
-class AlgorithmicPlasticityDelta(BaseModel):
+class AlgorithmicPlasticityDelta(CoreasonBaseModel):
     """
     Immutable cryptographic receipt of a cybernetic gradient update.
     Represents a declarative shift in swarm behavior following execution failure.

--- a/src/coreason_manifest/state/differentials.py
+++ b/src/coreason_manifest/state/differentials.py
@@ -165,9 +165,14 @@ class TemporalCheckpoint(CoreasonBaseModel):
 class RFC6902Patch(CoreasonBaseModel):
     """Deterministic, typed JSON patch for structural toolchain mutation."""
 
-    op: Literal["add", "remove", "replace", "move", "copy", "test"]
-    path: str
-    value: Any | None = None
+    op: Literal["add", "remove", "replace", "move", "copy", "test"] = Field(
+        description="The strict RFC 6902 JSON Patch operation."
+    )
+    path: str = Field(description="The JSON pointer indicating the exact state vector to mutate deterministically.")
+    value: Any | None = Field(
+        default=None,
+        description=("The payload to insert or test, if applicable, for this deterministic state vector mutation."),
+    )
 
 
 class AlgorithmicPlasticityDelta(CoreasonBaseModel):

--- a/src/coreason_manifest/state/differentials.py
+++ b/src/coreason_manifest/state/differentials.py
@@ -12,9 +12,10 @@ event sourcing, hardware attestations, and non-monotonic belief updates."""
 
 from typing import Any, Literal, Self
 
-from pydantic import Field, model_validator
+from pydantic import BaseModel, Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.core.primitives import TopologyHash
 
 type PatchOperation = Literal["add", "remove", "replace", "copy", "move", "test"]
 
@@ -159,3 +160,45 @@ class TemporalCheckpoint(CoreasonBaseModel):
     state_hash: str = Field(
         description="The canonical RFC 8785 SHA-256 hash of the entire topology at this exact index."
     )
+
+
+class RFC6902Patch(BaseModel):
+    """Deterministic, typed JSON patch for structural toolchain mutation."""
+
+    op: Literal["add", "remove", "replace", "move", "copy", "test"]
+    path: str
+    value: Any | None = None
+
+
+class AlgorithmicPlasticityDelta(BaseModel):
+    """
+    Immutable cryptographic receipt of a cybernetic gradient update.
+    Represents a declarative shift in swarm behavior following execution failure.
+    """
+
+    failed_topology_hash: TopologyHash = Field(
+        ..., description="Strict SHA-256 pointer to the degraded execution graph."
+    )
+    kinematic_constraint_mutation: list[RFC6902Patch] = Field(
+        default_factory=list, max_length=50, description="Bounded RFC 6902 patches defining toolchain state mutations."
+    )
+    latent_prompt_gradient_update: str = Field(
+        default="", max_length=8192, description="Text-based instructional embedding adjustment."
+    )
+    routing_reweighting: float = Field(
+        ..., ge=-1.0, le=1.0, description="Heuristic utility penalization for spot market routing."
+    )
+
+    @model_validator(mode="after")
+    def _enforce_economic_boundary(self) -> "AlgorithmicPlasticityDelta":
+        """Mathematically prove that a zero-sum delta does not exist."""
+        if (
+            self.routing_reweighting == 0.0
+            and not self.kinematic_constraint_mutation
+            and not self.latent_prompt_gradient_update
+        ):
+            raise ValueError(
+                "AlgorithmicPlasticityDelta cannot be empty. If routing_reweighting is 0.0, "
+                "a structural toolchain mutation or latent prompt update MUST exist."
+            )
+        return self

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -38,6 +38,7 @@ from coreason_manifest.presentation.intents import (
 )
 from coreason_manifest.presentation.scivis import AnyPanel, GrammarPanel, InsightCard
 from coreason_manifest.state.argumentation import ArgumentGraph
+from coreason_manifest.state.differentials import AlgorithmicPlasticityDelta, RFC6902Patch
 from coreason_manifest.state.events import (
     AnyStateEvent,
     BeliefUpdateEvent,
@@ -3459,3 +3460,73 @@ async def test_mcp_server_malformed_uri_fuzzing(malformed_path: str) -> None:
                 # Any exception raised by the read_resource itself is fine,
                 # as long as it isn't an unhandled server crash.
                 pass
+
+
+rfc_patch_strategy = st.builds(
+    RFC6902Patch,
+    op=st.sampled_from(["add", "remove", "replace", "move", "copy", "test"]),
+    path=st.text(min_size=1, max_size=100),
+    value=st.none() | st.text() | st.integers(),
+)
+
+plasticity_delta_strategy = st.builds(
+    AlgorithmicPlasticityDelta,
+    failed_topology_hash=st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+    kinematic_constraint_mutation=st.lists(rfc_patch_strategy, max_size=50),
+    latent_prompt_gradient_update=st.text(max_size=8192),
+    routing_reweighting=st.floats(min_value=-1.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+)
+
+
+# Rejection tests should feed dicts to TypeAdapter, otherwise st.builds fails during generation
+@given(
+    st.fixed_dictionaries(
+        {
+            "failed_topology_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+            "kinematic_constraint_mutation": st.just([]),
+            "latent_prompt_gradient_update": st.just(""),
+            "routing_reweighting": st.just(0.0),
+        }
+    )
+)
+def test_algorithmic_plasticity_delta_fuzzing_rejection(payload: dict[str, Any]) -> None:
+    from coreason_manifest.state.differentials import AlgorithmicPlasticityDelta
+
+    with pytest.raises(ValidationError):
+        TypeAdapter(AlgorithmicPlasticityDelta).validate_python(payload)
+
+
+# If we want a valid strategy, we can build from valid dicts
+valid_plasticity_delta_payload = st.fixed_dictionaries(
+    {
+        "failed_topology_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+        "kinematic_constraint_mutation": st.lists(
+            st.fixed_dictionaries(
+                {
+                    "op": st.sampled_from(["add", "remove", "replace", "move", "copy", "test"]),
+                    "path": st.text(min_size=1, max_size=100),
+                    "value": st.none() | st.text() | st.integers(),
+                }
+            ),
+            max_size=50,
+        ),
+        "latent_prompt_gradient_update": st.text(max_size=8192),
+        "routing_reweighting": st.floats(min_value=-1.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+    }
+).filter(
+    lambda x: (
+        not (
+            x["routing_reweighting"] == 0.0
+            and not x["kinematic_constraint_mutation"]
+            and not x["latent_prompt_gradient_update"]
+        )
+    )
+)
+
+
+@given(valid_plasticity_delta_payload)
+def test_algorithmic_plasticity_delta_fuzzing(payload: dict[str, Any]) -> None:
+    from coreason_manifest.state.differentials import AlgorithmicPlasticityDelta
+
+    parsed = TypeAdapter(AlgorithmicPlasticityDelta).validate_python(payload)
+    assert isinstance(parsed, AlgorithmicPlasticityDelta)


### PR DESCRIPTION
This PR adds the `RFC6902Patch` and `AlgorithmicPlasticityDelta` schemas to the `coreason-manifest` Universal Ontology.

It updates the `differentials.py` with the exact models specified by the system directive. In addition, structural fuzzer strategies have been injected into `test_fuzzing.py` utilizing the `hypothesis` testing matrix to verify that Pydantic properly enforces the boundary rejection constraints. 

All CI/CD steps including `ruff` for linting/formatting, `mypy` for static type safety, and `pytest` for the Stochastic Fuzzing passed locally with zero errors.

---
*PR created automatically by Jules for task [14149031883378828575](https://jules.google.com/task/14149031883378828575) started by @gowthamrao*