### PR TITLE
feat: Implement Exogenous Epistemic Shock schemas

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2105,6 +2105,14 @@
           },
           "title": "Faults",
           "type": "array"
+        },
+        "shocks": {
+          "description": "The declarative list of exogenous Black Swan events injected into the topology.",
+          "items": {
+            "$ref": "#/$defs/ExogenousEpistemicShock"
+          },
+          "title": "Shocks",
+          "type": "array"
         }
       },
       "required": [
@@ -4700,6 +4708,48 @@
         "start_time_unix_nano"
       ],
       "title": "ExecutionSpan",
+      "type": "object"
+    },
+    "ExogenousEpistemicShock": {
+      "additionalProperties": false,
+      "properties": {
+        "shock_id": {
+          "description": "Cryptographic identifier for the Black Swan event.",
+          "minLength": 1,
+          "title": "Shock Id",
+          "type": "string"
+        },
+        "target_node_hash": {
+          "description": "Regex-bound SHA-256 string targeting a specific Merkle root in the epistemic graph.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Target Node Hash",
+          "type": "string"
+        },
+        "bayesian_surprise_score": {
+          "description": "Strictly bounded mathematical quantification of the epistemic decay or Variational Free Energy.",
+          "minimum": 0.0,
+          "title": "Bayesian Surprise Score",
+          "type": "number"
+        },
+        "synthetic_payload": {
+          "additionalProperties": true,
+          "description": "Bounded dictionary representing the injected hallucination or observation.",
+          "title": "Synthetic Payload",
+          "type": "object"
+        },
+        "escrow": {
+          "$ref": "#/$defs/SimulationEscrow",
+          "description": "The cryptographic Proof-of-Stake funding the shock."
+        }
+      },
+      "required": [
+        "shock_id",
+        "target_node_hash",
+        "bayesian_surprise_score",
+        "synthetic_payload",
+        "escrow"
+      ],
+      "title": "ExogenousEpistemicShock",
       "type": "object"
     },
     "FYIIntent": {
@@ -9064,6 +9114,22 @@
         "variance_tolerance"
       ],
       "title": "SimulationConvergenceSLA",
+      "type": "object"
+    },
+    "SimulationEscrow": {
+      "additionalProperties": false,
+      "properties": {
+        "locked_microcents": {
+          "description": "The strictly typed economic boundary requiring locked funds to prevent zero-cost griefing of the swarm.",
+          "exclusiveMinimum": 0,
+          "title": "Locked Microcents",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "locked_microcents"
+      ],
+      "title": "SimulationEscrow",
       "type": "object"
     },
     "SpanEvent": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -223,7 +223,14 @@ from coreason_manifest.telemetry.schemas import (
     TraceExportBatch,
 )
 from coreason_manifest.telemetry.ux import AmbientSignal, SuspenseEnvelope
-from coreason_manifest.testing.chaos import ChaosExperiment, FaultInjectionProfile, FaultType, SteadyStateHypothesis
+from coreason_manifest.testing.chaos import (
+    ChaosExperiment,
+    ExogenousEpistemicShock,
+    FaultInjectionProfile,
+    FaultType,
+    SimulationEscrow,
+    SteadyStateHypothesis,
+)
 from coreason_manifest.testing.red_team import AdversarialSimulationProfile
 from coreason_manifest.testing.simulation import GenerativeManifoldSLA, SyntheticGenerationProfile
 from coreason_manifest.tooling.environments import (
@@ -394,6 +401,7 @@ __all__ = [
     "ExecutionNode",
     "ExecutionSLA",
     "ExecutionSpan",
+    "ExogenousEpistemicShock",
     "FYIIntent",
     "FacetMatrix",
     "FallbackSLA",
@@ -506,6 +514,7 @@ __all__ = [
     "SemanticVersion",
     "SideEffectProfile",
     "SimulationConvergenceSLA",
+    "SimulationEscrow",
     "SpanEvent",
     "SpanKind",
     "SpanStatusCode",

--- a/src/coreason_manifest/testing/__init__.py
+++ b/src/coreason_manifest/testing/__init__.py
@@ -7,7 +7,9 @@
 
 from .chaos import (
     ChaosExperiment,
+    ExogenousEpistemicShock,
     FaultInjectionProfile,
+    SimulationEscrow,
     SteadyStateHypothesis,
 )
 from .red_team import (
@@ -21,8 +23,10 @@ from .simulation import (
 __all__ = [
     "AdversarialSimulationProfile",
     "ChaosExperiment",
+    "ExogenousEpistemicShock",
     "FaultInjectionProfile",
     "GenerativeManifoldSLA",
+    "SimulationEscrow",
     "SteadyStateHypothesis",
     "SyntheticGenerationProfile",
 ]

--- a/src/coreason_manifest/testing/chaos.py
+++ b/src/coreason_manifest/testing/chaos.py
@@ -12,9 +12,9 @@ swarm topology (e.g., node latency, memory corruption, topological severing).
 Do not write standard QA schemas here. Focus entirely on Blast Radius and Steady-State Hypotheses.
 """
 
-from typing import Literal
+from typing import Any, Literal, Self
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 
@@ -44,9 +44,44 @@ class SteadyStateHypothesis(CoreasonBaseModel):
     )
 
 
+class SimulationEscrow(CoreasonBaseModel):
+    locked_microcents: int = Field(
+        gt=0,
+        description="The strictly typed economic boundary requiring locked funds "
+        "to prevent zero-cost griefing of the swarm.",
+    )
+
+
+class ExogenousEpistemicShock(CoreasonBaseModel):
+    shock_id: str = Field(min_length=1, description="Cryptographic identifier for the Black Swan event.")
+    target_node_hash: str = Field(
+        pattern=r"^[a-f0-9]{64}$",
+        description="Regex-bound SHA-256 string targeting a specific Merkle root in the epistemic graph.",
+    )
+    bayesian_surprise_score: float = Field(
+        ge=0.0,
+        allow_inf_nan=False,
+        description="Strictly bounded mathematical quantification of the epistemic decay or Variational Free Energy.",
+    )
+    synthetic_payload: dict[str, Any] = Field(
+        description="Bounded dictionary representing the injected hallucination or observation."
+    )
+    escrow: SimulationEscrow = Field(description="The cryptographic Proof-of-Stake funding the shock.")
+
+    @model_validator(mode="after")
+    def enforce_economic_escrow(self) -> Self:
+        if self.escrow.locked_microcents <= 0:
+            raise ValueError("ExogenousEpistemicShock requires a strictly positive economic escrow to execute.")
+        return self
+
+
 class ChaosExperiment(CoreasonBaseModel):
     experiment_id: str = Field(description="The unique identifier for the chaos experiment.")
     hypothesis: SteadyStateHypothesis = Field(description="The baseline steady state hypothesis being tested.")
     faults: list[FaultInjectionProfile] = Field(
         description="The list of fault injection profiles defining the chaotic elements."
+    )
+    shocks: list[ExogenousEpistemicShock] = Field(
+        default_factory=list,
+        description="The declarative list of exogenous Black Swan events injected into the topology.",
     )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1768,7 +1768,7 @@ def test_epistemic_shock_escrow_interlock() -> None:
             target_node_hash="a" * 64,
             bayesian_surprise_score=0.1,
             synthetic_payload={},
-            escrow=SimulationEscrow.model_construct(locked_microcents=0)
+            escrow=SimulationEscrow.model_construct(locked_microcents=0),
         )
 
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1756,10 +1756,20 @@ def draw_exogenous_epistemic_shock(draw: Any) -> dict[str, Any]:
 def test_epistemic_shock_escrow_interlock() -> None:
     from pydantic import ValidationError
 
-    from coreason_manifest.testing.chaos import SimulationEscrow
+    from coreason_manifest.testing.chaos import ExogenousEpistemicShock, SimulationEscrow
 
     with pytest.raises(ValidationError, match="greater than 0"):
         SimulationEscrow(locked_microcents=0)
+
+    # Test the model_validator branch in ExogenousEpistemicShock
+    with pytest.raises(ValidationError, match="ExogenousEpistemicShock requires a strictly positive economic escrow"):
+        ExogenousEpistemicShock(
+            shock_id="s1",
+            target_node_hash="a" * 64,
+            bayesian_surprise_score=0.1,
+            synthetic_payload={},
+            escrow=SimulationEscrow.model_construct(locked_microcents=0)
+        )
 
 
 @given(

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1731,6 +1731,37 @@ def test_anyresilience_routing(res_type: str, target: str, fallback: str, reason
         assert isinstance(parsed, FallbackTrigger)
 
 
+@st.composite
+def draw_simulation_escrow(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(st.fixed_dictionaries({"locked_microcents": st.integers(min_value=1)}))
+    return res
+
+
+@st.composite
+def draw_exogenous_epistemic_shock(draw: Any) -> dict[str, Any]:
+    res: dict[str, Any] = draw(
+        st.fixed_dictionaries(
+            {
+                "shock_id": st.text(min_size=1),
+                "target_node_hash": st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
+                "bayesian_surprise_score": st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
+                "synthetic_payload": st.dictionaries(st.text(), st.one_of(st.text(), st.integers(), st.booleans())),
+                "escrow": draw_simulation_escrow(),
+            }
+        )
+    )
+    return res
+
+
+def test_epistemic_shock_escrow_interlock() -> None:
+    from pydantic import ValidationError
+
+    from coreason_manifest.testing.chaos import SimulationEscrow
+
+    with pytest.raises(ValidationError, match="greater than 0"):
+        SimulationEscrow(locked_microcents=0)
+
+
 @given(
     st.text(),
     st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
@@ -1756,6 +1787,7 @@ def test_anyresilience_routing(res_type: str, target: str, fallback: str, reason
             }
         )
     ),
+    st.lists(draw_exogenous_epistemic_shock(), max_size=5),
 )
 def test_chaosexperiment_fuzzing(
     experiment_id: str,
@@ -1763,6 +1795,7 @@ def test_chaosexperiment_fuzzing(
     max_loops_allowed: int,
     required_tool_usage: list[str] | None,
     faults: list[dict[str, Any]],
+    shocks: list[dict[str, Any]],
 ) -> None:
     payload: dict[str, Any] = {
         "experiment_id": experiment_id,
@@ -1771,6 +1804,7 @@ def test_chaosexperiment_fuzzing(
             "max_loops_allowed": max_loops_allowed,
         },
         "faults": faults,
+        "shocks": shocks,
     }
     if required_tool_usage is not None:
         payload["hypothesis"]["required_tool_usage"] = required_tool_usage


### PR DESCRIPTION
Implemented the "Exogenous Epistemic Shock" (Black Swan) schemas for Chaos Engineering per the Coreason protocol. Updated `ChaosExperiment` with strictly typed schemas (`SimulationEscrow`, `ExogenousEpistemicShock`) and added comprehensive fuzzing verification using hypothesis strategies. Ensured all local verifications (ruff, mypy, pytest) run perfectly with 100% strict adherence.

---
*PR created automatically by Jules for task [10335745197539470725](https://jules.google.com/task/10335745197539470725) started by @gowthamrao*