### PR TITLE
feat: implement wetware cryptographic attestation boundary

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -5515,7 +5515,7 @@
             }
           ],
           "default": null,
-          "description": "AGENT INSTRUCTION: If set, the orchestrator MUST NOT resolve \n        this node without a cryptographically matching WetwareAttestationContract \n        supplied in the InterventionVerdict.",
+          "description": "AGENT INSTRUCTION: If set, the orchestrator MUST NOT resolve\n        this node without a cryptographically matching WetwareAttestationContract\n        supplied in the InterventionVerdict.",
           "title": "Required Attestation"
         }
       },

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -5499,6 +5499,24 @@
           "description": "Discriminator for a Human node.",
           "title": "Type",
           "type": "string"
+        },
+        "required_attestation": {
+          "anyOf": [
+            {
+              "enum": [
+                "fido2_webauthn",
+                "zk_snark_groth16",
+                "pqc_ml_dsa"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "AGENT INSTRUCTION: If set, the orchestrator MUST NOT resolve \n        this node without a cryptographically matching WetwareAttestationContract \n        supplied in the InterventionVerdict.",
+          "title": "Required Attestation"
         }
       },
       "required": [
@@ -5895,6 +5913,10 @@
           "title": "Type",
           "type": "string"
         },
+        "intervention_request_id": {
+          "description": "The cryptographic nonce uniquely identifying the intervention request.",
+          "title": "Intervention Request Id"
+        },
         "target_node_id": {
           "$ref": "#/$defs/NodeID",
           "description": "The ID of the target node."
@@ -5915,9 +5937,22 @@
           ],
           "description": "Optional feedback provided along with the verdict.",
           "title": "Feedback"
+        },
+        "attestation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WetwareAttestationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic proof provided by the human operator, if required."
         }
       },
       "required": [
+        "intervention_request_id",
         "target_node_id",
         "approved",
         "feedback"
@@ -10497,6 +10532,47 @@
         "seed_hash"
       ],
       "title": "VerifiableEntropy",
+      "type": "object"
+    },
+    "WetwareAttestationContract": {
+      "description": "AGENT INSTRUCTION: This model represents a SOTA cryptographic receipt\nproving a human in the loop physically authorized a state transition.",
+      "properties": {
+        "mechanism": {
+          "description": "The SOTA cryptographic mechanism used to generate the proof.",
+          "enum": [
+            "fido2_webauthn",
+            "zk_snark_groth16",
+            "pqc_ml_dsa"
+          ],
+          "title": "Mechanism",
+          "type": "string"
+        },
+        "did_subject": {
+          "description": "The Decentralized Identifier (DID) of the human operator.",
+          "pattern": "^did:[a-z0-9]+:.*$",
+          "title": "Did Subject",
+          "type": "string"
+        },
+        "cryptographic_payload": {
+          "description": "The strictly formatted (Base64url/Hex/Multibase) signature or proof.",
+          "pattern": "^[A-Za-z0-9+/=_-]+$",
+          "title": "Cryptographic Payload",
+          "type": "string"
+        },
+        "dag_node_nonce": {
+          "description": "The cryptographic nonce tightly binding this signature to the specific Merkle-DAG node.",
+          "format": "uuid",
+          "title": "Dag Node Nonce",
+          "type": "string"
+        }
+      },
+      "required": [
+        "mechanism",
+        "did_subject",
+        "cryptographic_payload",
+        "dag_node_nonce"
+      ],
+      "title": "WetwareAttestationContract",
       "type": "object"
     },
     "WorkflowEnvelope": {

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -5915,7 +5915,9 @@
         },
         "intervention_request_id": {
           "description": "The cryptographic nonce uniquely identifying the intervention request.",
-          "title": "Intervention Request Id"
+          "format": "uuid",
+          "title": "Intervention Request Id",
+          "type": "string"
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeID",

--- a/src/coreason_manifest/core/identity.py
+++ b/src/coreason_manifest/core/identity.py
@@ -14,11 +14,36 @@ Introducing upstream domains into this module will trigger a fatal dependency lo
 """
 
 from typing import Any, Literal
+from uuid import UUID
 
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
+
+AttestationMechanism = Literal["fido2_webauthn", "zk_snark_groth16", "pqc_ml_dsa"]
+
+
+class WetwareAttestationContract(BaseModel):
+    """
+    AGENT INSTRUCTION: This model represents a SOTA cryptographic receipt
+    proving a human in the loop physically authorized a state transition.
+    """
+
+    mechanism: AttestationMechanism = Field(
+        ..., description="The SOTA cryptographic mechanism used to generate the proof."
+    )
+    did_subject: str = Field(
+        ..., pattern=r"^did:[a-z0-9]+:.*$", description="The Decentralized Identifier (DID) of the human operator."
+    )
+    cryptographic_payload: str = Field(
+        ...,
+        pattern=r"^[A-Za-z0-9+/=_-]+$",
+        description="The strictly formatted (Base64url/Hex/Multibase) signature or proof.",
+    )
+    dag_node_nonce: UUID = Field(
+        ..., description="The cryptographic nonce tightly binding this signature to the specific Merkle-DAG node."
+    )
 
 
 class VerifiableCredentialPresentation(CoreasonBaseModel):

--- a/src/coreason_manifest/oversight/intervention.py
+++ b/src/coreason_manifest/oversight/intervention.py
@@ -13,6 +13,7 @@ All policies must be declarative, deterministic, and capable of severing memory 
 """
 
 from typing import Annotated, Any, Literal
+from uuid import UUID
 
 from pydantic import Field, model_validator
 
@@ -99,7 +100,7 @@ class InterventionVerdict(CoreasonBaseModel):
     """
 
     type: Literal["verdict"] = Field(default="verdict", description="The type of the intervention payload.")
-    intervention_request_id: Any = Field(
+    intervention_request_id: UUID = Field(
         description="The cryptographic nonce uniquely identifying the intervention request."
     )
     target_node_id: NodeID = Field(description="The ID of the target node.")

--- a/src/coreason_manifest/oversight/intervention.py
+++ b/src/coreason_manifest/oversight/intervention.py
@@ -14,9 +14,10 @@ All policies must be declarative, deterministic, and capable of severing memory 
 
 from typing import Annotated, Any, Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.core.identity import WetwareAttestationContract
 from coreason_manifest.core.primitives import NodeID
 
 type LifecycleTrigger = Literal[
@@ -98,9 +99,27 @@ class InterventionVerdict(CoreasonBaseModel):
     """
 
     type: Literal["verdict"] = Field(default="verdict", description="The type of the intervention payload.")
+    intervention_request_id: Any = Field(
+        description="The cryptographic nonce uniquely identifying the intervention request."
+    )
     target_node_id: NodeID = Field(description="The ID of the target node.")
     approved: bool = Field(description="Indicates whether the proposed action was approved.")
     feedback: str | None = Field(description="Optional feedback provided along with the verdict.")
+    attestation: WetwareAttestationContract | None = Field(
+        default=None, description="The cryptographic proof provided by the human operator, if required."
+    )
+
+    @model_validator(mode="after")
+    def verify_attestation_nonce(self) -> "InterventionVerdict":
+        """
+        Mathematically guarantees that if a cryptographic signature is presented,
+        it cannot be a replay attack from a different node in the DAG.
+        """
+        if self.attestation is not None and self.attestation.dag_node_nonce != self.intervention_request_id:
+            raise ValueError(
+                "Anti-Replay Lock Triggered: Attestation nonce does not match the intervention request ID."
+            )
+        return self
 
 
 class OverrideIntent(CoreasonBaseModel):

--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -21,7 +21,7 @@ from coreason_manifest.compute.stochastic import LogitSteganographyContract
 from coreason_manifest.compute.symbolic import NeuroSymbolicHandoff
 from coreason_manifest.compute.test_time import EscalationContract, ProcessRewardContract
 from coreason_manifest.core.base import CoreasonBaseModel
-from coreason_manifest.core.identity import VerifiableCredentialPresentation
+from coreason_manifest.core.identity import AttestationMechanism, VerifiableCredentialPresentation
 from coreason_manifest.core.primitives import TopologyHash
 from coreason_manifest.oversight.dlp import SecureSubSession
 from coreason_manifest.state.cognition import CognitiveStateProfile
@@ -222,6 +222,12 @@ class HumanNode(BaseNode):
     """
 
     type: Literal["human"] = Field(default="human", description="Discriminator for a Human node.")
+    required_attestation: AttestationMechanism | None = Field(
+        default=None,
+        description="""AGENT INSTRUCTION: If set, the orchestrator MUST NOT resolve
+        this node without a cryptographically matching WetwareAttestationContract
+        supplied in the InterventionVerdict.""",
+    )
 
 
 class SystemNode(BaseNode):

--- a/tests/domains/test_oversight_intervention.py
+++ b/tests/domains/test_oversight_intervention.py
@@ -5,11 +5,16 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
-from pydantic import TypeAdapter
+from uuid import uuid4
 
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from coreason_manifest.core.identity import WetwareAttestationContract
 from coreason_manifest.oversight.intervention import (
     AnyInterventionPayload,
     ConstitutionalAmendmentProposal,
+    InterventionVerdict,
 )
 
 
@@ -30,3 +35,36 @@ def test_constitutional_amendment_proposal_routing() -> None:
     assert (
         parsed_payload.justification == "The prior rule threshold of 0.9 caused loop condition #42 in state tracking."
     )
+
+
+def test_intervention_verdict_matching_nonce() -> None:
+    nonce = uuid4()
+    attestation = WetwareAttestationContract(
+        mechanism="fido2_webauthn", did_subject="did:example:123", cryptographic_payload="abcd", dag_node_nonce=nonce
+    )
+    verdict = InterventionVerdict(
+        type="verdict",
+        intervention_request_id=nonce,
+        target_node_id="did:node:test",
+        approved=True,
+        feedback=None,
+        attestation=attestation,
+    )
+    assert verdict.attestation == attestation
+
+
+def test_intervention_verdict_mismatched_nonce() -> None:
+    nonce1 = uuid4()
+    nonce2 = uuid4()
+    attestation = WetwareAttestationContract(
+        mechanism="fido2_webauthn", did_subject="did:example:123", cryptographic_payload="abcd", dag_node_nonce=nonce1
+    )
+    with pytest.raises(ValidationError, match="Anti-Replay Lock Triggered"):
+        InterventionVerdict(
+            type="verdict",
+            intervention_request_id=nonce2,
+            target_node_id="did:node:test",
+            approved=True,
+            feedback=None,
+            attestation=attestation,
+        )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -2881,6 +2881,7 @@ def draw_intervention_verdict(draw: Any) -> dict[str, Any]:
         st.fixed_dictionaries(
             {
                 "type": st.just("verdict"),
+                "intervention_request_id": st.uuids(),
                 "target_node_id": draw_did_string(),
                 "approved": st.booleans(),
                 "feedback": st.one_of(st.none(), st.text()),


### PR DESCRIPTION
Implemented the "Wetware" Cryptographic Attestation boundary as requested:
1. `src/coreason_manifest/core/identity.py`: Added the SOTA cryptographic primitives `AttestationMechanism` and `WetwareAttestationContract`.
2. `src/coreason_manifest/workflow/nodes.py`: Injected the `required_attestation` field into the `HumanNode` class.
3. `src/coreason_manifest/oversight/intervention.py`: Added the `attestation` and `intervention_request_id` fields to `InterventionVerdict` and implemented the `verify_attestation_nonce` model validator for anti-replay logic.
4. `tests/domains/test_oversight_intervention.py`: Wrote deterministic unit tests verifying the mathematical lock, with one testing a matched nonce and another testing a mismatched nonce resulting in a `ValidationError`.

All platform-engineering automated checks (`ruff check`, `ruff format`, `mypy src tests`, and `pytest`) have been executed and exit with code 0.

---
*PR created automatically by Jules for task [94367630734192695](https://jules.google.com/task/94367630734192695) started by @gowthamrao*