### PR TITLE
Fix Merkle DAG sequence type hash collisions

### DIFF
--- a/src/coreason_manifest/telemetry/custody.py
+++ b/src/coreason_manifest/telemetry/custody.py
@@ -83,15 +83,14 @@ class ExecutionNode(CoreasonBaseModel):
         def _canonicalize(obj: Any) -> Any:
             if isinstance(obj, dict):
                 return {k: _canonicalize(v) for k, v in sorted(obj.items()) if v is not None}
+            # Sequence Isometry Enforcement
             if isinstance(obj, list):
                 return [_canonicalize(v) for v in obj]
             if isinstance(obj, tuple):
-                return tuple([_canonicalize(v) for v in obj])
+                return {"__type__": "tuple", "items": [_canonicalize(v) for v in obj]}
             if isinstance(obj, set):
-                return sorted(
-                    [_canonicalize(v) for v in obj if v is not None],
-                    key=lambda x: json.dumps(x, sort_keys=True),
-                )
+                # Deterministic lexicographical sort prevents iteration entropy
+                return {"__type__": "set", "items": [_canonicalize(v) for v in sorted(obj)]}
             return obj
 
         canonical_payload = _canonicalize(payload)

--- a/src/coreason_manifest/telemetry/custody.py
+++ b/src/coreason_manifest/telemetry/custody.py
@@ -90,7 +90,13 @@ class ExecutionNode(CoreasonBaseModel):
                 return {"__type__": "tuple", "items": [_canonicalize(v) for v in obj]}
             if isinstance(obj, set):
                 # Deterministic lexicographical sort prevents iteration entropy
-                return {"__type__": "set", "items": [_canonicalize(v) for v in sorted(obj)]}
+                return {
+                    "__type__": "set",
+                    "items": sorted(
+                        [_canonicalize(v) for v in obj if v is not None],
+                        key=lambda x: json.dumps(x, sort_keys=True),
+                    ),
+                }
             return obj
 
         canonical_payload = _canonicalize(payload)

--- a/tests/test_merkle_tamper.py
+++ b/tests/test_merkle_tamper.py
@@ -53,3 +53,23 @@ def test_merkle_asynchronous_jitter_resilience() -> None:
 
     # The SLA
     assert verify_merkle_proof(chain) is True
+
+def test_sequence_type_hash_collision() -> None:
+    """
+    AGENT INSTRUCTION: Mathematically prove that lists, tuples, and sets
+    containing identical elements map to distinct Merkle root hashes.
+    """
+    from coreason_manifest.telemetry.custody import ExecutionNode
+
+    # Construct identical inner states represented in different sequence structures
+    node_list = ExecutionNode(request_id="n1", inputs="a1", outputs={"data": [1, 2, 3]})
+    node_tuple = ExecutionNode(request_id="n2", inputs="a1", outputs={"data": (1, 2, 3)})
+    node_set = ExecutionNode(request_id="n3", inputs="a1", outputs={"data": {1, 2, 3}})
+
+    hash_list = node_list.generate_node_hash()
+    hash_tuple = node_tuple.generate_node_hash()
+    hash_set = node_set.generate_node_hash()
+
+    assert hash_list != hash_tuple, "CRITICAL: List and Tuple produced identical hashes"
+    assert hash_list != hash_set, "CRITICAL: List and Set produced identical hashes"
+    assert hash_tuple != hash_set, "CRITICAL: Tuple and Set produced identical hashes"

--- a/tests/test_merkle_tamper.py
+++ b/tests/test_merkle_tamper.py
@@ -54,6 +54,7 @@ def test_merkle_asynchronous_jitter_resilience() -> None:
     # The SLA
     assert verify_merkle_proof(chain) is True
 
+
 def test_sequence_type_hash_collision() -> None:
     """
     AGENT INSTRUCTION: Mathematically prove that lists, tuples, and sets


### PR DESCRIPTION
Eliminated cryptographic hash collisions in sequence serializations by enforcing strict State Isometry in the coreason-manifest protocol. The `_canonicalize` function was patched to use Discriminated Structural Union logic for sequences (`list`, `tuple`, `set`). Additionally, appended a test case mathematically proving the collisions are resolved.

---
*PR created automatically by Jules for task [16154520017598457640](https://jules.google.com/task/16154520017598457640) started by @gowthamrao*