### PR TITLE
feat: enforce maximum composite node topology depth of 5

### DIFF
--- a/src/coreason_manifest/workflow/nodes.py
+++ b/src/coreason_manifest/workflow/nodes.py
@@ -12,7 +12,7 @@ multi-agent market dynamics."""
 
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 
 from coreason_manifest.compute.inference import ActiveInferenceContract, AnalogicalMappingTask, InterventionalCausalTask
 from coreason_manifest.compute.peft import PeftAdapterContract
@@ -247,6 +247,30 @@ class CompositeNode(BaseNode):
     topology: "AnyTopology" = Field(description="The encapsulated subgraph to execute.")
     input_mappings: list[InputMapping] = Field(default_factory=list, description="Explicit state projection inputs.")
     output_mappings: list[OutputMapping] = Field(default_factory=list, description="Explicit state projection outputs.")
+
+    @model_validator(mode="after")
+    def _enforce_topology_depth_limit(self) -> "CompositeNode":
+        """
+        AGENT INSTRUCTION: Passive structural envelope. Prevents fatal stack overflows
+        by bounding the maximum fractal depth of subgraph encapsulation to 5.
+        """
+
+        def _check_depth(topology: Any, current_depth: int) -> None:
+            if current_depth > 5:
+                raise ValueError(
+                    "CompositeNode topology encapsulation exceeds maximum allowable depth of 5. "
+                    "This violates the geometric bounds of the CoReason orchestration data plane."
+                )
+
+            # Safely traverse the instantiated topology nodes without circular execution
+            if hasattr(topology, "nodes") and isinstance(topology.nodes, dict):
+                for node in topology.nodes.values():
+                    # Identify nested CompositeNodes via their discriminator
+                    if getattr(node, "type", None) == "composite" and hasattr(node, "topology"):
+                        _check_depth(node.topology, current_depth + 1)
+
+        _check_depth(self.topology, 1)
+        return self
 
 
 class MemoizedNode(BaseNode):

--- a/tests/test_graph_overflow.py
+++ b/tests/test_graph_overflow.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
+from coreason_manifest.workflow.nodes import CompositeNode
 from coreason_manifest.workflow.topologies import AnyTopology
 
 topology_adapter: TypeAdapter[AnyTopology] = TypeAdapter(AnyTopology)
@@ -44,3 +45,45 @@ def test_cwe_674_deep_cycle_detection() -> None:
 
     # Verify the error message proves the DFS safely traversed the graph and found the cycle
     assert "Graph contains cycles" in str(exc_info.value)
+
+
+def test_composite_node_depth_limit_rejected() -> None:
+    """
+    AGENT INSTRUCTION: Mathematically prove that a 6-level deep CompositeNode
+    is rejected by the Pydantic Rust core before execution.
+    """
+    # Create a simple valid leaf node
+    leaf_node = {"description": "Leaf", "type": "system"}
+
+    # Manually nest a dictionary structure to bypass bottom-up instantiation blocks
+    # and test the top-level deserialization drop
+    # (Agent: Construct a recursive dictionary mapping that reaches depth 6,
+    # then attempt to parse it into a CompositeNode).
+
+    current_topology = {
+        "type": "dag",
+        "nodes": {"did:web:leaf_node": leaf_node},
+        "edges": [],
+        "allow_cycles": False,
+    }
+
+    for i in range(5):
+        current_topology = {
+            "type": "dag",
+            "nodes": {
+                f"did:web:composite_node_{i}": {
+                    "type": "composite",
+                    "description": f"Level {i + 1} composite node",
+                    "topology": current_topology,
+                }
+            },
+            "edges": [],
+            "allow_cycles": False,
+        }
+
+    payload = {"description": "Root composite node", "type": "composite", "topology": current_topology}
+
+    with pytest.raises(ValidationError) as exc_info:
+        CompositeNode.model_validate(payload)
+
+    assert "CompositeNode topology encapsulation exceeds maximum allowable depth of 5" in str(exc_info.value)


### PR DESCRIPTION
The orchestrator could run into stack overflow vulnerabilities when recursive deserialization gets too deep. This PR implements a rigorous limit on the maximum fractal depth of `CompositeNode` topologies. The limit is mathematically verified by new automated tests.

---
*PR created automatically by Jules for task [9775284671359909025](https://jules.google.com/task/9775284671359909025) started by @gowthamrao*