### PR TITLE
fix: Enforce strict path geometry on TerminalBufferState

### DIFF
--- a/src/coreason_manifest/state/toolchains.py
+++ b/src/coreason_manifest/state/toolchains.py
@@ -10,9 +10,10 @@ These schemas represent the append-only cognitive ledger of the swarm. YOU ARE E
 monotonic logic, standard CRUD database paradigms, or kinetic execution parameters. These models represent computable
 geometric graphs of cognition and causal inference."""
 
+import re
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 
@@ -42,6 +43,21 @@ class TerminalBufferState(CoreasonBaseModel):
     stdout_hash: str = Field(description="The SHA-256 hash of the Exogenous Perturbations captured.")
     stderr_hash: str = Field(description="The SHA-256 hash tracking structural deviation anomalies.")
     env_variables_hash: str = Field(description="The SHA-256 hash of the state-space context matrix.")
+
+    @field_validator("working_directory")
+    @classmethod
+    def _enforce_sandboxed_path(cls, v: str) -> str:
+        """
+        AGENT INSTRUCTION: Strictly confine path geometry.
+        Reject arbitrary absolute paths and traversal tokens purely mathematically.
+        """
+        if ".." in v:
+            raise ValueError("Path traversal sequences ('..') are strictly forbidden to preserve sandbox geometry.")
+        if v.startswith(("/", "\\")):
+            raise ValueError("Absolute Unix/Windows root paths are strictly forbidden.")
+        if re.match(r"^[a-zA-Z]:", v):
+            raise ValueError("Windows drive letter absolute paths are strictly forbidden.")
+        return v
 
 
 # =========================================================================

--- a/tests/domains/test_state_toolchains.py
+++ b/tests/domains/test_state_toolchains.py
@@ -1,0 +1,31 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.state.toolchains import TerminalBufferState
+
+
+def test_terminal_state_rejects_unix_absolute_path() -> None:
+    with pytest.raises(ValidationError, match="Absolute Unix/Windows root paths"):
+        # Provide dummy data for other required fields as dictated by the schema
+        TerminalBufferState(working_directory="/etc/shadow", stdout_hash="", stderr_hash="", env_variables_hash="")
+
+
+def test_terminal_state_rejects_windows_absolute_path() -> None:
+    with pytest.raises(ValidationError, match="Windows drive letter"):
+        TerminalBufferState(
+            working_directory="C:\\Windows\\System32", stdout_hash="", stderr_hash="", env_variables_hash=""
+        )
+
+
+def test_terminal_state_rejects_traversal_sequences() -> None:
+    with pytest.raises(ValidationError, match="Path traversal sequences"):
+        TerminalBufferState(
+            working_directory="../../var/log/syslog", stdout_hash="", stderr_hash="", env_variables_hash=""
+        )
+
+
+def test_terminal_state_accepts_safe_relative_path() -> None:
+    state = TerminalBufferState(
+        working_directory="local_scripts/runner", stdout_hash="", stderr_hash="", env_variables_hash=""
+    )
+    assert state.working_directory == "local_scripts/runner"

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1365,7 +1365,7 @@ def draw_terminal_buffer_state(draw: Any) -> dict[str, Any]:
         st.fixed_dictionaries(
             {
                 "type": st.just("terminal"),
-                "working_directory": st.text(min_size=1),
+                "working_directory": st.from_regex(r"^[a-zA-Z0-9_]+(?:/[a-zA-Z0-9_]+)*$", fullmatch=True),
                 "stdout_hash": st.text(min_size=10),
                 "stderr_hash": st.text(min_size=10),
                 "env_variables_hash": st.text(min_size=10),


### PR DESCRIPTION
# Description

Addresses Path Traversal vulnerabilities by enforcing strict Lexical Capability Confinement on the `TerminalBufferState` model.

* Added a pure Pydantic validator to `working_directory` that rejects absolute Unix/Windows paths, Windows drive letters, and traversal sequences like `..`
* Created domain tests (`test_terminal_state_rejects_unix_absolute_path`, etc) to confirm topological boundaries.
* Updated fuzzing maintenance (`test_fuzzing.py`) so `TerminalBufferState` generated payloads adhere to the new strict path logic using forward-moving alphanumeric strings.

---
*PR created automatically by Jules for task [11820632827670175793](https://jules.google.com/task/11820632827670175793) started by @gowthamrao*