### PR TITLE
fix: Enforce mathematical spatial monotonicity on MultimodalTokenAnchor

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -8728,11 +8728,14 @@
       "properties": {
         "baseline_importance": {
           "description": "The starting importance score of this memory from 0.0 to 1.0.",
+          "maximum": 1.0,
+          "minimum": 0.0,
           "title": "Baseline Importance",
           "type": "number"
         },
         "decay_rate": {
           "description": "The rate at which this memory's relevance decays over time.",
+          "minimum": 0.0,
           "title": "Decay Rate",
           "type": "number"
         }

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -64,6 +64,18 @@ class MultimodalTokenAnchor(CoreasonBaseModel):
             raise ValueError("token_span_end cannot be defined without a token_span_start.")
         return self
 
+    @model_validator(mode="after")
+    def validate_spatial_geometry(self) -> Self:
+        """AGENT INSTRUCTION: Enforce mathematical spatial monotonicity."""
+        if self.bounding_box is not None:
+            x_min, y_min, x_max, y_max = self.bounding_box
+            if x_min > x_max or y_min > y_max:
+                raise ValueError(
+                    f"Spatial invariant violated: min bounds (x:{x_min}, y:{y_min}) "
+                    f"exceed max bounds (x:{x_max}, y:{y_max})"
+                )
+        return self
+
 
 type CausalInterval = Literal["strictly_precedes", "overlaps", "contains", "causes", "mitigates"]
 

--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -10,7 +10,7 @@ These schemas represent the append-only cognitive ledger of the swarm. YOU ARE E
 mutable state loops, standard CRUD database paradigms, or downstream business logic. Focus purely on cryptographic
 event sourcing, hardware attestations, and non-monotonic belief updates."""
 
-from typing import Any, Literal, Self
+from typing import Literal, Self
 
 from pydantic import Field, model_validator
 
@@ -136,7 +136,7 @@ class TemporalBounds(CoreasonBaseModel):
     )
 
     @model_validator(mode="after")
-    def validate_temporal_bounds(self) -> Any:
+    def validate_temporal_bounds(self) -> Self:
         if self.valid_from is not None and self.valid_to is not None and self.valid_to < self.valid_from:
             raise ValueError("valid_to cannot be before valid_from")
         return self
@@ -181,8 +181,10 @@ class MemoryProvenance(CoreasonBaseModel):
 
 
 class SalienceProfile(CoreasonBaseModel):
-    baseline_importance: float = Field(description="The starting importance score of this memory from 0.0 to 1.0.")
-    decay_rate: float = Field(description="The rate at which this memory's relevance decays over time.")
+    baseline_importance: float = Field(
+        ge=0.0, le=1.0, description="The starting importance score of this memory from 0.0 to 1.0."
+    )
+    decay_rate: float = Field(ge=0.0, description="The rate at which this memory's relevance decays over time.")
 
 
 class HomomorphicEncryptionProfile(CoreasonBaseModel):

--- a/tests/domains/test_state_semantic.py
+++ b/tests/domains/test_state_semantic.py
@@ -33,3 +33,20 @@ def test_multimodal_token_anchor_bounds() -> None:
         MultimodalTokenAnchor(token_span_start=5, token_span_end=5)
     with pytest.raises(ValidationError, match="If token_span_start is defined, token_span_end MUST be defined"):
         MultimodalTokenAnchor(token_span_start=5)
+
+
+def test_multimodal_token_anchor_spatial_invariant():
+    """Verify that inverted bounding boxes raise strict struct-legible ValueErrors."""
+    from coreason_manifest.state.semantic import MultimodalTokenAnchor
+
+    # Valid geometry
+    anchor = MultimodalTokenAnchor(bounding_box=(0.0, 0.0, 10.0, 10.0))
+    assert anchor.bounding_box == (0.0, 0.0, 10.0, 10.0)
+
+    # Invalid geometry (x_min > x_max)
+    with pytest.raises(ValidationError, match="Spatial invariant violated"):
+        MultimodalTokenAnchor(bounding_box=(15.0, 0.0, 10.0, 10.0))
+
+    # Invalid geometry (y_min > y_max)
+    with pytest.raises(ValidationError, match="Spatial invariant violated"):
+        MultimodalTokenAnchor(bounding_box=(0.0, 20.0, 10.0, 10.0))

--- a/tests/domains/test_state_semantic.py
+++ b/tests/domains/test_state_semantic.py
@@ -35,7 +35,7 @@ def test_multimodal_token_anchor_bounds() -> None:
         MultimodalTokenAnchor(token_span_start=5)
 
 
-def test_multimodal_token_anchor_spatial_invariant():
+def test_multimodal_token_anchor_spatial_invariant() -> None:
     """Verify that inverted bounding boxes raise strict struct-legible ValueErrors."""
     from coreason_manifest.state.semantic import MultimodalTokenAnchor
 

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -2076,7 +2076,12 @@ def draw_multimodal_token_anchor(draw: Any) -> dict[str, Any]:
                         st.floats(allow_nan=False, allow_infinity=False),
                         st.floats(allow_nan=False, allow_infinity=False),
                         st.floats(allow_nan=False, allow_infinity=False),
-                    ),
+                    ).map(lambda bbox: (
+                        min(bbox[0], bbox[2]),
+                        min(bbox[1], bbox[3]),
+                        max(bbox[0], bbox[2]),
+                        max(bbox[1], bbox[3]),
+                    )),
                 ),
                 "block_type": st.one_of(
                     st.none(),

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -2152,8 +2152,8 @@ def draw_epistemic_transmutation_task(draw: Any) -> dict[str, Any]:
                 st.none(),
                 st.fixed_dictionaries(
                     {
-                        "baseline_importance": st.floats(allow_nan=False, allow_infinity=False),
-                        "decay_rate": st.floats(allow_nan=False, allow_infinity=False),
+                        "baseline_importance": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+                        "decay_rate": st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
                     }
                 ),
             ),

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -2152,7 +2152,9 @@ def draw_epistemic_transmutation_task(draw: Any) -> dict[str, Any]:
                 st.none(),
                 st.fixed_dictionaries(
                     {
-                        "baseline_importance": st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False),
+                        "baseline_importance": st.floats(
+                            min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False
+                        ),
                         "decay_rate": st.floats(min_value=0.0, allow_nan=False, allow_infinity=False),
                     }
                 ),

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -2076,12 +2076,14 @@ def draw_multimodal_token_anchor(draw: Any) -> dict[str, Any]:
                         st.floats(allow_nan=False, allow_infinity=False),
                         st.floats(allow_nan=False, allow_infinity=False),
                         st.floats(allow_nan=False, allow_infinity=False),
-                    ).map(lambda bbox: (
-                        min(bbox[0], bbox[2]),
-                        min(bbox[1], bbox[3]),
-                        max(bbox[0], bbox[2]),
-                        max(bbox[1], bbox[3]),
-                    )),
+                    ).map(
+                        lambda bbox: (
+                            min(bbox[0], bbox[2]),
+                            min(bbox[1], bbox[3]),
+                            max(bbox[0], bbox[2]),
+                            max(bbox[1], bbox[3]),
+                        )
+                    ),
                 ),
                 "block_type": st.one_of(
                     st.none(),


### PR DESCRIPTION
Eliminates Ontological Paradox where `MultimodalTokenAnchor.bounding_box` accepts impossible spatial geometries. Enforces a mathematical invariant at the Pydantic deserialization boundary, appends unit tests, and mutates the Hypothesis fuzzing strategy to ensure dynamically generated valid geometries to prevent upstream CI/CD failure.

---
*PR created automatically by Jules for task [6810241736320786483](https://jules.google.com/task/6810241736320786483) started by @gowthamrao*