### PR TITLE
fix: implement CRLF and XSS Pydantic boundaries

### DIFF
--- a/src/coreason_manifest/adapters/mcp/schemas.py
+++ b/src/coreason_manifest/adapters/mcp/schemas.py
@@ -147,6 +147,15 @@ class HTTPTransportConfig(CoreasonBaseModel):
         default_factory=dict, description="HTTP headers, strictly bounded for zero-trust credentials."
     )
 
+    @field_validator("headers", mode="after")
+    @classmethod
+    def _prevent_crlf_injection(cls, v: dict[str, str]) -> dict[str, str]:
+        """AGENT INSTRUCTION: Strictly forbid HTTP request smuggling vectors."""
+        for key, value in v.items():
+            if "\r" in key or "\n" in key or "\r" in value or "\n" in value:
+                raise ValueError("CRLF injection detected in headers")
+        return v
+
 
 class SSETransportConfig(CoreasonBaseModel):
     """Configuration for remote SSE-based MCP transport."""
@@ -154,6 +163,15 @@ class SSETransportConfig(CoreasonBaseModel):
     type: Literal["sse"] = Field(default="sse", description="Type of transport.")
     uri: HttpUrl = Field(..., description="The HTTP URL endpoint for the SSE connection.")
     headers: dict[str, str] = Field(default_factory=dict, description="HTTP headers, e.g., for authentication.")
+
+    @field_validator("headers", mode="after")
+    @classmethod
+    def _prevent_crlf_injection(cls, v: dict[str, str]) -> dict[str, str]:
+        """AGENT INSTRUCTION: Strictly forbid HTTP request smuggling vectors."""
+        for key, value in v.items():
+            if "\r" in key or "\n" in key or "\r" in value or "\n" in value:
+                raise ValueError("CRLF injection detected in headers")
+        return v
 
 
 type MCPTransport = StdioTransportConfig | SSETransportConfig | HTTPTransportConfig

--- a/src/coreason_manifest/presentation/scivis.py
+++ b/src/coreason_manifest/presentation/scivis.py
@@ -106,6 +106,15 @@ class InsightCard(CoreasonBaseModel):
             )
         return v
 
+    @field_validator("markdown_content", mode="after")
+    @classmethod
+    def _prevent_malicious_uri_schemes(cls, v: str) -> str:
+        """AGENT INSTRUCTION: Statically sever XSS vectors embedded in markdown links."""
+        # Detects schemes like [click here](javascript:alert(1))
+        if re.search(r"\]\(\s*(javascript|vbscript|data):", v, flags=re.IGNORECASE):
+            raise ValueError("Malicious executable link scheme detected in markdown content")
+        return v
+
 
 # =========================================================================
 # AGENT INSTRUCTION: WARNING - POLYMORPHIC ROUTER

--- a/tests/domains/test_mcp_boundary.py
+++ b/tests/domains/test_mcp_boundary.py
@@ -6,10 +6,9 @@ from hypothesis import HealthCheck, given, settings
 from mcp.server import Server
 from mcp.shared.session import SessionMessage  # type: ignore[attr-defined]
 from mcp.types import JSONRPCMessage
-from pydantic import ValidationError
+from pydantic import HttpUrl, ValidationError
 
 from coreason_manifest.adapters.mcp.schemas import BoundedJSONRPCRequest, HTTPTransportConfig
-from pydantic import HttpUrl
 from coreason_manifest.cli.mcp_server import _global_error_handler_shield
 
 # Initialize the global shield for tests

--- a/tests/domains/test_mcp_boundary.py
+++ b/tests/domains/test_mcp_boundary.py
@@ -8,7 +8,8 @@ from mcp.shared.session import SessionMessage  # type: ignore[attr-defined]
 from mcp.types import JSONRPCMessage
 from pydantic import ValidationError
 
-from coreason_manifest.adapters.mcp.schemas import BoundedJSONRPCRequest
+from coreason_manifest.adapters.mcp.schemas import BoundedJSONRPCRequest, HTTPTransportConfig
+from pydantic import HttpUrl
 from coreason_manifest.cli.mcp_server import _global_error_handler_shield
 
 # Initialize the global shield for tests
@@ -441,3 +442,15 @@ async def test_uptime_assertion_poison_pill() -> None:
     response_dict2 = sent_msg2.message.model_dump()
     assert response_dict2["jsonrpc"] == "2.0"
     assert response_dict2["error"]["code"] in (-32600, -32700)
+
+@given(
+    header_key=st.text(alphabet=["\r", "\n", "A", "B"], min_size=1),
+    header_val=st.text(alphabet=["\r", "\n", "1", "2"], min_size=1)
+)
+def test_crlf_rejection_in_http_transport(header_key: str, header_val: str) -> None:
+    if "\r" in header_key or "\n" in header_key or "\r" in header_val or "\n" in header_val:
+        with pytest.raises(ValidationError, match="CRLF injection detected in headers"):
+            HTTPTransportConfig(
+                uri=HttpUrl("https://api.coreason.ai"),
+                headers={header_key: header_val}
+            )

--- a/tests/domains/test_mcp_boundary.py
+++ b/tests/domains/test_mcp_boundary.py
@@ -442,14 +442,12 @@ async def test_uptime_assertion_poison_pill() -> None:
     assert response_dict2["jsonrpc"] == "2.0"
     assert response_dict2["error"]["code"] in (-32600, -32700)
 
+
 @given(
     header_key=st.text(alphabet=["\r", "\n", "A", "B"], min_size=1),
-    header_val=st.text(alphabet=["\r", "\n", "1", "2"], min_size=1)
+    header_val=st.text(alphabet=["\r", "\n", "1", "2"], min_size=1),
 )
 def test_crlf_rejection_in_http_transport(header_key: str, header_val: str) -> None:
     if "\r" in header_key or "\n" in header_key or "\r" in header_val or "\n" in header_val:
         with pytest.raises(ValidationError, match="CRLF injection detected in headers"):
-            HTTPTransportConfig(
-                uri=HttpUrl("https://api.coreason.ai"),
-                headers={header_key: header_val}
-            )
+            HTTPTransportConfig(uri=HttpUrl("https://api.coreason.ai"), headers={header_key: header_val})

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -127,17 +127,11 @@ def test_safe_rendering_test(title: str, safe_text: str, x_label: str, y_label: 
     assert grid.layout_matrix == [["panel_1", "panel_2"], ["panel_3", "panel_1"]]
     assert len(grid.panels) == 3
 
-@given(
-    scheme=st.sampled_from(["javascript", "vbscript", "data", "JaVaScRiPt"]),
-    payload=st.text()
-)
+
+@given(scheme=st.sampled_from(["javascript", "vbscript", "data", "JaVaScRiPt"]), payload=st.text())
 def test_insight_card_rejects_xss_links(scheme: str, payload: str) -> None:
     # Use 'payload' that does not contain `<` or `on...=` to bypass sanitize_markdown
     payload = payload.replace("<", "").replace("on", "")
     malicious_markdown = f"Look at this: [click me]({scheme}:{payload})"
     with pytest.raises(ValidationError, match="Malicious executable link scheme detected"):
-        InsightCard(
-            panel_id="test_xss",
-            title="XSS Test",
-            markdown_content=malicious_markdown
-        )
+        InsightCard(panel_id="test_xss", title="XSS Test", markdown_content=malicious_markdown)

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -126,3 +126,18 @@ def test_safe_rendering_test(title: str, safe_text: str, x_label: str, y_label: 
     grid = MacroGrid(layout_matrix=[["panel_1", "panel_2"], ["panel_3", "panel_1"]], panels=panels)
     assert grid.layout_matrix == [["panel_1", "panel_2"], ["panel_3", "panel_1"]]
     assert len(grid.panels) == 3
+
+@given(
+    scheme=st.sampled_from(["javascript", "vbscript", "data", "JaVaScRiPt"]),
+    payload=st.text()
+)
+def test_insight_card_rejects_xss_links(scheme: str, payload: str) -> None:
+    # Use 'payload' that does not contain `<` or `on...=` to bypass sanitize_markdown
+    payload = payload.replace("<", "").replace("on", "")
+    malicious_markdown = f"Look at this: [click me]({scheme}:{payload})"
+    with pytest.raises(ValidationError, match="Malicious executable link scheme detected"):
+        InsightCard(
+            panel_id="test_xss",
+            title="XSS Test",
+            markdown_content=malicious_markdown
+        )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1873,7 +1873,7 @@ def draw_http_transport_config(draw: Any) -> dict[str, Any]:
                 ),
                 "headers": st.dictionaries(
                     st.text().filter(lambda x: "\r" not in x and "\n" not in x),
-                    st.text().filter(lambda x: "\r" not in x and "\n" not in x)
+                    st.text().filter(lambda x: "\r" not in x and "\n" not in x),
                 ),
             }
         )

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1871,7 +1871,10 @@ def draw_http_transport_config(draw: Any) -> dict[str, Any]:
                 "uri": st.sampled_from(
                     ["http://localhost:8080", "https://api.coreason.ai/mcp", "https://10.0.0.1/rpc"]
                 ),
-                "headers": st.dictionaries(st.text(), st.text()),
+                "headers": st.dictionaries(
+                    st.text().filter(lambda x: "\r" not in x and "\n" not in x),
+                    st.text().filter(lambda x: "\r" not in x and "\n" not in x)
+                ),
             }
         )
     )


### PR DESCRIPTION
Implement strictly typed structural boundaries to neutralize two critical vulnerabilities: HTTP Header CRLF Injection in MCP transport schemas and Visual XSS via executable URI schemes in Markdown content. Structural proofs using Hypothesis are added to verify the boundaries.

---
*PR created automatically by Jules for task [9304881908271083060](https://jules.google.com/task/9304881908271083060) started by @gowthamrao*