### PR TITLE
Enforce mathematically proportional byte-dimensionality parity on VectorEmbedding

### DIFF
--- a/src/coreason_manifest/state/semantic.py
+++ b/src/coreason_manifest/state/semantic.py
@@ -10,6 +10,7 @@ These schemas represent the append-only cognitive ledger of the swarm. YOU ARE E
 mutable state loops, standard CRUD database paradigms, or downstream business logic. Focus purely on cryptographic
 event sourcing, hardware attestations, and non-monotonic belief updates."""
 
+import base64
 from typing import Any, Literal, Self
 
 from pydantic import Field, model_validator
@@ -112,6 +113,33 @@ class VectorEmbedding(CoreasonBaseModel):
     )
     dimensionality: int = Field(description="The size of the vector array.")
     model_name: str = Field(description="The provenance of the embedding model used (e.g., 'text-embedding-3-large').")
+
+    @model_validator(mode="after")
+    def _enforce_byte_dimensionality_parity(self) -> "VectorEmbedding":
+        """
+        AGENT INSTRUCTION: Strictly enforces zero-trust dimensionality boundaries.
+        Prevents Byzantine singularities by mathematically proving the decoded byte-length
+        is exactly proportional to the stated precision-agnostic dimensionality.
+        """
+        if not self.vector_base64:
+            return self
+
+        try:
+            raw_bytes = base64.b64decode(self.vector_base64)
+        except Exception as e:
+            raise ValueError(f"Structural fault: Malformed base64 payload. {e}") from e
+
+        byte_len = len(raw_bytes)
+        if byte_len == 0:
+            raise ValueError("Topology fault: Vector payload evaluates to a zero-point singularity (0 bytes).")
+
+        if byte_len % self.dimensionality != 0:
+            raise ValueError(
+                f"Byzantine fault detected: Decoded byte length ({byte_len}) is not "
+                f"mathematically proportional to stated dimensionality ({self.dimensionality})."
+            )
+
+        return self
 
 
 class TemporalBounds(CoreasonBaseModel):

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -446,7 +446,8 @@ def test_epistemic_payload_canonical_hashing() -> None:
 
 
 def test_semantic_memory_determinism() -> None:
-    embedding = VectorEmbedding(vector_base64="dGVzdA==", dimensionality=3, model_name="test-model")
+    # "dGVzdA==" decodes to b'test' which is 4 bytes. We set dimensionality to 4.
+    embedding = VectorEmbedding(vector_base64="dGVzdA==", dimensionality=4, model_name="test-model")
     temporal_bounds = TemporalBounds(valid_from=100.0, valid_to=200.0, interval_type="overlaps")
     provenance = MemoryProvenance(extracted_by="did:web:agent_1", source_event_id="event_1")
     salience = SalienceProfile(baseline_importance=0.9, decay_rate=0.1)

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -2015,7 +2015,8 @@ def draw_vector_embedding(draw: Any) -> dict[str, Any]:
     # generate random bytes of length exactly `dim`
     raw_bytes = draw(st.binary(min_size=dim, max_size=dim))
     import base64
-    vec = base64.b64encode(raw_bytes).decode('utf-8')
+
+    vec = base64.b64encode(raw_bytes).decode("utf-8")
     res: dict[str, Any] = {
         "vector_base64": vec,
         "dimensionality": dim,

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -51,6 +51,7 @@ from coreason_manifest.state.memory import EpistemicLedger
 from coreason_manifest.state.semantic import (
     SemanticEdge,
     SemanticNode,
+    VectorEmbedding,
 )
 from coreason_manifest.state.vision import (
     DocumentLayoutAnalysis,
@@ -2009,10 +2010,15 @@ semantic_edge_adapter: TypeAdapter[SemanticEdge] = TypeAdapter(SemanticEdge)
 
 @st.composite
 def draw_vector_embedding(draw: Any) -> dict[str, Any]:
-    vec = draw(st.from_regex(r"^[A-Za-z0-9+/]*={0,2}$", fullmatch=True))
+    # We must generate a structurally valid base64 payload proportional to the dimensionality
+    dim = draw(st.integers(min_value=1, max_value=128))
+    # generate random bytes of length exactly `dim`
+    raw_bytes = draw(st.binary(min_size=dim, max_size=dim))
+    import base64
+    vec = base64.b64encode(raw_bytes).decode('utf-8')
     res: dict[str, Any] = {
         "vector_base64": vec,
-        "dimensionality": draw(st.integers(min_value=1)),
+        "dimensionality": dim,
         "model_name": draw(st.text()),
     }
     return res
@@ -3522,3 +3528,28 @@ def test_fuzz_utility_justification_tensor_poisoning(fuzzed_vectors: dict[str, f
         # If Hypothesis happened to generate a clean dictionary, it MUST compile.
         graph = UtilityJustificationGraph(optimizing_vectors=fuzzed_vectors, superposition_variance_threshold=0.5)
         assert graph.superposition_variance_threshold == 0.5
+
+
+def test_vector_dimensionality_byzantine_fault() -> None:
+    """
+    AGENT INSTRUCTION: Mathematically proves that an invalid byte-width
+    allocation forces a structural compilation rejection.
+    """
+    import base64
+
+    from pydantic import ValidationError
+
+    # Create a vector with dimensionality 128, but inject an uneven byte length (e.g., 128 * 4 + 1 bytes)
+    dimensionality = 128
+    invalid_byte_length = (dimensionality * 4) + 1
+    malformed_bytes = b"0" * invalid_byte_length
+    malformed_base64 = base64.b64encode(malformed_bytes).decode("utf-8")
+
+    with pytest.raises(ValidationError) as exc_info:
+        VectorEmbedding(
+            dimensionality=dimensionality,
+            vector_base64=malformed_base64,
+            model_name="test-model",
+        )
+
+    assert "Byzantine fault detected" in str(exc_info.value)


### PR DESCRIPTION
Implemented byte dimensionality parity checks for `VectorEmbedding` via a declarative Pydantic boundary, satisfying the strict requirements of "The Coreason Protocol".

Changes:
1. `src/coreason_manifest/state/semantic.py`: Injected the `@model_validator` named `_enforce_byte_dimensionality_parity` and imported `base64`.
2. `tests/test_fuzzing.py`:
   - Added `test_vector_dimensionality_byzantine_fault` to enforce that invalid byte-width allocations force structural compilation rejections.
   - Updated `draw_vector_embedding` fuzzing strategy to construct `VectorEmbedding` instances with valid base64 payload proportional to their random dimensionality.
3. `tests/test_determinism.py`: Updated `test_semantic_memory_determinism` to use a `dimensionality` matching the 4 byte decoded length of `"dGVzdA=="` (`b'test'`).

All tests (`pytest tests/ -v`), type checks (`mypy`), and linters (`ruff`) passed successfully, adhering to the Verification Protocol.

---
*PR created automatically by Jules for task [16774333632096116373](https://jules.google.com/task/16774333632096116373) started by @gowthamrao*