### PR TITLE
Fix Kinetic Execution Bleed via AST-native boundary in DynamicLayoutTemplate

### DIFF
--- a/src/coreason_manifest/presentation/templates.py
+++ b/src/coreason_manifest/presentation/templates.py
@@ -12,6 +12,8 @@ YOU ARE EXPLICITLY FORBIDDEN from adding state-mutation or backend logic here.
 Think purely in terms of declarative graphical grammars (Marks, Channels, Scales).
 """
 
+import ast
+
 from pydantic import Field, field_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
@@ -24,12 +26,19 @@ class DynamicLayoutTemplate(CoreasonBaseModel):
         description="A Python 3.14 t-string template definition for dynamic UI grid evaluation."
     )
 
-    @field_validator("layout_tstring")
+    @field_validator("layout_tstring", mode="after")
     @classmethod
     def validate_tstring(cls, v: str) -> str:
-        """Reject any string containing Python execution patterns."""
-        forbidden_patterns = ["__import__", "eval", "exec", "open", "os.system"]
-        for pattern in forbidden_patterns:
-            if pattern in v:
-                raise ValueError(f"Forbidden execution pattern detected: {pattern}")
+        """
+        AGENT INSTRUCTION: Mathematically prove the absence of kinetic execution
+        bleed by parsing the layout string into an Abstract Syntax Tree.
+        """
+        try:
+            tree = ast.parse(v, mode="exec")
+        except SyntaxError:
+            pass  # If it mathematically cannot parse as Python, it cannot execute.
+        else:
+            for node in ast.walk(tree):
+                if isinstance(node, ast.Call):
+                    raise ValueError("Kinetic execution bleed detected: AST contains function calls.")
         return v

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -9,11 +9,14 @@ from coreason_manifest.presentation.scivis import AnyPanel, ChannelEncoding, Gra
 from coreason_manifest.presentation.templates import DynamicLayoutTemplate
 
 
-@pytest.mark.parametrize("payload", [
-    "getattr(__builtins__, 'ev' + 'al')('print(\\'hacked\\')')",
-    "__import__('o' + 's').system('echo 1')",
-    "__import__('subprocess').run(['echo', '1'])"
-])
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "getattr(__builtins__, 'ev' + 'al')('print(\\'hacked\\')')",
+        "__import__('o' + 's').system('echo 1')",
+        "__import__('subprocess').run(['echo', '1'])",
+    ],
+)
 def test_dynamic_layout_template_rejects_obfuscated_rce(payload: str):
     """
     AGENT INSTRUCTION: Verify the AST boundary deterministically severs

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -9,6 +9,20 @@ from coreason_manifest.presentation.scivis import AnyPanel, ChannelEncoding, Gra
 from coreason_manifest.presentation.templates import DynamicLayoutTemplate
 
 
+@pytest.mark.parametrize("payload", [
+    "getattr(__builtins__, 'ev' + 'al')('print(\\'hacked\\')')",
+    "__import__('o' + 's').system('echo 1')",
+    "__import__('subprocess').run(['echo', '1'])"
+])
+def test_dynamic_layout_template_rejects_obfuscated_rce(payload: str):
+    """
+    AGENT INSTRUCTION: Verify the AST boundary deterministically severs
+    polymorphic string concatenation attacks prior to instantiation.
+    """
+    with pytest.raises(ValidationError, match="Kinetic execution bleed detected"):
+        DynamicLayoutTemplate(layout_tstring=payload)
+
+
 @given(
     payload=st.sampled_from(
         [
@@ -25,7 +39,7 @@ def test_tstring_rce_fuzzer(payload: str) -> None:
     Generate adversarial payload strings and prove that DynamicLayoutTemplate
     definitively raises a ValidationError when instantiated with them.
     """
-    with pytest.raises(ValidationError, match="Forbidden execution pattern detected"):
+    with pytest.raises(ValidationError, match="Kinetic execution bleed detected"):
         DynamicLayoutTemplate(layout_tstring=payload)
 
 

--- a/tests/domains/test_presentation_quarantine.py
+++ b/tests/domains/test_presentation_quarantine.py
@@ -17,13 +17,30 @@ from coreason_manifest.presentation.templates import DynamicLayoutTemplate
         "__import__('subprocess').run(['echo', '1'])",
     ],
 )
-def test_dynamic_layout_template_rejects_obfuscated_rce(payload: str):
+def test_dynamic_layout_template_rejects_obfuscated_rce(payload: str) -> None:
     """
     AGENT INSTRUCTION: Verify the AST boundary deterministically severs
     polymorphic string concatenation attacks prior to instantiation.
     """
     with pytest.raises(ValidationError, match="Kinetic execution bleed detected"):
         DynamicLayoutTemplate(layout_tstring=payload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "Not a python string at all",
+        't"{user_name}"',
+        "{{ safe_variable }}",
+    ],
+)
+def test_dynamic_layout_template_allows_valid_strings(payload: str) -> None:
+    """
+    Verify that strings not containing function calls, or strings that
+    are syntactically invalid Python, are allowed to pass the AST boundary.
+    """
+    template = DynamicLayoutTemplate(layout_tstring=payload)
+    assert template.layout_tstring == payload
 
 
 @given(


### PR DESCRIPTION
This PR replaces the legacy string-based blacklist validation in `DynamicLayoutTemplate` with an AST-native security boundary. The new approach validates the template string (`layout_tstring`) by parsing it into an Abstract Syntax Tree (if it contains valid Python syntax) and mathematically proving the absence of kinetic execution bleed by rejecting the presence of any `ast.Call` nodes. This effectively severs polymorphic string concatenation attacks prior to instantiation. Tests were updated to reflect this deterministic boundary.

---
*PR created automatically by Jules for task [17338224641024242732](https://jules.google.com/task/17338224641024242732) started by @gowthamrao*