### PR TITLE
feat(state): enforce deterministic bounding on recursive payloads

### DIFF
--- a/src/coreason_manifest/state/events.py
+++ b/src/coreason_manifest/state/events.py
@@ -14,7 +14,7 @@ and retractions."""
 
 from typing import Annotated, Any, Literal
 
-from pydantic import Field, StringConstraints
+from pydantic import Field, StringConstraints, field_validator
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
@@ -22,6 +22,40 @@ from coreason_manifest.state.cognition import CognitiveUncertaintyProfile
 from coreason_manifest.state.embodied import EmbodiedSensoryVector
 from coreason_manifest.state.scratchpad import LatentScratchpadTrace
 from coreason_manifest.state.toolchains import AnyToolchainState
+
+
+def _validate_payload_bounds(value: Any, current_depth: int = 0) -> Any:
+    """
+    AGENT INSTRUCTION: Mathematically bound recursive dictionary payloads
+    to prevent OOM/CPU exhaustion during EpistemicLedger hashing.
+    """
+    max_depth = 10
+    max_dict_keys = 100
+    max_list_items = 1000
+    max_str_len = 10000
+
+    if current_depth > max_depth:
+        raise ValueError(f"Payload exceeds maximum recursion depth of {max_depth}")
+
+    if isinstance(value, dict):
+        if len(value) > max_dict_keys:
+            raise ValueError(f"Dictionary exceeds maximum key count of {max_dict_keys}")
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise ValueError("Dictionary keys must be strings")
+            if len(k) > max_str_len:
+                raise ValueError(f"Dictionary key exceeds max string length of {max_str_len}")
+            _validate_payload_bounds(v, current_depth + 1)
+    elif isinstance(value, list):
+        if len(value) > max_list_items:
+            raise ValueError(f"List exceeds maximum item count of {max_list_items}")
+        for item in value:
+            _validate_payload_bounds(item, current_depth + 1)
+    elif isinstance(value, str):
+        if len(value) > max_str_len:
+            raise ValueError(f"String exceeds maximum length of {max_str_len}")
+
+    return value
 
 
 class BaseStateEvent(CoreasonBaseModel):
@@ -135,6 +169,11 @@ class ObservationEvent(BaseStateEvent):
         "forming a strict bipartite directed edge.",
     )
 
+    @field_validator("payload", mode="before")
+    @classmethod
+    def enforce_payload_topology(cls, v: Any) -> Any:
+        return _validate_payload_bounds(v)
+
 
 class ToolInvocationEvent(BaseStateEvent):
     """A Priori Kinetic Commitment representing the Pearlian Do-Operator prior to network execution."""
@@ -198,6 +237,11 @@ class BeliefUpdateEvent(BaseStateEvent):
         default=None,
         description="The mathematical brain-scan proving exactly which neural circuits fired to append this event.",
     )
+
+    @field_validator("payload", mode="before")
+    @classmethod
+    def enforce_payload_topology(cls, v: Any) -> Any:
+        return _validate_payload_bounds(v)
 
 
 class SystemFaultEvent(BaseStateEvent):

--- a/tests/domains/test_state_events.py
+++ b/tests/domains/test_state_events.py
@@ -5,16 +5,41 @@
 #
 # For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
 
+from typing import Any
+
 import pytest
 from pydantic import TypeAdapter, ValidationError
 
 from coreason_manifest.state.events import (
     AnyStateEvent,
+    BeliefUpdateEvent,
     EpistemicPromotionEvent,
     NeuralAuditAttestation,
     NormativeDriftEvent,
+    ObservationEvent,
     SaeFeatureActivation,
 )
+
+
+def test_event_payload_rejects_max_depth() -> None:
+    deep_payload: dict[str, Any] = {}
+    current = deep_payload
+    for _ in range(12):
+        current["nested"] = {}
+        current = current["nested"]
+
+    with pytest.raises(ValueError, match="maximum recursion depth"):
+        ObservationEvent(event_id="obs-123", timestamp=1234567890.0, payload=deep_payload)
+
+
+def test_event_payload_rejects_max_keys() -> None:
+    wide_payload = {f"key_{i}": "val" for i in range(105)}
+    with pytest.raises(ValueError, match="maximum key count"):
+        BeliefUpdateEvent(
+            event_id="bel-123",
+            timestamp=1234567890.0,
+            payload=wide_payload,
+        )
 
 
 def test_sae_feature_activation_valid() -> None:

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -1538,11 +1538,30 @@ def _local_draw_any_state_event(draw: Any) -> dict[str, Any]:
         "timestamp": draw(st.floats(allow_nan=False, allow_infinity=False)),
     }
     if event_type in ("observation", "belief_update"):
+        json_primitives = st.one_of(
+            st.text(max_size=50),
+            st.integers(),
+            st.floats(allow_nan=False, allow_infinity=False),
+            st.booleans(),
+            st.none(),
+        )
+        base_dict = st.dictionaries(st.text(max_size=255), json_primitives, max_size=50)
+
         payload["payload"] = draw(
-            st.dictionaries(
-                st.text(),
-                st.one_of(st.text(), st.integers(), st.floats(allow_nan=False, allow_infinity=False), st.booleans()),
-                max_size=5,
+            st.one_of(
+                base_dict,
+                st.dictionaries(
+                    st.text(max_size=255),
+                    st.recursive(
+                        base_dict,
+                        lambda children: st.one_of(
+                            st.lists(children, max_size=50),
+                            st.dictionaries(st.text(max_size=255), children, max_size=50),
+                        ),
+                        max_leaves=50,
+                    ),
+                    max_size=50,
+                ),
             )
         )
         payload["source_node_id"] = draw(


### PR DESCRIPTION
This pull request implements the requested deterministic AST-native recursive bounding on `dict[str, Any]` payloads inside `coreason_manifest.state.events`. The change protects against unbounded payloads preventing State Exhaustion (OOM) attacks during downstream hashing processes. 

Key changes include:
- A new validation function (`_validate_payload_bounds`) implementing absolute boundaries on dictionaries (max recursion depth, max keys, max string sizes, and max list items).
- The inclusion of this validation bound on both `ObservationEvent` and `BeliefUpdateEvent` models leveraging a Pydantic V2 `before` `@field_validator`.
- Associated updates to Hypothesis generated payloads in `test_fuzzing.py` and dedicated unit tests in `test_state_events.py` bounding tests physically.

---
*PR created automatically by Jules for task [1061247959807525556](https://jules.google.com/task/1061247959807525556) started by @gowthamrao*