### PR TITLE
feat(cli): introduce autonomous mcp handshake generator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,11 +24,12 @@ dependencies = [
 ]
 
 [project.scripts]
-coreason-validate = "coreason_manifest.cli.validate:main"
+coreason-card = "coreason_manifest.cli.card:main"
 coreason-export = "coreason_manifest.cli.export:main"
 coreason-mcp = "coreason_manifest.cli.mcp_server:main"
+coreason-mcp-config = "coreason_manifest.cli.mcp_config:main"
+coreason-validate = "coreason_manifest.cli.validate:main"
 coreason-visualize = "coreason_manifest.cli.visualize:main"
-coreason-card = "coreason_manifest.cli.card:main"
 
 [project.urls]
 Homepage = "https://github.com/CoReason-AI/coreason_manifest"

--- a/src/coreason_manifest/cli/mcp_config.py
+++ b/src/coreason_manifest/cli/mcp_config.py
@@ -1,0 +1,35 @@
+"""
+AGENT INSTRUCTION: This module must remain strictly passive. Do not add execution loops.
+It purely calculates filesystem geometry and projects a deterministic JSON payload to stdout.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    """
+    Calculates the absolute repository root and emits the exact MCP configuration
+    payload required to bridge an external agentic sandbox into this environment.
+    """
+    # Mathematical anchor: __file__ -> cli/ -> coreason_manifest/ -> src/ -> REPO_ROOT
+    repo_root = Path(__file__).resolve().parent.parent.parent.parent
+
+    payload = {
+        "mcpServers": {
+            "coreason-manifest": {
+                "command": "uv",
+                "args": ["--directory", str(repo_root), "run", "coreason-mcp"],
+                "env": {"COREASON_GRANTED_LICENSES": ""},
+            }
+        }
+    }
+
+    # Strict compliance: Zero pollution output to stdout.
+    sys.stdout.write(json.dumps(payload, indent=2) + "\n")
+    sys.stdout.flush()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 import pytest
 
 from coreason_manifest.cli.export import main as export_main
+from coreason_manifest.cli.mcp_config import main as mcp_config_main
 from coreason_manifest.cli.mcp_server import get_epistemic_schema
 from coreason_manifest.cli.visualize import main as visualize_main
 
@@ -115,3 +116,29 @@ def test_mcp_server_rbac_projection(monkeypatch: pytest.MonkeyPatch) -> None:
     finally:
         # Clean up
         _AVAILABLE_SCHEMAS.pop(proprietary_name, None)
+
+
+def test_mcp_config_emission(capsys: pytest.CaptureFixture[str]) -> None:
+    """
+    Ensures the MCP configuration generator strictly adheres to the Dependency Airgap
+    and outputs a mathematically provable absolute path to the repository root.
+    """
+    mcp_config_main()
+    captured = capsys.readouterr()
+
+    # 1. Assert Pure JSON Emission
+    payload = json.loads(captured.out)
+    server_config = payload["mcpServers"]["coreason-manifest"]
+
+    # 2. Assert Dependency Airgap
+    assert server_config["command"] == "uv"
+
+    # 3. Assert Mathematical Path Resolution
+    args = server_config["args"]
+    assert "--directory" in args
+    dir_index = args.index("--directory") + 1
+    resolved_path = Path(args[dir_index])
+
+    assert resolved_path.is_absolute(), "Generated path must be absolute."
+    assert resolved_path.exists(), "Generated path must exist on the host file system."
+    assert (resolved_path / "pyproject.toml").exists(), "Generated path must point to the repository root."


### PR DESCRIPTION
Implemented a passive MCP configuration generator in `src/coreason_manifest/cli/mcp_config.py` per architectural directives. Registered `coreason-mcp-config` under `[project.scripts]` in `pyproject.toml` and injected `test_mcp_config_emission` in `tests/test_cli.py`. Passed all linting, type-checking, and testing protocols.

---
*PR created automatically by Jules for task [14540110095880968540](https://jules.google.com/task/14540110095880968540) started by @gowthamrao*