### PR TITLE
feat(mcp): implement generative bounding box scaffold prompt

### DIFF
--- a/src/coreason_manifest/cli/mcp_server.py
+++ b/src/coreason_manifest/cli/mcp_server.py
@@ -22,6 +22,15 @@ from coreason_manifest.core import CoreasonBaseModel
 """AGENT INSTRUCTION: This MCP Server is strictly passive. DO NOT register @mcp.tool() endpoints. Use @mcp.resource() for all ontological projections."""  # noqa: E501
 # fmt: on
 
+_GENERATIVE_BOUNDING_BOX_DIRECTIVE = """
+SYSTEM ARCHITECTURE DIRECTIVE (STRICT COMPLIANCE REQUIRED):
+You are generating a payload for the coreason-manifest. The manifest enforces a strict "Hollow Data Plane".
+1. DO NOT invent vertical ontologies or domain-specific terminology (e.g., no 'patient_id', no 'transaction_hash').
+2. You MUST use universal primitives (e.g., 'tenant_id', 'node_id', 'correlation_id').
+3. The output MUST be a pure data structure. Side effects are strictly forbidden.
+4. Adhere mathematically to the provided JSON schema projection.
+"""
+
 # Create an MCP server
 mcp = FastMCP("coreason-manifest-schema-service")
 
@@ -53,6 +62,21 @@ def _is_schema_allowed(schema_dict: dict[str, Any], granted_licenses: set[str]) 
     if not isinstance(required, list):
         required = []
     return set(required).issubset(granted_licenses)
+
+
+@mcp.prompt("scaffold_payload")
+async def scaffold_payload(schema_id: str) -> str:
+    """
+    Project a Generative Bounding Box into the orchestrator's latent space.
+    Provides a priori alignment constraints paired with the target JSON schema.
+    """
+    if schema_id not in _AVAILABLE_SCHEMAS:
+        return "ERROR: SCHEMA_NOT_FOUND. Query the schema index to discover available ontologies."
+
+    schema_model_json_schema = _AVAILABLE_SCHEMAS[schema_id]
+    schema_json_str = json.dumps(schema_model_json_schema, indent=2)
+
+    return f"{_GENERATIVE_BOUNDING_BOX_DIRECTIVE}\n\nTARGET SCHEMA:\n{schema_json_str}"
 
 
 @mcp.resource("schema://epistemic/{name}")

--- a/tests/domains/test_mcp_boundary.py
+++ b/tests/domains/test_mcp_boundary.py
@@ -9,10 +9,33 @@ from mcp.types import JSONRPCMessage
 from pydantic import HttpUrl, ValidationError
 
 from coreason_manifest.adapters.mcp.schemas import BoundedJSONRPCRequest, HTTPTransportConfig
-from coreason_manifest.cli.mcp_server import _global_error_handler_shield
+from coreason_manifest.cli.mcp_server import (
+    _GENERATIVE_BOUNDING_BOX_DIRECTIVE,
+    _global_error_handler_shield,
+    scaffold_payload,
+)
 
 # Initialize the global shield for tests
 _global_error_handler_shield()
+
+
+@pytest.mark.asyncio
+async def test_mcp_prompt_scaffold_payload_success() -> None:
+    """Ensure the prompt concatenates the directive and the schema without execution logic."""
+    result = await scaffold_payload("AgentAttestation")
+
+    assert "SYSTEM ARCHITECTURE DIRECTIVE" in result
+    assert "TARGET SCHEMA:" in result
+    assert "AgentAttestation" in result
+    assert _GENERATIVE_BOUNDING_BOX_DIRECTIVE in result
+
+
+@pytest.mark.asyncio
+async def test_mcp_prompt_scaffold_payload_degradation() -> None:
+    """Ensure invalid schemas return structured text, NOT runtime exceptions."""
+    result = await scaffold_payload("HallucinatedVerticalSchema")
+
+    assert result == "ERROR: SCHEMA_NOT_FOUND. Query the schema index to discover available ontologies."
 
 
 def test_jsonrpc_fuzzer_missing_jsonrpc() -> None:


### PR DESCRIPTION
Implements the "Cognitive Scaffolding via Generative Bounding Boxes" MCP prompt per the "Hollow Data Plane" architectural requirements.

- Injects `_GENERATIVE_BOUNDING_BOX_DIRECTIVE` at the module level.
- Adds `@mcp.prompt("scaffold_payload")` endpoint to return the concatenated prompt and schema strictly as text.
- Provides graceful degradation for non-existent schemas.
- Adds appropriate deterministic unit tests in `tests/domains/test_mcp_boundary.py`.

---
*PR created automatically by Jules for task [7874846813462037076](https://jules.google.com/task/7874846813462037076) started by @gowthamrao*