### PR TITLE
Add VS Code Workspace Settings

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,6 @@
+{
+  "recommendations": [
+    "charliermarsh.ruff",
+    "ms-python.mypy-type-checker"
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "editor.formatOnSave": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll.ruff": "explicit",
+    "source.organizeImports.ruff": "explicit"
+  },
+  "python.analysis.typeCheckingMode": "strict"
+}


### PR DESCRIPTION
Added `.vscode/extensions.json` and `.vscode/settings.json` with the exact JSON payload specified to configure Ruff linting and Mypy strict type checking on save. Verified via local tests that these files did not pollute the core repository or tests.

---
*PR created automatically by Jules for task [11660938791335031348](https://jules.google.com/task/11660938791335031348) started by @gowthamrao*