### PR TITLE
feat: add vscode settings to bind json schemas

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "json.schemas": [
+    {
+      "fileMatch": [
+        "*.topology.json",
+        "payloads/**/*.json",
+        "*.manifest.json"
+      ],
+      "url": "./coreason_ontology.schema.json"
+    }
+  ]
+}


### PR DESCRIPTION
Resolves the request to bind the exported JSON schema directly to the IDE's Language Server Protocol (LSP) for zero-latency deterministic perception. Created `.vscode/settings.json` and populated it with the required `json.schemas` configuration array. No Python execution logic was modified, ensuring strict adherence to the Hollow Data Plane constraints. All CI verification checks passed.

---
*PR created automatically by Jules for task [17949615036632134624](https://jules.google.com/task/17949615036632134624) started by @gowthamrao*