### PR TITLE
fix: Resolve Ontological Schism for DataClassification

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1686,7 +1686,7 @@
           "type": "string"
         },
         "max_permitted_classification": {
-          "$ref": "#/$defs/coreason_manifest__core__primitives__DataClassification",
+          "$ref": "#/$defs/DataClassification",
           "description": "The absolute highest data sensitivity allowed to cross this federated boundary."
         },
         "liability_limit_magnitude": {
@@ -3206,6 +3206,17 @@
       ],
       "title": "DAGTopology",
       "type": "object"
+    },
+    "DataClassification": {
+      "description": "Standardized Information Flow Control (IFC) lattice boundaries.",
+      "enum": [
+        "public",
+        "internal",
+        "confidential",
+        "restricted"
+      ],
+      "title": "DataClassification",
+      "type": "string"
     },
     "DefeasibleAttack": {
       "additionalProperties": false,
@@ -8311,7 +8322,7 @@
           "type": "string"
         },
         "classification": {
-          "$ref": "#/$defs/coreason_manifest__oversight__dlp__DataClassification",
+          "$ref": "#/$defs/DataClassification",
           "description": "The category of sensitive data this rule targets."
         },
         "target_pattern": {
@@ -10746,7 +10757,7 @@
           "anyOf": [
             {
               "items": {
-                "$ref": "#/$defs/coreason_manifest__core__primitives__DataClassification"
+                "$ref": "#/$defs/DataClassification"
               },
               "type": "array"
             },
@@ -10928,26 +10939,6 @@
           "$ref": "#/$defs/HTTPTransportConfig"
         }
       ]
-    },
-    "coreason_manifest__core__primitives__DataClassification": {
-      "description": "Standardized Information Flow Control (IFC) lattice boundaries.",
-      "enum": [
-        "public",
-        "internal",
-        "confidential",
-        "restricted"
-      ],
-      "title": "DataClassification",
-      "type": "string"
-    },
-    "coreason_manifest__oversight__dlp__DataClassification": {
-      "enum": [
-        "strictly_confidential",
-        "confidential",
-        "internal",
-        "public"
-      ],
-      "type": "string"
     },
     "coreason_manifest__tooling__environments__MCPTransport": {
       "enum": [

--- a/src/coreason_manifest/oversight/dlp.py
+++ b/src/coreason_manifest/oversight/dlp.py
@@ -18,8 +18,8 @@ from pydantic import Field, model_validator
 
 from coreason_manifest.compute.neuromodulation import SaeLatentFirewall
 from coreason_manifest.core.base import CoreasonBaseModel
+from coreason_manifest.core.primitives import DataClassification
 
-type DataClassification = Literal["strictly_confidential", "confidential", "internal", "public"]
 type SanitizationAction = Literal["redact", "hash", "drop_event", "trigger_quarantine"]
 
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -266,6 +266,7 @@ def test_rollback_determinism() -> None:
 
 def test_dlp_determinism() -> None:
     from coreason_manifest.core.primitives import DataClassification
+
     rule_a = RedactionRule(
         rule_id="a_phi_redact",
         classification=DataClassification.RESTRICTED,

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -265,9 +265,10 @@ def test_rollback_determinism() -> None:
 
 
 def test_dlp_determinism() -> None:
+    from coreason_manifest.core.primitives import DataClassification
     rule_a = RedactionRule(
         rule_id="a_phi_redact",
-        classification="strictly_confidential",
+        classification=DataClassification.RESTRICTED,
         target_pattern="pattern_a",
         target_regex_pattern="pattern_a",
         action="redact",
@@ -275,7 +276,7 @@ def test_dlp_determinism() -> None:
     )
     rule_b = RedactionRule(
         rule_id="b_pii_hash",
-        classification="confidential",
+        classification=DataClassification.CONFIDENTIAL,
         target_pattern="pattern_b",
         target_regex_pattern="pattern_b",
         action="hash",

--- a/tests/test_fuzzing.py
+++ b/tests/test_fuzzing.py
@@ -2481,7 +2481,14 @@ def draw_redaction_rule(draw: Any) -> dict[str, Any]:
         st.fixed_dictionaries(
             {
                 "rule_id": st.text(),
-                "classification": st.sampled_from(["strictly_confidential", "confidential", "internal", "public"]),
+                "classification": st.sampled_from(
+                    [
+                        DataClassification.PUBLIC,
+                        DataClassification.INTERNAL,
+                        DataClassification.CONFIDENTIAL,
+                        DataClassification.RESTRICTED,
+                    ]
+                ),
                 "target_pattern": st.text(),
                 "target_regex_pattern": st.text(max_size=200),
                 "context_exclusion_zones": st.one_of(st.none(), st.lists(st.text(), max_size=100)),


### PR DESCRIPTION
Fixes the duplicated and conflicting `DataClassification` type definition by using the canonical version from `coreason_manifest.core.primitives`. Realigned related tests to use the new canonical primitive. Compliance with the Prosperity 3.0 license is maintained.

---
*PR created automatically by Jules for task [1030763743039938580](https://jules.google.com/task/1030763743039938580) started by @gowthamrao*