### PR TITLE
fix: restore semantic isometry and ast-native anchoring

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -10638,6 +10638,7 @@
       "type": "object"
     },
     "WetwareAttestationContract": {
+      "additionalProperties": false,
       "description": "AGENT INSTRUCTION: This model represents a SOTA cryptographic receipt\nproving a human in the loop physically authorized a state transition.",
       "properties": {
         "mechanism": {

--- a/src/coreason_manifest/core/identity.py
+++ b/src/coreason_manifest/core/identity.py
@@ -16,7 +16,7 @@ Introducing upstream domains into this module will trigger a fatal dependency lo
 from typing import Any, Literal
 from uuid import UUID
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
 from coreason_manifest.core.base import CoreasonBaseModel
 from coreason_manifest.core.primitives import NodeID
@@ -24,7 +24,7 @@ from coreason_manifest.core.primitives import NodeID
 AttestationMechanism = Literal["fido2_webauthn", "zk_snark_groth16", "pqc_ml_dsa"]
 
 
-class WetwareAttestationContract(BaseModel):
+class WetwareAttestationContract(CoreasonBaseModel):
     """
     AGENT INSTRUCTION: This model represents a SOTA cryptographic receipt
     proving a human in the loop physically authorized a state transition.

--- a/src/coreason_manifest/workflow/federation.py
+++ b/src/coreason_manifest/workflow/federation.py
@@ -14,6 +14,11 @@ from coreason_manifest.core.primitives import NodeID
 from coreason_manifest.oversight.dlp import SecureSubSession
 from coreason_manifest.workflow.envelope import BilateralSLA
 
+"""AGENT INSTRUCTION: This file maps the federated workflow schemas. This is a STRICTLY TOPOLOGICAL BOUNDARY.
+These schemas define the zero-trust information flow constraints and cross-swarm handshakes.
+YOU ARE EXPLICITLY FORBIDDEN from introducing active network dispatch logic, socket connections,
+or mutable state loops here. Focus purely on structural DAG definitions and bilateral SLAs."""
+
 
 class FederatedDiscoveryProtocol(CoreasonBaseModel):
     broadcast_endpoints: list[str] = Field(description="A list of MCP URI endpoints open for B2B task bidding.")


### PR DESCRIPTION
- Enforce cryptographic immutability on `WetwareAttestationContract` by replacing its generic Pydantic inheritance with the locked base model `CoreasonBaseModel` in `src/coreason_manifest/core/identity.py`.
- Inject a mandatory AST-Native semantic anchor in `src/coreason_manifest/workflow/federation.py` to prevent downstream code-generation tools from hallucinating kinetic network dispatch logic.
- Executed strict post-execution verification protocol (`uv run ruff format .`, `uv run ruff check . --fix`, `uv run mypy src/ tests/`, `uv run pytest`).

---
*PR created automatically by Jules for task [3077426091492077041](https://jules.google.com/task/3077426091492077041) started by @gowthamrao*