### PR TITLE
feat: implement canonical serialization for residual epistemic arrays

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -775,6 +775,11 @@ class SaeLatentPolicy(CoreasonBaseModel):
     )
 
     @model_validator(mode="after")
+    def sort_sae_arrays(self) -> Self:
+        object.__setattr__(self, "monitored_layers", sorted(self.monitored_layers))
+        return self
+
+    @model_validator(mode="after")
     def validate_smooth_decay(self) -> Self:
         if self.violation_action == "smooth_decay":
             if self.smoothing_profile is None:
@@ -1787,6 +1792,11 @@ class EpistemicPromotionEvent(BaseStateEvent):
     compression_ratio: float = Field(
         description="A mathematical proof of the token savings achieved (e.g., old_token_count / new_token_count)."
     )
+
+    @model_validator(mode="after")
+    def sort_promotion_arrays(self) -> Self:
+        object.__setattr__(self, "source_episodic_event_ids", sorted(self.source_episodic_event_ids))
+        return self
 
 
 class EpistemicScanningPolicy(CoreasonBaseModel):
@@ -2948,6 +2958,11 @@ class OntologicalHandshake(CoreasonBaseModel):
         default=None,
         description="The projection applied if the agents natively used different embedding dimensionalities.",
     )
+
+    @model_validator(mode="after")
+    def sort_handshake_arrays(self) -> Self:
+        object.__setattr__(self, "participant_node_ids", sorted(self.participant_node_ids))
+        return self
 
 
 class OutputMappingContract(CoreasonBaseModel):
@@ -4224,6 +4239,14 @@ class SwarmTopology(BaseTopology):
     )
 
     @model_validator(mode="after")
+    def sort_swarm_arrays(self) -> Self:
+        object.__setattr__(
+            self, "active_prediction_markets", sorted(self.active_prediction_markets, key=lambda x: x.market_id)
+        )
+        object.__setattr__(self, "resolved_markets", sorted(self.resolved_markets, key=lambda x: x.market_id))
+        return self
+
+    @model_validator(mode="after")
     def enforce_concurrency_ceiling(self) -> Self:
         if self.spawning_threshold > self.max_concurrent_agents:
             raise ValueError("spawning_threshold cannot exceed max_concurrent_agents")
@@ -4351,6 +4374,14 @@ class WorkflowManifest(CoreasonBaseModel):
     pq_signature: PostQuantumSignature | None = Field(
         default=None, description="The quantum-resistant signature securing the root execution graph."
     )
+
+    @model_validator(mode="after")
+    def sort_workflow_arrays(self) -> Self:
+        if self.allowed_information_classifications is not None:
+            object.__setattr__(
+                self, "allowed_information_classifications", sorted(self.allowed_information_classifications)
+            )
+        return self
 
 
 class WetwareAttestationContract(CoreasonBaseModel):

--- a/tests/domains/test_deterministic_sorting.py
+++ b/tests/domains/test_deterministic_sorting.py
@@ -63,17 +63,12 @@ def test_adversarial_market_sorting_determinism() -> None:
 def test_workflow_manifest_sorting_determinism() -> None:
     manifest = WorkflowManifest(
         manifest_version="1.0.0",
-        topology=DAGTopology(
-            nodes={},
-            edges=[],
-            max_depth=10,
-            max_fan_out=10
-        ),
+        topology=DAGTopology(nodes={}, edges=[], max_depth=10, max_fan_out=10),
         allowed_information_classifications=[
             InformationClassification.RESTRICTED,
             InformationClassification.PUBLIC,
             InformationClassification.INTERNAL,
-        ]
+        ],
     )
     assert manifest.allowed_information_classifications == ["internal", "public", "restricted"]
 

--- a/tests/domains/test_deterministic_sorting.py
+++ b/tests/domains/test_deterministic_sorting.py
@@ -2,10 +2,19 @@
 
 from coreason_manifest.spec.ontology import (
     AdversarialMarketTopology,
+    DAGTopology,
+    EpistemicPromotionEvent,
+    InformationClassification,
     LatentScratchpadReceipt,
+    MarketResolutionState,
+    OntologicalHandshake,
     PredictionMarketPolicy,
+    PredictionMarketState,
+    SaeLatentPolicy,
     SecureSubSessionState,
+    SwarmTopology,
     ThoughtBranch,
+    WorkflowManifest,
 )
 
 
@@ -49,3 +58,84 @@ def test_adversarial_market_sorting_determinism() -> None:
     )
     assert macro.blue_team_ids == ["did:web:node_A", "did:web:node_Z"]
     assert macro.red_team_ids == ["did:web:node_B", "did:web:node_X"]
+
+
+def test_workflow_manifest_sorting_determinism() -> None:
+    manifest = WorkflowManifest(
+        manifest_version="1.0.0",
+        topology=DAGTopology(
+            nodes={},
+            edges=[],
+            max_depth=10,
+            max_fan_out=10
+        ),
+        allowed_information_classifications=[
+            InformationClassification.RESTRICTED,
+            InformationClassification.PUBLIC,
+            InformationClassification.INTERNAL,
+        ]
+    )
+    assert manifest.allowed_information_classifications == ["internal", "public", "restricted"]
+
+
+def test_swarm_topology_sorting_determinism() -> None:
+    p1 = PredictionMarketState(
+        market_id="mkt_Z",
+        resolution_oracle_condition_id="cond1",
+        lmsr_b_parameter="1.0",
+        order_book=[],
+        current_market_probabilities={},
+    )
+    p2 = PredictionMarketState(
+        market_id="mkt_A",
+        resolution_oracle_condition_id="cond2",
+        lmsr_b_parameter="1.0",
+        order_book=[],
+        current_market_probabilities={},
+    )
+
+    r1 = MarketResolutionState(
+        market_id="mkt_Y", winning_hypothesis_id="hyp1", falsified_hypothesis_ids=[], payout_distribution={}
+    )
+    r2 = MarketResolutionState(
+        market_id="mkt_B", winning_hypothesis_id="hyp2", falsified_hypothesis_ids=[], payout_distribution={}
+    )
+
+    topology = SwarmTopology(nodes={}, active_prediction_markets=[p1, p2], resolved_markets=[r1, r2])
+    assert topology.active_prediction_markets[0].market_id == "mkt_A"
+    assert topology.active_prediction_markets[1].market_id == "mkt_Z"
+    assert topology.resolved_markets[0].market_id == "mkt_B"
+    assert topology.resolved_markets[1].market_id == "mkt_Y"
+
+
+def test_ontological_handshake_sorting_determinism() -> None:
+    handshake = OntologicalHandshake(
+        handshake_id="hs_1",
+        participant_node_ids=["did:web:node_Z", "did:web:node_A"],
+        measured_cosine_similarity=0.99,
+        alignment_status="aligned",
+    )
+    assert handshake.participant_node_ids == ["did:web:node_A", "did:web:node_Z"]
+
+
+def test_sae_latent_policy_sorting_determinism() -> None:
+    policy = SaeLatentPolicy(
+        target_feature_index=42,
+        monitored_layers=[12, 1, 8, 4],
+        max_activation_threshold=2.5,
+        violation_action="clamp",
+        clamp_value=0.0,
+        sae_dictionary_hash="a" * 64,
+    )
+    assert policy.monitored_layers == [1, 4, 8, 12]
+
+
+def test_epistemic_promotion_event_sorting_determinism() -> None:
+    event = EpistemicPromotionEvent(
+        event_id="promo_1",
+        timestamp=12345.0,
+        source_episodic_event_ids=["obs_Z", "obs_A", "obs_M"],
+        crystallized_semantic_node_id="did:web:semantic_1",
+        compression_ratio=10.0,
+    )
+    assert event.source_episodic_event_ids == ["obs_A", "obs_M", "obs_Z"]


### PR DESCRIPTION
Implement Canonical Serialization for Residual Epistemic Arrays

This commit mathematically eliminates Byzantine Hash Fractures by injecting structural, pre-flight array sorting into five specific Pydantic schemas within the Coreason Manifest (`WorkflowManifest`, `SwarmTopology`, `OntologicalHandshake`, `SaeLatentPolicy`, `EpistemicPromotionEvent`). 

Due to strict immutability boundaries (`frozen=True`), these schemas use `@model_validator(mode="after")` to bypass traditional Python property assignment via `object.__setattr__(self, field, sorted(...))`. This ensures deterministic array orders for hashing without polluting AST-dependent docstrings or adding external dependencies. 

Deterministic sorting tests have also been implemented in `test_deterministic_sorting.py` to cryptographically prove exact alphanumeric sorting. All four zero-trust CI gates (`ruff format`, `ruff check`, `mypy`, and `pytest`) have been run locally and verified to pass.

---
*PR created automatically by Jules for task [9697615763092682342](https://jules.google.com/task/9697615763092682342) started by @gowthamrao*