### PR TITLE
Inject sort_arrays validators to deterministic schemas

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1949,6 +1949,11 @@ class ExecutionNodeReceipt(CoreasonBaseModel):
     node_hash: str | None = Field(default=None, description="The cryptographic SHA-256 hash of this node.")
 
     @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "parent_hashes", sorted(self.parent_hashes))
+        return self
+
+    @model_validator(mode="after")
     def validate_lineage(self) -> Self:
         if self.parent_request_id is not None and self.root_request_id is None:
             raise ValueError("Orphaned Lineage: parent_request_id is set but root_request_id is None")
@@ -2187,6 +2192,13 @@ class DynamicRoutingManifest(CoreasonBaseModel):
     branch_budgets_magnitude: dict[NodeID, int] = Field(
         description="The strict allocation of compute budget bound to specific nodes."
     )
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        sorted_subgraphs = {k: sorted(v) for k, v in self.active_subgraphs.items()}
+        object.__setattr__(self, "active_subgraphs", sorted_subgraphs)
+        object.__setattr__(self, "bypassed_steps", sorted(self.bypassed_steps, key=lambda x: x.bypassed_node_id))
+        return self
 
     @model_validator(mode="after")
     def validate_modality_alignment(self) -> Self:
@@ -2708,6 +2720,11 @@ class MacroGridProfile(CoreasonBaseModel):
 
     layout_matrix: list[list[str]] = Field(description="A matrix defining the layout structure, using panel IDs.")
     panels: list[AnyPanel] = Field(description="A list of panels included in the grid.")
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "panels", sorted(self.panels, key=lambda x: x.panel_id))
+        return self
 
     @model_validator(mode="after")
     def verify_referential_integrity(self) -> Self:
@@ -3349,6 +3366,11 @@ class StatisticalChartExtractionState(CoreasonBaseModel):
     data_series: list[dict[str, float | str]] = Field(
         description="The discrete semantic tuples extracted from the chart markers."
     )
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "data_series", sorted(self.data_series, key=lambda x: json.dumps(x, sort_keys=True)))
+        return self
 
     @model_validator(mode="after")
     def verify_dimensional_isometry(self) -> Self:

--- a/tests/domains/test_deterministic_sorting.py
+++ b/tests/domains/test_deterministic_sorting.py
@@ -1,10 +1,20 @@
 # Copyright (c) 2026 CoReason, Inc.. All Rights Reserved
 
+import json
+
 from coreason_manifest.spec.ontology import (
     AdversarialMarketTopology,
+    BypassReceipt,
+    DynamicRoutingManifest,
+    ExecutionNodeReceipt,
+    GlobalSemanticProfile,
+    GrammarPanel,
+    InsightCard,
     LatentScratchpadReceipt,
+    MacroGridProfile,
     PredictionMarketPolicy,
     SecureSubSessionState,
+    StatisticalChartExtractionState,
     ThoughtBranch,
 )
 
@@ -49,3 +59,56 @@ def test_adversarial_market_sorting_determinism() -> None:
     )
     assert macro.blue_team_ids == ["did:web:node_A", "did:web:node_Z"]
     assert macro.red_team_ids == ["did:web:node_B", "did:web:node_X"]
+
+
+def test_execution_node_receipt_sorting_determinism() -> None:
+    hashes = ["z_hash", "a_hash", "m_hash"]
+    node = ExecutionNodeReceipt(request_id="req_1", inputs="input", outputs="output", parent_hashes=hashes)
+    assert node.parent_hashes == ["a_hash", "m_hash", "z_hash"]
+
+
+def test_dynamic_routing_manifest_sorting_determinism() -> None:
+    profile = GlobalSemanticProfile(artifact_event_id="art_1", detected_modalities=["text"], token_density=10)
+    b1 = BypassReceipt(
+        artifact_event_id="art_1",
+        bypassed_node_id="did:web:node_Z",
+        justification="modality_mismatch",
+        cryptographic_null_hash="0" * 64,
+    )
+    b2 = BypassReceipt(
+        artifact_event_id="art_1",
+        bypassed_node_id="did:web:node_A",
+        justification="sla_timeout",
+        cryptographic_null_hash="0" * 64,
+    )
+
+    manifest = DynamicRoutingManifest(
+        manifest_id="man_1",
+        artifact_profile=profile,
+        active_subgraphs={"text": ["did:web:Z", "did:web:A"]},
+        bypassed_steps=[b1, b2],
+        branch_budgets_magnitude={"did:web:A": 10},
+    )
+    assert manifest.active_subgraphs["text"] == ["did:web:A", "did:web:Z"]
+    assert manifest.bypassed_steps[0].bypassed_node_id == "did:web:node_A"
+    assert manifest.bypassed_steps[1].bypassed_node_id == "did:web:node_Z"
+
+
+def test_macro_grid_profile_sorting_determinism() -> None:
+    p1 = InsightCard(panel_id="panel_Z", title="Z", markdown_content="Z")
+    p2 = GrammarPanel(panel_id="panel_A", title="A", data_source_id="d1", mark="point", encodings=[])
+
+    grid = MacroGridProfile(layout_matrix=[["panel_A", "panel_Z"]], panels=[p1, p2])
+    assert grid.panels[0].panel_id == "panel_A"
+    assert grid.panels[1].panel_id == "panel_Z"
+
+
+def test_statistical_chart_extraction_sorting_determinism() -> None:
+    data: list[dict[str, float | str]] = [{"x": 10.0, "y": "Z"}, {"x": 5.0, "y": "A"}]
+    # "x": 10 vs "x": 5 json string sorting:
+    # '{"x": 10, "y": "Z"}' vs '{"x": 5, "y": "A"}'
+    # '{"x": 10' comes before '{"x": 5' algebraically in string sorts.
+
+    state = StatisticalChartExtractionState(axes={}, data_series=data)
+    expected_order = sorted(data, key=lambda x: json.dumps(x, sort_keys=True))
+    assert state.data_series == expected_order


### PR DESCRIPTION
Injects deterministic `sort_arrays` validators to freeze topological arrays in four specific Pydantic schemas. The changes apply to `ExecutionNodeReceipt`, `DynamicRoutingManifest`, `MacroGridProfile`, and `StatisticalChartExtractionState`. The implementation uses `object.__setattr__` to respect the `frozen=True` immutability constraint and preserves existing validators to avoid AST collisions. Property-based BDD tests are appended to `tests/domains/test_deterministic_sorting.py` and pass all local verification checks (Ruff, Mypy, Pytest).

---
*PR created automatically by Jules for task [1692981184740713626](https://jules.google.com/task/1692981184740713626) started by @gowthamrao*