### PR TITLE
feat: Enforce deterministic sorting on topological arrays

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1969,6 +1969,11 @@ class ExecutionNodeReceipt(CoreasonBaseModel):
             raise ValueError("Orphaned Lineage: parent_request_id is set but root_request_id is None")
         return self
 
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "parent_hashes", sorted(self.parent_hashes))
+        return self
+
     def generate_node_hash(self) -> str:
         """
         Generate a strictly deterministic SHA-256 hash for the node via RFC 8785 canonicalization.
@@ -2221,6 +2226,13 @@ class DynamicRoutingManifest(CoreasonBaseModel):
                 raise ValueError(
                     "Merkle Violation: BypassReceipt artifact_event_id does not match the root artifact_profile."
                 )
+        return self
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        sorted_subgraphs = {k: sorted(v) for k, v in self.active_subgraphs.items()}
+        object.__setattr__(self, "active_subgraphs", sorted_subgraphs)
+        object.__setattr__(self, "bypassed_steps", sorted(self.bypassed_steps, key=lambda x: x.bypassed_node_id))
         return self
 
 
@@ -2737,6 +2749,11 @@ class MacroGridProfile(CoreasonBaseModel):
             for panel_id in row:
                 if panel_id not in panel_ids:
                     raise ValueError(f"Ghost Panel referenced in layout_matrix: {panel_id}")
+        return self
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "panels", sorted(self.panels, key=lambda x: x.panel_id))
         return self
 
 
@@ -3384,6 +3401,11 @@ class StatisticalChartExtractionState(CoreasonBaseModel):
                 missing = axis_keys - point_keys
                 if missing:
                     raise ValueError(f"Data point missing required axis dimensions: {missing}")
+        return self
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "data_series", sorted(self.data_series, key=lambda x: json.dumps(x, sort_keys=True)))
         return self
 
 

--- a/tests/domains/test_deterministic_sorting.py
+++ b/tests/domains/test_deterministic_sorting.py
@@ -1,17 +1,27 @@
 # Copyright (c) 2026 CoReason, Inc.. All Rights Reserved
 
+import json
+
 from coreason_manifest.spec.ontology import (
     AdversarialMarketTopology,
+    BypassReceipt,
     DAGTopology,
+    DynamicRoutingManifest,
     EpistemicPromotionEvent,
+    ExecutionNodeReceipt,
+    GlobalSemanticProfile,
+    GrammarPanel,
     InformationClassification,
+    InsightCard,
     LatentScratchpadReceipt,
+    MacroGridProfile,
     MarketResolutionState,
     OntologicalHandshake,
     PredictionMarketPolicy,
     PredictionMarketState,
     SaeLatentPolicy,
     SecureSubSessionState,
+    StatisticalChartExtractionState,
     SwarmTopology,
     ThoughtBranch,
     WorkflowManifest,
@@ -134,3 +144,56 @@ def test_epistemic_promotion_event_sorting_determinism() -> None:
         compression_ratio=10.0,
     )
     assert event.source_episodic_event_ids == ["obs_A", "obs_M", "obs_Z"]
+
+
+def test_execution_node_receipt_sorting_determinism() -> None:
+    hashes = ["z_hash", "a_hash", "m_hash"]
+    node = ExecutionNodeReceipt(request_id="req_1", inputs="input", outputs="output", parent_hashes=hashes)
+    assert node.parent_hashes == ["a_hash", "m_hash", "z_hash"]
+
+
+def test_dynamic_routing_manifest_sorting_determinism() -> None:
+    profile = GlobalSemanticProfile(artifact_event_id="art_1", detected_modalities=["text"], token_density=10)
+    b1 = BypassReceipt(
+        artifact_event_id="art_1",
+        bypassed_node_id="did:web:node_Z",
+        justification="modality_mismatch",
+        cryptographic_null_hash="0" * 64,
+    )
+    b2 = BypassReceipt(
+        artifact_event_id="art_1",
+        bypassed_node_id="did:web:node_A",
+        justification="sla_timeout",
+        cryptographic_null_hash="0" * 64,
+    )
+
+    manifest = DynamicRoutingManifest(
+        manifest_id="man_1",
+        artifact_profile=profile,
+        active_subgraphs={"text": ["did:web:Z", "did:web:A"]},
+        bypassed_steps=[b1, b2],
+        branch_budgets_magnitude={"did:web:A": 10},
+    )
+    assert manifest.active_subgraphs["text"] == ["did:web:A", "did:web:Z"]
+    assert manifest.bypassed_steps[0].bypassed_node_id == "did:web:node_A"
+    assert manifest.bypassed_steps[1].bypassed_node_id == "did:web:node_Z"
+
+
+def test_macro_grid_profile_sorting_determinism() -> None:
+    p1 = InsightCard(panel_id="panel_Z", title="Z", markdown_content="Z")
+    p2 = GrammarPanel(panel_id="panel_A", title="A", data_source_id="d1", mark="point", encodings=[])
+
+    grid = MacroGridProfile(layout_matrix=[["panel_A", "panel_Z"]], panels=[p1, p2])
+    assert grid.panels[0].panel_id == "panel_A"
+    assert grid.panels[1].panel_id == "panel_Z"
+
+
+def test_statistical_chart_extraction_sorting_determinism() -> None:
+    data: list[dict[str, float | str]] = [{"x": 10.0, "y": "Z"}, {"x": 5.0, "y": "A"}]
+    # "x": 10 vs "x": 5 json string sorting:
+    # '{"x": 10, "y": "Z"}' vs '{"x": 5, "y": "A"}'
+    # '{"x": 10' comes before '{"x": 5' algebraically in string sorts.
+
+    state = StatisticalChartExtractionState(axes={}, data_series=data)
+    expected_order = sorted(data, key=lambda x: json.dumps(x, sort_keys=True))
+    assert state.data_series == expected_order


### PR DESCRIPTION
Enforced deterministic sorting on topological arrays inside four specified Pydantic schemas in `src/coreason_manifest/spec/ontology.py`. Tested their deterministic behavior using BDD tests in `tests/domains/test_deterministic_sorting.py`. The local tests passed and static checks (`ruff check`, `mypy`) succeeded.

---
*PR created automatically by Jules for task [4938543167586689613](https://jules.google.com/task/4938543167586689613) started by @gowthamrao*