### PR TITLE
Add legal boilerplate

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from __future__ import annotations
 
 import ast

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 import hashlib
 from typing import Literal
 

--- a/tests/test_cli_validate.py
+++ b/tests/test_cli_validate.py
@@ -1,3 +1,10 @@
+# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+#
+# This software is licensed under the Prosperity Public License 3.0.0.
+# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+#
+# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+
 from pathlib import Path
 from unittest.mock import patch
 


### PR DESCRIPTION
Adds legal boilerplate to ensure compliance with the Prosperity Public License 3.0. This change prepends the boilerplate as an inert comment block at Line 1 of specified files, followed by an empty line, without any functional changes.

Verified locally with `ruff`, `mypy`, and `pytest`.

---
*PR created automatically by Jules for task [2645821934253267573](https://jules.google.com/task/2645821934253267573) started by @gowthamrao*