### PR TITLE
Enforce lexicographical determinism on MarketResolutionState

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2777,6 +2777,11 @@ class MarketResolutionState(CoreasonBaseModel):
         description="The deterministic mapping of agent IDs to their earned compute budget/magnitude based on Brier scoring."  # noqa: E501
     )
 
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "falsified_hypothesis_ids", sorted(self.falsified_hypothesis_ids))
+        return self
+
 
 class MathematicalNotationExtractionState(CoreasonBaseModel):
     math_type: Literal["inline", "display"] = Field(description="The structural context of the equation.")

--- a/tests/test_deterministic_sorting.py
+++ b/tests/test_deterministic_sorting.py
@@ -5,6 +5,7 @@ from coreason_manifest.spec.ontology import (
     EnsembleTopologyProfile,
     EvictionPolicy,
     LatentScratchpadReceipt,
+    MarketResolutionState,
     MigrationContract,
     PeftAdapterContract,
     PredictionMarketPolicy,
@@ -92,3 +93,14 @@ def test_migration_contract_sorting_determinism() -> None:
         dropped_paths=["/z_path", "/a_path", "/m_path"],
     )
     assert contract.dropped_paths == ["/a_path", "/m_path", "/z_path"]
+
+
+def test_market_resolution_sorting_determinism() -> None:
+    """Prove that injecting chaotic arrays yields a mathematically pristine, sorted hash state."""
+    state = MarketResolutionState(
+        market_id="mkt_1",
+        winning_hypothesis_id="hyp_Z",
+        falsified_hypothesis_ids=["hyp_M", "hyp_A", "hyp_X"],
+        payout_distribution={"did:web:agent_1": 100},
+    )
+    assert state.falsified_hypothesis_ids == ["hyp_A", "hyp_M", "hyp_X"]


### PR DESCRIPTION
This commit modifies `MarketResolutionState` to add a `@model_validator` to enforce lexicographical sorting of `falsified_hypothesis_ids`. It also adds a mathematical proof test `test_market_resolution_sorting_determinism` to mathematically prove the deterministic serialization bound survives chaotic injection.

---
*PR created automatically by Jules for task [15723671322591992879](https://jules.google.com/task/15723671322591992879) started by @gowthamrao*