### PR TITLE
refactor: apply AST-native semantic anchoring and latent space bounding

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -228,7 +228,7 @@
           "type": "string"
         },
         "criteria": {
-          "description": "List of criteria used in the rubric.",
+          "description": "The explicit array of strict evaluation criteria defining the rubric.",
           "items": {
             "$ref": "#/$defs/GradingCriterionProfile"
           },
@@ -1686,7 +1686,7 @@
       "description": "Constraints bounding human interaction for interventions.",
       "properties": {
         "allowed_fields": {
-          "description": "List of specific fields the human is permitted to mutate.",
+          "description": "The explicit whitelist of top-level JSON pointers mathematically open to mutation.",
           "items": {
             "type": "string"
           },
@@ -2497,7 +2497,7 @@
           "type": "string"
         },
         "forbidden_intents": {
-          "description": "List of intents that are forbidden by this rule.",
+          "description": "The explicit, structurally bounded set of forbidden semantic intents.",
           "items": {
             "minLength": 1,
             "type": "string"
@@ -3043,7 +3043,7 @@
           "type": "string"
         },
         "edges": {
-          "description": "List of edges between nodes.",
+          "description": "The strict, topologically bounded matrix of directed causal edges.",
           "items": {
             "maxItems": 2,
             "minItems": 2,
@@ -5134,7 +5134,7 @@
       "additionalProperties": false,
       "properties": {
         "broadcast_endpoints": {
-          "description": "A list of MCP URI endpoints open for B2B task bidding.",
+          "description": "The explicit array of strictly bounded MCP URI broadcast endpoints.",
           "items": {
             "type": "string"
           },
@@ -5142,7 +5142,7 @@
           "type": "array"
         },
         "supported_ontologies": {
-          "description": "A list of cryptographic hashes of domain ontologies this swarm is capable of processing.",
+          "description": "The explicit array of cryptographic hashes defining acceptable domain ontologies.",
           "items": {
             "type": "string"
           },
@@ -7189,7 +7189,7 @@
           "type": "integer"
         },
         "capabilities": {
-          "description": "A list of supported capabilities by the model.",
+          "description": "The explicit, structurally bounded array of capabilities authorized for this model.",
           "items": {
             "type": "string"
           },
@@ -9959,7 +9959,7 @@
           "type": "number"
         },
         "allowed_read_only_tools": {
-          "description": "List of read-only tools allowed during a reflex action.",
+          "description": "The explicit, bounded array of strictly read-only tool capabilities.",
           "items": {
             "type": "string"
           },
@@ -10425,7 +10425,7 @@
           "type": "string"
         },
         "assumed_shared_beliefs": {
-          "description": "A list of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses.",
+          "description": "The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses.",
           "items": {
             "type": "string"
           },

--- a/src/coreason_manifest/cli/validate.py
+++ b/src/coreason_manifest/cli/validate.py
@@ -16,15 +16,13 @@ from typing import Final
 
 from pydantic import BaseModel, ValidationError
 
-# Statically bound God-Context imports
 from coreason_manifest.spec.ontology import (
-    CognitiveStateProfile,  # Representative schema
+    CognitiveStateProfile,
     DocumentLayoutManifest,
-    StateMutationIntent,  # Representative schema
+    StateMutationIntent,
     System2RemediationIntent,
 )
 
-# Immutable AOT Schema Registry
 SCHEMA_REGISTRY: Final[dict[str, type[BaseModel]]] = {
     "step8_vision": DocumentLayoutManifest,
     "state_differential": StateMutationIntent,
@@ -55,11 +53,9 @@ def main() -> None:
         return
 
     try:
-        # Pure functional evaluation
         target_schema.model_validate_json(payload_bytes)
         sys.exit(0)
     except ValidationError as e:
-        # AST-Compliant Error Projection (RFC 6902 parsable)
         sys.stderr.write(e.json())
         sys.stderr.write("\n")
         sys.exit(1)

--- a/src/coreason_manifest/cli/visualize.py
+++ b/src/coreason_manifest/cli/visualize.py
@@ -29,11 +29,9 @@ def project_manifest_to_mermaid(manifest: DynamicRoutingManifest) -> str:
     safe_root_id = manifest.manifest_id.replace(":", "_").replace("-", "_").replace(".", "_")
     lines.append(f"    {safe_root_id}[{manifest.manifest_id}]")
 
-    # 1. Map Structural Modalities
     for modality in manifest.artifact_profile.detected_modalities:
         lines.append(f"    subgraph {modality}")
 
-        # 2. Map Active Nodes
         if modality in manifest.active_subgraphs:
             for node_id in manifest.active_subgraphs[modality]:
                 safe_id = node_id.replace(":", "_").replace("-", "_").replace(".", "_")
@@ -42,7 +40,6 @@ def project_manifest_to_mermaid(manifest: DynamicRoutingManifest) -> str:
 
         lines.append("    end")
 
-    # 3. Map Bypassed Steps
     if manifest.bypassed_steps:
         lines.append("    subgraph Quarantined_Bypass")
         for bypass in manifest.bypassed_steps:

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -437,7 +437,9 @@ class ModelProfile(CoreasonBaseModel):
     model_name: str = Field(description="The identifier of the underlying model.")
     provider: str = Field(description="The name of the provider hosting the model.")
     context_window_size: int = Field(description="The maximum context window size in tokens.")
-    capabilities: list[str] = Field(description="A list of supported capabilities by the model.")
+    capabilities: list[str] = Field(
+        description="The explicit, structurally bounded array of capabilities authorized for this model."
+    )
     rate_card: ComputeRateContract = Field(description="The economic cost definition associated with the model.")
     supported_functional_experts: list[str] = Field(
         default_factory=list,
@@ -624,7 +626,7 @@ class ConstitutionalPolicy(CoreasonBaseModel):
         description="Severity level if the rule is violated."
     )
     forbidden_intents: set[Annotated[str, StringConstraints(min_length=1)]] = Field(
-        description="List of intents that are forbidden by this rule."
+        description="The explicit, structurally bounded set of forbidden semantic intents."
     )
 
 
@@ -644,7 +646,9 @@ class AdjudicationRubricProfile(CoreasonBaseModel):
     """
 
     rubric_id: str = Field(description="Unique identifier for the rubric.")
-    criteria: list[GradingCriterionProfile] = Field(description="List of criteria used in the rubric.")
+    criteria: list[GradingCriterionProfile] = Field(
+        description="The explicit array of strict evaluation criteria defining the rubric."
+    )
     passing_threshold: float = Field(ge=0.0, le=100.0, description="The minimum score required to pass.")
 
     @model_validator(mode="after")
@@ -1089,9 +1093,11 @@ class BilateralSLA(CoreasonBaseModel):
 
 
 class FederatedDiscoveryManifest(CoreasonBaseModel):
-    broadcast_endpoints: list[str] = Field(description="A list of MCP URI endpoints open for B2B task bidding.")
+    broadcast_endpoints: list[str] = Field(
+        description="The explicit array of strictly bounded MCP URI broadcast endpoints."
+    )
     supported_ontologies: list[str] = Field(
-        description="A list of cryptographic hashes of domain ontologies this swarm is capable of processing."
+        description="The explicit array of cryptographic hashes defining acceptable domain ontologies."
     )
 
     @model_validator(mode="after")
@@ -1294,7 +1300,9 @@ class BoundedInterventionScopePolicy(CoreasonBaseModel):
     Constraints bounding human interaction for interventions.
     """
 
-    allowed_fields: list[str] = Field(description="List of specific fields the human is permitted to mutate.")
+    allowed_fields: list[str] = Field(
+        description="The explicit whitelist of top-level JSON pointers mathematically open to mutation."
+    )
     json_schema_whitelist: dict[str, str | int | float | bool | None | list[Any] | dict[str, Any]] = Field(
         description="Strict JSON Schema constraints for the human's input."
     )
@@ -3534,7 +3542,9 @@ class System1ReflexPolicy(CoreasonBaseModel):
     confidence_threshold: float = Field(
         ge=0.0, le=1.0, description="The confidence threshold required to execute a reflex action."
     )
-    allowed_read_only_tools: list[str] = Field(description="List of read-only tools allowed during a reflex action.")
+    allowed_read_only_tools: list[str] = Field(
+        description="The explicit, bounded array of strictly read-only tool capabilities."
+    )
 
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
@@ -3730,7 +3740,7 @@ class TheoryOfMindSnapshot(CoreasonBaseModel):
         description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark linking this node to the agent whose mind is being modeled.",  # noqa: E501
     )
     assumed_shared_beliefs: list[str] = Field(
-        description="A list of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses."  # noqa: E501
+        description="The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses."  # noqa: E501
     )
     identified_knowledge_gaps: list[str] = Field(
         description="Specific topics or logical premises the target agent is assumed to be missing."
@@ -4089,7 +4099,9 @@ class DAGTopology(BaseTopology):
     """
 
     type: Literal["dag"] = Field(default="dag", description="Discriminator for a DAG topology.")
-    edges: list[tuple[NodeID, NodeID]] = Field(default_factory=list, description="List of edges between nodes.")
+    edges: list[tuple[NodeID, NodeID]] = Field(
+        default_factory=list, description="The strict, topologically bounded matrix of directed causal edges."
+    )
     allow_cycles: bool = Field(
         default=False, description="Configuration indicating if cycles are allowed during validation."
     )


### PR DESCRIPTION
Resolves Epic 4: AST-Native Semantic Anchoring Corrections (Track B).

* Removed specified conversational comments from `src/coreason_manifest/cli/visualize.py` and `src/coreason_manifest/cli/validate.py`.
* Updated descriptions in Pydantic `Field` declarations for 9 specific classes in `src/coreason_manifest/spec/ontology.py` to enforce mathematical bounding terminology.
* Regenerated the coreason ontology JSON schema with the updated Pydantic descriptions.
* Successfully executed `ruff format`, `ruff check`, `mypy`, and `pytest` locally to ensure no structural regressions.

---
*PR created automatically by Jules for task [350539589923893061](https://jules.google.com/task/350539589923893061) started by @gowthamrao*