### PR TITLE
fix: complete semantic anchoring and verify legal boilerplate

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -6737,7 +6737,7 @@
           "type": "string"
         },
         "uris": {
-          "description": "List of resource URIs available to the agent.",
+          "description": "The explicit array of resource URIs mathematically bound to the agent.",
           "items": {
             "type": "string"
           },
@@ -6778,7 +6778,7 @@
           "title": "Transport"
         },
         "required_capabilities": {
-          "description": "A list of capabilities required from the MCP server.",
+          "description": "The structurally bounded array of capabilities mandated for this server connection.",
           "items": {
             "type": "string"
           },
@@ -6875,7 +6875,7 @@
           "type": "array"
         },
         "panels": {
-          "description": "A list of panels included in the grid.",
+          "description": "The ordered array of topological UI panels physically rendered in the grid.",
           "items": {
             "$ref": "#/$defs/AnyPanel"
           },

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2713,7 +2713,7 @@ class MCPResourceManifest(CoreasonBaseModel):
     """A collection of Semantic Memory resource URIs provided by a specific MCP server."""
 
     server_id: str = Field(..., description="The ID of the MCP server providing these resources.")
-    uris: list[str] = Field(default_factory=list, description="List of resource URIs available to the agent.")
+    uris: list[str] = Field(default_factory=list, description="The explicit array of resource URIs mathematically bound to the agent.")
 
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
@@ -2750,7 +2750,7 @@ class MacroGridProfile(CoreasonBaseModel):
     """A layout matrix containing a list of panels."""
 
     layout_matrix: list[list[str]] = Field(description="A matrix defining the layout structure, using panel IDs.")
-    panels: list[AnyPanel] = Field(description="A list of panels included in the grid.")
+    panels: list[AnyPanel] = Field(description="The ordered array of topological UI panels physically rendered in the grid.")
 
     @model_validator(mode="after")
     def verify_referential_integrity(self) -> Self:
@@ -3443,7 +3443,7 @@ class MCPServerBindingProfile(CoreasonBaseModel):
     transport: MCPTransport = Field(..., discriminator="type", description="Polymorphic transport configuration.")
     required_capabilities: list[str] = Field(
         default_factory=lambda: ["tools", "resources", "prompts"],
-        description="A list of capabilities required from the MCP server.",
+        description="The structurally bounded array of capabilities mandated for this server connection.",
     )
 
     @model_validator(mode="after")

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2713,7 +2713,10 @@ class MCPResourceManifest(CoreasonBaseModel):
     """A collection of Semantic Memory resource URIs provided by a specific MCP server."""
 
     server_id: str = Field(..., description="The ID of the MCP server providing these resources.")
-    uris: list[str] = Field(default_factory=list, description="The explicit array of resource URIs mathematically bound to the agent.")
+    uris: list[str] = Field(
+        default_factory=list,
+        description="The explicit array of resource URIs mathematically bound to the agent.",
+    )
 
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
@@ -2750,7 +2753,9 @@ class MacroGridProfile(CoreasonBaseModel):
     """A layout matrix containing a list of panels."""
 
     layout_matrix: list[list[str]] = Field(description="A matrix defining the layout structure, using panel IDs.")
-    panels: list[AnyPanel] = Field(description="The ordered array of topological UI panels physically rendered in the grid.")
+    panels: list[AnyPanel] = Field(
+        description="The ordered array of topological UI panels physically rendered in the grid.",
+    )
 
     @model_validator(mode="after")
     def verify_referential_integrity(self) -> Self:


### PR DESCRIPTION
Fix Remaining Semantic Anchoring Violations (Epic 4) and verify Legal Boilerplate Compliance (Epic 5).
Updates `Field(description=...)` strings in `src/coreason_manifest/spec/ontology.py` to be mathematically strict and bounded. Verifies that the required legal boilerplate is at the top of the two files. Tests run correctly with no touch to `tests/`.

---
*PR created automatically by Jules for task [12401862786182104481](https://jules.google.com/task/12401862786182104481) started by @gowthamrao*