### PR TITLE
Optimize testing using pytest-xdist

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,7 +87,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov=coreason_manifest --cov-report=term-missing --cov-report=xml --cov-fail-under=0"
+addopts = "-n auto --cov=coreason_manifest --cov-report=term-missing --cov-report=xml --cov-fail-under=0"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 filterwarnings = ["ignore:Pydantic serializer warnings:UserWarning"]


### PR DESCRIPTION
This pull request adds `-n auto` to `pytest.ini_options` in `pyproject.toml` to automatically enable test execution in parallel. The project already includes `pytest-xdist` as a dependency, so this change immediately optimizes the test suite performance.

Before: ~37 seconds
After: ~12 seconds

---
*PR created automatically by Jules for task [16934856158024808048](https://jules.google.com/task/16934856158024808048) started by @gowthamrao*