### PR TITLE
AST-Purification pass

### DIFF
--- a/scripts/evaluate_architecture.py
+++ b/scripts/evaluate_architecture.py
@@ -23,7 +23,6 @@ def main() -> None:
     for line in diff_content.splitlines():
         if line.startswith("+++ "):
             filename = line[4:].strip()
-            # If it's not /dev/null, standard git diff prefix b/
             filename = filename.removeprefix("b/")
             in_py_file = filename.endswith(".py")
             continue

--- a/scripts/semantic_diff.py
+++ b/scripts/semantic_diff.py
@@ -40,14 +40,12 @@ def main() -> None:
 
     if "iterable_item_added" in diff:
         for path in diff["iterable_item_added"]:
-            # e.g. root['$defs']['AgentNode']['required'][1]
             if "['required']" in path:
                 print(f"Error: Backward-breaking schema change detected! A new required field was added: {path}")
                 sys.exit(1)
 
     if "dictionary_item_added" in diff:
         for path in diff["dictionary_item_added"]:
-            # e.g. root['$defs']['AgentNode']['required']
             if "['required']" in path:
                 print(f"Error: Backward-breaking schema change detected! A new required field was added: {path}")
                 sys.exit(1)

--- a/src/coreason_manifest/cli/export.py
+++ b/src/coreason_manifest/cli/export.py
@@ -24,7 +24,6 @@ def main() -> None:
 
     for name in sorted(set(coreason_manifest.__all__)):
         obj = getattr(coreason_manifest, name, None)
-        # Strictly filter for BaseModel classes only to avoid crashing models_json_schema
         if isinstance(obj, type) and issubclass(obj, CoreasonBaseModel) and obj is not CoreasonBaseModel:
             models_to_export.append(obj)
 

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -942,7 +942,7 @@ class StateDifferentialManifest(CoreasonBaseModel):
     patches: list[StateMutationIntent] = Field(
         default_factory=list, description="The exact, ordered sequence of deterministic state vector mutations."
     )
-    # Note: patches is a structurally ordered sequence (Chronological Mutations) and MUST NOT be sorted.
+    # Topological invariant: Structurally ordered sequence. MUST NOT be sorted.
 
 
 class TemporalCheckpointState(CoreasonBaseModel):
@@ -1665,7 +1665,7 @@ class DocumentLayoutManifest(CoreasonBaseModel):
         default_factory=list,
         description="Directed edges defining the topological sort (chronological flow) of the document.",
     )
-    # Note: reading_order_edges is a structurally ordered sequence (Topological Sort) and MUST NOT be sorted.
+    # Topological invariant: Structurally ordered sequence. MUST NOT be sorted.
 
     @model_validator(mode="after")
     def verify_dag_and_integrity(self) -> Self:
@@ -3338,7 +3338,7 @@ class ExecutionSpanReceipt(CoreasonBaseModel):
     events: list[SpanEvent] = Field(
         default_factory=list, max_length=10000, description="Structured log records emitted during the span."
     )
-    # Note: events is a structurally ordered sequence (Temporal execution) and MUST NOT be sorted.
+    # Topological invariant: Structurally ordered sequence. MUST NOT be sorted.
 
     @model_validator(mode="after")
     def validate_temporal_bounds(self) -> Any:
@@ -3367,7 +3367,7 @@ class SpatialKinematicActionIntent(CoreasonBaseModel):
     bezier_control_points: list[SpatialCoordinateProfile] = Field(
         default_factory=list, description="Waypoints for constructing non-linear, bot-evasive movement curves."
     )
-    # Note: bezier_control_points is a structurally ordered sequence (Geometry/Time) and MUST NOT be sorted.
+    # Topological invariant: Structurally ordered sequence. MUST NOT be sorted.
     expected_visual_concept: str | None = Field(
         default=None,
         description="The visual anchor (e.g., 'Submit Button'). The orchestrator must verify this semantic concept exists at the target_coordinate before executing the macro, preventing blind clicks.",  # noqa: E501


### PR DESCRIPTION
- Deleted legacy, human-centric conversational comments in `src/coreason_manifest/cli/export.py`, `scripts/evaluate_architecture.py`, and `scripts/semantic_diff.py`.
- Replaced specific legacy conversational notes with `# Topological invariant:` tags in `src/coreason_manifest/spec/ontology.py` to guarantee deterministic LLM parsing.

---
*PR created automatically by Jules for task [1803749046859718982](https://jules.google.com/task/1803749046859718982) started by @gowthamrao*