### PR TITLE
fix: Enforce SOTA cryptographic determinism and topological exemptions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,14 +213,18 @@ You are strictly forbidden from introducing "Active" or "Runtime" logic into thi
 * **Typing:** Strict `mypy`. Use `Pydantic` models for all data structures. Avoid `dict` or `Any` where a schema can be defined.
 
 ### **Cryptographic Determinism (The Merkle Rule)**
-* **Array Sorting:** Because `CoreasonBaseModel` enforces strict RFC 8785 canonical hashing and `frozen=True` immutability, dictionary keys are sorted automatically, but **array ordering is preserved**. To prevent Byzantine hash fractures (`TamperError`) across distributed nodes, you MUST deterministically sort all list/array fields (e.g., alphabetically or by a unique ID) inside the schemas.
-* **Implementation:** You must bypass the frozen lock by using `object.__setattr__` within a post-init validator.
-    ```python
-    @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
-        object.__setattr__(self, "my_array", sorted(self.my_array, key=lambda x: x.id))
-        return self
-    ```
+* **The Physics of RFC 8785:** Because `CoreasonBaseModel` enforces strict canonical hashing and `frozen=True` immutability, dictionary keys are sorted automatically, but **array ordering is mathematically preserved**. To prevent Byzantine hash fractures (`TamperError`) across distributed nodes, you must strictly categorize all arrays into one of two paradigms:
+* **Paradigm 1: Unordered Sets (Must Be Sorted):** If the array represents a set of capabilities, IDs, or enums, you MUST deterministically sort it (e.g., alphabetically or by a unique ID) via a post-init validator.
+    * *Implementation:* Bypass the frozen lock using `object.__setattr__`.
+      ```python
+      @model_validator(mode="after")
+      def sort_arrays(self) -> Self:
+          object.__setattr__(self, "my_array", sorted(self.my_array, key=lambda x: x.id))
+          return self
+      ```
+* **Paradigm 2: Structural Sequences (The Topological Exemption):** If the array encodes physical, temporal, or causal reality (e.g., chronological Last-Writer-Wins patches, topological DAG edges, or spatial kinematics), sorting it destroys its epistemic value. You are strictly forbidden from sorting these arrays.
+    * *Implementation:* To invoke this exemption, you MUST physically anchor the structural reality into the AST using an inline comment immediately below the field definition:
+      `# Note: <field_name> is a structurally ordered sequence (<Reason>) and MUST NOT be sorted.`
 
 ### **Logging (Passive Pattern)**
 * **Library Responsibility:** Expose a logger object (`loguru.logger`) but **DO NOT** configure it.

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2753,9 +2753,11 @@ class MacroGridProfile(CoreasonBaseModel):
     """A layout matrix containing a list of panels."""
 
     layout_matrix: list[list[str]] = Field(description="A matrix defining the layout structure, using panel IDs.")
+    # Note: layout_matrix is a structurally ordered sequence (2D Visual Grammar) and MUST NOT be sorted.
     panels: list[AnyPanel] = Field(
         description="The ordered array of topological UI panels physically rendered in the grid.",
     )
+    # Note: panels is a structurally ordered sequence (2D Visual Grammar) and MUST NOT be sorted.
 
     @model_validator(mode="after")
     def verify_referential_integrity(self) -> Self:
@@ -3426,6 +3428,11 @@ class StatisticalChartExtractionState(CoreasonBaseModel):
                     raise ValueError(f"Data point missing required axis dimensions: {missing}")
         return self
 
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "data_series", sorted(self.data_series, key=lambda d: json.dumps(d, sort_keys=True)))
+        return self
+
 
 class StdioTransportProfile(CoreasonBaseModel):
     """Configuration for local Stdio-based MCP transport."""
@@ -3433,6 +3440,7 @@ class StdioTransportProfile(CoreasonBaseModel):
     type: Literal["stdio"] = Field(default="stdio", description="Type of transport.")
     command: str = Field(..., description="The command executable to run (e.g., 'node', 'python').")
     args: list[str] = Field(default_factory=list, description="List of arguments to pass to the command.")
+    # Note: args is a structurally ordered sequence (Execution Command Sequence) and MUST NOT be sorted.
     env_vars: dict[str, str] = Field(
         default_factory=dict, description="Environment variables required by the transport."
     )
@@ -4422,6 +4430,14 @@ class WorkflowManifest(CoreasonBaseModel):
     pq_signature: PostQuantumSignatureReceipt | None = Field(
         default=None, description="The quantum-resistant signature securing the root execution graph."
     )
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if self.allowed_information_classifications is not None:
+            object.__setattr__(
+                self, "allowed_information_classifications", sorted(self.allowed_information_classifications)
+            )
+        return self
 
 
 class WetwareAttestationContract(CoreasonBaseModel):


### PR DESCRIPTION
This commit applies mathematical hardening patches to the Universal Ontology. It updates the Epistemic Ledger (AGENTS.md) to define SOTA cryptographic determinism rules, enforces deterministic sorts on unordered sets (`data_series` in `StatisticalChartExtractionState` and `allowed_information_classifications` in `WorkflowManifest`), and adds topological exemption AST comments to structural sequences (`layout_matrix` and `panels` in `MacroGridProfile`, and `args` in `StdioTransportProfile`). All required local verification steps (linting, type checking, testing, schema export, and semantic diffs) pass successfully.

---
*PR created automatically by Jules for task [18318256944862411585](https://jules.google.com/task/18318256944862411585) started by @gowthamrao*