### PR TITLE
Add static firewalls to enforce epistemic boundaries and byte-determinism

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,21 @@
+# THE COREASON SHARED KERNEL PROTOCOL
+You are operating within a 2026+ State-of-the-Art Neurosymbolic architecture. You must adhere to the following laws without exception:
+
+1. **The "God Context" Monolith Directive:**
+   - NEVER federate or split `src/coreason_manifest/spec/ontology.py`. The entire universe of the ecosystem's state MUST live together in this single artifact to guarantee deterministic alignment.
+   - Ignore traditional "Separation of Concerns" (SoC) anti-patterns.
+
+2. **The Anti-CRUD Mandate (Strict Lexical Architecture):**
+   - You are explicitly forbidden from using legacy CRUD terminology (Create, Read, Update, Delete, User, Data).
+   - You MUST use geometric, causal, and structural descriptors (e.g., `Transmutation`, `Cascade`, `StateDiff`, `Topology`, `Manifold`).
+   - Every object MUST terminate with a strictly typed bounding suffix (`...Event`, `...Receipt`, `...Policy`, `...Contract`, `...Intent`, `...State`).
+
+3. **AST-Native Semantic Anchoring:**
+   - Conversational `# comments` explaining intent are BANNED.
+   - All capability definitions and constraints MUST live inside Python `"""docstrings"""` or Pydantic `Field(description="...")`.
+   - Use `"""AGENT INSTRUCTION:"""` for strict behavioral commands.
+
+4. **Passive by Design (No Execution):**
+   - This repository is a pure structural data library.
+   - Importing any module MUST NOT trigger side effects. (NO `os.mkdir`, NO global loggers, NO sockets).
+   - Dependencies are strictly limited to pure data parsers (`pydantic`, `pyyaml`).

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# The God Context
+src/coreason_manifest/spec/ontology.py @CoReason-AI/core-architects
+
+# Architectural CI Gates
+scripts/evaluate_architecture.py @CoReason-AI/core-architects
+scripts/semantic_diff.py @CoReason-AI/core-architects

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,21 @@
+# THE COREASON SHARED KERNEL PROTOCOL
+You are operating within a 2026+ State-of-the-Art Neurosymbolic architecture. You must adhere to the following laws without exception:
+
+1. **The "God Context" Monolith Directive:**
+   - NEVER federate or split `src/coreason_manifest/spec/ontology.py`. The entire universe of the ecosystem's state MUST live together in this single artifact to guarantee deterministic alignment.
+   - Ignore traditional "Separation of Concerns" (SoC) anti-patterns.
+
+2. **The Anti-CRUD Mandate (Strict Lexical Architecture):**
+   - You are explicitly forbidden from using legacy CRUD terminology (Create, Read, Update, Delete, User, Data).
+   - You MUST use geometric, causal, and structural descriptors (e.g., `Transmutation`, `Cascade`, `StateDiff`, `Topology`, `Manifold`).
+   - Every object MUST terminate with a strictly typed bounding suffix (`...Event`, `...Receipt`, `...Policy`, `...Contract`, `...Intent`, `...State`).
+
+3. **AST-Native Semantic Anchoring:**
+   - Conversational `# comments` explaining intent are BANNED.
+   - All capability definitions and constraints MUST live inside Python `"""docstrings"""` or Pydantic `Field(description="...")`.
+   - Use `"""AGENT INSTRUCTION:"""` for strict behavioral commands.
+
+4. **Passive by Design (No Execution):**
+   - This repository is a pure structural data library.
+   - Importing any module MUST NOT trigger side effects. (NO `os.mkdir`, NO global loggers, NO sockets).
+   - Dependencies are strictly limited to pure data parsers (`pydantic`, `pyyaml`).


### PR DESCRIPTION
This PR introduces several static configuration files to enforce epistemic boundaries and byte-determinism for the `coreason-manifest` repository:

1. **`.cursorrules` and `.github/copilot-instructions.md`**: Implements ambient firewalls to project structural laws into the IDE/Copilot context window, enforcing zero-execution, anti-CRUD semantics, and AST-native semantic anchoring.
2. **`.github/CODEOWNERS`**: Mathematically locks the structural boundaries of the repository.
3. **`.editorconfig`**: Guarantees RFC 8785 canonicalization consistency across mixed OS environments.

---
*PR created automatically by Jules for task [16085221948349608095](https://jules.google.com/task/16085221948349608095) started by @gowthamrao*