### PR TITLE
Test Coverage Patch for Epic 1

### DIFF
--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -103,6 +103,17 @@ def test_project_manifest_to_markdown() -> None:
             "extracted_by": "did:web:agent-1",
             "source_event_id": "bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
         },
+        "governance": {
+            "mandatory_license_rule": {
+                "rule_id": "PPL_3_0_COMPLIANCE",
+                "severity": "critical",
+                "description": "Ensure Prosperity Public License 3.0 Compliance.",
+                "forbidden_intents": [],
+            },
+            "max_budget_magnitude": 1000,
+            "max_global_tokens": 100000,
+            "global_timeout_seconds": 3600,
+        },
         "topology": {
             "type": "dag",
             "max_depth": 10,

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -9,9 +9,11 @@ from coreason_manifest.spec.ontology import (
     BoundedJSONRPCIntent,
     BrowserDOMState,
     ContinuousMutationPolicy,
+    ConstitutionalPolicy,
     DynamicLayoutManifest,
     EpistemicCompressionSLA,
     EpistemicTransmutationTask,
+    GlobalGovernancePolicy,
     InsightCardProfile,
 )
 
@@ -80,4 +82,18 @@ def test_multimodal_grounding_density_alignment(visual_modality: Any) -> None:
             artifact_event_id="artifact_1",
             target_modalities=[visual_modality],
             compression_sla=compression_sla,
+        )
+
+
+def test_epistemic_license_enforcement() -> None:
+    """Prove that attempting to instantiate GlobalGovernancePolicy with an invalid mandatory_license_rule triggers a ValidationError."""
+    invalid_license = ConstitutionalPolicy(
+        rule_id="MIT_LICENSE", severity="low", description="test", forbidden_intents=[]
+    )
+    with pytest.raises(ValidationError, match="CRITICAL LICENSE VIOLATION"):
+        GlobalGovernancePolicy(
+            mandatory_license_rule=invalid_license,
+            max_budget_magnitude=1000,
+            max_global_tokens=100000,
+            global_timeout_seconds=3600,
         )

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -8,8 +8,8 @@ from pydantic import ValidationError
 from coreason_manifest.spec.ontology import (
     BoundedJSONRPCIntent,
     BrowserDOMState,
-    ContinuousMutationPolicy,
     ConstitutionalPolicy,
+    ContinuousMutationPolicy,
     DynamicLayoutManifest,
     EpistemicCompressionSLA,
     EpistemicTransmutationTask,
@@ -86,7 +86,7 @@ def test_multimodal_grounding_density_alignment(visual_modality: Any) -> None:
 
 
 def test_epistemic_license_enforcement() -> None:
-    """Prove that attempting to instantiate GlobalGovernancePolicy with an invalid mandatory_license_rule triggers a ValidationError."""
+    """Prove that instantiating GlobalGovernancePolicy with invalid mandatory_license_rule triggers ValidationError."""
     invalid_license = ConstitutionalPolicy(
         rule_id="MIT_LICENSE", severity="low", description="test", forbidden_intents=[]
     )


### PR DESCRIPTION
Fixes code coverage regression caused by Epic 1's introduction of `mandatory_license_rule` in `GlobalGovernancePolicy` and `genesis_provenance` into `WorkflowManifest`.

Adds `test_epistemic_license_enforcement` to ensure attempting to instantiate `GlobalGovernancePolicy` with an invalid license triggers a `ValidationError`.

Updates `test_project_manifest_to_markdown` mock envelope data with `governance` and `mandatory_license_rule` to pass schema validation.

---
*PR created automatically by Jules for task [17727181678232833485](https://jules.google.com/task/17727181678232833485) started by @gowthamrao*