### PR TITLE
feat: Tool Execution Cryptographic Interlock and MCP Quarantine Gateway

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -6969,12 +6969,16 @@
         "capability_whitelist": {
           "$ref": "#/$defs/MCPCapabilityWhitelistPolicy",
           "description": "The strict capability bounds enforced by the orchestrator prior to connection."
+        },
+        "attestation_receipt": {
+          "$ref": "#/$defs/VerifiableCredentialPresentationReceipt"
         }
       },
       "required": [
         "server_uri",
         "transport_type",
-        "capability_whitelist"
+        "capability_whitelist",
+        "attestation_receipt"
       ],
       "title": "MCPServerManifest",
       "type": "object"
@@ -10765,13 +10769,22 @@
           "default": null,
           "description": "The maximum escrow unlocked for this specific run.",
           "title": "Authorized Budget Magnitude"
+        },
+        "agent_attestation": {
+          "$ref": "#/$defs/AgentAttestationReceipt"
+        },
+        "zk_proof": {
+          "$ref": "#/$defs/ZeroKnowledgeReceipt",
+          "description": "AGENT INSTRUCTION: The strict mathematical proof that the agent was authorized by the CoReason execution engine to evaluate this tool. Stripping this field violates the Zero-Trust execution boundary."
         }
       },
       "required": [
         "event_id",
         "timestamp",
         "tool_name",
-        "parameters"
+        "parameters",
+        "agent_attestation",
+        "zk_proof"
       ],
       "title": "ToolInvocationEvent",
       "type": "object"

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -3985,7 +3985,6 @@ class ToolInvocationEvent(BaseStateEvent):
     )
 
 
-
 class TraceExportManifest(CoreasonBaseState):
     batch_id: str = Field(description="Unique identifier for this telemetry snapshot.")
     spans: list[ExecutionSpanReceipt] = Field(

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2749,6 +2749,13 @@ class MCPServerManifest(CoreasonBaseState):
     capability_whitelist: MCPCapabilityWhitelistPolicy = Field(
         description="The strict capability bounds enforced by the orchestrator prior to connection."
     )
+    attestation_receipt: VerifiableCredentialPresentationReceipt
+
+    @model_validator(mode="after")
+    def enforce_coreason_did_authority(self) -> Self:
+        if not self.attestation_receipt.issuer_did.startswith("did:coreason:"):
+            raise ValueError("UNAUTHORIZED MCP MOUNT: The presented Verifiable Credential is not signed by a valid CoReason issuer DID. The orchestrator MUST immediately emit a QuarantineIntent and terminate the handshake.")
+        return self
 
 
 class ActionSpaceManifest(CoreasonBaseState):
@@ -3968,6 +3975,11 @@ class ToolInvocationEvent(BaseStateEvent):
     authorized_budget_magnitude: int | None = Field(
         default=None, ge=0, description="The maximum escrow unlocked for this specific run."
     )
+    agent_attestation: AgentAttestationReceipt
+    zk_proof: ZeroKnowledgeReceipt = Field(
+        description="""AGENT INSTRUCTION: The strict mathematical proof that the agent was authorized by the CoReason execution engine to evaluate this tool. Stripping this field violates the Zero-Trust execution boundary."""
+    )
+
 
 
 class TraceExportManifest(CoreasonBaseState):

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2754,7 +2754,11 @@ class MCPServerManifest(CoreasonBaseState):
     @model_validator(mode="after")
     def enforce_coreason_did_authority(self) -> Self:
         if not self.attestation_receipt.issuer_did.startswith("did:coreason:"):
-            raise ValueError("UNAUTHORIZED MCP MOUNT: The presented Verifiable Credential is not signed by a valid CoReason issuer DID. The orchestrator MUST immediately emit a QuarantineIntent and terminate the handshake.")
+            raise ValueError(
+                "UNAUTHORIZED MCP MOUNT: The presented Verifiable Credential is not signed by a valid "
+                "CoReason issuer DID. The orchestrator MUST immediately emit a QuarantineIntent and "
+                "terminate the handshake."
+            )
         return self
 
 
@@ -3977,7 +3981,7 @@ class ToolInvocationEvent(BaseStateEvent):
     )
     agent_attestation: AgentAttestationReceipt
     zk_proof: ZeroKnowledgeReceipt = Field(
-        description="""AGENT INSTRUCTION: The strict mathematical proof that the agent was authorized by the CoReason execution engine to evaluate this tool. Stripping this field violates the Zero-Trust execution boundary."""
+        description="""AGENT INSTRUCTION: The strict mathematical proof that the agent was authorized by the CoReason execution engine to evaluate this tool. Stripping this field violates the Zero-Trust execution boundary."""  # noqa: E501
     )
 
 

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -97,3 +97,39 @@ def test_epistemic_license_enforcement() -> None:
             max_global_tokens=100000,
             global_timeout_seconds=3600,
         )
+
+
+
+def test_mcp_quarantine_gateway_tripwire() -> None:
+    from coreason_manifest.spec.ontology import VerifiableCredentialPresentationReceipt, MCPServerManifest, MCPCapabilityWhitelistPolicy
+
+    receipt = VerifiableCredentialPresentationReceipt(
+        presentation_format="jwt_vc",
+        issuer_did="did:web:rogue-actor:123",
+        cryptographic_proof_blob="a"*64,
+        authorization_claims={}
+    )
+    with pytest.raises(ValidationError, match="UNAUTHORIZED MCP MOUNT"):
+        MCPServerManifest(
+            server_uri="http://rogue-server",
+            transport_type="http",
+            capability_whitelist=MCPCapabilityWhitelistPolicy(
+                allowed_tools=["shell"],
+                allowed_resources=["file://*"],
+                allowed_prompts=["system"]
+            ),
+            attestation_receipt=receipt
+        )
+
+def test_tool_invocation_cryptographic_starvation() -> None:
+    from coreason_manifest.spec.ontology import ToolInvocationEvent
+
+    with pytest.raises(ValidationError):
+        ToolInvocationEvent(
+            event_id="test_event",
+            timestamp=1234567890.0,
+            tool_name="test_tool",
+            parameters={},
+            agent_attestation=None, # type: ignore
+            zk_proof=None # type: ignore
+        )

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -135,3 +135,31 @@ def test_tool_invocation_cryptographic_starvation() -> None:
             agent_attestation=None,  # type: ignore
             zk_proof=None,  # type: ignore
         )
+
+
+def test_mcp_quarantine_gateway_authorized_mount() -> None:
+    """Prove the 'Happy Path' for the MCP Gateway, achieving 100% branch coverage."""
+    from coreason_manifest.spec.ontology import (
+        MCPCapabilityWhitelistPolicy,
+        MCPServerManifest,
+        VerifiableCredentialPresentationReceipt,
+    )
+
+    valid_receipt = VerifiableCredentialPresentationReceipt(
+        presentation_format="jwt_vc",
+        issuer_did="did:coreason:core-engine:v1",
+        cryptographic_proof_blob="secure_proof_hash_12345",
+        authorization_claims={"clearance": "RESTRICTED"},
+    )
+
+    # This must instantiate cleanly without raising a ValidationError
+    manifest = MCPServerManifest(
+        server_uri="stdio://coreason-mcp",
+        transport_type="stdio",
+        capability_whitelist=MCPCapabilityWhitelistPolicy(
+            allowed_tools=["fetch"], allowed_resources=[], allowed_prompts=[]
+        ),
+        attestation_receipt=valid_receipt,
+    )
+
+    assert manifest.attestation_receipt.issuer_did.startswith("did:coreason:")

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -101,7 +101,11 @@ def test_epistemic_license_enforcement() -> None:
 
 
 def test_mcp_quarantine_gateway_tripwire() -> None:
-    from coreason_manifest.spec.ontology import VerifiableCredentialPresentationReceipt, MCPServerManifest, MCPCapabilityWhitelistPolicy
+    from coreason_manifest.spec.ontology import (
+        MCPCapabilityWhitelistPolicy,
+        MCPServerManifest,
+        VerifiableCredentialPresentationReceipt,
+    )
 
     receipt = VerifiableCredentialPresentationReceipt(
         presentation_format="jwt_vc",

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -99,7 +99,6 @@ def test_epistemic_license_enforcement() -> None:
         )
 
 
-
 def test_mcp_quarantine_gateway_tripwire() -> None:
     from coreason_manifest.spec.ontology import (
         MCPCapabilityWhitelistPolicy,
@@ -110,20 +109,19 @@ def test_mcp_quarantine_gateway_tripwire() -> None:
     receipt = VerifiableCredentialPresentationReceipt(
         presentation_format="jwt_vc",
         issuer_did="did:web:rogue-actor:123",
-        cryptographic_proof_blob="a"*64,
-        authorization_claims={}
+        cryptographic_proof_blob="a" * 64,
+        authorization_claims={},
     )
     with pytest.raises(ValidationError, match="UNAUTHORIZED MCP MOUNT"):
         MCPServerManifest(
             server_uri="http://rogue-server",
             transport_type="http",
             capability_whitelist=MCPCapabilityWhitelistPolicy(
-                allowed_tools=["shell"],
-                allowed_resources=["file://*"],
-                allowed_prompts=["system"]
+                allowed_tools=["shell"], allowed_resources=["file://*"], allowed_prompts=["system"]
             ),
-            attestation_receipt=receipt
+            attestation_receipt=receipt,
         )
+
 
 def test_tool_invocation_cryptographic_starvation() -> None:
     from coreason_manifest.spec.ontology import ToolInvocationEvent
@@ -134,6 +132,6 @@ def test_tool_invocation_cryptographic_starvation() -> None:
             timestamp=1234567890.0,
             tool_name="test_tool",
             parameters={},
-            agent_attestation=None, # type: ignore
-            zk_proof=None # type: ignore
+            agent_attestation=None,  # type: ignore
+            zk_proof=None,  # type: ignore
         )


### PR DESCRIPTION
Added fields to `ToolInvocationEvent` to mandate `agent_attestation` and `zk_proof` keys prior to execution. Also modified `MCPServerManifest` to require an `attestation_receipt` signed by a valid `did:coreason:` issuer to prevent unauthorized mounts. Both bounds are thoroughly verified in `test_boundaries.py`.

---
*PR created automatically by Jules for task [16195958197740769227](https://jules.google.com/task/16195958197740769227) started by @gowthamrao*