### PR TITLE
feat: Implement Kinetic Separation Policy

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -32,6 +32,18 @@
           },
           "title": "Ephemeral Partitions",
           "type": "array"
+        },
+        "kinetic_separation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/KineticSeparationPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The bipartite graph constraint preventing toxic tool combinations."
         }
       },
       "required": [
@@ -6599,6 +6611,44 @@
           "type": "null"
         }
       ]
+    },
+    "KineticSeparationPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nA strict bipartite graph constraint mathematically preventing toxic tool combinations\nfrom existing in the same causal execution chain.",
+      "properties": {
+        "policy_id": {
+          "description": "Unique identifier for this specific separation boundary.",
+          "title": "Policy Id",
+          "type": "string"
+        },
+        "mutually_exclusive_clusters": {
+          "description": "A topological matrix of tool names or MCP URIs. If an agent mounts one capability in a cluster, all other capabilities in that cluster are mathematically quarantined.",
+          "items": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": "Mutually Exclusive Clusters",
+          "type": "array"
+        },
+        "enforcement_action": {
+          "description": "The deterministic action the orchestrator must take if a bipartite cycle is detected.",
+          "enum": [
+            "halt_and_quarantine",
+            "sever_causal_chain"
+          ],
+          "title": "Enforcement Action",
+          "type": "string"
+        }
+      },
+      "required": [
+        "policy_id",
+        "mutually_exclusive_clusters",
+        "enforcement_action"
+      ],
+      "title": "KineticSeparationPolicy",
+      "type": "object"
     },
     "LakehouseMountProfile": {
       "additionalProperties": false,

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2862,6 +2862,31 @@ class MCPServerManifest(CoreasonBaseState):
         return self
 
 
+class KineticSeparationPolicy(CoreasonBaseState):
+    """
+    A strict bipartite graph constraint mathematically preventing toxic tool combinations
+    from existing in the same causal execution chain.
+    """
+
+    policy_id: str = Field(description="Unique identifier for this specific separation boundary.")
+    mutually_exclusive_clusters: list[list[str]] = Field(
+        description="A topological matrix of tool names or MCP URIs. If an agent mounts one capability in a cluster, all other capabilities in that cluster are mathematically quarantined."  # noqa: E501
+    )
+    enforcement_action: Literal["halt_and_quarantine", "sever_causal_chain"] = Field(
+        description="The deterministic action the orchestrator must take if a bipartite cycle is detected."
+    )
+
+    @model_validator(mode="after")
+    def sort_clusters(self) -> Self:
+        """
+        AGENT INSTRUCTION: Mathematically stabilize the 2D array to guarantee
+        deterministic RFC 8785 canonical hashing across distributed nodes.
+        """
+        sorted_inner = [sorted(cluster) for cluster in self.mutually_exclusive_clusters]
+        object.__setattr__(self, "mutually_exclusive_clusters", sorted(sorted_inner))
+        return self
+
+
 class ActionSpaceManifest(CoreasonBaseState):
     """
     A curated environment of tools accessible to an agent or node.
@@ -2879,6 +2904,9 @@ class ActionSpaceManifest(CoreasonBaseState):
     ephemeral_partitions: list[EphemeralNamespacePartitionState] = Field(
         default_factory=list,
         description="Hermetically sealed context boundaries for dynamically resolved scripts and PEFT adapters.",
+    )
+    kinetic_separation: KineticSeparationPolicy | None = Field(
+        default=None, description="The bipartite graph constraint preventing toxic tool combinations."
     )
 
     @model_validator(mode="after")

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -163,3 +163,19 @@ def test_mcp_quarantine_gateway_authorized_mount() -> None:
     )
 
     assert manifest.attestation_receipt.issuer_did.startswith("did:coreason:")
+
+
+def test_kinetic_separation_canonical_sort() -> None:
+    """Prove that the 2D cluster matrix deterministically collapses to a stable hash state."""
+    from coreason_manifest.spec.ontology import KineticSeparationPolicy
+
+    chaotic_clusters = [["mcp://server-b", "mcp://server-a"], ["tool-z", "tool-x", "tool-y"]]
+
+    policy = KineticSeparationPolicy(
+        policy_id="test_bipartite_01",
+        mutually_exclusive_clusters=chaotic_clusters,
+        enforcement_action="halt_and_quarantine",
+    )
+
+    # Assert inner lists are sorted, then outer list is sorted by the first element of inner lists
+    assert policy.mutually_exclusive_clusters == [["mcp://server-a", "mcp://server-b"], ["tool-x", "tool-y", "tool-z"]]


### PR DESCRIPTION
This PR introduces the `KineticSeparationPolicy` object into the CoReason Shared Kernel Protocol.

### Changes
- **ontology.py**: Injected the `KineticSeparationPolicy` class right above `ActionSpaceManifest` to prevent tool poisoning cycles, keeping the 2D cluster list strictly sorted.
- **ontology.py**: Mounted `kinetic_separation` natively into `ActionSpaceManifest`.
- **test_boundaries.py**: Added fuzzing test logic directly validating the stability and fault tolerance of the newly implemented cluster matrix sorting.
- Verified mathematically safe AST boundary execution and ran pre-commit suite across `ruff`, `mypy`, and `pytest`.

---
*PR created automatically by Jules for task [7869715019356437342](https://jules.google.com/task/7869715019356437342) started by @gowthamrao*