### PR TITLE
feat: Add SemanticSlicingPolicy

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2207,6 +2207,18 @@
           ],
           "default": null,
           "description": "The structural mandate overriding default token routing to enforce this cognitive state."
+        },
+        "semantic_slicing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SemanticSlicingPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical data starvation mechanism bounding the working memory context."
         }
       },
       "required": [
@@ -9646,6 +9658,49 @@
         "provenance"
       ],
       "title": "SemanticNodeState",
+      "type": "object"
+    },
+    "SemanticSlicingPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Deterministic Epistemic Firewall that mathematically\nstarves the working memory context of irrelevant or over-classified data\nto prevent attention dilution and enforce zero-trust isolation.",
+      "properties": {
+        "permitted_classification_tiers": {
+          "description": "The explicit whitelist of sensitivity bounds allowed into context.",
+          "items": {
+            "$ref": "#/$defs/InformationClassificationProfile"
+          },
+          "minItems": 1,
+          "title": "Permitted Classification Tiers",
+          "type": "array"
+        },
+        "required_semantic_labels": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The declarative whitelist of strictly typed ontological node labels authorized for context projection.",
+          "title": "Required Semantic Labels"
+        },
+        "context_window_token_ceiling": {
+          "description": "The mathematical physical limit of the working memory partition to prevent VRAM exhaustion.",
+          "exclusiveMinimum": 0,
+          "title": "Context Window Token Ceiling",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "permitted_classification_tiers",
+        "context_window_token_ceiling"
+      ],
+      "title": "SemanticSlicingPolicy",
       "type": "object"
     },
     "SemanticVersionState": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -236,6 +236,7 @@ __all__ = [
     "SemanticEdgeState",
     "SemanticFirewallPolicy",
     "SemanticNodeState",
+    "SemanticSlicingPolicy",
     "SemanticVersionState",
     "SideEffectProfile",
     "SimulationConvergenceSLA",

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -583,6 +583,37 @@ class ActivationSteeringContract(CoreasonBaseState):
         return self
 
 
+class SemanticSlicingPolicy(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A Deterministic Epistemic Firewall that mathematically
+    starves the working memory context of irrelevant or over-classified data
+    to prevent attention dilution and enforce zero-trust isolation.
+    """
+
+    permitted_classification_tiers: list[InformationClassificationProfile] = Field(
+        min_length=1, description="The explicit whitelist of sensitivity bounds allowed into context."
+    )
+    required_semantic_labels: list[str] | None = Field(
+        default=None,
+        description="The declarative whitelist of strictly typed ontological node labels authorized for context projection.",  # noqa: E501
+    )
+    context_window_token_ceiling: int = Field(
+        gt=0, description="The mathematical physical limit of the working memory partition to prevent VRAM exhaustion."
+    )
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        """Mathematically sort arrays to guarantee deterministic canonical hashing."""
+        object.__setattr__(
+            self,
+            "permitted_classification_tiers",
+            sorted(self.permitted_classification_tiers, key=lambda x: str(x.value)),
+        )
+        if self.required_semantic_labels is not None:
+            object.__setattr__(self, "required_semantic_labels", sorted(self.required_semantic_labels))
+        return self
+
+
 class CognitiveRoutingContract(CoreasonBaseState):
     """
     Hardware-level contract overriding MoE routing to enforce functional/specialist paths.
@@ -627,6 +658,9 @@ class CognitiveStateProfile(CoreasonBaseState):
     moe_routing_directive: CognitiveRoutingContract | None = Field(
         default=None,
         description="The structural mandate overriding default token routing to enforce this cognitive state.",
+    )
+    semantic_slicing: SemanticSlicingPolicy | None = Field(
+        default=None, description="The mathematical data starvation mechanism bounding the working memory context."
     )
 
 

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -14,7 +14,9 @@ from coreason_manifest.spec.ontology import (
     EpistemicCompressionSLA,
     EpistemicTransmutationTask,
     GlobalGovernancePolicy,
+    InformationClassificationProfile,
     InsightCardProfile,
+    SemanticSlicingPolicy,
 )
 
 
@@ -179,3 +181,31 @@ def test_kinetic_separation_canonical_sort() -> None:
 
     # Assert inner lists are sorted, then outer list is sorted by the first element of inner lists
     assert policy.mutually_exclusive_clusters == [["mcp://server-a", "mcp://server-b"], ["tool-x", "tool-y", "tool-z"]]
+
+
+def test_semantic_slicing_epistemic_bounds() -> None:
+    """Prove the deterministic epistemic firewall rejects negative ceilings and perfectly sorts its canonical arrays."""
+
+    # 1. Prove OOM/Zero-Token starvation rejection
+    with pytest.raises(ValidationError, match="greater_than"):
+        SemanticSlicingPolicy(
+            permitted_classification_tiers=[InformationClassificationProfile.PUBLIC], context_window_token_ceiling=0
+        )
+
+    # 2. Prove Cryptographic Determinism (Sorting)
+    policy = SemanticSlicingPolicy(
+        permitted_classification_tiers=[
+            InformationClassificationProfile.RESTRICTED,
+            InformationClassificationProfile.INTERNAL,
+            InformationClassificationProfile.PUBLIC,
+        ],
+        required_semantic_labels=["Zeta", "Alpha", "Gamma"],
+        context_window_token_ceiling=4096,
+    )
+
+    assert policy.required_semantic_labels == ["Alpha", "Gamma", "Zeta"]
+    assert policy.permitted_classification_tiers == [
+        InformationClassificationProfile.INTERNAL,
+        InformationClassificationProfile.PUBLIC,
+        InformationClassificationProfile.RESTRICTED,
+    ]


### PR DESCRIPTION
- Added `SemanticSlicingPolicy` to `coreason_manifest/spec/ontology.py`.
- Integrated `semantic_slicing` into `CognitiveStateProfile`.
- Updated `coreason_manifest/__init__.py` to export the new class.
- Added boundary tests to `tests/fuzzing/test_boundaries.py` to enforce deterministic sorting and bounds.

---
*PR created automatically by Jules for task [82449647547596011](https://jules.google.com/task/82449647547596011) started by @gowthamrao*