### PR TITLE
feat: Introduce ProceduralMetadataManifest and Epistemic Discovery Surface

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -8220,6 +8220,14 @@
           },
           "title": "Supported Personas",
           "type": "array"
+        },
+        "available_procedural_manifolds": {
+          "description": "The lightweight progressive disclosure tier for procedural skills.",
+          "items": {
+            "$ref": "#/$defs/ProceduralMetadataManifest"
+          },
+          "title": "Available Procedural Manifolds",
+          "type": "array"
         }
       },
       "required": [
@@ -8627,6 +8635,48 @@
         "grid"
       ],
       "title": "PresentationManifest",
+      "type": "object"
+    },
+    "ProceduralMetadataManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Level-1 Epistemic Discovery Surface acting as a\nprogressive disclosure pointer to a massive EpistemicSOPManifest in cold storage.\nPrevents context window token exhaustion.",
+      "properties": {
+        "metadata_id": {
+          "description": "A strict cryptographic string identifier for this L1 procedural pointer.",
+          "minLength": 1,
+          "title": "Metadata Id",
+          "type": "string"
+        },
+        "target_sop_id": {
+          "description": "The Content Identifier (CID) of the heavy EpistemicSOPManifest resting in cold storage.",
+          "minLength": 1,
+          "title": "Target Sop Id",
+          "type": "string"
+        },
+        "trigger_description": {
+          "description": "The mathematically bounded semantic projection defining when the router must trigger this SOP.",
+          "title": "Trigger Description",
+          "type": "string"
+        },
+        "latent_vector_coordinate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VectorEmbeddingState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional dense-vector geometry for zero-shot semantic routing without LLM forward-pass evaluation."
+        }
+      },
+      "required": [
+        "metadata_id",
+        "target_sop_id",
+        "trigger_description"
+      ],
+      "title": "ProceduralMetadataManifest",
       "type": "object"
     },
     "ProcessRewardContract": {

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -213,6 +213,7 @@ __all__ = [
     "PredictionMarketPolicy",
     "PredictionMarketState",
     "PresentationManifest",
+    "ProceduralMetadataManifest",
     "ProcessRewardContract",
     "ProfileIdentifierState",
     "QoSClassificationProfile",

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2976,7 +2976,9 @@ class ProceduralMetadataManifest(CoreasonBaseState):
     )
     latent_vector_coordinate: VectorEmbeddingState | None = Field(
         default=None,
-        description="Optional dense-vector geometry for zero-shot semantic routing without LLM forward-pass evaluation.",
+        description=(
+            "Optional dense-vector geometry for zero-shot semantic routing without LLM forward-pass evaluation."
+        ),
     )
 
 

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2957,6 +2957,29 @@ class ActionSpaceManifest(CoreasonBaseState):
         return self
 
 
+class ProceduralMetadataManifest(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A Level-1 Epistemic Discovery Surface acting as a
+    progressive disclosure pointer to a massive EpistemicSOPManifest in cold storage.
+    Prevents context window token exhaustion.
+    """
+
+    metadata_id: str = Field(
+        min_length=1, description="A strict cryptographic string identifier for this L1 procedural pointer."
+    )
+    target_sop_id: str = Field(
+        min_length=1,
+        description="The Content Identifier (CID) of the heavy EpistemicSOPManifest resting in cold storage.",
+    )
+    trigger_description: str = Field(
+        description="The mathematically bounded semantic projection defining when the router must trigger this SOP."
+    )
+    latent_vector_coordinate: VectorEmbeddingState | None = Field(
+        default=None,
+        description="Optional dense-vector geometry for zero-shot semantic routing without LLM forward-pass evaluation.",
+    )
+
+
 class OntologicalSurfaceProjectionManifest(CoreasonBaseState):
     """
     A mathematically bounded, declarative subgraph of all ToolManifests and
@@ -2972,6 +2995,9 @@ class OntologicalSurfaceProjectionManifest(CoreasonBaseState):
     supported_personas: list[ProfileIdentifierState] = Field(
         default_factory=list, description="The strict array of foundational model personas available."
     )
+    available_procedural_manifolds: list[ProceduralMetadataManifest] = Field(
+        default_factory=list, description="The lightweight progressive disclosure tier for procedural skills."
+    )
 
     @model_validator(mode="after")
     def verify_unique_action_spaces(self) -> Self:
@@ -2980,6 +3006,11 @@ class OntologicalSurfaceProjectionManifest(CoreasonBaseState):
             raise ValueError("Action spaces within a projection must have strictly unique action_space_ids.")
         object.__setattr__(self, "action_spaces", sorted(self.action_spaces, key=lambda x: x.action_space_id))
         object.__setattr__(self, "supported_personas", sorted(self.supported_personas))
+        object.__setattr__(
+            self,
+            "available_procedural_manifolds",
+            sorted(self.available_procedural_manifolds, key=lambda x: x.metadata_id),
+        )
         return self
 
 

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -209,3 +209,17 @@ def test_semantic_slicing_epistemic_bounds() -> None:
         InformationClassificationProfile.PUBLIC,
         InformationClassificationProfile.RESTRICTED,
     ]
+
+
+def test_procedural_manifold_deterministic_sort() -> None:
+    """Prove that OntologicalSurfaceProjectionManifest deterministically sorts available_procedural_manifolds."""
+    from coreason_manifest.spec.ontology import OntologicalSurfaceProjectionManifest, ProceduralMetadataManifest
+
+    m1 = ProceduralMetadataManifest(metadata_id="zeta_01", target_sop_id="sop_1", trigger_description="Zeta SOP")
+    m2 = ProceduralMetadataManifest(metadata_id="alpha_02", target_sop_id="sop_2", trigger_description="Alpha SOP")
+
+    projection = OntologicalSurfaceProjectionManifest(projection_id="proj_1", available_procedural_manifolds=[m1, m2])
+
+    # Assert the array was mathematically sorted by metadata_id
+    assert projection.available_procedural_manifolds[0].metadata_id == "alpha_02"
+    assert projection.available_procedural_manifolds[1].metadata_id == "zeta_01"


### PR DESCRIPTION
This PR implements the "Progressive Disclosure" strategy by introducing the `ProceduralMetadataManifest` schema, a Level-1 Epistemic Discovery Surface acting as a progressive disclosure pointer to a massive EpistemicSOPManifest in cold storage. It prevents context window token exhaustion. 
The schema is attached to `OntologicalSurfaceProjectionManifest` with strict deterministic sorting by `metadata_id`. It updates the global `__all__` list to export this new entity, and adds a test `test_procedural_manifold_deterministic_sort` to prove canonical ordering.

---
*PR created automatically by Jules for task [1187836103409427285](https://jules.google.com/task/1187836103409427285) started by @gowthamrao*