### PR TITLE
feat: Inject SOTA RAG Schemas into ontology.py

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2616,6 +2616,63 @@
       "title": "ConstitutionalPolicy",
       "type": "object"
     },
+    "ContextExpansionPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "expansion_paradigm": {
+          "description": "The mathematical paradigm governing how context is expanded.",
+          "enum": [
+            "sliding_window",
+            "hierarchical_merge",
+            "document_summary"
+          ],
+          "title": "Expansion Paradigm",
+          "type": "string"
+        },
+        "max_token_budget": {
+          "description": "The maximum physical token allowance for expansion.",
+          "exclusiveMinimum": 0,
+          "title": "Max Token Budget",
+          "type": "integer"
+        },
+        "surrounding_sentences_k": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strict temporal window of surrounding sentences.",
+          "title": "Surrounding Sentences K"
+        },
+        "parent_merge_threshold": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The geometric cosine similarity threshold required to merge parent nodes.",
+          "title": "Parent Merge Threshold"
+        }
+      },
+      "required": [
+        "expansion_paradigm",
+        "max_token_budget"
+      ],
+      "title": "ContextExpansionPolicy",
+      "type": "object"
+    },
     "ContinuousMutationPolicy": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology",
@@ -6698,6 +6755,67 @@
         "schema_evolution_mode"
       ],
       "title": "LakehouseMountProfile",
+      "type": "object"
+    },
+    "LatentProjectionIntent": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "type": {
+          "const": "latent_projection",
+          "default": "latent_projection",
+          "description": "Discriminator for RAG projection intent.",
+          "title": "Type",
+          "type": "string"
+        },
+        "synthetic_target_vector": {
+          "$ref": "#/$defs/VectorEmbeddingState",
+          "description": "The strictly typed embedding tensor directing the query."
+        },
+        "top_k_candidates": {
+          "description": "The maximum number of nodes to extract from the index.",
+          "exclusiveMinimum": 0,
+          "title": "Top K Candidates",
+          "type": "integer"
+        },
+        "min_isometry_score": {
+          "description": "The minimum cosine similarity bounds for accepting a vector match.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Min Isometry Score",
+          "type": "number"
+        },
+        "topological_bounds": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TopologicalRetrievalContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The explicit graph traversal contract."
+        },
+        "context_expansion": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContextExpansionPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural rules governing context hydration."
+        }
+      },
+      "required": [
+        "synthetic_target_vector",
+        "top_k_candidates",
+        "min_isometry_score"
+      ],
+      "title": "LatentProjectionIntent",
       "type": "object"
     },
     "LatentScratchpadReceipt": {
@@ -11320,6 +11438,45 @@
         "permissions"
       ],
       "title": "ToolManifest",
+      "type": "object"
+    },
+    "TopologicalRetrievalContract": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "max_hop_depth": {
+          "description": "The strictly typed search depth bound for the cDAG.",
+          "minimum": 1,
+          "title": "Max Hop Depth",
+          "type": "integer"
+        },
+        "allowed_causal_relationships": {
+          "description": "The explicit whitelist of permissible causal edges to traverse.",
+          "items": {
+            "enum": [
+              "causes",
+              "confounds",
+              "correlates_with",
+              "undirected"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Allowed Causal Relationships",
+          "type": "array"
+        },
+        "enforce_isometry": {
+          "default": true,
+          "description": "Enforces preservation of geometric distances.",
+          "title": "Enforce Isometry",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "max_hop_depth",
+        "allowed_causal_relationships"
+      ],
+      "title": "TopologicalRetrievalContract",
       "type": "object"
     },
     "TopologyHashReceipt": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1815,6 +1815,54 @@ class DocumentLayoutManifest(CoreasonBaseState):
         return self
 
 
+class ContextExpansionPolicy(CoreasonBaseState):
+    expansion_paradigm: Literal["sliding_window", "hierarchical_merge", "document_summary"] = Field(
+        description="The mathematical paradigm governing how context is expanded."
+    )
+    max_token_budget: int = Field(gt=0, description="The maximum physical token allowance for expansion.")
+    surrounding_sentences_k: int | None = Field(
+        default=None, ge=1, description="The strict temporal window of surrounding sentences."
+    )
+    parent_merge_threshold: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1.0,
+        description="The geometric cosine similarity threshold required to merge parent nodes.",
+    )
+
+
+class TopologicalRetrievalContract(CoreasonBaseState):
+    max_hop_depth: int = Field(ge=1, description="The strictly typed search depth bound for the cDAG.")
+    allowed_causal_relationships: list[Literal["causes", "confounds", "correlates_with", "undirected"]] = Field(
+        min_length=1, description="The explicit whitelist of permissible causal edges to traverse."
+    )
+    enforce_isometry: bool = Field(default=True, description="Enforces preservation of geometric distances.")
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "allowed_causal_relationships", sorted(self.allowed_causal_relationships))
+        return self
+
+
+class LatentProjectionIntent(CoreasonBaseState):
+    type: Literal["latent_projection"] = Field(
+        default="latent_projection", description="Discriminator for RAG projection intent."
+    )
+    synthetic_target_vector: VectorEmbeddingState = Field(
+        description="The strictly typed embedding tensor directing the query."
+    )
+    top_k_candidates: int = Field(gt=0, description="The maximum number of nodes to extract from the index.")
+    min_isometry_score: float = Field(
+        ge=-1.0, le=1.0, description="The minimum cosine similarity bounds for accepting a vector match."
+    )
+    topological_bounds: TopologicalRetrievalContract | None = Field(
+        default=None, description="The explicit graph traversal contract."
+    )
+    context_expansion: ContextExpansionPolicy | None = Field(
+        default=None, description="The structural rules governing context hydration."
+    )
+
+
 class SemanticDiscoveryIntent(CoreasonBaseState):
     type: Literal["semantic_discovery"] = Field(
         default="semantic_discovery", description="Discriminator for geometric boundary of latent tool discovery."
@@ -2584,7 +2632,12 @@ type AnyPresentationIntent = Annotated[
 ]
 
 type AnyIntent = Annotated[
-    InformationalIntent | DraftingIntent | AdjudicationIntent | EscalationIntent | SemanticDiscoveryIntent,
+    InformationalIntent
+    | DraftingIntent
+    | AdjudicationIntent
+    | EscalationIntent
+    | SemanticDiscoveryIntent
+    | LatentProjectionIntent,
     Field(discriminator="type"),
 ]
 
@@ -5149,3 +5202,5 @@ EpistemicSOPManifest.model_rebuild()
 DelegatedCapabilityManifest.model_rebuild()
 TokenBurnReceipt.model_rebuild()
 BudgetExhaustionEvent.model_rebuild()
+
+LatentProjectionIntent.model_rebuild()

--- a/tests/fuzzing/test_epistemology.py
+++ b/tests/fuzzing/test_epistemology.py
@@ -3,7 +3,15 @@ from typing import Any
 import hypothesis.strategies as st
 from hypothesis import given
 
-from coreason_manifest.spec.ontology import ExecutionNodeReceipt, LatentScratchpadReceipt, ThoughtBranchState
+from pydantic import TypeAdapter
+
+from coreason_manifest.spec.ontology import (
+    AnyIntent,
+    ExecutionNodeReceipt,
+    LatentProjectionIntent,
+    LatentScratchpadReceipt,
+    ThoughtBranchState,
+)
 from coreason_manifest.utils.algebra import verify_merkle_proof
 
 scalar_st = st.one_of(
@@ -58,3 +66,64 @@ def test_latent_scratchpad_trace_sorting_determinism() -> None:
     )
     assert trace.discarded_branches == ["branch_A", "branch_Z"]
     assert trace.explored_branches[0].branch_id == "branch_A"
+
+
+@st.composite
+def draw_latent_projection_intent(draw: st.DrawFn) -> dict[str, Any]:
+    context_expansion_st = st.one_of(
+        st.none(),
+        st.fixed_dictionaries(
+            {
+                "expansion_paradigm": st.sampled_from(["sliding_window", "hierarchical_merge", "document_summary"]),
+                "max_token_budget": st.integers(min_value=1),
+                "surrounding_sentences_k": st.one_of(st.none(), st.integers(min_value=1)),
+                "parent_merge_threshold": st.one_of(
+                    st.none(), st.floats(min_value=0.0, max_value=1.0, allow_nan=False, allow_infinity=False)
+                ),
+            }
+        ),
+    )
+
+    topological_bounds_st = st.one_of(
+        st.none(),
+        st.fixed_dictionaries(
+            {
+                "max_hop_depth": st.integers(min_value=1),
+                "allowed_causal_relationships": st.lists(
+                    st.sampled_from(["causes", "confounds", "correlates_with", "undirected"]), min_size=1
+                ),
+                "enforce_isometry": st.booleans(),
+            }
+        ),
+    )
+
+    vector_embedding_st = st.fixed_dictionaries(
+        {
+            "vector_base64": st.just("bWFnaWM="),  # Valid base64
+            "dimensionality": st.integers(),
+            "model_name": st.text(),
+        }
+    )
+
+    return {
+        "type": "latent_projection",
+        "synthetic_target_vector": draw(vector_embedding_st),
+        "top_k_candidates": draw(st.integers(min_value=1)),
+        "min_isometry_score": draw(st.floats(min_value=-1.0, max_value=1.0, allow_nan=False, allow_infinity=False)),
+        "topological_bounds": draw(topological_bounds_st),
+        "context_expansion": draw(context_expansion_st),
+    }
+
+
+@given(payload=draw_latent_projection_intent())
+def test_latent_projection_intent_fuzzing(payload: dict[str, Any]) -> None:
+    adapter = TypeAdapter(AnyIntent)
+    intent = adapter.validate_python(payload)
+
+    assert isinstance(intent, LatentProjectionIntent)
+
+    if intent.topological_bounds is not None:
+        # Verify deterministic array sorting for mathematical fuzzing
+        relationships = payload["topological_bounds"]["allowed_causal_relationships"]
+        sorted_relationships = sorted(relationships)
+        assert intent.topological_bounds.allowed_causal_relationships == sorted_relationships

--- a/tests/fuzzing/test_epistemology.py
+++ b/tests/fuzzing/test_epistemology.py
@@ -2,7 +2,6 @@ from typing import Any
 
 import hypothesis.strategies as st
 from hypothesis import given
-
 from pydantic import TypeAdapter
 
 from coreason_manifest.spec.ontology import (


### PR DESCRIPTION
Injected ContextExpansionPolicy, TopologicalRetrievalContract, and LatentProjectionIntent schemas into ontology.py.
Updated the AnyIntent polymorphic router to include LatentProjectionIntent.
Resolved forward references for LatentProjectionIntent.
Wrote strict mathematical fuzzing tests for LatentProjectionIntent to prove sorting determinism.

---
*PR created automatically by Jules for task [13038584355377458372](https://jules.google.com/task/13038584355377458372) started by @gowthamrao*