### PR TITLE
feat: Introduce test-time compute schemas

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2121,6 +2121,43 @@
       "title": "CircuitBreakerEvent",
       "type": "object"
     },
+    "CognitiveCritiqueProfile": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, dense supervision vector generated\nby a Process Reward Model (PRM) to steer intermediate test-time reasoning.",
+      "properties": {
+        "reasoning_trace_hash": {
+          "description": "CoReason Shared Kernel Ontology: The cryptographic Merkle root of the specific ThoughtBranch being evaluated.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Reasoning Trace Hash",
+          "type": "string"
+        },
+        "logical_flaw_embedding": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VectorEmbeddingState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "CoReason Shared Kernel Ontology: A dense latent space representation of the specific logical fallacy identified, used to mathematically repel future generation trajectories."
+        },
+        "epistemic_penalty_scalar": {
+          "description": "CoReason Shared Kernel Ontology: A continuous penalty applied to the branch's probability mass if normative drift or hallucination is detected.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Epistemic Penalty Scalar",
+          "type": "number"
+        }
+      },
+      "required": [
+        "reasoning_trace_hash",
+        "epistemic_penalty_scalar"
+      ],
+      "title": "CognitiveCritiqueProfile",
+      "type": "object"
+    },
     "CognitiveRoutingContract": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nHardware-level contract overriding MoE routing to enforce functional/specialist paths.",
@@ -4083,6 +4120,37 @@
       "title": "EpistemicCompressionSLA",
       "type": "object"
     },
+    "EpistemicEscalationContract": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The strict mathematical agreement governing when\nan agent is authorized to expand its test-time compute allocation based on measured doubt.",
+      "properties": {
+        "baseline_entropy_threshold": {
+          "description": "CoReason Shared Kernel Ontology: The mathematical measure of uncertainty (e.g., variance in generated hypotheses) required to trigger escalation.",
+          "minimum": 0.0,
+          "title": "Baseline Entropy Threshold",
+          "type": "number"
+        },
+        "test_time_multiplier": {
+          "description": "CoReason Shared Kernel Ontology: The continuous scalar applied to the agent's baseline max_latent_tokens_budget when the entropy threshold is breached.",
+          "exclusiveMinimum": 1.0,
+          "title": "Test Time Multiplier",
+          "type": "number"
+        },
+        "max_escalation_tiers": {
+          "description": "CoReason Shared Kernel Ontology: The absolute integer limit on how many times the orchestrator can recursively multiply the compute budget before forcing a SystemFaultEvent.",
+          "minimum": 1,
+          "title": "Max Escalation Tiers",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "baseline_entropy_threshold",
+        "test_time_multiplier",
+        "max_escalation_tiers"
+      ],
+      "title": "EpistemicEscalationContract",
+      "type": "object"
+    },
     "EpistemicLedgerState": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nThe Committed Epistemic Ledger (crystallized truth), completely partitioned from volatile working memory\nor Epistemic Quarantine.",
@@ -5458,6 +5526,45 @@
       "title": "FederatedDiscoveryManifest",
       "type": "object"
     },
+    "FederatedPeftContract": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The physical and temporal bounding constraints\nfor hot-swapping low-rank adapter tensors into GPU memory.",
+      "properties": {
+        "adapter_merkle_root": {
+          "description": "CoReason Shared Kernel Ontology: The tamper-evident SHA-256 hash of the exact safetensors weight matrix.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Adapter Merkle Root",
+          "type": "string"
+        },
+        "vram_footprint_bytes": {
+          "description": "CoReason Shared Kernel Ontology: The exact spatial geometry required in VRAM to mount this adapter.",
+          "exclusiveMinimum": 0,
+          "title": "Vram Footprint Bytes",
+          "type": "integer"
+        },
+        "ephemeral_ttl_ms": {
+          "description": "CoReason Shared Kernel Ontology: The absolute Time-To-Live for the adapter to exist in the kinetic execution plane before forced eviction.",
+          "exclusiveMinimum": 0,
+          "title": "Ephemeral Ttl Ms",
+          "type": "integer"
+        },
+        "cache_priority_weight": {
+          "description": "CoReason Shared Kernel Ontology: The relative importance scalar used by the orchestrator's LRU eviction algorithm when VRAM limits are saturated.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Cache Priority Weight",
+          "type": "number"
+        }
+      },
+      "required": [
+        "adapter_merkle_root",
+        "vram_footprint_bytes",
+        "ephemeral_ttl_ms",
+        "cache_priority_weight"
+      ],
+      "title": "FederatedPeftContract",
+      "type": "object"
+    },
     "FederatedStateSnapshot": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology",
@@ -6623,6 +6730,41 @@
           "type": "null"
         }
       ]
+    },
+    "KineticBudgetPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The mathematical boundary forcing the collapse of\nprobability waves and wide-search trees as physical compute resources deplete.",
+      "properties": {
+        "exploration_decay_curve": {
+          "description": "CoReason Shared Kernel Ontology: The mathematical function dictating how rapidly lateral ThoughtBranches are restricted over time.",
+          "enum": [
+            "linear",
+            "exponential",
+            "step"
+          ],
+          "title": "Exploration Decay Curve",
+          "type": "string"
+        },
+        "forced_exploitation_threshold_ms": {
+          "description": "CoReason Shared Kernel Ontology: The physical wall-clock time remaining at which the orchestrator is mathematically forbidden from opening new lateral branches.",
+          "exclusiveMinimum": 0,
+          "title": "Forced Exploitation Threshold Ms",
+          "type": "integer"
+        },
+        "dynamic_temperature_asymptote": {
+          "description": "CoReason Shared Kernel Ontology: The absolute minimum sampling temperature the system must converge to during the final exploitation phase.",
+          "minimum": 0.0,
+          "title": "Dynamic Temperature Asymptote",
+          "type": "number"
+        }
+      },
+      "required": [
+        "exploration_decay_curve",
+        "forced_exploitation_threshold_ms",
+        "dynamic_temperature_asymptote"
+      ],
+      "title": "KineticBudgetPolicy",
+      "type": "object"
     },
     "KineticSeparationPolicy": {
       "additionalProperties": false,

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -4255,6 +4255,91 @@ class VectorEmbeddingState(CoreasonBaseState):
     model_name: str = Field(description="The provenance of the embedding model used (e.g., 'text-embedding-3-large').")
 
 
+class CognitiveCritiqueProfile(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A declarative, dense supervision vector generated
+    by a Process Reward Model (PRM) to steer intermediate test-time reasoning.
+    """
+
+    reasoning_trace_hash: str = Field(
+        pattern="^[a-f0-9]{64}$",
+        description="CoReason Shared Kernel Ontology: The cryptographic Merkle root of the specific ThoughtBranch being evaluated.",  # noqa: E501
+    )
+    logical_flaw_embedding: VectorEmbeddingState | None = Field(
+        default=None,
+        description="CoReason Shared Kernel Ontology: A dense latent space representation of the specific logical fallacy identified, used to mathematically repel future generation trajectories.",  # noqa: E501
+    )
+    epistemic_penalty_scalar: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="CoReason Shared Kernel Ontology: A continuous penalty applied to the branch's probability mass if normative drift or hallucination is detected.",  # noqa: E501
+    )
+
+
+class KineticBudgetPolicy(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: The mathematical boundary forcing the collapse of
+    probability waves and wide-search trees as physical compute resources deplete.
+    """
+
+    exploration_decay_curve: Literal["linear", "exponential", "step"] = Field(
+        description="CoReason Shared Kernel Ontology: The mathematical function dictating how rapidly lateral ThoughtBranches are restricted over time."  # noqa: E501
+    )
+    forced_exploitation_threshold_ms: int = Field(
+        gt=0,
+        description="CoReason Shared Kernel Ontology: The physical wall-clock time remaining at which the orchestrator is mathematically forbidden from opening new lateral branches.",  # noqa: E501
+    )
+    dynamic_temperature_asymptote: float = Field(
+        ge=0.0,
+        description="CoReason Shared Kernel Ontology: The absolute minimum sampling temperature the system must converge to during the final exploitation phase.",  # noqa: E501
+    )
+
+
+class EpistemicEscalationContract(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: The strict mathematical agreement governing when
+    an agent is authorized to expand its test-time compute allocation based on measured doubt.
+    """
+
+    baseline_entropy_threshold: float = Field(
+        ge=0.0,
+        description="CoReason Shared Kernel Ontology: The mathematical measure of uncertainty (e.g., variance in generated hypotheses) required to trigger escalation.",  # noqa: E501
+    )
+    test_time_multiplier: float = Field(
+        gt=1.0,
+        description="CoReason Shared Kernel Ontology: The continuous scalar applied to the agent's baseline max_latent_tokens_budget when the entropy threshold is breached.",  # noqa: E501
+    )
+    max_escalation_tiers: int = Field(
+        ge=1,
+        description="CoReason Shared Kernel Ontology: The absolute integer limit on how many times the orchestrator can recursively multiply the compute budget before forcing a SystemFaultEvent.",  # noqa: E501
+    )
+
+
+class FederatedPeftContract(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: The physical and temporal bounding constraints
+    for hot-swapping low-rank adapter tensors into GPU memory.
+    """
+
+    adapter_merkle_root: str = Field(
+        pattern="^[a-f0-9]{64}$",
+        description="CoReason Shared Kernel Ontology: The tamper-evident SHA-256 hash of the exact safetensors weight matrix.",  # noqa: E501
+    )
+    vram_footprint_bytes: int = Field(
+        gt=0,
+        description="CoReason Shared Kernel Ontology: The exact spatial geometry required in VRAM to mount this adapter.",  # noqa: E501
+    )
+    ephemeral_ttl_ms: int = Field(
+        gt=0,
+        description="CoReason Shared Kernel Ontology: The absolute Time-To-Live for the adapter to exist in the kinetic execution plane before forced eviction.",  # noqa: E501
+    )
+    cache_priority_weight: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="CoReason Shared Kernel Ontology: The relative importance scalar used by the orchestrator's LRU eviction algorithm when VRAM limits are saturated.",  # noqa: E501
+    )
+
+
 class SemanticEdgeState(CoreasonBaseState):
     edge_id: str = Field(
         description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic edge to the Merkle-DAG."  # noqa: E501

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -223,3 +223,88 @@ def test_procedural_manifold_deterministic_sort() -> None:
     # Assert the array was mathematically sorted by metadata_id
     assert projection.available_procedural_manifolds[0].metadata_id == "alpha_02"
     assert projection.available_procedural_manifolds[1].metadata_id == "zeta_01"
+
+
+@given(
+    trace_hash=st.text().filter(lambda x: not __import__("re").match("^[a-f0-9]{64}$", x)),
+    penalty=st.floats(min_value=-10.0, max_value=10.0).filter(lambda x: x < 0.0 or x > 1.0),
+)
+def test_cognitive_critique_profile_bounds(trace_hash: str, penalty: float) -> None:
+    from coreason_manifest.spec.ontology import CognitiveCritiqueProfile
+
+    with pytest.raises(ValidationError):
+        CognitiveCritiqueProfile(reasoning_trace_hash=trace_hash, epistemic_penalty_scalar=0.5)
+    with pytest.raises(ValidationError):
+        CognitiveCritiqueProfile(reasoning_trace_hash="a" * 64, epistemic_penalty_scalar=penalty)
+
+
+@given(threshold=st.integers(max_value=0), asymptote=st.floats(max_value=-0.0001))
+def test_kinetic_budget_policy_bounds(threshold: int, asymptote: float) -> None:
+    from coreason_manifest.spec.ontology import KineticBudgetPolicy
+
+    with pytest.raises(ValidationError):
+        KineticBudgetPolicy(
+            exploration_decay_curve="linear",
+            forced_exploitation_threshold_ms=threshold,
+            dynamic_temperature_asymptote=0.5,
+        )
+    with pytest.raises(ValidationError):
+        KineticBudgetPolicy(
+            exploration_decay_curve="linear",
+            forced_exploitation_threshold_ms=10,
+            dynamic_temperature_asymptote=asymptote,
+        )
+    with pytest.raises(ValidationError):
+        KineticBudgetPolicy(
+            exploration_decay_curve="invalid_curve",  # type: ignore
+            forced_exploitation_threshold_ms=10,
+            dynamic_temperature_asymptote=0.5,
+        )
+
+
+@given(entropy=st.floats(max_value=-0.0001), multiplier=st.floats(max_value=1.0), tiers=st.integers(max_value=0))
+def test_epistemic_escalation_contract_bounds(entropy: float, multiplier: float, tiers: int) -> None:
+    from coreason_manifest.spec.ontology import EpistemicEscalationContract
+
+    with pytest.raises(ValidationError):
+        EpistemicEscalationContract(
+            baseline_entropy_threshold=entropy, test_time_multiplier=2.0, max_escalation_tiers=5
+        )
+    with pytest.raises(ValidationError):
+        EpistemicEscalationContract(
+            baseline_entropy_threshold=0.5, test_time_multiplier=multiplier, max_escalation_tiers=5
+        )
+    with pytest.raises(ValidationError):
+        EpistemicEscalationContract(
+            baseline_entropy_threshold=0.5, test_time_multiplier=2.0, max_escalation_tiers=tiers
+        )
+
+
+@given(
+    merkle_root=st.text().filter(lambda x: not __import__("re").match("^[a-f0-9]{64}$", x)),
+    vram=st.integers(max_value=0),
+    ttl=st.integers(max_value=0),
+    priority=st.floats().filter(lambda x: x < 0.0 or x > 1.0),
+)
+def test_federated_peft_contract_bounds(merkle_root: str, vram: int, ttl: int, priority: float) -> None:
+    from coreason_manifest.spec.ontology import FederatedPeftContract
+
+    with pytest.raises(ValidationError):
+        FederatedPeftContract(
+            adapter_merkle_root=merkle_root, vram_footprint_bytes=1000, ephemeral_ttl_ms=1000, cache_priority_weight=0.5
+        )
+    with pytest.raises(ValidationError):
+        FederatedPeftContract(
+            adapter_merkle_root="a" * 64, vram_footprint_bytes=vram, ephemeral_ttl_ms=1000, cache_priority_weight=0.5
+        )
+    with pytest.raises(ValidationError):
+        FederatedPeftContract(
+            adapter_merkle_root="a" * 64, vram_footprint_bytes=1000, ephemeral_ttl_ms=ttl, cache_priority_weight=0.5
+        )
+    with pytest.raises(ValidationError):
+        FederatedPeftContract(
+            adapter_merkle_root="a" * 64,
+            vram_footprint_bytes=1000,
+            ephemeral_ttl_ms=1000,
+            cache_priority_weight=priority,
+        )


### PR DESCRIPTION
Introduces four new test-time compute schemas into the coreason-manifest Shared Kernel (`CognitiveCritiqueProfile`, `KineticBudgetPolicy`, `EpistemicEscalationContract`, and `FederatedPeftContract`). The changes adhere to the "God Context" Monolith Directive and the Topological Lock constraint. Fuzzing strategies were implemented to rigorously test the `ge`/`le` validation boundaries. All CI/CD simulation checks passed locally.

---
*PR created automatically by Jules for task [17269186220608849475](https://jules.google.com/task/17269186220608849475) started by @gowthamrao*