### PR TITLE
Refactor: Enforce Lexical Purity & AST-Native Scrubbing

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1571,7 +1571,7 @@
         },
         "payload": {
           "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitive"
+            "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "Topologically Bounded Latent Spaces capturing the semantic representation of the agent's internal cognitive shift or synthesis that anchor statistical probability to a definitive causal event hash.",
           "title": "Payload",
@@ -6866,7 +6866,7 @@
       "title": "JSONRPCErrorState",
       "type": "object"
     },
-    "JsonPrimitive": {
+    "JsonPrimitiveState": {
       "anyOf": [
         {
           "type": "string"
@@ -6882,13 +6882,13 @@
         },
         {
           "items": {
-            "$ref": "#/$defs/JsonPrimitive"
+            "$ref": "#/$defs/JsonPrimitiveState"
           },
           "type": "array"
         },
         {
           "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitive"
+            "$ref": "#/$defs/JsonPrimitiveState"
           },
           "type": "object"
         },
@@ -8369,7 +8369,7 @@
         },
         "payload": {
           "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitive"
+            "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "Neurosymbolic Bindings of the raw, lossless semantic output appended from the environment or tool execution that anchor statistical probability to a definitive causal event hash.",
           "title": "Payload",
@@ -10567,7 +10567,7 @@
           "type": "string"
         },
         "value": {
-          "$ref": "#/$defs/JsonPrimitive",
+          "$ref": "#/$defs/JsonPrimitiveState",
           "default": null,
           "description": "The payload to insert or test, if applicable, for this deterministic state vector mutation."
         }

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -20,10 +20,10 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, HttpUrl, StringConstraints, field_validator, model_validator
 
-type JsonPrimitive = str | int | float | bool | None | list["JsonPrimitive"] | dict[str, "JsonPrimitive"]
+type JsonPrimitiveState = str | int | float | bool | None | list["JsonPrimitiveState"] | dict[str, "JsonPrimitiveState"]
 
 
-def _validate_payload_bounds(value: JsonPrimitive, current_depth: int = 0) -> JsonPrimitive:
+def _validate_payload_bounds(value: JsonPrimitiveState, current_depth: int = 0) -> JsonPrimitiveState:
     """
     AGENT INSTRUCTION: Mathematically bound recursive dictionary payloads
     to prevent OOM/CPU exhaustion during EpistemicLedgerState hashing.
@@ -998,7 +998,7 @@ class StateMutationIntent(CoreasonBaseState):
         description="The strict RFC 6902 JSON Patch operation, acting as a deterministic state vector mutation."
     )
     path: str = Field(description="The JSON pointer indicating the exact state vector to mutate deterministically.")
-    value: JsonPrimitive = Field(
+    value: JsonPrimitiveState = Field(
         default=None,
         description="The payload to insert or test, if applicable, for this deterministic state vector mutation.",
     )
@@ -5204,7 +5204,7 @@ class BeliefMutationEvent(BaseStateEvent):
     type: Literal["belief_mutation"] = Field(
         default="belief_mutation", description="Discriminator type for a Belief Assertion event."
     )
-    payload: dict[str, JsonPrimitive] = Field(
+    payload: dict[str, JsonPrimitiveState] = Field(
         description="Topologically Bounded Latent Spaces capturing the semantic representation of the agent's internal cognitive shift or synthesis that anchor statistical probability to a definitive causal event hash."  # noqa: E501
     )
     source_node_id: NodeIdentifierState | None = Field(
@@ -5251,7 +5251,7 @@ class ObservationEvent(BaseStateEvent):
     type: Literal["observation"] = Field(
         default="observation", description="Discriminator type for an observation event."
     )
-    payload: dict[str, JsonPrimitive] = Field(
+    payload: dict[str, JsonPrimitiveState] = Field(
         description="Neurosymbolic Bindings of the raw, lossless semantic output appended from the environment or tool execution that anchor statistical probability to a definitive causal event hash."  # noqa: E501
     )
     source_node_id: NodeIdentifierState | None = Field(

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -342,7 +342,6 @@ def apply_state_differential(
         path = patch.path
         if not path.startswith("/"):
             if path == "":
-                # Root level operations
                 if patch.op == "test":
                     if new_state != patch.value:
                         raise ValueError("Patch test operation failed.")
@@ -350,10 +349,8 @@ def apply_state_differential(
                 raise ValueError(f"Invalid path or root operation not supported: {path}")
             raise ValueError(f"Invalid JSON pointer: {path}")
 
-        # Split and decode
         parts = [p.replace("~1", "/").replace("~0", "~") for p in path.split("/")[1:]]
 
-        # Traverse to parent
         target: Any = new_state
         for part in parts[:-1]:
             if isinstance(target, dict):
@@ -394,7 +391,7 @@ def apply_state_differential(
             from_last = from_parts[-1]
             return from_target, from_last
 
-        def read_from_target(t: Any, key: str) -> Any:
+        def extract_from_target(t: Any, key: str) -> Any:
             if isinstance(t, dict):
                 if key not in t:
                     raise ValueError("Key not found")
@@ -409,7 +406,7 @@ def apply_state_differential(
                     raise ValueError("Invalid index") from e
             raise ValueError("Target is not dict or list")
 
-        def delete_from_target(t: Any, key: str) -> None:
+        def ablate_from_target(t: Any, key: str) -> None:
             if isinstance(t, dict):
                 if key not in t:
                     raise ValueError("Key not found")
@@ -442,14 +439,13 @@ def apply_state_differential(
 
         elif patch.op == "remove":
             try:
-                delete_from_target(target, last_part)
+                ablate_from_target(target, last_part)
             except ValueError as e:
                 raise ValueError(f"Cannot remove from path {path}: {e}") from e
 
         elif patch.op == "replace":
             try:
-                # Ensure it exists first before replacing
-                read_from_target(target, last_part)
+                extract_from_target(target, last_part)
 
                 if isinstance(target, dict):
                     target[last_part] = patch.value
@@ -460,16 +456,14 @@ def apply_state_differential(
                 raise ValueError(f"Cannot replace at path {path}: {e}") from e
 
         elif patch.op in ("copy", "move"):
-            # The prompt requires extracting from_path to evaluate another pointer.
-            # StateMutationIntent doesn't define from_path, so we assume it's stored in patch.value
             from_path = patch.value
             if not isinstance(from_path, str):
                 raise ValueError(f"Invalid from_path: {from_path}")
             try:
                 from_target, from_last = resolve_from_path(from_path)
-                val = read_from_target(from_target, from_last)
+                val = extract_from_target(from_target, from_last)
                 if patch.op == "move":
-                    delete_from_target(from_target, from_last)
+                    ablate_from_target(from_target, from_last)
                 if patch.op == "copy":
                     val = copy.deepcopy(val)
             except ValueError as e:
@@ -493,7 +487,7 @@ def apply_state_differential(
 
         elif patch.op == "test":
             try:
-                current_val = read_from_target(target, last_part)
+                current_val = extract_from_target(target, last_part)
                 if current_val != patch.value:
                     raise ValueError("Patch test operation failed.")
             except ValueError as e:


### PR DESCRIPTION
This PR implements the requested "Epic 1: Lexical Purity & AST-Native Scrubbing" changes.
- It enforces the "Anti-CRUD Mandate" by renaming legacy internal helper functions within `apply_state_differential`.
- It removes conversational inline comments.
- It ensures "Categorical Suffixing" by renaming `JsonPrimitive` to `JsonPrimitiveState` and updating all references within Pydantic models and logic functions across the codebase.
- Verified that all unit tests, `mypy`, and `ruff` checks pass completely locally.

---
*PR created automatically by Jules for task [6813232671832907498](https://jules.google.com/task/6813232671832907498) started by @gowthamrao*