### PR TITLE
refactor: update verify_ast_safety docstring and remove comment

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -293,13 +293,15 @@ def verify_ast_safety(payload: str) -> bool:
     """
     Mechanistically sandboxes dynamically generated strings by compiling them into an AST
     and rigorously walking the graph to ensure no kinetic execution bleed occurs.
+
+    AGENT INSTRUCTION: The `base_allowlist` mathematically defines a strict Default-Deny
+    node perimeter. Any AST node not explicitly projected within this matrix is quarantined.
     """
     try:
         tree = ast.parse(payload, mode="eval")
     except SyntaxError as e:
         raise ValueError("Payload is not valid syntax.") from e
 
-    # Default-Deny node allowlist
     base_allowlist = [
         ast.Expression,
         ast.Constant,


### PR DESCRIPTION
Replaced the existing docstring of `verify_ast_safety` in `src/coreason_manifest/utils/algebra.py` with an exact, strictly typed projection that includes the `AGENT INSTRUCTION` directive. Also, removed the conversational comment `# Default-Deny node allowlist` to adhere to the Anti-Conversational Mandate (Rule 0.4.1).

Verified the changes locally using:
- `uv run ruff format .`
- `uv run ruff check . --fix`
- `uv run mypy src/ tests/`
- `uv run pytest`

---
*PR created automatically by Jules for task [16944281949168266261](https://jules.google.com/task/16944281949168266261) started by @gowthamrao*