### PR TITLE
Lexical Architecture Transmutation (Eradication of "Memory")

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -4166,7 +4166,7 @@
     },
     "EpistemicLedgerState": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nThe Committed Epistemic Ledger (crystallized truth), completely partitioned from volatile working memory\nor Epistemic Quarantine.",
+      "description": "CoReason Shared Kernel Ontology\n\nThe Committed Epistemic Ledger (crystallized truth), completely partitioned from volatile working context\nor Epistemic Quarantine.",
       "properties": {
         "history": {
           "description": "An append-only, cryptographic ledger of state events. [SITD-Alpha: Non-Monotonic Epistemic Quarantine Isometry]",
@@ -7396,7 +7396,7 @@
     },
     "MCPResourceManifest": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nA collection of Semantic Memory resource URIs provided by a specific MCP server.",
+      "description": "CoReason Shared Kernel Ontology\n\nA collection of Latent State resource URIs provided by a specific MCP server.",
       "properties": {
         "server_id": {
           "description": "The ID of the MCP server providing these resources.",
@@ -9537,14 +9537,14 @@
       "description": "CoReason Shared Kernel Ontology",
       "properties": {
         "baseline_importance": {
-          "description": "The starting importance score of this memory from 0.0 to 1.0.",
+          "description": "The starting importance score of this latent state from 0.0 to 1.0.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Baseline Importance",
           "type": "number"
         },
         "decay_rate": {
-          "description": "The rate at which this memory's relevance decays over time.",
+          "description": "The rate at which this epistemic coordinate's relevance decays over time.",
           "minimum": 0.0,
           "title": "Decay Rate",
           "type": "number"
@@ -9953,7 +9953,7 @@
     },
     "SemanticSlicingPolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Deterministic Epistemic Firewall that mathematically\nstarves the working memory context of irrelevant or over-classified data\nto prevent attention dilution and enforce zero-trust isolation.",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Deterministic Epistemic Firewall that mathematically\nstarves the active context partition of irrelevant or over-classified data\nto prevent attention dilution and enforce zero-trust isolation.",
       "properties": {
         "permitted_classification_tiers": {
           "description": "The explicit whitelist of sensitivity bounds allowed into context.",
@@ -9981,7 +9981,7 @@
           "title": "Required Semantic Labels"
         },
         "context_window_token_ceiling": {
-          "description": "The mathematical physical limit of the working memory partition to prevent VRAM exhaustion.",
+          "description": "The mathematical physical limit of the active context partition to prevent VRAM exhaustion.",
           "exclusiveMinimum": 0,
           "title": "Context Window Token Ceiling",
           "type": "integer"
@@ -10394,19 +10394,19 @@
           "title": "Epistemic Coordinate",
           "type": "string"
         },
-        "crystallized_memory_cids": {
+        "crystallized_ledger_cids": {
           "description": "A list of cryptographic pointers to past immutable EpistemicLedgerState blocks.",
           "items": {
             "pattern": "^[a-f0-9]{64}$",
             "type": "string"
           },
-          "title": "Crystallized Memory Cids",
+          "title": "Crystallized Ledger Cids",
           "type": "array"
         },
-        "working_memory_variables": {
+        "working_context_variables": {
           "additionalProperties": true,
           "description": "A strictly typed dictionary for ephemeral context variables injected at runtime.",
-          "title": "Working Memory Variables",
+          "title": "Working Context Variables",
           "type": "object"
         },
         "max_retained_tokens": {
@@ -10418,8 +10418,8 @@
       },
       "required": [
         "epistemic_coordinate",
-        "crystallized_memory_cids",
-        "working_memory_variables",
+        "crystallized_ledger_cids",
+        "working_context_variables",
         "max_retained_tokens"
       ],
       "title": "StateHydrationManifest",

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -562,7 +562,7 @@ class ActivationSteeringContract(CoreasonBaseState):
 class SemanticSlicingPolicy(CoreasonBaseState):
     """
     AGENT INSTRUCTION: A Deterministic Epistemic Firewall that mathematically
-    starves the working memory context of irrelevant or over-classified data
+    starves the active context partition of irrelevant or over-classified data
     to prevent attention dilution and enforce zero-trust isolation.
     """
 
@@ -574,7 +574,7 @@ class SemanticSlicingPolicy(CoreasonBaseState):
         description="The declarative whitelist of strictly typed ontological node labels authorized for context projection.",  # noqa: E501
     )
     context_window_token_ceiling: int = Field(
-        gt=0, description="The mathematical physical limit of the working memory partition to prevent VRAM exhaustion."
+        gt=0, description="The mathematical physical limit of the active context partition to prevent VRAM exhaustion."
     )
 
     @model_validator(mode="after")
@@ -1004,20 +1004,20 @@ class StateHydrationManifest(CoreasonBaseState):
     epistemic_coordinate: str = Field(
         description="A string ID representing the session or specific spatial trace binding."
     )
-    crystallized_memory_cids: list[Annotated[str, StringConstraints(pattern="^[a-f0-9]{64}$")]] = Field(
+    crystallized_ledger_cids: list[Annotated[str, StringConstraints(pattern="^[a-f0-9]{64}$")]] = Field(
         description="A list of cryptographic pointers to past immutable EpistemicLedgerState blocks."
     )
-    working_memory_variables: dict[str, Any] = Field(
+    working_context_variables: dict[str, Any] = Field(
         description="A strictly typed dictionary for ephemeral context variables injected at runtime."
     )
-    # Note: working_memory_variables is deterministically sorted by CoreasonBaseState natively.
+    # Note: working_context_variables is deterministically sorted by CoreasonBaseState natively.
     max_retained_tokens: int = Field(
         gt=0, description="An integer representing the physical limit of the context window."
     )
 
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
-        object.__setattr__(self, "crystallized_memory_cids", sorted(self.crystallized_memory_cids))
+        object.__setattr__(self, "crystallized_ledger_cids", sorted(self.crystallized_ledger_cids))
         return self
 
 
@@ -3128,7 +3128,7 @@ class MCPPromptReferenceState(CoreasonBaseState):
 
 
 class MCPResourceManifest(CoreasonBaseState):
-    """A collection of Semantic Memory resource URIs provided by a specific MCP server."""
+    """A collection of Latent State resource URIs provided by a specific MCP server."""
 
     server_id: str = Field(..., description="The ID of the MCP server providing these resources.")
     uris: list[str] = Field(
@@ -3666,9 +3666,11 @@ class SSETransportProfile(CoreasonBaseState):
 
 class SalienceProfile(CoreasonBaseState):
     baseline_importance: float = Field(
-        ge=0.0, le=1.0, description="The starting importance score of this memory from 0.0 to 1.0."
+        ge=0.0, le=1.0, description="The starting importance score of this latent state from 0.0 to 1.0."
     )
-    decay_rate: float = Field(ge=0.0, description="The rate at which this memory's relevance decays over time.")
+    decay_rate: float = Field(
+        ge=0.0, description="The rate at which this epistemic coordinate's relevance decays over time."
+    )
 
 
 type ScaleTypeProfile = Literal["linear", "log", "time", "ordinal", "nominal"]
@@ -5203,7 +5205,7 @@ type AnyStateEvent = Annotated[
 
 
 class EpistemicLedgerState(CoreasonBaseState):
-    """The Committed Epistemic Ledger (crystallized truth), completely partitioned from volatile working memory
+    """The Committed Epistemic Ledger (crystallized truth), completely partitioned from volatile working context
     or Epistemic Quarantine."""
 
     history: list[AnyStateEvent] = Field(


### PR DESCRIPTION
Implemented the Lexical Architecture Transmutation as requested, eradicating the banned "Memory" terminology in favor of "cryptographic ledgers", "epistemic bounds", and "latent states". All required AST mutations and docstring updates were executed successfully inside `src/coreason_manifest/spec/ontology.py`.

Local verification workflow commands (`uv run ruff format .`, `uv run ruff check . --fix`, `uv run mypy src/ tests/`, `uv run pytest`) were run and passed without issues.

---
*PR created automatically by Jules for task [7904504556269571613](https://jules.google.com/task/7904504556269571613) started by @gowthamrao*