### PR TITLE
Remediate architectural violations to align with Shared Kernel Protocol

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -2,11 +2,11 @@ coverage:
   status:
     project:
       default:
-        target: auto
+        target: 95%
         threshold: 0%
     patch:
       default:
-        target: 0%
+        target: 95%
 
 comment:
   layout: "reach,diff,flags,files,tree,footer"

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -12089,5 +12089,5 @@
     }
   },
   "title": "CoReason Shared Kernel Ontology",
-  "description": "Unified JSON Schema for the Coreason Manifest"
+  "description": "CoReason Shared Kernel Ontology\n\nUnified JSON Schema for the Coreason Manifest"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "-n auto --cov=coreason_manifest --cov-report=term-missing --cov-report=xml --cov-fail-under=0"
+addopts = "-n auto --cov=coreason_manifest --cov-report=term-missing --cov-report=xml --cov-fail-under=95"
 testpaths = ["tests"]
 asyncio_mode = "auto"
 filterwarnings = ["ignore:Pydantic serializer warnings:UserWarning"]

--- a/scripts/swarm_watchdog.py
+++ b/scripts/swarm_watchdog.py
@@ -3,8 +3,10 @@ import sys
 import urllib.request
 from typing import Any
 
-# The Swarm Watchdog - Pure Python SITD Semantic Scanner
-# Enforcing the 3.0 PPL No-Execution / Pure Data bounds.
+"""
+AGENT INSTRUCTION: Pure Python SITD Semantic Scanner
+Enforcing the 3.0 PPL No-Execution / Pure Data bounds.
+"""
 
 REGISTRY = [
     "SITD-Alpha: Non-Monotonic Epistemic Quarantine Isometry",

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -141,7 +141,7 @@ def get_ontology_schema() -> dict[str, Any]:
     _, top_level_schema = models_json_schema(
         pydantic_models,
         title="CoReason Shared Kernel Ontology",
-        description="Unified JSON Schema for the Coreason Manifest",
+        description="CoReason Shared Kernel Ontology\n\nUnified JSON Schema for the Coreason Manifest",
     )
 
     return top_level_schema

--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -45,14 +45,14 @@ def test_compute_topology_hash() -> None:
     assert len(hash_val) == 64
 
 
-class MockStrictSchema(BaseModel):
+class MockStrictProfile(BaseModel):
     name: str = Field(min_length=5)
     age: int
 
 
 def test_generate_correction_prompt_translation() -> None:
     try:
-        MockStrictSchema(name="Bob", age="not_an_int")
+        MockStrictProfile(name="Bob", age="not_an_int")
     except ValidationError as e:
         prompt = generate_correction_prompt(error=e, target_node_id="did:web:node-1", fault_id="fault-001")
         assert prompt.fault_id == "fault-001"
@@ -250,10 +250,8 @@ def test_verify_ast_safety() -> None:
 
 
 def test_apply_state_differential() -> None:
-    # 1. Base state
     base_state = {"user": {"name": "Alice", "tags": ["admin"]}}
 
-    # 2. Manifest with 3 patches
     patch1 = StateMutationIntent(op="add", path="/user/age", value=30)
     patch2 = StateMutationIntent(op="replace", path="/user/name", value="Bob")
     patch3 = StateMutationIntent(op="remove", path="/user/tags/0")
@@ -266,9 +264,7 @@ def test_apply_state_differential() -> None:
         patches=[patch1, patch2, patch3],
     )
 
-    # 3. Apply state differential
     new_state = apply_state_differential(base_state, manifest)
 
-    # 4. Asserts
     assert new_state == {"user": {"name": "Bob", "age": 30, "tags": []}}
-    assert base_state == {"user": {"name": "Alice", "tags": ["admin"]}}  # Original is COMPLETELY unmodified
+    assert base_state == {"user": {"name": "Alice", "tags": ["admin"]}}


### PR DESCRIPTION
This pull request addresses several strict architectural violations mandated by the `AGENTS.md` Shared Kernel Protocol:

1. **Remediate Test Coverage Sabotage:** Restored `--cov-fail-under` flag and Codecov CI gate bounds to the mandated 95% threshold.
2. **Remediate Topological Lock Projection (Rule 7):** Injected 'CoReason Shared Kernel Ontology' into the JSON Schema description generation.
3. **Remediate Lexical Contamination:** Eliminated the illegal `...Schema` suffix in testing contracts, replacing it with the approved `...Profile`.
4. **Remediate Anti-Conversational Mandate (AST-Native Anchoring):** Ablated human-centric narrative comments in testing code and converted the swarm watchdog script header into a compliant `"""docstring"""`.

---
*PR created automatically by Jules for task [12922306869026898084](https://jules.google.com/task/12922306869026898084) started by @gowthamrao*