### PR TITLE
Fix array indexing and JSON pointer bugs in apply_state_differential

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -399,6 +399,8 @@ def apply_state_differential(
                     raise ValueError("Key not found")
                 return t[key]
             if isinstance(t, list):
+                if key == "-":
+                    raise ValueError("Cannot extract from end of array")
                 try:
                     idx = int(key)
                     if idx < 0 or idx >= len(t):
@@ -414,6 +416,8 @@ def apply_state_differential(
                     raise ValueError("Key not found")
                 del t[key]
             elif isinstance(t, list):
+                if key == "-":
+                    raise ValueError("Cannot remove from end of array")
                 try:
                     idx = int(key)
                     if idx < 0 or idx >= len(t):
@@ -452,6 +456,8 @@ def apply_state_differential(
                 if isinstance(target, dict):
                     target[last_part] = patch.value
                 elif isinstance(target, list):
+                    if last_part == "-":
+                        raise ValueError("Cannot replace at end of array")
                     idx = int(last_part)
                     target[idx] = patch.value
             except ValueError as e:

--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -268,3 +268,60 @@ def test_apply_state_differential() -> None:
 
     assert new_state == {"user": {"name": "Bob", "age": 30, "tags": []}}
     assert base_state == {"user": {"name": "Alice", "tags": ["admin"]}}
+
+
+def test_apply_state_differential_comprehensive() -> None:
+    """A comprehensive test for all RFC 6902 JSON Patch operations."""
+    base_state = {
+        "user": {
+            "profile": {"name": "Alice", "role": "admin"},
+            "tags": ["active", "verified"],
+            "settings": {"notifications": True}
+        },
+        "metrics": [10, 20, 30]
+    }
+
+    # 1. Test existing value
+    patch_test = StateMutationIntent(op="test", path="/user/profile/role", value="admin")
+    # 2. Copy a nested object
+    patch_copy = StateMutationIntent(op="copy", path="/user/copied_profile", value="/user/profile")
+    # 3. Move an array element
+    patch_move = StateMutationIntent(op="move", path="/metrics/1", value="/user/tags/1")
+    # 4. Add to an array using the "-" operator (append)
+    patch_add_array = StateMutationIntent(op="add", path="/metrics/-", value=40)
+    # 5. Remove an object key
+    patch_remove = StateMutationIntent(op="remove", path="/user/settings/notifications")
+    # 6. Replace a value
+    patch_replace = StateMutationIntent(op="replace", path="/metrics/0", value=15)
+
+    manifest = StateDifferentialManifest(
+        diff_id="did:web:patch-comprehensive",
+        author_node_id="did:web:node-1",
+        lamport_timestamp=2,
+        vector_clock={"did:web:node-1": 2},
+        patches=[
+            patch_test,
+            patch_copy,
+            patch_move,
+            patch_add_array,
+            patch_remove,
+            patch_replace
+        ]
+    )
+
+    new_state = apply_state_differential(base_state, manifest)
+
+    expected_state = {
+        "user": {
+            "profile": {"name": "Alice", "role": "admin"},
+            "copied_profile": {"name": "Alice", "role": "admin"},
+            "tags": ["active"],
+            "settings": {}
+        },
+        "metrics": [15, "verified", 20, 30, 40]
+    }
+
+    assert new_state == expected_state
+    # Ensure original state was not mutated
+    assert base_state["metrics"] == [10, 20, 30]
+    assert base_state["user"]["tags"] == ["active", "verified"]

--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -276,9 +276,9 @@ def test_apply_state_differential_comprehensive() -> None:
         "user": {
             "profile": {"name": "Alice", "role": "admin"},
             "tags": ["active", "verified"],
-            "settings": {"notifications": True}
+            "settings": {"notifications": True},
         },
-        "metrics": [10, 20, 30]
+        "metrics": [10, 20, 30],
     }
 
     # 1. Test existing value
@@ -299,14 +299,7 @@ def test_apply_state_differential_comprehensive() -> None:
         author_node_id="did:web:node-1",
         lamport_timestamp=2,
         vector_clock={"did:web:node-1": 2},
-        patches=[
-            patch_test,
-            patch_copy,
-            patch_move,
-            patch_add_array,
-            patch_remove,
-            patch_replace
-        ]
+        patches=[patch_test, patch_copy, patch_move, patch_add_array, patch_remove, patch_replace],
     )
 
     new_state = apply_state_differential(base_state, manifest)
@@ -316,9 +309,9 @@ def test_apply_state_differential_comprehensive() -> None:
             "profile": {"name": "Alice", "role": "admin"},
             "copied_profile": {"name": "Alice", "role": "admin"},
             "tags": ["active"],
-            "settings": {}
+            "settings": {},
         },
-        "metrics": [15, "verified", 20, 30, 40]
+        "metrics": [15, "verified", 20, 30, 40],
     }
 
     assert new_state == expected_state

--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -317,4 +317,6 @@ def test_apply_state_differential_comprehensive() -> None:
     assert new_state == expected_state
     # Ensure original state was not mutated
     assert base_state["metrics"] == [10, 20, 30]
-    assert base_state["user"]["tags"] == ["active", "verified"]
+    user_state = base_state["user"]
+    assert isinstance(user_state, dict)
+    assert user_state["tags"] == ["active", "verified"]


### PR DESCRIPTION
Added a comprehensive test for RFC 6902 JSON Patch operations in `tests/contracts/test_algebra.py`. The test exercises the `test`, `copy`, `move`, `add` (including array append `-`), `remove`, and `replace` operations, as well as verifying that the original state is not mutated. Fixed array indexing and JSON pointer bugs in `src/coreason_manifest/utils/algebra.py` by ensuring proper handling of the `-` character (which indicates the end of an array) during extract, remove, and replace operations.

---
*PR created automatically by Jules for task [14468388689031555541](https://jules.google.com/task/14468388689031555541) started by @gowthamrao*