### PR TITLE
fix: do not sort structural DAG topology edges in DAGTopologyManifest

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -4672,11 +4672,7 @@ class DAGTopologyManifest(BaseTopologyManifest):
     "\n    TOPOLOGICAL BOUNDARY: Must be >= 1 and <= 256. Prevents runaway agentic cyclic recursion.\n    "
     max_fan_out: int = Field(ge=1, le=1024, description="The maximum number of parallel child nodes.")
     "\n    TOPOLOGICAL BOUNDARY: Must be >= 1 and <= 1024. Limits horizontal compute explosion.\n    "
-
-    @model_validator(mode="after")
-    def sort_dag_topology_arrays(self) -> Self:
-        object.__setattr__(self, "edges", sorted(self.edges))
-        return self
+    # Note: edges is a structurally ordered sequence (Topological DAG edges) and MUST NOT be sorted.
 
     @model_validator(mode="after")
     def verify_edges_exist(self) -> Self:

--- a/tests/contracts/test_activation_steering_contract.py
+++ b/tests/contracts/test_activation_steering_contract.py
@@ -1,0 +1,60 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import ActivationSteeringContract
+
+
+def test_activation_steering_contract_valid() -> None:
+    contract = ActivationSteeringContract(
+        steering_vector_hash="a" * 64,
+        injection_layers=[12, 5, 8],
+        scaling_factor=2.5,
+        vector_modality="additive",
+    )
+
+    # Check that sorting was applied to injection_layers
+    assert contract.injection_layers == [5, 8, 12]
+    assert contract.scaling_factor == 2.5
+    assert contract.vector_modality == "additive"
+
+
+def test_activation_steering_contract_invalid_hash() -> None:
+    # Hash too short
+    with pytest.raises(ValidationError, match="steering_vector_hash"):
+        ActivationSteeringContract(
+            steering_vector_hash="a" * 63,
+            injection_layers=[5],
+            scaling_factor=1.0,
+            vector_modality="additive",
+        )
+
+    # Hash has uppercase characters
+    with pytest.raises(ValidationError, match="steering_vector_hash"):
+        ActivationSteeringContract(
+            steering_vector_hash="A" * 64,
+            injection_layers=[5],
+            scaling_factor=1.0,
+            vector_modality="additive",
+        )
+
+
+def test_activation_steering_contract_invalid_injection_layers() -> None:
+    # Array too short (min_length=1)
+    with pytest.raises(ValidationError, match="injection_layers"):
+        ActivationSteeringContract(
+            steering_vector_hash="a" * 64,
+            injection_layers=[],
+            scaling_factor=1.0,
+            vector_modality="additive",
+        )
+
+
+def test_activation_steering_contract_invalid_modality() -> None:
+    # Invalid literal
+    with pytest.raises(ValidationError, match="vector_modality"):
+        ActivationSteeringContract(
+            steering_vector_hash="a" * 64,
+            injection_layers=[5],
+            scaling_factor=1.0,
+            vector_modality="multiply",  # type: ignore
+        )

--- a/tests/contracts/test_dag_topology_manifest.py
+++ b/tests/contracts/test_dag_topology_manifest.py
@@ -1,4 +1,3 @@
-
 from coreason_manifest.spec.ontology import DAGTopologyManifest
 
 

--- a/tests/contracts/test_dag_topology_manifest.py
+++ b/tests/contracts/test_dag_topology_manifest.py
@@ -1,0 +1,25 @@
+
+from coreason_manifest.spec.ontology import DAGTopologyManifest
+
+
+def test_dag_topology_manifest_edges_are_not_sorted() -> None:
+    # Creating a valid DAG topology
+    manifest = DAGTopologyManifest(
+        type="dag",
+        max_depth=10,
+        max_fan_out=10,
+        lifecycle_phase="draft",
+        nodes={},
+        edges=[
+            ("did:example:nodeC", "did:example:nodeA"),
+            ("did:example:nodeB", "did:example:nodeC"),
+            ("did:example:nodeA", "did:example:nodeD"),
+        ],
+    )
+
+    # It should strictly preserve the causal edge order defined above
+    assert manifest.edges == [
+        ("did:example:nodeC", "did:example:nodeA"),
+        ("did:example:nodeB", "did:example:nodeC"),
+        ("did:example:nodeA", "did:example:nodeD"),
+    ], "DAG topology edges MUST NOT be sorted. It destroys epistemic value."

--- a/tests/contracts/test_epistemic_transmutation_task.py
+++ b/tests/contracts/test_epistemic_transmutation_task.py
@@ -1,4 +1,3 @@
-
 from coreason_manifest.spec.ontology import EpistemicCompressionSLA, EpistemicTransmutationTask
 
 

--- a/tests/contracts/test_epistemic_transmutation_task.py
+++ b/tests/contracts/test_epistemic_transmutation_task.py
@@ -1,0 +1,16 @@
+
+from coreason_manifest.spec.ontology import EpistemicCompressionSLA, EpistemicTransmutationTask
+
+
+def test_epistemic_transmutation_task() -> None:
+    sla = EpistemicCompressionSLA(
+        strict_probability_retention=True, max_allowed_entropy_loss=0.5, required_grounding_density="dense"
+    )
+    task = EpistemicTransmutationTask(
+        task_id="t1",
+        artifact_event_id="e1",
+        target_modalities=["tabular_grid", "raster_image"],
+        compression_sla=sla,
+        execution_cost_budget_magnitude=10,
+    )
+    assert task.target_modalities == ["raster_image", "tabular_grid"]


### PR DESCRIPTION
DAG topology edges were being incorrectly sorted by a pydantic validator, which violated the AGENTS.md instruction (Paradigm 2: Structural Sequences) not to sort causal reality edges, as it ruins their epistemic value. 

Removed `sort_dag_topology_arrays` and added an AST structural note explicitly stating they MUST NOT be sorted. Added a test ensuring they are not sorted.

---
*PR created automatically by Jules for task [2261296089954878273](https://jules.google.com/task/2261296089954878273) started by @gowthamrao*