### PR TITLE
fix(algebra): fix JSON Patch copy and move operations to use 'from' path

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -10442,6 +10442,19 @@
           "$ref": "#/$defs/JsonPrimitiveState",
           "default": null,
           "description": "The payload to insert or test, if applicable, for this deterministic state vector mutation."
+        },
+        "from": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The JSON pointer from which to copy or move the state vector, if applicable.",
+          "title": "From"
         }
       },
       "required": [

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -978,6 +978,11 @@ class StateMutationIntent(CoreasonBaseState):
         default=None,
         description="The payload to insert or test, if applicable, for this deterministic state vector mutation.",
     )
+    from_path: str | None = Field(
+        default=None,
+        alias="from",
+        description="The JSON pointer from which to copy or move the state vector, if applicable.",
+    )
 
 
 class StateDifferentialManifest(CoreasonBaseState):

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -464,7 +464,7 @@ def apply_state_differential(
                 raise ValueError(f"Cannot replace at path {path}: {e}") from e
 
         elif patch.op in ("copy", "move"):
-            from_path = patch.value
+            from_path = patch.from_path
             if not isinstance(from_path, str):
                 raise ValueError(f"Invalid from_path: {from_path}")
             try:

--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -1,7 +1,11 @@
 import base64
 import struct
+from copy import deepcopy
+from typing import Any
 
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 from coreason_manifest.spec.ontology import (
@@ -284,9 +288,9 @@ def test_apply_state_differential_comprehensive() -> None:
     # 1. Test existing value
     patch_test = StateMutationIntent(op="test", path="/user/profile/role", value="admin")
     # 2. Copy a nested object
-    patch_copy = StateMutationIntent(op="copy", path="/user/copied_profile", value="/user/profile")
+    patch_copy = StateMutationIntent(op="copy", path="/user/copied_profile", **{"from": "/user/profile"})
     # 3. Move an array element
-    patch_move = StateMutationIntent(op="move", path="/metrics/1", value="/user/tags/1")
+    patch_move = StateMutationIntent(op="move", path="/metrics/1", **{"from": "/user/tags/1"})
     # 4. Add to an array using the "-" operator (append)
     patch_add_array = StateMutationIntent(op="add", path="/metrics/-", value=40)
     # 5. Remove an object key
@@ -320,3 +324,62 @@ def test_apply_state_differential_comprehensive() -> None:
     user_state = base_state["user"]
     assert isinstance(user_state, dict)
     assert user_state["tags"] == ["active", "verified"]
+
+
+# Strategy to generate valid JSON primitives
+json_primitive = st.recursive(
+    st.none()
+    | st.booleans()
+    | st.floats(allow_nan=False, allow_infinity=False)
+    | st.integers()
+    | st.text(max_size=100),
+    lambda children: st.lists(children, max_size=5) | st.dictionaries(st.text(max_size=50), children, max_size=5),
+    max_leaves=10,
+)
+
+# Generate a list of StateMutationIntent
+
+
+@st.composite
+def random_mutations(draw: Any) -> StateDifferentialManifest:
+    ops = draw(st.lists(st.sampled_from(["add", "remove", "replace", "copy", "move", "test"]), min_size=1, max_size=10))
+
+    patches = []
+    for op in ops:
+        path = "/" + "/".join(draw(st.lists(st.text(min_size=1, max_size=10), min_size=1, max_size=3)))
+        kwargs = {"op": op, "path": path}
+        if op in ("add", "replace", "test"):
+            kwargs["value"] = draw(json_primitive)
+        elif op in ("copy", "move"):
+            kwargs["from"] = "/" + "/".join(draw(st.lists(st.text(min_size=1, max_size=10), min_size=1, max_size=3)))
+
+        import contextlib
+
+        with contextlib.suppress(ValidationError):
+            patches.append(StateMutationIntent(**kwargs))
+
+    return StateDifferentialManifest(
+        diff_id="random_diff",
+        author_node_id="did:web:node-1",
+        lamport_timestamp=1,
+        vector_clock={"did:web:node-1": 1},
+        patches=patches,
+    )
+
+
+@given(json_primitive, random_mutations())
+def test_apply_state_differential_property(
+    initial_state: dict[str, Any] | list[Any] | str | int | float | bool | None, manifest: StateDifferentialManifest
+) -> None:
+    """Property test to ensure apply_state_differential never crashes unexpectedly."""
+    original_state = deepcopy(initial_state)
+
+    try:
+        _ = apply_state_differential(initial_state, manifest)  # type: ignore
+
+        # If it succeeds, initial state should remain unchanged
+        assert initial_state == original_state
+
+    except ValueError:
+        # ValueErrors (e.g., path not found, invalid operation) are expected for random invalid patches
+        pass


### PR DESCRIPTION
This PR addresses an RFC 6902 violation in `StateMutationIntent` and `apply_state_differential`. The `copy` and `move` JSON Patch operations were incorrectly expecting the `value` property to define the origin path. This patch adds a `from_path` property (aliased to `from` in JSON) to comply with the standard and updates the algebraic engine to apply it. Comprehensive property-based tests using `hypothesis` have been included.

---
*PR created automatically by Jules for task [18275205963779282120](https://jules.google.com/task/18275205963779282120) started by @gowthamrao*