### PR TITLE
Restore Fuzzer and Add Missing Benchmark Contract

### DIFF
--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -1,7 +1,11 @@
 import base64
 import struct
+from copy import deepcopy
+from typing import Any
 
+import hypothesis.strategies as st
 import pytest
+from hypothesis import given
 from pydantic import BaseModel, Field, TypeAdapter, ValidationError
 
 from coreason_manifest.spec.ontology import (
@@ -320,3 +324,55 @@ def test_apply_state_differential_comprehensive() -> None:
     user_state = base_state["user"]
     assert isinstance(user_state, dict)
     assert user_state["tags"] == ["active", "verified"]
+
+
+# Strategy to generate valid JSON primitives
+json_primitive = st.recursive(
+    st.none()
+    | st.booleans()
+    | st.floats(allow_nan=False, allow_infinity=False)
+    | st.integers()
+    | st.text(max_size=100),
+    lambda children: st.lists(children, max_size=5) | st.dictionaries(st.text(max_size=50), children, max_size=5),
+    max_leaves=10,
+)
+
+
+@st.composite
+def random_mutations(draw: Any) -> StateDifferentialManifest:
+    import contextlib
+
+    ops = draw(st.lists(st.sampled_from(["add", "remove", "replace", "copy", "move", "test"]), min_size=1, max_size=10))
+
+    patches = []
+    for op in ops:
+        path = "/" + "/".join(draw(st.lists(st.text(min_size=1, max_size=10), min_size=1, max_size=3)))
+        kwargs = {"op": op, "path": path}
+        if op in ("add", "replace", "test"):
+            kwargs["value"] = draw(json_primitive)
+        elif op in ("copy", "move"):
+            kwargs["from"] = "/" + "/".join(draw(st.lists(st.text(min_size=1, max_size=10), min_size=1, max_size=3)))
+
+        with contextlib.suppress(ValidationError):
+            patches.append(StateMutationIntent(**kwargs))
+
+    return StateDifferentialManifest(
+        diff_id="random_diff",
+        author_node_id="did:web:node-1",
+        lamport_timestamp=1,
+        vector_clock={"did:web:node-1": 1},
+        patches=patches,
+    )
+
+
+@given(json_primitive, random_mutations())
+def test_apply_state_differential_property(
+    initial_state: dict[str, Any] | list[Any] | str | int | float | bool | None, manifest: StateDifferentialManifest
+) -> None:
+    """Property test to ensure apply_state_differential never crashes unexpectedly."""
+    original_state = deepcopy(initial_state)
+    try:
+        _ = apply_state_differential(initial_state, manifest)  # type: ignore
+        assert initial_state == original_state
+    except ValueError:
+        pass

--- a/tests/contracts/test_benchmarks.py
+++ b/tests/contracts/test_benchmarks.py
@@ -1,0 +1,26 @@
+from typing import Any
+
+from pytest_benchmark.fixture import BenchmarkFixture
+
+from coreason_manifest.spec.ontology import ExecutionNodeReceipt
+
+
+def test_benchmark_merkle_trace_hashing(benchmark: BenchmarkFixture) -> None:
+    """
+    AGENT INSTRUCTION: Mathematically prove that canonical hashing of execution
+    nodes does not exceed bounded latency thresholds.
+    """
+    # Setup a heavy payload to stress the dictionary recursion bounds
+    # using 100 to avoid dictionary size bounds limits.
+    payload: dict[str, Any] = {"k" + str(i): "v" * 100 for i in range(100)}
+    node = ExecutionNodeReceipt(
+        request_id="req_bench_1",
+        inputs=payload,
+        outputs=payload,
+        parent_hashes=["a" * 64, "b" * 64],
+    )
+
+    # Benchmark the canonical JSON dump and SHA-256 generation
+    result = benchmark(node.generate_node_hash)
+
+    assert len(result) == 64


### PR DESCRIPTION
- Appended fuzzing tests to `tests/contracts/test_algebra.py`.
- Added new benchmark tests in `tests/contracts/test_benchmarks.py`.
- Modified the benchmark payload to 100 items (down from 1000) to adhere to dictionary bounds validation in `ExecutionNodeReceipt`.
- Fixed typing, formatting and linting errors to conform to `AGENTS.md` Shared Kernel protocol.

---
*PR created automatically by Jules for task [3534025526547527470](https://jules.google.com/task/3534025526547527470) started by @gowthamrao*