### PR TITLE
test(ontology): Add tensor size and DAG cycle topology test coverage

### DIFF
--- a/tests/contracts/test_document_layout_manifest.py
+++ b/tests/contracts/test_document_layout_manifest.py
@@ -1,0 +1,65 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import (
+    DocumentLayoutManifest,
+    DocumentLayoutRegionState,
+    MultimodalTokenAnchorState,
+)
+
+
+def create_region(block_id: str) -> DocumentLayoutRegionState:
+    return DocumentLayoutRegionState(
+        block_id=block_id,
+        block_type="paragraph",
+        anchor=MultimodalTokenAnchorState(
+            token_span_start=0,
+            token_span_end=10,
+        ),
+    )
+
+
+def test_document_layout_manifest_valid_dag() -> None:
+    manifest = DocumentLayoutManifest(
+        blocks={
+            "A": create_region("A"),
+            "B": create_region("B"),
+            "C": create_region("C"),
+        },
+        chronological_flow_edges=[("A", "B"), ("B", "C")],
+    )
+    assert len(manifest.blocks) == 3
+
+
+def test_document_layout_manifest_invalid_source() -> None:
+    with pytest.raises(ValidationError, match="Source block 'X' does not exist"):
+        DocumentLayoutManifest(
+            blocks={
+                "A": create_region("A"),
+                "B": create_region("B"),
+            },
+            chronological_flow_edges=[("X", "B")],
+        )
+
+
+def test_document_layout_manifest_invalid_target() -> None:
+    with pytest.raises(ValidationError, match="Target block 'Y' does not exist"):
+        DocumentLayoutManifest(
+            blocks={
+                "A": create_region("A"),
+                "B": create_region("B"),
+            },
+            chronological_flow_edges=[("A", "Y")],
+        )
+
+
+def test_document_layout_manifest_cyclic_contradiction() -> None:
+    with pytest.raises(ValidationError, match=r"Reading order contains a cyclical contradiction\."):
+        DocumentLayoutManifest(
+            blocks={
+                "A": create_region("A"),
+                "B": create_region("B"),
+                "C": create_region("C"),
+            },
+            chronological_flow_edges=[("A", "B"), ("B", "C"), ("C", "A")],
+        )

--- a/tests/contracts/test_document_layout_manifest.py
+++ b/tests/contracts/test_document_layout_manifest.py
@@ -1,4 +1,8 @@
+from typing import Any
+
+import hypothesis.strategies as st
 import pytest
+from hypothesis import HealthCheck, given, settings
 from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import (
@@ -8,58 +12,69 @@ from coreason_manifest.spec.ontology import (
 )
 
 
-def create_region(block_id: str) -> DocumentLayoutRegionState:
-    return DocumentLayoutRegionState(
-        block_id=block_id,
+# 1. Base Factory for DRY Context Generation
+def build_anchor() -> MultimodalTokenAnchorState:
+    return MultimodalTokenAnchorState(
+        token_span_start=0,
+        token_span_end=10,
+        visual_patch_hashes=[],
+        bounding_box=(0.0, 0.0, 1.0, 1.0),
         block_type="paragraph",
-        anchor=MultimodalTokenAnchorState(
-            token_span_start=0,
-            token_span_end=10,
-        ),
     )
 
 
-def test_document_layout_manifest_valid_dag() -> None:
-    manifest = DocumentLayoutManifest(
-        blocks={
-            "A": create_region("A"),
-            "B": create_region("B"),
-            "C": create_region("C"),
-        },
-        chronological_flow_edges=[("A", "B"), ("B", "C")],
-    )
-    assert len(manifest.blocks) == 3
+def build_block(block_id: str) -> DocumentLayoutRegionState:
+    return DocumentLayoutRegionState(block_id=block_id, block_type="paragraph", anchor=build_anchor())
 
 
-def test_document_layout_manifest_invalid_source() -> None:
-    with pytest.raises(ValidationError, match="Source block 'X' does not exist"):
-        DocumentLayoutManifest(
-            blocks={
-                "A": create_region("A"),
-                "B": create_region("B"),
-            },
-            chronological_flow_edges=[("X", "B")],
-        )
+# 2. Atomic Parameterized Tests for Referential Integrity (Ghost Nodes)
+@pytest.mark.parametrize(
+    ("edges", "match_string"),
+    [([("D", "B")], r"Source block 'D' does not exist"), ([("A", "D")], r"Target block 'D' does not exist")],
+)
+def test_document_layout_manifest_ghost_nodes(edges: list[tuple[str, str]], match_string: str) -> None:
+    """Prove the topological boundary strictly severs missing coordinate references."""
+    blocks = {"A": build_block("A"), "B": build_block("B"), "C": build_block("C")}
+    with pytest.raises(ValidationError, match=match_string):
+        DocumentLayoutManifest(blocks=blocks, chronological_flow_edges=edges)
 
 
-def test_document_layout_manifest_invalid_target() -> None:
-    with pytest.raises(ValidationError, match="Target block 'Y' does not exist"):
-        DocumentLayoutManifest(
-            blocks={
-                "A": create_region("A"),
-                "B": create_region("B"),
-            },
-            chronological_flow_edges=[("A", "Y")],
-        )
+# 3. Atomic Parameterized Tests for Static Cycles
+@pytest.mark.parametrize(
+    "edges",
+    [
+        [("A", "A")],  # Self-cycle
+        [("A", "B"), ("B", "C"), ("C", "A")],  # 3-node cycle
+        [("A", "B"), ("B", "A")],  # 2-node cycle
+    ],
+)
+def test_document_layout_manifest_static_cycles(edges: list[tuple[str, str]]) -> None:
+    """Prove the manifest deterministically collapses when chronological paradoxes are injected."""
+    blocks = {"A": build_block("A"), "B": build_block("B"), "C": build_block("C")}
+    with pytest.raises(ValidationError, match=r"Reading order contains a cyclical contradiction"):
+        DocumentLayoutManifest(blocks=blocks, chronological_flow_edges=edges)
 
 
-def test_document_layout_manifest_cyclic_contradiction() -> None:
-    with pytest.raises(ValidationError, match=r"Reading order contains a cyclical contradiction\."):
-        DocumentLayoutManifest(
-            blocks={
-                "A": create_region("A"),
-                "B": create_region("B"),
-                "C": create_region("C"),
-            },
-            chronological_flow_edges=[("A", "B"), ("B", "C"), ("C", "A")],
-        )
+# 4. Fuzzing Valid DAG Topologies
+@st.composite
+def valid_dag_strategy(draw: st.DrawFn) -> dict[str, Any]:
+    """Generates mathematically guaranteed DAGs by strictly pointing edges from lower to higher array indices."""
+    node_ids = draw(st.lists(st.text(min_size=1, max_size=10), min_size=2, max_size=15, unique=True))
+    edges: list[tuple[str, str]] = []
+    for i in range(len(node_ids)):
+        edges.extend((node_ids[i], node_ids[j]) for j in range(i + 1, len(node_ids)) if draw(st.booleans()))
+    return {"nodes": node_ids, "edges": edges}
+
+
+@given(dag_data=valid_dag_strategy())
+@settings(max_examples=50, suppress_health_check=[HealthCheck.too_slow])
+def test_document_layout_manifest_fuzz_valid_dag(dag_data: dict[str, Any]) -> None:
+    """
+    AGENT INSTRUCTION: Fuzz the topological engine. Prove that any mathematically
+    sound DAG is strictly accepted without hallucinating false-positive cycle rejections.
+    """
+    blocks = {n_id: build_block(n_id) for n_id in dag_data["nodes"]}
+    manifest = DocumentLayoutManifest(blocks=blocks, chronological_flow_edges=dag_data["edges"])
+
+    assert len(manifest.blocks) == len(dag_data["nodes"])
+    assert manifest.chronological_flow_edges == dag_data["edges"]

--- a/tests/contracts/test_n_dimensional_tensor_manifest.py
+++ b/tests/contracts/test_n_dimensional_tensor_manifest.py
@@ -1,0 +1,64 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import NDimensionalTensorManifest, TensorStructuralFormatProfile
+
+
+def test_n_dimensional_tensor_manifest_valid() -> None:
+    # float32 is 4 bytes per element. 2 * 3 * 4 = 24 bytes
+    manifest = NDimensionalTensorManifest(
+        structural_type=TensorStructuralFormatProfile.FLOAT32,
+        shape=(2, 3),
+        vram_footprint_bytes=24,
+        merkle_root="a" * 64,
+        storage_uri="s3://bucket/tensor.bin",
+    )
+    assert manifest.vram_footprint_bytes == 24
+
+
+def test_n_dimensional_tensor_manifest_empty_shape() -> None:
+    with pytest.raises(ValidationError, match="Tensor shape must have at least 1 dimension"):
+        NDimensionalTensorManifest(
+            structural_type=TensorStructuralFormatProfile.FLOAT32,
+            shape=(),
+            vram_footprint_bytes=0,
+            merkle_root="a" * 64,
+            storage_uri="s3://bucket/tensor.bin",
+        )
+
+
+def test_n_dimensional_tensor_manifest_negative_dimension() -> None:
+    with pytest.raises(ValidationError, match="Tensor dimensions must be strictly positive integers"):
+        NDimensionalTensorManifest(
+            structural_type=TensorStructuralFormatProfile.FLOAT32,
+            shape=(2, -3),
+            vram_footprint_bytes=24,
+            merkle_root="a" * 64,
+            storage_uri="s3://bucket/tensor.bin",
+        )
+
+
+def test_n_dimensional_tensor_manifest_zero_dimension() -> None:
+    with pytest.raises(ValidationError, match="Tensor dimensions must be strictly positive integers"):
+        NDimensionalTensorManifest(
+            structural_type=TensorStructuralFormatProfile.FLOAT32,
+            shape=(2, 0),
+            vram_footprint_bytes=0,
+            merkle_root="a" * 64,
+            storage_uri="s3://bucket/tensor.bin",
+        )
+
+
+def test_n_dimensional_tensor_manifest_footprint_mismatch() -> None:
+    # 2 * 3 * 4 = 24 bytes, but manifest declares 20
+    with pytest.raises(
+        ValidationError,
+        match=r"Topological mismatch: Shape \(2, 3\) of float32 requires 24 bytes, but manifest declares 20 bytes",
+    ):
+        NDimensionalTensorManifest(
+            structural_type=TensorStructuralFormatProfile.FLOAT32,
+            shape=(2, 3),
+            vram_footprint_bytes=20,
+            merkle_root="a" * 64,
+            storage_uri="s3://bucket/tensor.bin",
+        )

--- a/tests/contracts/test_n_dimensional_tensor_manifest.py
+++ b/tests/contracts/test_n_dimensional_tensor_manifest.py
@@ -1,64 +1,54 @@
+import math
+
+import hypothesis.strategies as st
 import pytest
+from hypothesis import given, settings
 from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import NDimensionalTensorManifest, TensorStructuralFormatProfile
 
 
-def test_n_dimensional_tensor_manifest_valid() -> None:
-    # float32 is 4 bytes per element. 2 * 3 * 4 = 24 bytes
+# 1. Fuzzing the Valid Mathematical Space
+@given(
+    structural_type=st.sampled_from(list(TensorStructuralFormatProfile)),
+    shape=st.lists(st.integers(min_value=1, max_value=100), min_size=1, max_size=5).map(tuple),
+)
+@settings(max_examples=100)
+def test_n_dimensional_tensor_manifest_fuzz_valid(
+    structural_type: TensorStructuralFormatProfile, shape: tuple[int, ...]
+) -> None:
+    """Mathematically prove the deterministic acceptance of correct spatial boundaries across infinite shapes."""
+    expected_bytes = math.prod(shape) * structural_type.bytes_per_element
+
     manifest = NDimensionalTensorManifest(
-        structural_type=TensorStructuralFormatProfile.FLOAT32,
-        shape=(2, 3),
-        vram_footprint_bytes=24,
+        structural_type=structural_type,
+        shape=shape,
+        vram_footprint_bytes=expected_bytes,
         merkle_root="a" * 64,
         storage_uri="s3://bucket/tensor.bin",
     )
-    assert manifest.vram_footprint_bytes == 24
+    assert manifest.vram_footprint_bytes == expected_bytes
 
 
-def test_n_dimensional_tensor_manifest_empty_shape() -> None:
-    with pytest.raises(ValidationError, match="Tensor shape must have at least 1 dimension"):
+# 2. Parameterizing Atomic Boundary Violations
+@pytest.mark.parametrize(
+    ("shape", "footprint", "match_string"),
+    [
+        ((), 0, "must have at least 1 dimension"),
+        ((2, -3), 24, "strictly positive integers"),
+        ((2, 0), 0, "strictly positive integers"),
+        ((2, 3), 20, "Topological mismatch"),  # For float32 (4 bytes), requires 24
+    ],
+)
+def test_n_dimensional_tensor_manifest_atomic_violations(
+    shape: tuple[int, ...], footprint: int, match_string: str
+) -> None:
+    """Prove the physical bounds engine rejects mathematically impossible geometries."""
+    with pytest.raises(ValidationError, match=match_string):
         NDimensionalTensorManifest(
             structural_type=TensorStructuralFormatProfile.FLOAT32,
-            shape=(),
-            vram_footprint_bytes=0,
-            merkle_root="a" * 64,
-            storage_uri="s3://bucket/tensor.bin",
-        )
-
-
-def test_n_dimensional_tensor_manifest_negative_dimension() -> None:
-    with pytest.raises(ValidationError, match="Tensor dimensions must be strictly positive integers"):
-        NDimensionalTensorManifest(
-            structural_type=TensorStructuralFormatProfile.FLOAT32,
-            shape=(2, -3),
-            vram_footprint_bytes=24,
-            merkle_root="a" * 64,
-            storage_uri="s3://bucket/tensor.bin",
-        )
-
-
-def test_n_dimensional_tensor_manifest_zero_dimension() -> None:
-    with pytest.raises(ValidationError, match="Tensor dimensions must be strictly positive integers"):
-        NDimensionalTensorManifest(
-            structural_type=TensorStructuralFormatProfile.FLOAT32,
-            shape=(2, 0),
-            vram_footprint_bytes=0,
-            merkle_root="a" * 64,
-            storage_uri="s3://bucket/tensor.bin",
-        )
-
-
-def test_n_dimensional_tensor_manifest_footprint_mismatch() -> None:
-    # 2 * 3 * 4 = 24 bytes, but manifest declares 20
-    with pytest.raises(
-        ValidationError,
-        match=r"Topological mismatch: Shape \(2, 3\) of float32 requires 24 bytes, but manifest declares 20 bytes",
-    ):
-        NDimensionalTensorManifest(
-            structural_type=TensorStructuralFormatProfile.FLOAT32,
-            shape=(2, 3),
-            vram_footprint_bytes=20,
+            shape=shape,
+            vram_footprint_bytes=footprint,
             merkle_root="a" * 64,
             storage_uri="s3://bucket/tensor.bin",
         )


### PR DESCRIPTION
This submission covers gaps in structural and topological tests as requested, improving overall coverage. It specifically verifies the cycle detection in `DocumentLayoutManifest` and the tensor size physics bounding in `NDimensionalTensorManifest`. All tests satisfy the required `coreason_manifest` local development laws, ensuring zero runtime side effects and strictly deterministic Pydantic execution.

---
*PR created automatically by Jules for task [13257983583531153939](https://jules.google.com/task/13257983583531153939) started by @gowthamrao*