### PR TITLE
Add tests for manifest validators and fix syntax error

### DIFF
--- a/tests/contracts/test_topology_manifests.py
+++ b/tests/contracts/test_topology_manifests.py
@@ -19,12 +19,9 @@ def test_council_topology_enforce_funded_byzantine_slashing():
         max_tolerable_faults=1,
         min_quorum_size=4,
         state_validation_metric="ledger_hash",
-        byzantine_action="slash_escrow"
+        byzantine_action="slash_escrow",
     )
-    consensus_policy = ConsensusPolicy(
-        strategy="pbft",
-        quorum_rules=quorum_rules
-    )
+    consensus_policy = ConsensusPolicy(strategy="pbft", quorum_rules=quorum_rules)
     nodes = {
         "did:web:adj": SystemNodeProfile(description="Adjudicator Node"),
         "did:web:n1": SystemNodeProfile(description="Worker 1"),
@@ -37,11 +34,7 @@ def test_council_topology_enforce_funded_byzantine_slashing():
         ValidationError,
         match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\.",
     ):
-        CouncilTopologyManifest(
-            adjudicator_id="did:web:adj",
-            nodes=nodes,
-            consensus_policy=consensus_policy
-        )
+        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus_policy)
 
     with pytest.raises(
         ValidationError,
@@ -52,10 +45,8 @@ def test_council_topology_enforce_funded_byzantine_slashing():
             nodes=nodes,
             consensus_policy=consensus_policy,
             council_escrow=EscrowPolicy(
-                escrow_locked_magnitude=0,
-                release_condition_metric="pass",
-                refund_target_node_id="did:web:user"
-            )
+                escrow_locked_magnitude=0, release_condition_metric="pass", refund_target_node_id="did:web:user"
+            ),
         )
 
     manifest = CouncilTopologyManifest(
@@ -63,22 +54,19 @@ def test_council_topology_enforce_funded_byzantine_slashing():
         nodes=nodes,
         consensus_policy=consensus_policy,
         council_escrow=EscrowPolicy(
-            escrow_locked_magnitude=100,
-            release_condition_metric="pass",
-            refund_target_node_id="did:web:user"
-        )
+            escrow_locked_magnitude=100, release_condition_metric="pass", refund_target_node_id="did:web:user"
+        ),
     )
     assert manifest.adjudicator_id == "did:web:adj"
+
 
 def test_council_topology_check_adjudicator_id():
     nodes = {
         "did:web:n1": SystemNodeProfile(description="Worker 1"),
     }
     with pytest.raises(ValidationError, match=r"Adjudicator ID 'did:web:adj' is not in nodes registry\."):
-        CouncilTopologyManifest(
-            adjudicator_id="did:web:adj",
-            nodes=nodes
-        )
+        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes)
+
 
 def test_dag_topology_verify_edges_exist():
     nodes = {
@@ -88,62 +76,41 @@ def test_dag_topology_verify_edges_exist():
     }
 
     manifest = DAGTopologyManifest(
-        nodes=nodes,
-        edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3")],
-        max_depth=10,
-        max_fan_out=10
+        nodes=nodes, edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3")], max_depth=10, max_fan_out=10
     )
     assert manifest.edges == sorted([("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3")])
 
     draft_manifest = DAGTopologyManifest(
-        lifecycle_phase="draft",
-        nodes=nodes,
-        edges=[("did:web:n1", "did:web:missing")],
-        max_depth=10,
-        max_fan_out=10
+        lifecycle_phase="draft", nodes=nodes, edges=[("did:web:n1", "did:web:missing")], max_depth=10, max_fan_out=10
     )
     assert len(draft_manifest.edges) == 1
 
     with pytest.raises(ValidationError, match=r"Edge source 'did:web:missing' does not exist in nodes registry\."):
-        DAGTopologyManifest(
-            nodes=nodes,
-            edges=[("did:web:missing", "did:web:n2")],
-            max_depth=10,
-            max_fan_out=10
-        )
+        DAGTopologyManifest(nodes=nodes, edges=[("did:web:missing", "did:web:n2")], max_depth=10, max_fan_out=10)
 
     with pytest.raises(ValidationError, match=r"Edge target 'did:web:missing' does not exist in nodes registry\."):
-        DAGTopologyManifest(
-            nodes=nodes,
-            edges=[("did:web:n1", "did:web:missing")],
-            max_depth=10,
-            max_fan_out=10
-        )
+        DAGTopologyManifest(nodes=nodes, edges=[("did:web:n1", "did:web:missing")], max_depth=10, max_fan_out=10)
 
     with pytest.raises(ValidationError, match=r"Graph contains cycles but allow_cycles is False\."):
         DAGTopologyManifest(
             nodes=nodes,
             edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")],
             max_depth=10,
-            max_fan_out=10
+            max_fan_out=10,
         )
 
     with pytest.raises(ValidationError, match=r"Graph contains cycles but allow_cycles is False\."):
-        DAGTopologyManifest(
-            nodes=nodes,
-            edges=[("did:web:n1", "did:web:n1")],
-            max_depth=10,
-            max_fan_out=10
-        )
+        DAGTopologyManifest(nodes=nodes, edges=[("did:web:n1", "did:web:n1")], max_depth=10, max_fan_out=10)
 
     manifest_cycles = DAGTopologyManifest(
         nodes=nodes,
         edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")],
         max_depth=10,
         max_fan_out=10,
-        allow_cycles=True
+        allow_cycles=True,
     )
     assert len(manifest_cycles.edges) == 3
+
 
 def test_task_award_receipt():
     with pytest.raises(ValidationError, match=r"Escrow locked amount cannot exceed the total cleared price\."):
@@ -152,17 +119,13 @@ def test_task_award_receipt():
             awarded_syndicate={"did:web:n1": 100},
             cleared_price_magnitude=100,
             escrow=EscrowPolicy(
-                escrow_locked_magnitude=200,
-                release_condition_metric="pass",
-                refund_target_node_id="did:web:user"
-            )
+                escrow_locked_magnitude=200, release_condition_metric="pass", refund_target_node_id="did:web:user"
+            ),
         )
 
     with pytest.raises(ValidationError, match="Syndicate allocation sum must exactly equal cleared_price_magnitude"):
         TaskAwardReceipt(
-            task_id="task-1",
-            awarded_syndicate={"did:web:n1": 50, "did:web:n2": 40},
-            cleared_price_magnitude=100
+            task_id="task-1", awarded_syndicate={"did:web:n1": 50, "did:web:n2": 40}, cleared_price_magnitude=100
         )
 
     valid_receipt = TaskAwardReceipt(
@@ -170,25 +133,22 @@ def test_task_award_receipt():
         awarded_syndicate={"did:web:n1": 60, "did:web:n2": 40},
         cleared_price_magnitude=100,
         escrow=EscrowPolicy(
-            escrow_locked_magnitude=50,
-            release_condition_metric="pass",
-            refund_target_node_id="did:web:user"
-        )
+            escrow_locked_magnitude=50, release_condition_metric="pass", refund_target_node_id="did:web:user"
+        ),
     )
     assert valid_receipt.cleared_price_magnitude == 100
+
 
 def test_market_contract():
     with pytest.raises(
         ValidationError,
         match=r"ECONOMIC INVARIANT VIOLATION: slashing_penalty cannot exceed minimum_collateral\.",
     ):
-        MarketContract(
-            minimum_collateral=100.0,
-            slashing_penalty=150.0
-        )
+        MarketContract(minimum_collateral=100.0, slashing_penalty=150.0)
 
     mc = MarketContract(minimum_collateral=100.0, slashing_penalty=50.0)
     assert mc.slashing_penalty == 50.0
+
 
 def test_multimodal_token_anchor_state():
     with pytest.raises(ValidationError, match=r"If token_span_start is defined, token_span_end MUST be defined\."):
@@ -206,10 +166,6 @@ def test_multimodal_token_anchor_state():
     with pytest.raises(ValidationError, match=r"Spatial invariant violated: min bounds .* exceed max bounds .*"):
         MultimodalTokenAnchorState(bounding_box=(0.2, 0.8, 0.5, 0.6))
 
-    valid = MultimodalTokenAnchorState(
-        token_span_start=10,
-        token_span_end=20,
-        bounding_box=(0.1, 0.2, 0.5, 0.6)
-    )
+    valid = MultimodalTokenAnchorState(token_span_start=10, token_span_end=20, bounding_box=(0.1, 0.2, 0.5, 0.6))
     assert valid.token_span_end == 20
     assert valid.bounding_box == (0.1, 0.2, 0.5, 0.6)

--- a/tests/contracts/test_topology_manifests.py
+++ b/tests/contracts/test_topology_manifests.py
@@ -1,7 +1,7 @@
-import pytest
-from pydantic import ValidationError
-from hypothesis import given, settings, HealthCheck
 import hypothesis.strategies as st
+import pytest
+from hypothesis import HealthCheck, given, settings
+from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import (
     ConsensusPolicy,
@@ -14,6 +14,7 @@ from coreason_manifest.spec.ontology import (
     SystemNodeProfile,
     TaskAwardReceipt,
 )
+
 
 # --- 1. Market Contract Fuzzing ---
 @given(collateral=st.floats(min_value=0.0, max_value=1e6), penalty=st.floats(min_value=0.0, max_value=1e6))
@@ -36,21 +37,29 @@ def test_multimodal_anchor_1d_fuzz_valid(start: int, span_len: int) -> None:
     assert anchor.token_span_end is not None
     assert anchor.token_span_end > start
 
-@pytest.mark.parametrize("start, end, match_str", [
-    (10, None, r"token_span_end MUST be defined"),
-    (None, 20, r"cannot be defined without a token_span_start"),
-    (10, 10, r"MUST be strictly greater than"),
-    (20, 10, r"MUST be strictly greater than")
-])
+
+@pytest.mark.parametrize(
+    ("start", "end", "match_str"),
+    [
+        (10, None, r"token_span_end MUST be defined"),
+        (None, 20, r"cannot be defined without a token_span_start"),
+        (10, 10, r"MUST be strictly greater than"),
+        (20, 10, r"MUST be strictly greater than"),
+    ],
+)
 def test_multimodal_anchor_1d_atomic_invalid(start: int | None, end: int | None, match_str: str) -> None:
     """Prove invalid 1D geometries are structurally severed."""
     with pytest.raises(ValidationError, match=match_str):
         MultimodalTokenAnchorState(token_span_start=start, token_span_end=end)
 
-@pytest.mark.parametrize("box", [
-    (0.8, 0.2, 0.5, 0.6), # x_min > x_max
-    (0.2, 0.8, 0.5, 0.6)  # y_min > y_max
-])
+
+@pytest.mark.parametrize(
+    "box",
+    [
+        (0.8, 0.2, 0.5, 0.6),  # x_min > x_max
+        (0.2, 0.8, 0.5, 0.6),  # y_min > y_max
+    ],
+)
 def test_multimodal_anchor_2d_atomic_invalid(box: tuple[float, float, float, float]) -> None:
     """Prove mathematically impossible 2D spatial geometries are rejected."""
     with pytest.raises(ValidationError, match="Spatial invariant violated"):
@@ -58,12 +67,18 @@ def test_multimodal_anchor_2d_atomic_invalid(box: tuple[float, float, float, flo
 
 
 # --- 3. DAG Topology Atomicity ---
-@pytest.mark.parametrize("edges, match_str", [
-    ([("did:web:missing", "did:web:n2")], r"Edge source 'did:web:missing' does not exist"),
-    ([("did:web:n1", "did:web:missing")], r"Edge target 'did:web:missing' does not exist"),
-    ([("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")], r"Graph contains cycles"),
-    ([("did:web:n1", "did:web:n1")], r"Graph contains cycles")
-])
+@pytest.mark.parametrize(
+    ("edges", "match_str"),
+    [
+        ([("did:web:missing", "did:web:n2")], r"Edge source 'did:web:missing' does not exist"),
+        ([("did:web:n1", "did:web:missing")], r"Edge target 'did:web:missing' does not exist"),
+        (
+            [("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")],
+            r"Graph contains cycles",
+        ),
+        ([("did:web:n1", "did:web:n1")], r"Graph contains cycles"),
+    ],
+)
 def test_dag_topology_atomic_invalid_edges(edges: list[tuple[str, str]], match_str: str) -> None:
     """Prove specific ghost nodes and cyclic dependencies collapse the instantiation."""
     nodes = {
@@ -80,33 +95,66 @@ def test_council_topology_missing_adjudicator() -> None:
     with pytest.raises(ValidationError, match=r"Adjudicator ID 'did:web:adj' is not in nodes registry"):
         CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes={"did:web:n1": SystemNodeProfile(description="W1")})
 
+
 def test_council_topology_unfunded_slashing_none() -> None:
     nodes = {"did:web:adj": SystemNodeProfile(description="Adj")}
-    quorum = QuorumPolicy(max_tolerable_faults=1, min_quorum_size=4, state_validation_metric="ledger_hash", byzantine_action="slash_escrow")
+    quorum = QuorumPolicy(
+        max_tolerable_faults=1,
+        min_quorum_size=4,
+        state_validation_metric="ledger_hash",
+        byzantine_action="slash_escrow",
+    )
     consensus = ConsensusPolicy(strategy="pbft", quorum_rules=quorum)
 
     with pytest.raises(ValidationError, match=r"PBFT with slash_escrow requires a funded council_escrow"):
-        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=None)
+        CouncilTopologyManifest(
+            adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=None
+        )
+
 
 def test_council_topology_unfunded_slashing_zero() -> None:
     nodes = {"did:web:adj": SystemNodeProfile(description="Adj")}
-    quorum = QuorumPolicy(max_tolerable_faults=1, min_quorum_size=4, state_validation_metric="ledger_hash", byzantine_action="slash_escrow")
+    quorum = QuorumPolicy(
+        max_tolerable_faults=1,
+        min_quorum_size=4,
+        state_validation_metric="ledger_hash",
+        byzantine_action="slash_escrow",
+    )
     consensus = ConsensusPolicy(strategy="pbft", quorum_rules=quorum)
-    escrow = EscrowPolicy(escrow_locked_magnitude=0, release_condition_metric="pass", refund_target_node_id="did:web:user")
+    escrow = EscrowPolicy(
+        escrow_locked_magnitude=0, release_condition_metric="pass", refund_target_node_id="did:web:user"
+    )
 
     with pytest.raises(ValidationError, match=r"PBFT with slash_escrow requires a funded council_escrow"):
-        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=escrow)
+        CouncilTopologyManifest(
+            adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=escrow
+        )
 
 
 # --- 5. Task Award Receipt Fuzzing ---
-@given(cleared_price=st.integers(min_value=1, max_value=100000), locked_amount=st.integers(min_value=1, max_value=200000))
+@given(
+    cleared_price=st.integers(min_value=1, max_value=100000),
+    locked_amount=st.integers(min_value=1, max_value=200000),
+)
 def test_task_award_escrow_bounds(cleared_price: int, locked_amount: int) -> None:
     """Mathematically prove the physical limit: escrow cannot exceed cleared price."""
-    escrow = EscrowPolicy(escrow_locked_magnitude=locked_amount, release_condition_metric="pass", refund_target_node_id="did:web:user")
+    escrow = EscrowPolicy(
+        escrow_locked_magnitude=locked_amount, release_condition_metric="pass", refund_target_node_id="did:web:user"
+    )
 
     if locked_amount > cleared_price:
         with pytest.raises(ValidationError, match=r"Escrow locked amount cannot exceed the total cleared price"):
-            TaskAwardReceipt(task_id="t1", awarded_syndicate={"did:web:n1": cleared_price}, cleared_price_magnitude=cleared_price, escrow=escrow)
+            TaskAwardReceipt(
+                task_id="t1",
+                awarded_syndicate={"did:web:n1": cleared_price},
+                cleared_price_magnitude=cleared_price,
+                escrow=escrow,
+            )
     else:
-        receipt = TaskAwardReceipt(task_id="t1", awarded_syndicate={"did:web:n1": cleared_price}, cleared_price_magnitude=cleared_price, escrow=escrow)
+        receipt = TaskAwardReceipt(
+            task_id="t1",
+            awarded_syndicate={"did:web:n1": cleared_price},
+            cleared_price_magnitude=cleared_price,
+            escrow=escrow,
+        )
         assert receipt.cleared_price_magnitude == cleared_price

--- a/tests/contracts/test_topology_manifests.py
+++ b/tests/contracts/test_topology_manifests.py
@@ -33,14 +33,20 @@ def test_council_topology_enforce_funded_byzantine_slashing():
         "did:web:n4": SystemNodeProfile(description="Worker 4"),
     }
 
-    with pytest.raises(ValidationError, match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\."):
+    with pytest.raises(
+        ValidationError,
+        match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\.",
+    ):
         CouncilTopologyManifest(
             adjudicator_id="did:web:adj",
             nodes=nodes,
             consensus_policy=consensus_policy
         )
 
-    with pytest.raises(ValidationError, match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\."):
+    with pytest.raises(
+        ValidationError,
+        match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\.",
+    ):
         CouncilTopologyManifest(
             adjudicator_id="did:web:adj",
             nodes=nodes,
@@ -172,7 +178,10 @@ def test_task_award_receipt():
     assert valid_receipt.cleared_price_magnitude == 100
 
 def test_market_contract():
-    with pytest.raises(ValidationError, match=r"ECONOMIC INVARIANT VIOLATION: slashing_penalty cannot exceed minimum_collateral\."):
+    with pytest.raises(
+        ValidationError,
+        match=r"ECONOMIC INVARIANT VIOLATION: slashing_penalty cannot exceed minimum_collateral\.",
+    ):
         MarketContract(
             minimum_collateral=100.0,
             slashing_penalty=150.0

--- a/tests/contracts/test_topology_manifests.py
+++ b/tests/contracts/test_topology_manifests.py
@@ -87,13 +87,14 @@ def test_dag_topology_atomic_invalid_edges(edges: list[tuple[str, str]], match_s
         "did:web:n3": SystemNodeProfile(description="W3"),
     }
     with pytest.raises(ValidationError, match=match_str):
-        DAGTopologyManifest(nodes=nodes, edges=edges, max_depth=10, max_fan_out=10)
+        DAGTopologyManifest(nodes=nodes, edges=edges, max_depth=10, max_fan_out=10)  # type: ignore[arg-type]
 
 
 # --- 4. Council Topology Atomicity ---
 def test_council_topology_missing_adjudicator() -> None:
+    nodes = {"did:web:n1": SystemNodeProfile(description="W1")}
     with pytest.raises(ValidationError, match=r"Adjudicator ID 'did:web:adj' is not in nodes registry"):
-        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes={"did:web:n1": SystemNodeProfile(description="W1")})
+        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes)  # type: ignore[arg-type]
 
 
 def test_council_topology_unfunded_slashing_none() -> None:
@@ -108,7 +109,7 @@ def test_council_topology_unfunded_slashing_none() -> None:
 
     with pytest.raises(ValidationError, match=r"PBFT with slash_escrow requires a funded council_escrow"):
         CouncilTopologyManifest(
-            adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=None
+            adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=None  # type: ignore[arg-type]
         )
 
 
@@ -127,7 +128,7 @@ def test_council_topology_unfunded_slashing_zero() -> None:
 
     with pytest.raises(ValidationError, match=r"PBFT with slash_escrow requires a funded council_escrow"):
         CouncilTopologyManifest(
-            adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=escrow
+            adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=escrow  # type: ignore[arg-type]
         )
 
 

--- a/tests/contracts/test_topology_manifests.py
+++ b/tests/contracts/test_topology_manifests.py
@@ -1,5 +1,7 @@
 import pytest
 from pydantic import ValidationError
+from hypothesis import given, settings, HealthCheck
+import hypothesis.strategies as st
 
 from coreason_manifest.spec.ontology import (
     ConsensusPolicy,
@@ -13,159 +15,98 @@ from coreason_manifest.spec.ontology import (
     TaskAwardReceipt,
 )
 
+# --- 1. Market Contract Fuzzing ---
+@given(collateral=st.floats(min_value=0.0, max_value=1e6), penalty=st.floats(min_value=0.0, max_value=1e6))
+@settings(max_examples=100, suppress_health_check=[HealthCheck.too_slow])
+def test_market_contract_bounds(collateral: float, penalty: float) -> None:
+    """Mathematically prove the economic invariant: penalty <= collateral."""
+    if penalty > collateral:
+        with pytest.raises(ValidationError, match="slashing_penalty cannot exceed minimum_collateral"):
+            MarketContract(minimum_collateral=collateral, slashing_penalty=penalty)
+    else:
+        contract = MarketContract(minimum_collateral=collateral, slashing_penalty=penalty)
+        assert contract.slashing_penalty == penalty
 
-def test_council_topology_enforce_funded_byzantine_slashing():
-    quorum_rules = QuorumPolicy(
-        max_tolerable_faults=1,
-        min_quorum_size=4,
-        state_validation_metric="ledger_hash",
-        byzantine_action="slash_escrow",
-    )
-    consensus_policy = ConsensusPolicy(strategy="pbft", quorum_rules=quorum_rules)
+
+# --- 2. Multimodal Anchor Fuzzing & Atomicity ---
+@given(start=st.integers(min_value=0, max_value=10000), span_len=st.integers(min_value=1, max_value=1000))
+def test_multimodal_anchor_1d_fuzz_valid(start: int, span_len: int) -> None:
+    """Prove the 1D token bounds accept infinite valid mathematical spans."""
+    anchor = MultimodalTokenAnchorState(token_span_start=start, token_span_end=start + span_len)
+    assert anchor.token_span_end is not None
+    assert anchor.token_span_end > start
+
+@pytest.mark.parametrize("start, end, match_str", [
+    (10, None, r"token_span_end MUST be defined"),
+    (None, 20, r"cannot be defined without a token_span_start"),
+    (10, 10, r"MUST be strictly greater than"),
+    (20, 10, r"MUST be strictly greater than")
+])
+def test_multimodal_anchor_1d_atomic_invalid(start: int | None, end: int | None, match_str: str) -> None:
+    """Prove invalid 1D geometries are structurally severed."""
+    with pytest.raises(ValidationError, match=match_str):
+        MultimodalTokenAnchorState(token_span_start=start, token_span_end=end)
+
+@pytest.mark.parametrize("box", [
+    (0.8, 0.2, 0.5, 0.6), # x_min > x_max
+    (0.2, 0.8, 0.5, 0.6)  # y_min > y_max
+])
+def test_multimodal_anchor_2d_atomic_invalid(box: tuple[float, float, float, float]) -> None:
+    """Prove mathematically impossible 2D spatial geometries are rejected."""
+    with pytest.raises(ValidationError, match="Spatial invariant violated"):
+        MultimodalTokenAnchorState(bounding_box=box)
+
+
+# --- 3. DAG Topology Atomicity ---
+@pytest.mark.parametrize("edges, match_str", [
+    ([("did:web:missing", "did:web:n2")], r"Edge source 'did:web:missing' does not exist"),
+    ([("did:web:n1", "did:web:missing")], r"Edge target 'did:web:missing' does not exist"),
+    ([("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")], r"Graph contains cycles"),
+    ([("did:web:n1", "did:web:n1")], r"Graph contains cycles")
+])
+def test_dag_topology_atomic_invalid_edges(edges: list[tuple[str, str]], match_str: str) -> None:
+    """Prove specific ghost nodes and cyclic dependencies collapse the instantiation."""
     nodes = {
-        "did:web:adj": SystemNodeProfile(description="Adjudicator Node"),
-        "did:web:n1": SystemNodeProfile(description="Worker 1"),
-        "did:web:n2": SystemNodeProfile(description="Worker 2"),
-        "did:web:n3": SystemNodeProfile(description="Worker 3"),
-        "did:web:n4": SystemNodeProfile(description="Worker 4"),
+        "did:web:n1": SystemNodeProfile(description="W1"),
+        "did:web:n2": SystemNodeProfile(description="W2"),
+        "did:web:n3": SystemNodeProfile(description="W3"),
     }
-
-    with pytest.raises(
-        ValidationError,
-        match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\.",
-    ):
-        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus_policy)
-
-    with pytest.raises(
-        ValidationError,
-        match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\.",
-    ):
-        CouncilTopologyManifest(
-            adjudicator_id="did:web:adj",
-            nodes=nodes,
-            consensus_policy=consensus_policy,
-            council_escrow=EscrowPolicy(
-                escrow_locked_magnitude=0, release_condition_metric="pass", refund_target_node_id="did:web:user"
-            ),
-        )
-
-    manifest = CouncilTopologyManifest(
-        adjudicator_id="did:web:adj",
-        nodes=nodes,
-        consensus_policy=consensus_policy,
-        council_escrow=EscrowPolicy(
-            escrow_locked_magnitude=100, release_condition_metric="pass", refund_target_node_id="did:web:user"
-        ),
-    )
-    assert manifest.adjudicator_id == "did:web:adj"
+    with pytest.raises(ValidationError, match=match_str):
+        DAGTopologyManifest(nodes=nodes, edges=edges, max_depth=10, max_fan_out=10)
 
 
-def test_council_topology_check_adjudicator_id():
-    nodes = {
-        "did:web:n1": SystemNodeProfile(description="Worker 1"),
-    }
-    with pytest.raises(ValidationError, match=r"Adjudicator ID 'did:web:adj' is not in nodes registry\."):
-        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes)
+# --- 4. Council Topology Atomicity ---
+def test_council_topology_missing_adjudicator() -> None:
+    with pytest.raises(ValidationError, match=r"Adjudicator ID 'did:web:adj' is not in nodes registry"):
+        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes={"did:web:n1": SystemNodeProfile(description="W1")})
+
+def test_council_topology_unfunded_slashing_none() -> None:
+    nodes = {"did:web:adj": SystemNodeProfile(description="Adj")}
+    quorum = QuorumPolicy(max_tolerable_faults=1, min_quorum_size=4, state_validation_metric="ledger_hash", byzantine_action="slash_escrow")
+    consensus = ConsensusPolicy(strategy="pbft", quorum_rules=quorum)
+
+    with pytest.raises(ValidationError, match=r"PBFT with slash_escrow requires a funded council_escrow"):
+        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=None)
+
+def test_council_topology_unfunded_slashing_zero() -> None:
+    nodes = {"did:web:adj": SystemNodeProfile(description="Adj")}
+    quorum = QuorumPolicy(max_tolerable_faults=1, min_quorum_size=4, state_validation_metric="ledger_hash", byzantine_action="slash_escrow")
+    consensus = ConsensusPolicy(strategy="pbft", quorum_rules=quorum)
+    escrow = EscrowPolicy(escrow_locked_magnitude=0, release_condition_metric="pass", refund_target_node_id="did:web:user")
+
+    with pytest.raises(ValidationError, match=r"PBFT with slash_escrow requires a funded council_escrow"):
+        CouncilTopologyManifest(adjudicator_id="did:web:adj", nodes=nodes, consensus_policy=consensus, council_escrow=escrow)
 
 
-def test_dag_topology_verify_edges_exist():
-    nodes = {
-        "did:web:n1": SystemNodeProfile(description="Worker 1"),
-        "did:web:n2": SystemNodeProfile(description="Worker 2"),
-        "did:web:n3": SystemNodeProfile(description="Worker 3"),
-    }
+# --- 5. Task Award Receipt Fuzzing ---
+@given(cleared_price=st.integers(min_value=1, max_value=100000), locked_amount=st.integers(min_value=1, max_value=200000))
+def test_task_award_escrow_bounds(cleared_price: int, locked_amount: int) -> None:
+    """Mathematically prove the physical limit: escrow cannot exceed cleared price."""
+    escrow = EscrowPolicy(escrow_locked_magnitude=locked_amount, release_condition_metric="pass", refund_target_node_id="did:web:user")
 
-    manifest = DAGTopologyManifest(
-        nodes=nodes, edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3")], max_depth=10, max_fan_out=10
-    )
-    assert manifest.edges == sorted([("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3")])
-
-    draft_manifest = DAGTopologyManifest(
-        lifecycle_phase="draft", nodes=nodes, edges=[("did:web:n1", "did:web:missing")], max_depth=10, max_fan_out=10
-    )
-    assert len(draft_manifest.edges) == 1
-
-    with pytest.raises(ValidationError, match=r"Edge source 'did:web:missing' does not exist in nodes registry\."):
-        DAGTopologyManifest(nodes=nodes, edges=[("did:web:missing", "did:web:n2")], max_depth=10, max_fan_out=10)
-
-    with pytest.raises(ValidationError, match=r"Edge target 'did:web:missing' does not exist in nodes registry\."):
-        DAGTopologyManifest(nodes=nodes, edges=[("did:web:n1", "did:web:missing")], max_depth=10, max_fan_out=10)
-
-    with pytest.raises(ValidationError, match=r"Graph contains cycles but allow_cycles is False\."):
-        DAGTopologyManifest(
-            nodes=nodes,
-            edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")],
-            max_depth=10,
-            max_fan_out=10,
-        )
-
-    with pytest.raises(ValidationError, match=r"Graph contains cycles but allow_cycles is False\."):
-        DAGTopologyManifest(nodes=nodes, edges=[("did:web:n1", "did:web:n1")], max_depth=10, max_fan_out=10)
-
-    manifest_cycles = DAGTopologyManifest(
-        nodes=nodes,
-        edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")],
-        max_depth=10,
-        max_fan_out=10,
-        allow_cycles=True,
-    )
-    assert len(manifest_cycles.edges) == 3
-
-
-def test_task_award_receipt():
-    with pytest.raises(ValidationError, match=r"Escrow locked amount cannot exceed the total cleared price\."):
-        TaskAwardReceipt(
-            task_id="task-1",
-            awarded_syndicate={"did:web:n1": 100},
-            cleared_price_magnitude=100,
-            escrow=EscrowPolicy(
-                escrow_locked_magnitude=200, release_condition_metric="pass", refund_target_node_id="did:web:user"
-            ),
-        )
-
-    with pytest.raises(ValidationError, match="Syndicate allocation sum must exactly equal cleared_price_magnitude"):
-        TaskAwardReceipt(
-            task_id="task-1", awarded_syndicate={"did:web:n1": 50, "did:web:n2": 40}, cleared_price_magnitude=100
-        )
-
-    valid_receipt = TaskAwardReceipt(
-        task_id="task-1",
-        awarded_syndicate={"did:web:n1": 60, "did:web:n2": 40},
-        cleared_price_magnitude=100,
-        escrow=EscrowPolicy(
-            escrow_locked_magnitude=50, release_condition_metric="pass", refund_target_node_id="did:web:user"
-        ),
-    )
-    assert valid_receipt.cleared_price_magnitude == 100
-
-
-def test_market_contract():
-    with pytest.raises(
-        ValidationError,
-        match=r"ECONOMIC INVARIANT VIOLATION: slashing_penalty cannot exceed minimum_collateral\.",
-    ):
-        MarketContract(minimum_collateral=100.0, slashing_penalty=150.0)
-
-    mc = MarketContract(minimum_collateral=100.0, slashing_penalty=50.0)
-    assert mc.slashing_penalty == 50.0
-
-
-def test_multimodal_token_anchor_state():
-    with pytest.raises(ValidationError, match=r"If token_span_start is defined, token_span_end MUST be defined\."):
-        MultimodalTokenAnchorState(token_span_start=10)
-
-    with pytest.raises(ValidationError, match=r"token_span_end cannot be defined without a token_span_start\."):
-        MultimodalTokenAnchorState(token_span_end=20)
-
-    with pytest.raises(ValidationError, match=r"token_span_end MUST be strictly greater than token_span_start\."):
-        MultimodalTokenAnchorState(token_span_start=10, token_span_end=10)
-
-    with pytest.raises(ValidationError, match=r"Spatial invariant violated: min bounds .* exceed max bounds .*"):
-        MultimodalTokenAnchorState(bounding_box=(0.8, 0.2, 0.5, 0.6))
-
-    with pytest.raises(ValidationError, match=r"Spatial invariant violated: min bounds .* exceed max bounds .*"):
-        MultimodalTokenAnchorState(bounding_box=(0.2, 0.8, 0.5, 0.6))
-
-    valid = MultimodalTokenAnchorState(token_span_start=10, token_span_end=20, bounding_box=(0.1, 0.2, 0.5, 0.6))
-    assert valid.token_span_end == 20
-    assert valid.bounding_box == (0.1, 0.2, 0.5, 0.6)
+    if locked_amount > cleared_price:
+        with pytest.raises(ValidationError, match=r"Escrow locked amount cannot exceed the total cleared price"):
+            TaskAwardReceipt(task_id="t1", awarded_syndicate={"did:web:n1": cleared_price}, cleared_price_magnitude=cleared_price, escrow=escrow)
+    else:
+        receipt = TaskAwardReceipt(task_id="t1", awarded_syndicate={"did:web:n1": cleared_price}, cleared_price_magnitude=cleared_price, escrow=escrow)
+        assert receipt.cleared_price_magnitude == cleared_price

--- a/tests/contracts/test_topology_manifests.py
+++ b/tests/contracts/test_topology_manifests.py
@@ -1,0 +1,206 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import (
+    ConsensusPolicy,
+    CouncilTopologyManifest,
+    DAGTopologyManifest,
+    EscrowPolicy,
+    MarketContract,
+    MultimodalTokenAnchorState,
+    QuorumPolicy,
+    SystemNodeProfile,
+    TaskAwardReceipt,
+)
+
+
+def test_council_topology_enforce_funded_byzantine_slashing():
+    quorum_rules = QuorumPolicy(
+        max_tolerable_faults=1,
+        min_quorum_size=4,
+        state_validation_metric="ledger_hash",
+        byzantine_action="slash_escrow"
+    )
+    consensus_policy = ConsensusPolicy(
+        strategy="pbft",
+        quorum_rules=quorum_rules
+    )
+    nodes = {
+        "did:web:adj": SystemNodeProfile(description="Adjudicator Node"),
+        "did:web:n1": SystemNodeProfile(description="Worker 1"),
+        "did:web:n2": SystemNodeProfile(description="Worker 2"),
+        "did:web:n3": SystemNodeProfile(description="Worker 3"),
+        "did:web:n4": SystemNodeProfile(description="Worker 4"),
+    }
+
+    with pytest.raises(ValidationError, match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\."):
+        CouncilTopologyManifest(
+            adjudicator_id="did:web:adj",
+            nodes=nodes,
+            consensus_policy=consensus_policy
+        )
+
+    with pytest.raises(ValidationError, match=r"Topological Interlock Failed: PBFT with slash_escrow requires a funded council_escrow\."):
+        CouncilTopologyManifest(
+            adjudicator_id="did:web:adj",
+            nodes=nodes,
+            consensus_policy=consensus_policy,
+            council_escrow=EscrowPolicy(
+                escrow_locked_magnitude=0,
+                release_condition_metric="pass",
+                refund_target_node_id="did:web:user"
+            )
+        )
+
+    manifest = CouncilTopologyManifest(
+        adjudicator_id="did:web:adj",
+        nodes=nodes,
+        consensus_policy=consensus_policy,
+        council_escrow=EscrowPolicy(
+            escrow_locked_magnitude=100,
+            release_condition_metric="pass",
+            refund_target_node_id="did:web:user"
+        )
+    )
+    assert manifest.adjudicator_id == "did:web:adj"
+
+def test_council_topology_check_adjudicator_id():
+    nodes = {
+        "did:web:n1": SystemNodeProfile(description="Worker 1"),
+    }
+    with pytest.raises(ValidationError, match=r"Adjudicator ID 'did:web:adj' is not in nodes registry\."):
+        CouncilTopologyManifest(
+            adjudicator_id="did:web:adj",
+            nodes=nodes
+        )
+
+def test_dag_topology_verify_edges_exist():
+    nodes = {
+        "did:web:n1": SystemNodeProfile(description="Worker 1"),
+        "did:web:n2": SystemNodeProfile(description="Worker 2"),
+        "did:web:n3": SystemNodeProfile(description="Worker 3"),
+    }
+
+    manifest = DAGTopologyManifest(
+        nodes=nodes,
+        edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3")],
+        max_depth=10,
+        max_fan_out=10
+    )
+    assert manifest.edges == sorted([("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3")])
+
+    draft_manifest = DAGTopologyManifest(
+        lifecycle_phase="draft",
+        nodes=nodes,
+        edges=[("did:web:n1", "did:web:missing")],
+        max_depth=10,
+        max_fan_out=10
+    )
+    assert len(draft_manifest.edges) == 1
+
+    with pytest.raises(ValidationError, match=r"Edge source 'did:web:missing' does not exist in nodes registry\."):
+        DAGTopologyManifest(
+            nodes=nodes,
+            edges=[("did:web:missing", "did:web:n2")],
+            max_depth=10,
+            max_fan_out=10
+        )
+
+    with pytest.raises(ValidationError, match=r"Edge target 'did:web:missing' does not exist in nodes registry\."):
+        DAGTopologyManifest(
+            nodes=nodes,
+            edges=[("did:web:n1", "did:web:missing")],
+            max_depth=10,
+            max_fan_out=10
+        )
+
+    with pytest.raises(ValidationError, match=r"Graph contains cycles but allow_cycles is False\."):
+        DAGTopologyManifest(
+            nodes=nodes,
+            edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")],
+            max_depth=10,
+            max_fan_out=10
+        )
+
+    with pytest.raises(ValidationError, match=r"Graph contains cycles but allow_cycles is False\."):
+        DAGTopologyManifest(
+            nodes=nodes,
+            edges=[("did:web:n1", "did:web:n1")],
+            max_depth=10,
+            max_fan_out=10
+        )
+
+    manifest_cycles = DAGTopologyManifest(
+        nodes=nodes,
+        edges=[("did:web:n1", "did:web:n2"), ("did:web:n2", "did:web:n3"), ("did:web:n3", "did:web:n1")],
+        max_depth=10,
+        max_fan_out=10,
+        allow_cycles=True
+    )
+    assert len(manifest_cycles.edges) == 3
+
+def test_task_award_receipt():
+    with pytest.raises(ValidationError, match=r"Escrow locked amount cannot exceed the total cleared price\."):
+        TaskAwardReceipt(
+            task_id="task-1",
+            awarded_syndicate={"did:web:n1": 100},
+            cleared_price_magnitude=100,
+            escrow=EscrowPolicy(
+                escrow_locked_magnitude=200,
+                release_condition_metric="pass",
+                refund_target_node_id="did:web:user"
+            )
+        )
+
+    with pytest.raises(ValidationError, match="Syndicate allocation sum must exactly equal cleared_price_magnitude"):
+        TaskAwardReceipt(
+            task_id="task-1",
+            awarded_syndicate={"did:web:n1": 50, "did:web:n2": 40},
+            cleared_price_magnitude=100
+        )
+
+    valid_receipt = TaskAwardReceipt(
+        task_id="task-1",
+        awarded_syndicate={"did:web:n1": 60, "did:web:n2": 40},
+        cleared_price_magnitude=100,
+        escrow=EscrowPolicy(
+            escrow_locked_magnitude=50,
+            release_condition_metric="pass",
+            refund_target_node_id="did:web:user"
+        )
+    )
+    assert valid_receipt.cleared_price_magnitude == 100
+
+def test_market_contract():
+    with pytest.raises(ValidationError, match=r"ECONOMIC INVARIANT VIOLATION: slashing_penalty cannot exceed minimum_collateral\."):
+        MarketContract(
+            minimum_collateral=100.0,
+            slashing_penalty=150.0
+        )
+
+    mc = MarketContract(minimum_collateral=100.0, slashing_penalty=50.0)
+    assert mc.slashing_penalty == 50.0
+
+def test_multimodal_token_anchor_state():
+    with pytest.raises(ValidationError, match=r"If token_span_start is defined, token_span_end MUST be defined\."):
+        MultimodalTokenAnchorState(token_span_start=10)
+
+    with pytest.raises(ValidationError, match=r"token_span_end cannot be defined without a token_span_start\."):
+        MultimodalTokenAnchorState(token_span_end=20)
+
+    with pytest.raises(ValidationError, match=r"token_span_end MUST be strictly greater than token_span_start\."):
+        MultimodalTokenAnchorState(token_span_start=10, token_span_end=10)
+
+    with pytest.raises(ValidationError, match=r"Spatial invariant violated: min bounds .* exceed max bounds .*"):
+        MultimodalTokenAnchorState(bounding_box=(0.8, 0.2, 0.5, 0.6))
+
+    with pytest.raises(ValidationError, match=r"Spatial invariant violated: min bounds .* exceed max bounds .*"):
+        MultimodalTokenAnchorState(bounding_box=(0.2, 0.8, 0.5, 0.6))
+
+    valid = MultimodalTokenAnchorState(
+        token_span_start=10,
+        token_span_end=20,
+        bounding_box=(0.1, 0.2, 0.5, 0.6)
+    )
+    assert valid.token_span_end == 20
+    assert valid.bounding_box == (0.1, 0.2, 0.5, 0.6)


### PR DESCRIPTION
Added new unit tests targeting validation edge cases for `ontology.py` classes.
Fixed a bug in `ontology.py` `BrowserDOMState` where `except ValueError, OverflowError` raised a Python `SyntaxError`.

---
*PR created automatically by Jules for task [15331238234964437680](https://jules.google.com/task/15331238234964437680) started by @gowthamrao*