### PR TITLE
Add tests for apply_state_differential in utils/algebra.py

### DIFF
--- a/tests/contracts/test_state_differential.py
+++ b/tests/contracts/test_state_differential.py
@@ -1,124 +1,200 @@
 import pytest
-from coreason_manifest.utils.algebra import apply_state_differential
+
 from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMutationIntent
+from coreason_manifest.utils.algebra import apply_state_differential
+
 
 def test_apply_state_differential_add_dict():
     current_state = {"a": 1}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="add", path="/b", value=2)]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="add", path="/b", value=2)],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": 1, "b": 2}
     assert current_state == {"a": 1}
 
+
 def test_apply_state_differential_add_list_append():
     current_state = {"a": [1, 2]}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="add", path="/a/-", value=3)]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="add", path="/a/-", value=3)],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": [1, 2, 3]}
 
+
 def test_apply_state_differential_add_list_insert():
     current_state = {"a": [1, 2]}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="add", path="/a/0", value=0)]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="add", path="/a/0", value=0)],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": [0, 1, 2]}
 
+
 def test_apply_state_differential_remove_dict():
     current_state = {"a": 1, "b": 2}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="remove", path="/b")]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="remove", path="/b")],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": 1}
 
+
 def test_apply_state_differential_remove_list():
     current_state = {"a": [1, 2, 3]}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="remove", path="/a/1")]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="remove", path="/a/1")],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": [1, 3]}
 
+
 def test_apply_state_differential_replace_dict():
     current_state = {"a": 1}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="replace", path="/a", value=2)]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="replace", path="/a", value=2)],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": 2}
 
+
 def test_apply_state_differential_replace_list():
     current_state = {"a": [1, 2, 3]}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="replace", path="/a/1", value=4)]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="replace", path="/a/1", value=4)],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": [1, 4, 3]}
 
+
 def test_apply_state_differential_move():
     current_state = {"a": {"b": 1}, "c": {}}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="move", **{"from": "/a/b", "path": "/c/b"})]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="move", **{"from": "/a/b", "path": "/c/b"})],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": {}, "c": {"b": 1}}
 
+
 def test_apply_state_differential_copy():
     current_state = {"a": {"b": 1}, "c": {}}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="copy", **{"from": "/a/b", "path": "/c/b"})]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="copy", **{"from": "/a/b", "path": "/c/b"})],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": {"b": 1}, "c": {"b": 1}}
 
+
 def test_apply_state_differential_test_success():
     current_state = {"a": 1}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="test", path="/a", value=1)]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="test", path="/a", value=1)],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": 1}
+
 
 def test_apply_state_differential_test_fail():
     current_state = {"a": 1}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="test", path="/a", value=2)]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="test", path="/a", value=2)],
     )
-    with pytest.raises(ValueError, match="Patch test operation failed."):
+    with pytest.raises(ValueError, match=r"Patch test operation failed\."):
         apply_state_differential(current_state, manifest)
+
 
 def test_apply_state_differential_test_fail_root():
     current_state = {"a": 1}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="test", path="", value={"a": 2})]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="test", path="", value={"a": 2})],
     )
-    with pytest.raises(ValueError, match="Patch test operation failed."):
+    with pytest.raises(ValueError, match=r"Patch test operation failed\."):
         apply_state_differential(current_state, manifest)
+
 
 def test_apply_state_differential_test_success_root():
     current_state = {"a": 1}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="test", path="", value={"a": 1})]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="test", path="", value={"a": 1})],
     )
     new_state = apply_state_differential(current_state, manifest)
     assert new_state == {"a": 1}
 
+
 def test_apply_state_differential_invalid_op_root():
     current_state = {"a": 1}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="add", path="", value={"a": 1})]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="add", path="", value={"a": 1})],
     )
     with pytest.raises(ValueError, match="Invalid path or root operation not supported"):
         apply_state_differential(current_state, manifest)
 
+
 def test_apply_state_differential_invalid_pointer():
     current_state = {"a": 1}
-    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
-        patches=[StateMutationIntent(op="add", path="invalid", value=1)]
+    manifest = StateDifferentialManifest(
+        diff_id="id",
+        author_node_id="node",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="add", path="invalid", value=1)],
     )
     with pytest.raises(ValueError, match="Invalid JSON pointer"):
         apply_state_differential(current_state, manifest)

--- a/tests/contracts/test_state_differential.py
+++ b/tests/contracts/test_state_differential.py
@@ -4,7 +4,7 @@ from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMuta
 from coreason_manifest.utils.algebra import apply_state_differential
 
 
-def test_apply_state_differential_add_dict():
+def test_apply_state_differential_add_dict() -> None:
     current_state = {"a": 1}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -18,7 +18,7 @@ def test_apply_state_differential_add_dict():
     assert current_state == {"a": 1}
 
 
-def test_apply_state_differential_add_list_append():
+def test_apply_state_differential_add_list_append() -> None:
     current_state = {"a": [1, 2]}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -31,7 +31,7 @@ def test_apply_state_differential_add_list_append():
     assert new_state == {"a": [1, 2, 3]}
 
 
-def test_apply_state_differential_add_list_insert():
+def test_apply_state_differential_add_list_insert() -> None:
     current_state = {"a": [1, 2]}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -44,7 +44,7 @@ def test_apply_state_differential_add_list_insert():
     assert new_state == {"a": [0, 1, 2]}
 
 
-def test_apply_state_differential_remove_dict():
+def test_apply_state_differential_remove_dict() -> None:
     current_state = {"a": 1, "b": 2}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -57,7 +57,7 @@ def test_apply_state_differential_remove_dict():
     assert new_state == {"a": 1}
 
 
-def test_apply_state_differential_remove_list():
+def test_apply_state_differential_remove_list() -> None:
     current_state = {"a": [1, 2, 3]}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -70,7 +70,7 @@ def test_apply_state_differential_remove_list():
     assert new_state == {"a": [1, 3]}
 
 
-def test_apply_state_differential_replace_dict():
+def test_apply_state_differential_replace_dict() -> None:
     current_state = {"a": 1}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -83,7 +83,7 @@ def test_apply_state_differential_replace_dict():
     assert new_state == {"a": 2}
 
 
-def test_apply_state_differential_replace_list():
+def test_apply_state_differential_replace_list() -> None:
     current_state = {"a": [1, 2, 3]}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -96,7 +96,7 @@ def test_apply_state_differential_replace_list():
     assert new_state == {"a": [1, 4, 3]}
 
 
-def test_apply_state_differential_move():
+def test_apply_state_differential_move() -> None:
     current_state = {"a": {"b": 1}, "c": {}}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -109,7 +109,7 @@ def test_apply_state_differential_move():
     assert new_state == {"a": {}, "c": {"b": 1}}
 
 
-def test_apply_state_differential_copy():
+def test_apply_state_differential_copy() -> None:
     current_state = {"a": {"b": 1}, "c": {}}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -122,7 +122,7 @@ def test_apply_state_differential_copy():
     assert new_state == {"a": {"b": 1}, "c": {"b": 1}}
 
 
-def test_apply_state_differential_test_success():
+def test_apply_state_differential_test_success() -> None:
     current_state = {"a": 1}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -135,7 +135,7 @@ def test_apply_state_differential_test_success():
     assert new_state == {"a": 1}
 
 
-def test_apply_state_differential_test_fail():
+def test_apply_state_differential_test_fail() -> None:
     current_state = {"a": 1}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -148,7 +148,7 @@ def test_apply_state_differential_test_fail():
         apply_state_differential(current_state, manifest)
 
 
-def test_apply_state_differential_test_fail_root():
+def test_apply_state_differential_test_fail_root() -> None:
     current_state = {"a": 1}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -161,7 +161,7 @@ def test_apply_state_differential_test_fail_root():
         apply_state_differential(current_state, manifest)
 
 
-def test_apply_state_differential_test_success_root():
+def test_apply_state_differential_test_success_root() -> None:
     current_state = {"a": 1}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -174,7 +174,7 @@ def test_apply_state_differential_test_success_root():
     assert new_state == {"a": 1}
 
 
-def test_apply_state_differential_invalid_op_root():
+def test_apply_state_differential_invalid_op_root() -> None:
     current_state = {"a": 1}
     manifest = StateDifferentialManifest(
         diff_id="id",
@@ -187,7 +187,7 @@ def test_apply_state_differential_invalid_op_root():
         apply_state_differential(current_state, manifest)
 
 
-def test_apply_state_differential_invalid_pointer():
+def test_apply_state_differential_invalid_pointer() -> None:
     current_state = {"a": 1}
     manifest = StateDifferentialManifest(
         diff_id="id",

--- a/tests/contracts/test_state_differential.py
+++ b/tests/contracts/test_state_differential.py
@@ -1,0 +1,124 @@
+import pytest
+from coreason_manifest.utils.algebra import apply_state_differential
+from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMutationIntent
+
+def test_apply_state_differential_add_dict():
+    current_state = {"a": 1}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="add", path="/b", value=2)]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": 1, "b": 2}
+    assert current_state == {"a": 1}
+
+def test_apply_state_differential_add_list_append():
+    current_state = {"a": [1, 2]}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="add", path="/a/-", value=3)]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": [1, 2, 3]}
+
+def test_apply_state_differential_add_list_insert():
+    current_state = {"a": [1, 2]}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="add", path="/a/0", value=0)]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": [0, 1, 2]}
+
+def test_apply_state_differential_remove_dict():
+    current_state = {"a": 1, "b": 2}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="remove", path="/b")]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": 1}
+
+def test_apply_state_differential_remove_list():
+    current_state = {"a": [1, 2, 3]}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="remove", path="/a/1")]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": [1, 3]}
+
+def test_apply_state_differential_replace_dict():
+    current_state = {"a": 1}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="replace", path="/a", value=2)]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": 2}
+
+def test_apply_state_differential_replace_list():
+    current_state = {"a": [1, 2, 3]}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="replace", path="/a/1", value=4)]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": [1, 4, 3]}
+
+def test_apply_state_differential_move():
+    current_state = {"a": {"b": 1}, "c": {}}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="move", **{"from": "/a/b", "path": "/c/b"})]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": {}, "c": {"b": 1}}
+
+def test_apply_state_differential_copy():
+    current_state = {"a": {"b": 1}, "c": {}}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="copy", **{"from": "/a/b", "path": "/c/b"})]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": {"b": 1}, "c": {"b": 1}}
+
+def test_apply_state_differential_test_success():
+    current_state = {"a": 1}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="test", path="/a", value=1)]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": 1}
+
+def test_apply_state_differential_test_fail():
+    current_state = {"a": 1}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="test", path="/a", value=2)]
+    )
+    with pytest.raises(ValueError, match="Patch test operation failed."):
+        apply_state_differential(current_state, manifest)
+
+def test_apply_state_differential_test_fail_root():
+    current_state = {"a": 1}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="test", path="", value={"a": 2})]
+    )
+    with pytest.raises(ValueError, match="Patch test operation failed."):
+        apply_state_differential(current_state, manifest)
+
+def test_apply_state_differential_test_success_root():
+    current_state = {"a": 1}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="test", path="", value={"a": 1})]
+    )
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": 1}
+
+def test_apply_state_differential_invalid_op_root():
+    current_state = {"a": 1}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="add", path="", value={"a": 1})]
+    )
+    with pytest.raises(ValueError, match="Invalid path or root operation not supported"):
+        apply_state_differential(current_state, manifest)
+
+def test_apply_state_differential_invalid_pointer():
+    current_state = {"a": 1}
+    manifest = StateDifferentialManifest(diff_id="id", author_node_id="node", lamport_timestamp=1, vector_clock={},
+        patches=[StateMutationIntent(op="add", path="invalid", value=1)]
+    )
+    with pytest.raises(ValueError, match="Invalid JSON pointer"):
+        apply_state_differential(current_state, manifest)


### PR DESCRIPTION
Added comprehensive tests for `apply_state_differential` to improve coverage and verify JSON patch functionality (add, remove, replace, move, copy, test).

---
*PR created automatically by Jules for task [15984563148971522153](https://jules.google.com/task/15984563148971522153) started by @gowthamrao*