### PR TITLE
Fix release workflow for PyPI Trusted Publishing and version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*.*.*'
+      - '*.*.*'
 
 permissions:
   contents: write
@@ -12,6 +13,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: pypi
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,6 +40,9 @@ jobs:
           format: spdx-json
           output-file: sbom.spdx.json
 
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
       - name: Sign Wheel
         uses: sigstore/gh-action-sigstore-python@v3.0.0
         with:
@@ -57,9 +62,6 @@ jobs:
             dist/*.tar.gz.crt
             coreason_ontology.schema.json
             sbom.spdx.json
-
-      - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
 
       - name: Configure Git Author
         run: |


### PR DESCRIPTION
This updates `.github/workflows/release.yml` with the following fixes:
1. Reordered the PyPI publish step to occur before Sigstore signing to prevent `.sig` and `.crt` files from being uploaded to PyPI, avoiding 400 Bad Request errors.
2. Added `environment: pypi` to the `release` job to provide the required OIDC configuration for PyPI Trusted Publishing.
3. Updated the push tag triggers to support both `v*.*.*` and `*.*.*` formats to allow standard semantic versions without a 'v' prefix.

---
*PR created automatically by Jules for task [6381581930978383910](https://jules.google.com/task/6381581930978383910) started by @gowthamrao*