### PR TITLE
Fix PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/*.whl.sig
-            dist/*.tar.gz.sig
-            dist/*.whl.crt
-            dist/*.tar.gz.crt
+            dist/*.sigstore.json
             coreason_ontology.schema.json
             sbom.spdx.json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "coreason_manifest"
-version = "0.25.1"
+dynamic = ["version"]
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -107,3 +107,6 @@ exclude_lines = [
     "if os.name == \"posix\":",
     "\\.\\.\\.",
 ]
+
+[tool.hatch.version]
+source = "vcs"

--- a/uv.lock
+++ b/uv.lock
@@ -100,7 +100,6 @@ wheels = [
 
 [[package]]
 name = "coreason-manifest"
-version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
Fixes the automated PyPI release workflow.

- Modifies `pyproject.toml` to dynamically determine version via `hatch-vcs` to prevent 400 Bad Request file already exists from PyPI when publishing new tags.
- Modifies `release.yml` to pick up `dist/*.sigstore.json` generated by Sigstore Action v3.0.0 instead of looking for deprecated `.sig` and `.crt` files.

---
*PR created automatically by Jules for task [14535941633436408137](https://jules.google.com/task/14535941633436408137) started by @gowthamrao*