### PR TITLE
Fix PyPI release workflow: dynamic versioning and sigstore artifact p…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,10 +56,7 @@ jobs:
           files: |
             dist/*.whl
             dist/*.tar.gz
-            dist/*.whl.sig
-            dist/*.tar.gz.sig
-            dist/*.whl.crt
-            dist/*.tar.gz.crt
+            dist/*.sigstore.json
             coreason_ontology.schema.json
             sbom.spdx.json
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "coreason_manifest"
-version = "0.25.1"
+dynamic = ["version"]
 description = "This package is the definitive source of truth. If it isn't in the manifest, it doesn't exist. If it violates the manifest, it doesn't run."
 readme = "README.md"
 requires-python = ">=3.14"
@@ -107,3 +107,6 @@ exclude_lines = [
     "if os.name == \"posix\":",
     "\\.\\.\\.",
 ]
+
+[tool.hatch.version]
+source = "vcs"

--- a/uv.lock
+++ b/uv.lock
@@ -100,7 +100,6 @@ wheels = [
 
 [[package]]
 name = "coreason-manifest"
-version = "0.25.1"
 source = { editable = "." }
 dependencies = [
     { name = "pydantic" },


### PR DESCRIPTION
…aths (#1212)

1. Switched from static version `0.25.1` to dynamic VCS versioning using `hatch-vcs` in `pyproject.toml`.
2. Updated `.github/workflows/release.yml` to use `dist/*.sigstore.json` for the Sigstore artifact instead of the deprecated detached signatures and certificates.