### PR TITLE
feat: add epistemic distillation schemas and contracts

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1004,7 +1004,6 @@
           "council": "#/$defs/CouncilTopologyManifest",
           "dag": "#/$defs/DAGTopologyManifest",
           "digital_twin": "#/$defs/DigitalTwinTopologyManifest",
-          "epistemic_domain_graph_manifest": "#/$defs/EpistemicDomainGraphManifest",
           "evaluator_optimizer": "#/$defs/EvaluatorOptimizerTopologyManifest",
           "evolutionary": "#/$defs/EvolutionaryTopologyManifest",
           "macro_adversarial": "#/$defs/AdversarialMarketTopologyManifest",
@@ -1041,9 +1040,6 @@
         },
         {
           "$ref": "#/$defs/ConsensusFederationTopologyManifest"
-        },
-        {
-          "$ref": "#/$defs/EpistemicDomainGraphManifest"
         }
       ]
     },
@@ -2126,35 +2122,65 @@
       "title": "CognitiveCritiqueProfile",
       "type": "object"
     },
+    "CognitiveDualVerificationReceipt": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nCognitive Dual Verification Receipt.",
+      "properties": {
+        "primary_verifier_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "primary verifier id."
+        },
+        "secondary_verifier_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "secondary verifier id."
+        },
+        "trace_factual_alignment": {
+          "description": "trace factual alignment.",
+          "title": "Trace Factual Alignment",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "primary_verifier_id",
+        "secondary_verifier_id",
+        "trace_factual_alignment"
+      ],
+      "title": "CognitiveDualVerificationReceipt",
+      "type": "object"
+    },
     "CognitivePredictionReceipt": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology: Cognitive Prediction Receipt.",
+      "description": "CoReason Shared Kernel Ontology\n\nCognitive Prediction Receipt.",
       "properties": {
+        "event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "title": "Timestamp",
+          "type": "number"
+        },
         "type": {
           "const": "cognitive_prediction",
           "default": "cognitive_prediction",
-          "description": "CoReason Shared Kernel Ontology: Discriminator type for cognitive prediction.",
+          "description": "Discriminator type for cognitive prediction.",
           "title": "Type",
           "type": "string"
         },
-        "prediction_id": {
-          "description": "CoReason Shared Kernel Ontology: prediction id.",
-          "minLength": 1,
-          "title": "Prediction Id",
-          "type": "string"
-        },
         "source_chain_id": {
-          "description": "CoReason Shared Kernel Ontology: source chain id.",
+          "description": "source chain id.",
           "title": "Source Chain Id",
           "type": "string"
         },
         "target_source_concept": {
-          "description": "CoReason Shared Kernel Ontology: target source concept.",
+          "description": "target source concept.",
           "title": "Target Source Concept",
           "type": "string"
         },
         "predicted_top_k_tokens": {
-          "description": "CoReason Shared Kernel Ontology: predicted top k tokens.",
+          "description": "predicted top k tokens.",
           "items": {
             "type": "string"
           },
@@ -2164,12 +2190,49 @@
         }
       },
       "required": [
-        "prediction_id",
+        "event_id",
+        "timestamp",
         "source_chain_id",
         "target_source_concept",
         "predicted_top_k_tokens"
       ],
       "title": "CognitivePredictionReceipt",
+      "type": "object"
+    },
+    "CognitiveReasoningTraceState": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nCognitive Reasoning Trace State.",
+      "properties": {
+        "trace_id": {
+          "description": "trace id.",
+          "minLength": 1,
+          "title": "Trace Id",
+          "type": "string"
+        },
+        "source_proof_id": {
+          "description": "source proof id.",
+          "title": "Source Proof Id",
+          "type": "string"
+        },
+        "token_length": {
+          "description": "token length.",
+          "minimum": 0,
+          "title": "Token Length",
+          "type": "integer"
+        },
+        "trace_payload": {
+          "description": "trace payload.",
+          "title": "Trace Payload",
+          "type": "string"
+        }
+      },
+      "required": [
+        "trace_id",
+        "source_proof_id",
+        "token_length",
+        "trace_payload"
+      ],
+      "title": "CognitiveReasoningTraceState",
       "type": "object"
     },
     "CognitiveRoutingContract": {
@@ -2208,6 +2271,29 @@
         "routing_temperature"
       ],
       "title": "CognitiveRoutingContract",
+      "type": "object"
+    },
+    "CognitiveSamplingPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nCognitive Sampling Policy.",
+      "properties": {
+        "max_complexity_hops": {
+          "description": "max complexity hops.",
+          "minimum": 1,
+          "title": "Max Complexity Hops",
+          "type": "integer"
+        },
+        "inverse_frequency_smoothing_epsilon": {
+          "default": 1.0,
+          "description": "inverse frequency smoothing epsilon.",
+          "title": "Inverse Frequency Smoothing Epsilon",
+          "type": "number"
+        }
+      },
+      "required": [
+        "max_complexity_hops"
+      ],
+      "title": "CognitiveSamplingPolicy",
       "type": "object"
     },
     "CognitiveStateProfile": {
@@ -4208,20 +4294,20 @@
     },
     "EpistemicAxiomState": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology: Epistemic Axiom State.",
+      "description": "CoReason Shared Kernel Ontology\n\nEpistemic Axiom State.",
       "properties": {
         "source_concept_id": {
-          "description": "CoReason Shared Kernel Ontology: CID of the origin node.",
+          "description": "CID of the origin node.",
           "title": "Source Concept Id",
           "type": "string"
         },
         "directed_edge_type": {
-          "description": "CoReason Shared Kernel Ontology: the topological relationship.",
+          "description": "the topological relationship.",
           "title": "Directed Edge Type",
           "type": "string"
         },
         "target_concept_id": {
-          "description": "CoReason Shared Kernel Ontology: CID of destination node.",
+          "description": "CID of destination node.",
           "title": "Target Concept Id",
           "type": "string"
         }
@@ -4236,41 +4322,46 @@
     },
     "EpistemicAxiomVerificationReceipt": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology: Epistemic Axiom Verification Receipt.",
+      "description": "CoReason Shared Kernel Ontology\n\nEpistemic Axiom Verification Receipt.",
       "properties": {
+        "event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "title": "Timestamp",
+          "type": "number"
+        },
         "type": {
           "const": "epistemic_axiom_verification",
           "default": "epistemic_axiom_verification",
-          "description": "CoReason Shared Kernel Ontology: Discriminator type for epistemic axiom verification.",
+          "description": "Discriminator type for epistemic axiom verification.",
           "title": "Type",
           "type": "string"
         },
-        "verification_id": {
-          "description": "CoReason Shared Kernel Ontology: verification id.",
-          "minLength": 1,
-          "title": "Verification Id",
-          "type": "string"
-        },
         "source_prediction_id": {
-          "description": "CoReason Shared Kernel Ontology: source prediction id.",
+          "description": "source prediction id.",
           "title": "Source Prediction Id",
           "type": "string"
         },
         "sequence_similarity_score": {
-          "description": "CoReason Shared Kernel Ontology: sequence similarity score.",
+          "description": "sequence similarity score.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Sequence Similarity Score",
           "type": "number"
         },
         "fact_score_passed": {
-          "description": "CoReason Shared Kernel Ontology: fact score passed.",
+          "description": "fact score passed.",
           "title": "Fact Score Passed",
           "type": "boolean"
         }
       },
       "required": [
-        "verification_id",
+        "event_id",
+        "timestamp",
         "source_prediction_id",
         "sequence_similarity_score",
         "fact_score_passed"
@@ -4280,16 +4371,16 @@
     },
     "EpistemicChainGraphState": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology: Epistemic Chain Graph State.",
+      "description": "CoReason Shared Kernel Ontology\n\nEpistemic Chain Graph State.",
       "properties": {
         "chain_id": {
-          "description": "CoReason Shared Kernel Ontology: chain id.",
+          "description": "chain id.",
           "minLength": 1,
           "title": "Chain Id",
           "type": "string"
         },
         "syntactic_roots": {
-          "description": "CoReason Shared Kernel Ontology: syntactic roots.",
+          "description": "syntactic roots.",
           "items": {
             "type": "string"
           },
@@ -4298,7 +4389,7 @@
           "type": "array"
         },
         "semantic_leaves": {
-          "description": "CoReason Shared Kernel Ontology: semantic leaves.",
+          "description": "semantic leaves.",
           "items": {
             "$ref": "#/$defs/EpistemicAxiomState"
           },
@@ -4349,25 +4440,51 @@
       "title": "EpistemicCompressionSLA",
       "type": "object"
     },
+    "EpistemicCurriculumManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nEpistemic Curriculum Manifest.",
+      "properties": {
+        "curriculum_id": {
+          "description": "curriculum id.",
+          "title": "Curriculum Id",
+          "type": "string"
+        },
+        "tasks": {
+          "description": "tasks.",
+          "items": {
+            "$ref": "#/$defs/EpistemicGroundedTaskManifest"
+          },
+          "minItems": 1,
+          "title": "Tasks",
+          "type": "array"
+        }
+      },
+      "required": [
+        "curriculum_id",
+        "tasks"
+      ],
+      "title": "EpistemicCurriculumManifest",
+      "type": "object"
+    },
     "EpistemicDomainGraphManifest": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology: Epistemic Domain Graph Manifest.",
+      "description": "CoReason Shared Kernel Ontology\n\nEpistemic Domain Graph Manifest.",
       "properties": {
         "type": {
           "const": "epistemic_domain_graph_manifest",
           "default": "epistemic_domain_graph_manifest",
-          "description": "CoReason Shared Kernel Ontology: Discriminator type for epistemic domain graph manifest.",
+          "description": "Discriminator type for epistemic domain graph manifest.",
           "title": "Type",
           "type": "string"
         },
         "graph_id": {
-          "description": "CoReason Shared Kernel Ontology: graph id.",
+          "description": "graph id.",
           "minLength": 1,
           "title": "Graph Id",
           "type": "string"
         },
         "verified_axioms": {
-          "description": "CoReason Shared Kernel Ontology: verified axioms.",
+          "description": "verified axioms.",
           "items": {
             "$ref": "#/$defs/EpistemicAxiomState"
           },
@@ -4412,6 +4529,44 @@
         "max_escalation_tiers"
       ],
       "title": "EpistemicEscalationContract",
+      "type": "object"
+    },
+    "EpistemicGroundedTaskManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nEpistemic Grounded Task Manifest.",
+      "properties": {
+        "task_id": {
+          "description": "task id.",
+          "minLength": 1,
+          "title": "Task Id",
+          "type": "string"
+        },
+        "topological_proof": {
+          "$ref": "#/$defs/EpistemicTopologicalProofManifest",
+          "description": "topological proof."
+        },
+        "vignette_payload": {
+          "description": "vignette payload.",
+          "title": "Vignette Payload",
+          "type": "string"
+        },
+        "thinking_trace": {
+          "$ref": "#/$defs/CognitiveReasoningTraceState",
+          "description": "thinking trace."
+        },
+        "verification_lock": {
+          "$ref": "#/$defs/CognitiveDualVerificationReceipt",
+          "description": "verification lock."
+        }
+      },
+      "required": [
+        "task_id",
+        "topological_proof",
+        "vignette_payload",
+        "thinking_trace",
+        "verification_lock"
+      ],
+      "title": "EpistemicGroundedTaskManifest",
       "type": "object"
     },
     "EpistemicLedgerState": {
@@ -4779,17 +4934,17 @@
     },
     "EpistemicSeedInjectionPolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology: Epistemic Seed Injection Policy.",
+      "description": "CoReason Shared Kernel Ontology\n\nEpistemic Seed Injection Policy.",
       "properties": {
         "similarity_threshold_alpha": {
-          "description": "CoReason Shared Kernel Ontology: similarity threshold alpha.",
+          "description": "similarity threshold alpha.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Similarity Threshold Alpha",
           "type": "number"
         },
         "relation_diversity_bucket_size": {
-          "description": "CoReason Shared Kernel Ontology: relation diversity bucket size.",
+          "description": "relation diversity bucket size.",
           "exclusiveMinimum": 0,
           "title": "Relation Diversity Bucket Size",
           "type": "integer"
@@ -4873,6 +5028,33 @@
         "target_node_id"
       ],
       "title": "EpistemicTelemetryEvent",
+      "type": "object"
+    },
+    "EpistemicTopologicalProofManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nEpistemic Topological Proof Manifest.",
+      "properties": {
+        "proof_id": {
+          "description": "proof id.",
+          "minLength": 1,
+          "title": "Proof Id",
+          "type": "string"
+        },
+        "axiomatic_chain": {
+          "description": "axiomatic chain.",
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "minItems": 1,
+          "title": "Axiomatic Chain",
+          "type": "array"
+        }
+      },
+      "required": [
+        "proof_id",
+        "axiomatic_chain"
+      ],
+      "title": "EpistemicTopologicalProofManifest",
       "type": "object"
     },
     "EpistemicTransmutationTask": {

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -916,7 +916,9 @@
           "barge_in": "#/$defs/BargeInInterruptEvent",
           "belief_mutation": "#/$defs/BeliefMutationEvent",
           "budget_exhaustion": "#/$defs/BudgetExhaustionEvent",
+          "cognitive_prediction": "#/$defs/CognitivePredictionReceipt",
           "counterfactual_regret": "#/$defs/CounterfactualRegretEvent",
+          "epistemic_axiom_verification": "#/$defs/EpistemicAxiomVerificationReceipt",
           "epistemic_promotion": "#/$defs/EpistemicPromotionEvent",
           "epistemic_telemetry": "#/$defs/EpistemicTelemetryEvent",
           "hypothesis": "#/$defs/HypothesisGenerationEvent",
@@ -968,6 +970,12 @@
         },
         {
           "$ref": "#/$defs/EpistemicTelemetryEvent"
+        },
+        {
+          "$ref": "#/$defs/CognitivePredictionReceipt"
+        },
+        {
+          "$ref": "#/$defs/EpistemicAxiomVerificationReceipt"
         }
       ]
     },
@@ -996,6 +1004,7 @@
           "council": "#/$defs/CouncilTopologyManifest",
           "dag": "#/$defs/DAGTopologyManifest",
           "digital_twin": "#/$defs/DigitalTwinTopologyManifest",
+          "epistemic_domain_graph_manifest": "#/$defs/EpistemicDomainGraphManifest",
           "evaluator_optimizer": "#/$defs/EvaluatorOptimizerTopologyManifest",
           "evolutionary": "#/$defs/EvolutionaryTopologyManifest",
           "macro_adversarial": "#/$defs/AdversarialMarketTopologyManifest",
@@ -1032,6 +1041,9 @@
         },
         {
           "$ref": "#/$defs/ConsensusFederationTopologyManifest"
+        },
+        {
+          "$ref": "#/$defs/EpistemicDomainGraphManifest"
         }
       ]
     },
@@ -2112,6 +2124,52 @@
         "epistemic_penalty_scalar"
       ],
       "title": "CognitiveCritiqueProfile",
+      "type": "object"
+    },
+    "CognitivePredictionReceipt": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology: Cognitive Prediction Receipt.",
+      "properties": {
+        "type": {
+          "const": "cognitive_prediction",
+          "default": "cognitive_prediction",
+          "description": "CoReason Shared Kernel Ontology: Discriminator type for cognitive prediction.",
+          "title": "Type",
+          "type": "string"
+        },
+        "prediction_id": {
+          "description": "CoReason Shared Kernel Ontology: prediction id.",
+          "minLength": 1,
+          "title": "Prediction Id",
+          "type": "string"
+        },
+        "source_chain_id": {
+          "description": "CoReason Shared Kernel Ontology: source chain id.",
+          "title": "Source Chain Id",
+          "type": "string"
+        },
+        "target_source_concept": {
+          "description": "CoReason Shared Kernel Ontology: target source concept.",
+          "title": "Target Source Concept",
+          "type": "string"
+        },
+        "predicted_top_k_tokens": {
+          "description": "CoReason Shared Kernel Ontology: predicted top k tokens.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Predicted Top K Tokens",
+          "type": "array"
+        }
+      },
+      "required": [
+        "prediction_id",
+        "source_chain_id",
+        "target_source_concept",
+        "predicted_top_k_tokens"
+      ],
+      "title": "CognitivePredictionReceipt",
       "type": "object"
     },
     "CognitiveRoutingContract": {
@@ -4148,6 +4206,114 @@
       "title": "EpistemicArgumentGraphState",
       "type": "object"
     },
+    "EpistemicAxiomState": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology: Epistemic Axiom State.",
+      "properties": {
+        "source_concept_id": {
+          "description": "CoReason Shared Kernel Ontology: CID of the origin node.",
+          "title": "Source Concept Id",
+          "type": "string"
+        },
+        "directed_edge_type": {
+          "description": "CoReason Shared Kernel Ontology: the topological relationship.",
+          "title": "Directed Edge Type",
+          "type": "string"
+        },
+        "target_concept_id": {
+          "description": "CoReason Shared Kernel Ontology: CID of destination node.",
+          "title": "Target Concept Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_concept_id",
+        "directed_edge_type",
+        "target_concept_id"
+      ],
+      "title": "EpistemicAxiomState",
+      "type": "object"
+    },
+    "EpistemicAxiomVerificationReceipt": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology: Epistemic Axiom Verification Receipt.",
+      "properties": {
+        "type": {
+          "const": "epistemic_axiom_verification",
+          "default": "epistemic_axiom_verification",
+          "description": "CoReason Shared Kernel Ontology: Discriminator type for epistemic axiom verification.",
+          "title": "Type",
+          "type": "string"
+        },
+        "verification_id": {
+          "description": "CoReason Shared Kernel Ontology: verification id.",
+          "minLength": 1,
+          "title": "Verification Id",
+          "type": "string"
+        },
+        "source_prediction_id": {
+          "description": "CoReason Shared Kernel Ontology: source prediction id.",
+          "title": "Source Prediction Id",
+          "type": "string"
+        },
+        "sequence_similarity_score": {
+          "description": "CoReason Shared Kernel Ontology: sequence similarity score.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Sequence Similarity Score",
+          "type": "number"
+        },
+        "fact_score_passed": {
+          "description": "CoReason Shared Kernel Ontology: fact score passed.",
+          "title": "Fact Score Passed",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "verification_id",
+        "source_prediction_id",
+        "sequence_similarity_score",
+        "fact_score_passed"
+      ],
+      "title": "EpistemicAxiomVerificationReceipt",
+      "type": "object"
+    },
+    "EpistemicChainGraphState": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology: Epistemic Chain Graph State.",
+      "properties": {
+        "chain_id": {
+          "description": "CoReason Shared Kernel Ontology: chain id.",
+          "minLength": 1,
+          "title": "Chain Id",
+          "type": "string"
+        },
+        "syntactic_roots": {
+          "description": "CoReason Shared Kernel Ontology: syntactic roots.",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Syntactic Roots",
+          "type": "array"
+        },
+        "semantic_leaves": {
+          "description": "CoReason Shared Kernel Ontology: semantic leaves.",
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "title": "Semantic Leaves",
+          "type": "array"
+        }
+      },
+      "required": [
+        "chain_id",
+        "syntactic_roots",
+        "semantic_leaves"
+      ],
+      "title": "EpistemicChainGraphState",
+      "type": "object"
+    },
     "EpistemicCompressionSLA": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology",
@@ -4181,6 +4347,40 @@
         "required_grounding_density"
       ],
       "title": "EpistemicCompressionSLA",
+      "type": "object"
+    },
+    "EpistemicDomainGraphManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology: Epistemic Domain Graph Manifest.",
+      "properties": {
+        "type": {
+          "const": "epistemic_domain_graph_manifest",
+          "default": "epistemic_domain_graph_manifest",
+          "description": "CoReason Shared Kernel Ontology: Discriminator type for epistemic domain graph manifest.",
+          "title": "Type",
+          "type": "string"
+        },
+        "graph_id": {
+          "description": "CoReason Shared Kernel Ontology: graph id.",
+          "minLength": 1,
+          "title": "Graph Id",
+          "type": "string"
+        },
+        "verified_axioms": {
+          "description": "CoReason Shared Kernel Ontology: verified axioms.",
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "minItems": 1,
+          "title": "Verified Axioms",
+          "type": "array"
+        }
+      },
+      "required": [
+        "graph_id",
+        "verified_axioms"
+      ],
+      "title": "EpistemicDomainGraphManifest",
       "type": "object"
     },
     "EpistemicEscalationContract": {
@@ -4575,6 +4775,31 @@
         "action_on_gap"
       ],
       "title": "EpistemicScanningPolicy",
+      "type": "object"
+    },
+    "EpistemicSeedInjectionPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology: Epistemic Seed Injection Policy.",
+      "properties": {
+        "similarity_threshold_alpha": {
+          "description": "CoReason Shared Kernel Ontology: similarity threshold alpha.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Similarity Threshold Alpha",
+          "type": "number"
+        },
+        "relation_diversity_bucket_size": {
+          "description": "CoReason Shared Kernel Ontology: relation diversity bucket size.",
+          "exclusiveMinimum": 0,
+          "title": "Relation Diversity Bucket Size",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "similarity_threshold_alpha",
+        "relation_diversity_bucket_size"
+      ],
+      "title": "EpistemicSeedInjectionPolicy",
       "type": "object"
     },
     "EpistemicTelemetryEvent": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -4930,6 +4930,106 @@ class ConsensusFederationTopologyManifest(CoreasonBaseState):
         )
 
 
+class EpistemicAxiomState(CoreasonBaseState):
+    """CoReason Shared Kernel Ontology: Epistemic Axiom State."""
+
+    source_concept_id: str = Field(description="CoReason Shared Kernel Ontology: CID of the origin node.")
+    directed_edge_type: str = Field(description="CoReason Shared Kernel Ontology: the topological relationship.")
+    target_concept_id: str = Field(description="CoReason Shared Kernel Ontology: CID of destination node.")
+
+
+class EpistemicSeedInjectionPolicy(CoreasonBaseState):
+    """CoReason Shared Kernel Ontology: Epistemic Seed Injection Policy."""
+
+    similarity_threshold_alpha: float = Field(
+        ge=0.0, le=1.0, description="CoReason Shared Kernel Ontology: similarity threshold alpha."
+    )
+    relation_diversity_bucket_size: int = Field(
+        gt=0, description="CoReason Shared Kernel Ontology: relation diversity bucket size."
+    )
+
+
+class EpistemicChainGraphState(CoreasonBaseState):
+    """CoReason Shared Kernel Ontology: Epistemic Chain Graph State."""
+
+    chain_id: str = Field(min_length=1, description="CoReason Shared Kernel Ontology: chain id.")
+    syntactic_roots: list[str] = Field(min_length=1, description="CoReason Shared Kernel Ontology: syntactic roots.")
+    # Note: syntactic_roots is a structurally ordered sequence (Linguistic Syntax) and MUST NOT be sorted.
+    semantic_leaves: list[EpistemicAxiomState] = Field(description="CoReason Shared Kernel Ontology: semantic leaves.")
+
+    @model_validator(mode="after")
+    def sort_semantic_leaves(self) -> Self:
+        object.__setattr__(
+            self,
+            "semantic_leaves",
+            sorted(
+                self.semantic_leaves, key=lambda x: (x.source_concept_id, x.directed_edge_type, x.target_concept_id)
+            ),
+        )
+        return self
+
+
+class CognitivePredictionReceipt(CoreasonBaseState):
+    """CoReason Shared Kernel Ontology: Cognitive Prediction Receipt."""
+
+    type: Literal["cognitive_prediction"] = Field(
+        default="cognitive_prediction",
+        description="CoReason Shared Kernel Ontology: Discriminator type for cognitive prediction.",
+    )
+    prediction_id: str = Field(min_length=1, description="CoReason Shared Kernel Ontology: prediction id.")
+    source_chain_id: str = Field(description="CoReason Shared Kernel Ontology: source chain id.")
+    target_source_concept: str = Field(description="CoReason Shared Kernel Ontology: target source concept.")
+    predicted_top_k_tokens: list[str] = Field(
+        min_length=1, description="CoReason Shared Kernel Ontology: predicted top k tokens."
+    )
+    # Note: predicted_top_k_tokens is a structurally ordered sequence (Probability Rank) and MUST NOT be sorted.
+
+
+class EpistemicAxiomVerificationReceipt(CoreasonBaseState):
+    """CoReason Shared Kernel Ontology: Epistemic Axiom Verification Receipt."""
+
+    type: Literal["epistemic_axiom_verification"] = Field(
+        default="epistemic_axiom_verification",
+        description="CoReason Shared Kernel Ontology: Discriminator type for epistemic axiom verification.",
+    )
+    verification_id: str = Field(min_length=1, description="CoReason Shared Kernel Ontology: verification id.")
+    source_prediction_id: str = Field(description="CoReason Shared Kernel Ontology: source prediction id.")
+    sequence_similarity_score: float = Field(
+        ge=0.0, le=1.0, description="CoReason Shared Kernel Ontology: sequence similarity score."
+    )
+    fact_score_passed: bool = Field(description="CoReason Shared Kernel Ontology: fact score passed.")
+
+    @model_validator(mode="after")
+    def enforce_epistemic_quarantine(self) -> Self:
+        if not self.fact_score_passed:
+            raise ValueError("Epistemic Contagion Prevented: Axioms failing validation cannot be verified.")
+        return self
+
+
+class EpistemicDomainGraphManifest(CoreasonBaseState):
+    """CoReason Shared Kernel Ontology: Epistemic Domain Graph Manifest."""
+
+    type: Literal["epistemic_domain_graph_manifest"] = Field(
+        default="epistemic_domain_graph_manifest",
+        description="CoReason Shared Kernel Ontology: Discriminator type for epistemic domain graph manifest.",
+    )
+    graph_id: str = Field(min_length=1, description="CoReason Shared Kernel Ontology: graph id.")
+    verified_axioms: list[EpistemicAxiomState] = Field(
+        min_length=1, description="CoReason Shared Kernel Ontology: verified axioms."
+    )
+
+    @model_validator(mode="after")
+    def sort_verified_axioms(self) -> Self:
+        object.__setattr__(
+            self,
+            "verified_axioms",
+            sorted(
+                self.verified_axioms, key=lambda x: (x.source_concept_id, x.directed_edge_type, x.target_concept_id)
+            ),
+        )
+        return self
+
+
 type AnyTopologyManifest = Annotated[
     DAGTopologyManifest
     | CouncilTopologyManifest
@@ -4939,7 +5039,8 @@ type AnyTopologyManifest = Annotated[
     | EvaluatorOptimizerTopologyManifest
     | DigitalTwinTopologyManifest
     | AdversarialMarketTopologyManifest
-    | ConsensusFederationTopologyManifest,
+    | ConsensusFederationTopologyManifest
+    | EpistemicDomainGraphManifest,
     Field(discriminator="type", description="A discriminated union of workflow topologies."),
 ]
 
@@ -5229,7 +5330,9 @@ type AnyStateEvent = Annotated[
     | PersistenceCommitReceipt
     | TokenBurnReceipt
     | BudgetExhaustionEvent
-    | EpistemicTelemetryEvent,
+    | EpistemicTelemetryEvent
+    | CognitivePredictionReceipt
+    | EpistemicAxiomVerificationReceipt,
     Field(discriminator="type", description="A discriminated union of state events."),
 ]
 
@@ -5305,3 +5408,8 @@ TokenBurnReceipt.model_rebuild()
 BudgetExhaustionEvent.model_rebuild()
 
 LatentProjectionIntent.model_rebuild()
+
+EpistemicChainGraphState.model_rebuild()
+CognitivePredictionReceipt.model_rebuild()
+EpistemicAxiomVerificationReceipt.model_rebuild()
+EpistemicDomainGraphManifest.model_rebuild()

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -4931,31 +4931,27 @@ class ConsensusFederationTopologyManifest(CoreasonBaseState):
 
 
 class EpistemicAxiomState(CoreasonBaseState):
-    """CoReason Shared Kernel Ontology: Epistemic Axiom State."""
+    """Epistemic Axiom State."""
 
-    source_concept_id: str = Field(description="CoReason Shared Kernel Ontology: CID of the origin node.")
-    directed_edge_type: str = Field(description="CoReason Shared Kernel Ontology: the topological relationship.")
-    target_concept_id: str = Field(description="CoReason Shared Kernel Ontology: CID of destination node.")
+    source_concept_id: str = Field(description="CID of the origin node.")
+    directed_edge_type: str = Field(description="the topological relationship.")
+    target_concept_id: str = Field(description="CID of destination node.")
 
 
 class EpistemicSeedInjectionPolicy(CoreasonBaseState):
-    """CoReason Shared Kernel Ontology: Epistemic Seed Injection Policy."""
+    """Epistemic Seed Injection Policy."""
 
-    similarity_threshold_alpha: float = Field(
-        ge=0.0, le=1.0, description="CoReason Shared Kernel Ontology: similarity threshold alpha."
-    )
-    relation_diversity_bucket_size: int = Field(
-        gt=0, description="CoReason Shared Kernel Ontology: relation diversity bucket size."
-    )
+    similarity_threshold_alpha: float = Field(ge=0.0, le=1.0, description="similarity threshold alpha.")
+    relation_diversity_bucket_size: int = Field(gt=0, description="relation diversity bucket size.")
 
 
 class EpistemicChainGraphState(CoreasonBaseState):
-    """CoReason Shared Kernel Ontology: Epistemic Chain Graph State."""
+    """Epistemic Chain Graph State."""
 
-    chain_id: str = Field(min_length=1, description="CoReason Shared Kernel Ontology: chain id.")
-    syntactic_roots: list[str] = Field(min_length=1, description="CoReason Shared Kernel Ontology: syntactic roots.")
+    chain_id: str = Field(min_length=1, description="chain id.")
+    syntactic_roots: list[str] = Field(min_length=1, description="syntactic roots.")
     # Note: syntactic_roots is a structurally ordered sequence (Linguistic Syntax) and MUST NOT be sorted.
-    semantic_leaves: list[EpistemicAxiomState] = Field(description="CoReason Shared Kernel Ontology: semantic leaves.")
+    semantic_leaves: list[EpistemicAxiomState] = Field(description="semantic leaves.")
 
     @model_validator(mode="after")
     def sort_semantic_leaves(self) -> Self:
@@ -4969,35 +4965,29 @@ class EpistemicChainGraphState(CoreasonBaseState):
         return self
 
 
-class CognitivePredictionReceipt(CoreasonBaseState):
-    """CoReason Shared Kernel Ontology: Cognitive Prediction Receipt."""
+class CognitivePredictionReceipt(BaseStateEvent):
+    """Cognitive Prediction Receipt."""
 
     type: Literal["cognitive_prediction"] = Field(
         default="cognitive_prediction",
-        description="CoReason Shared Kernel Ontology: Discriminator type for cognitive prediction.",
+        description="Discriminator type for cognitive prediction.",
     )
-    prediction_id: str = Field(min_length=1, description="CoReason Shared Kernel Ontology: prediction id.")
-    source_chain_id: str = Field(description="CoReason Shared Kernel Ontology: source chain id.")
-    target_source_concept: str = Field(description="CoReason Shared Kernel Ontology: target source concept.")
-    predicted_top_k_tokens: list[str] = Field(
-        min_length=1, description="CoReason Shared Kernel Ontology: predicted top k tokens."
-    )
+    source_chain_id: str = Field(description="source chain id.")
+    target_source_concept: str = Field(description="target source concept.")
+    predicted_top_k_tokens: list[str] = Field(min_length=1, description="predicted top k tokens.")
     # Note: predicted_top_k_tokens is a structurally ordered sequence (Probability Rank) and MUST NOT be sorted.
 
 
-class EpistemicAxiomVerificationReceipt(CoreasonBaseState):
-    """CoReason Shared Kernel Ontology: Epistemic Axiom Verification Receipt."""
+class EpistemicAxiomVerificationReceipt(BaseStateEvent):
+    """Epistemic Axiom Verification Receipt."""
 
     type: Literal["epistemic_axiom_verification"] = Field(
         default="epistemic_axiom_verification",
-        description="CoReason Shared Kernel Ontology: Discriminator type for epistemic axiom verification.",
+        description="Discriminator type for epistemic axiom verification.",
     )
-    verification_id: str = Field(min_length=1, description="CoReason Shared Kernel Ontology: verification id.")
-    source_prediction_id: str = Field(description="CoReason Shared Kernel Ontology: source prediction id.")
-    sequence_similarity_score: float = Field(
-        ge=0.0, le=1.0, description="CoReason Shared Kernel Ontology: sequence similarity score."
-    )
-    fact_score_passed: bool = Field(description="CoReason Shared Kernel Ontology: fact score passed.")
+    source_prediction_id: str = Field(description="source prediction id.")
+    sequence_similarity_score: float = Field(ge=0.0, le=1.0, description="sequence similarity score.")
+    fact_score_passed: bool = Field(description="fact score passed.")
 
     @model_validator(mode="after")
     def enforce_epistemic_quarantine(self) -> Self:
@@ -5007,16 +4997,14 @@ class EpistemicAxiomVerificationReceipt(CoreasonBaseState):
 
 
 class EpistemicDomainGraphManifest(CoreasonBaseState):
-    """CoReason Shared Kernel Ontology: Epistemic Domain Graph Manifest."""
+    """Epistemic Domain Graph Manifest."""
 
     type: Literal["epistemic_domain_graph_manifest"] = Field(
         default="epistemic_domain_graph_manifest",
-        description="CoReason Shared Kernel Ontology: Discriminator type for epistemic domain graph manifest.",
+        description="Discriminator type for epistemic domain graph manifest.",
     )
-    graph_id: str = Field(min_length=1, description="CoReason Shared Kernel Ontology: graph id.")
-    verified_axioms: list[EpistemicAxiomState] = Field(
-        min_length=1, description="CoReason Shared Kernel Ontology: verified axioms."
-    )
+    graph_id: str = Field(min_length=1, description="graph id.")
+    verified_axioms: list[EpistemicAxiomState] = Field(min_length=1, description="verified axioms.")
 
     @model_validator(mode="after")
     def sort_verified_axioms(self) -> Self:
@@ -5030,6 +5018,72 @@ class EpistemicDomainGraphManifest(CoreasonBaseState):
         return self
 
 
+class EpistemicTopologicalProofManifest(CoreasonBaseState):
+    """Epistemic Topological Proof Manifest."""
+
+    proof_id: str = Field(min_length=1, description="proof id.")
+    axiomatic_chain: list[EpistemicAxiomState] = Field(min_length=1, description="axiomatic chain.")
+    # Note: axiomatic_chain is a structurally ordered sequence (Causal Path) and MUST NOT be sorted.
+
+
+class CognitiveSamplingPolicy(CoreasonBaseState):
+    """Cognitive Sampling Policy."""
+
+    max_complexity_hops: int = Field(ge=1, description="max complexity hops.")
+    inverse_frequency_smoothing_epsilon: float = Field(default=1.0, description="inverse frequency smoothing epsilon.")
+
+
+class CognitiveReasoningTraceState(CoreasonBaseState):
+    """Cognitive Reasoning Trace State."""
+
+    trace_id: str = Field(min_length=1, description="trace id.")
+    source_proof_id: str = Field(description="source proof id.")
+    token_length: int = Field(ge=0, description="token length.")
+    trace_payload: str = Field(description="trace payload.")
+
+
+class CognitiveDualVerificationReceipt(CoreasonBaseState):
+    """Cognitive Dual Verification Receipt."""
+
+    primary_verifier_id: NodeIdentifierState = Field(description="primary verifier id.")
+    secondary_verifier_id: NodeIdentifierState = Field(description="secondary verifier id.")
+    trace_factual_alignment: bool = Field(description="trace factual alignment.")
+
+    @model_validator(mode="after")
+    def enforce_dual_key_lock(self) -> Self:
+        if self.primary_verifier_id == self.secondary_verifier_id:
+            raise ValueError(
+                "Topological Contradiction: Dual verification requires two distinct and independent evaluator nodes."
+            )
+        return self
+
+
+class EpistemicGroundedTaskManifest(CoreasonBaseState):
+    """Epistemic Grounded Task Manifest."""
+
+    task_id: str = Field(min_length=1, description="task id.")
+    topological_proof: EpistemicTopologicalProofManifest = Field(description="topological proof.")
+    vignette_payload: str = Field(description="vignette payload.")
+    thinking_trace: CognitiveReasoningTraceState = Field(description="thinking trace.")
+    verification_lock: CognitiveDualVerificationReceipt = Field(description="verification lock.")
+
+
+class EpistemicCurriculumManifest(CoreasonBaseState):
+    """Epistemic Curriculum Manifest."""
+
+    curriculum_id: str = Field(description="curriculum id.")
+    tasks: list[EpistemicGroundedTaskManifest] = Field(min_length=1, description="tasks.")
+
+    @model_validator(mode="after")
+    def sort_tasks(self) -> Self:
+        object.__setattr__(
+            self,
+            "tasks",
+            sorted(self.tasks, key=lambda x: x.task_id),
+        )
+        return self
+
+
 type AnyTopologyManifest = Annotated[
     DAGTopologyManifest
     | CouncilTopologyManifest
@@ -5039,8 +5093,7 @@ type AnyTopologyManifest = Annotated[
     | EvaluatorOptimizerTopologyManifest
     | DigitalTwinTopologyManifest
     | AdversarialMarketTopologyManifest
-    | ConsensusFederationTopologyManifest
-    | EpistemicDomainGraphManifest,
+    | ConsensusFederationTopologyManifest,
     Field(discriminator="type", description="A discriminated union of workflow topologies."),
 ]
 
@@ -5413,3 +5466,10 @@ EpistemicChainGraphState.model_rebuild()
 CognitivePredictionReceipt.model_rebuild()
 EpistemicAxiomVerificationReceipt.model_rebuild()
 EpistemicDomainGraphManifest.model_rebuild()
+
+EpistemicTopologicalProofManifest.model_rebuild()
+CognitiveSamplingPolicy.model_rebuild()
+CognitiveReasoningTraceState.model_rebuild()
+CognitiveDualVerificationReceipt.model_rebuild()
+EpistemicGroundedTaskManifest.model_rebuild()
+EpistemicCurriculumManifest.model_rebuild()

--- a/tests/contracts/test_curriculum_synthesis.py
+++ b/tests/contracts/test_curriculum_synthesis.py
@@ -1,0 +1,98 @@
+import re
+
+import pytest
+
+from coreason_manifest.spec.ontology import (
+    CognitiveDualVerificationReceipt,
+    CognitiveReasoningTraceState,
+    EpistemicAxiomState,
+    EpistemicCurriculumManifest,
+    EpistemicGroundedTaskManifest,
+    EpistemicTopologicalProofManifest,
+)
+
+
+def test_cognitive_dual_verification_receipt_identical_verifiers() -> None:
+    """
+    Prove CognitiveDualVerificationReceipt successfully raises a ValueError
+    when initialized with identical verifier IDs.
+    """
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Topological Contradiction: Dual verification requires two distinct and independent evaluator nodes."
+        ),
+    ):
+        CognitiveDualVerificationReceipt(
+            primary_verifier_id="did:node:verifier1",
+            secondary_verifier_id="did:node:verifier1",
+            trace_factual_alignment=True,
+        )
+
+    # Should succeed with distinct verifiers
+    receipt = CognitiveDualVerificationReceipt(
+        primary_verifier_id="did:node:verifier1",
+        secondary_verifier_id="did:node:verifier2",
+        trace_factual_alignment=True,
+    )
+    assert receipt.primary_verifier_id != receipt.secondary_verifier_id
+
+
+def test_epistemic_curriculum_manifest_deterministic_sorting() -> None:
+    """
+    Prove EpistemicCurriculumManifest deterministically sorts its tasks array
+    upon instantiation.
+    """
+    axiom = EpistemicAxiomState(source_concept_id="cid_1", directed_edge_type="leads_to", target_concept_id="cid_2")
+    proof = EpistemicTopologicalProofManifest(proof_id="proof_1", axiomatic_chain=[axiom])
+    trace = CognitiveReasoningTraceState(
+        trace_id="trace_1", source_proof_id="proof_1", token_length=100, trace_payload="payload"
+    )
+    verification = CognitiveDualVerificationReceipt(
+        primary_verifier_id="did:node:verifier1",
+        secondary_verifier_id="did:node:verifier2",
+        trace_factual_alignment=True,
+    )
+
+    task_c = EpistemicGroundedTaskManifest(
+        task_id="task_C",
+        topological_proof=proof,
+        vignette_payload="vignette_c",
+        thinking_trace=trace,
+        verification_lock=verification,
+    )
+    task_a = EpistemicGroundedTaskManifest(
+        task_id="task_A",
+        topological_proof=proof,
+        vignette_payload="vignette_a",
+        thinking_trace=trace,
+        verification_lock=verification,
+    )
+    task_b = EpistemicGroundedTaskManifest(
+        task_id="task_B",
+        topological_proof=proof,
+        vignette_payload="vignette_b",
+        thinking_trace=trace,
+        verification_lock=verification,
+    )
+
+    curriculum = EpistemicCurriculumManifest(curriculum_id="curr_1", tasks=[task_c, task_a, task_b])
+
+    assert [task.task_id for task in curriculum.tasks] == ["task_A", "task_B", "task_C"]
+
+
+def test_epistemic_topological_proof_manifest_order_preservation() -> None:
+    """
+    Prove EpistemicTopologicalProofManifest preserves the sequential order
+    of its axiomatic_chain.
+    """
+    axiom1 = EpistemicAxiomState(source_concept_id="cid_B", directed_edge_type="causes", target_concept_id="cid_C")
+    axiom2 = EpistemicAxiomState(source_concept_id="cid_A", directed_edge_type="leads_to", target_concept_id="cid_B")
+
+    # Initialize with out-of-alphanumeric-order elements
+    proof = EpistemicTopologicalProofManifest(proof_id="proof_1", axiomatic_chain=[axiom1, axiom2])
+
+    # Sequence should remain exactly as inserted [axiom1, axiom2] and not be sorted
+    assert proof.axiomatic_chain == [axiom1, axiom2]
+    assert proof.axiomatic_chain[0].source_concept_id == "cid_B"
+    assert proof.axiomatic_chain[1].source_concept_id == "cid_A"

--- a/tests/contracts/test_epistemic_distillation.py
+++ b/tests/contracts/test_epistemic_distillation.py
@@ -47,7 +47,8 @@ def test_epistemic_axiom_verification_receipt_fact_score() -> None:
         ValueError, match=re.escape("Epistemic Contagion Prevented: Axioms failing validation cannot be verified.")
     ):
         EpistemicAxiomVerificationReceipt(
-            verification_id="verif_1",
+            event_id="verif_1",
+            timestamp=123.0,
             source_prediction_id="pred_1",
             sequence_similarity_score=0.9,
             fact_score_passed=False,
@@ -55,7 +56,8 @@ def test_epistemic_axiom_verification_receipt_fact_score() -> None:
 
     # Should pass when fact_score_passed is True
     receipt = EpistemicAxiomVerificationReceipt(
-        verification_id="verif_2",
+        event_id="verif_2",
+        timestamp=123.0,
         source_prediction_id="pred_2",
         sequence_similarity_score=0.9,
         fact_score_passed=True,

--- a/tests/contracts/test_epistemic_distillation.py
+++ b/tests/contracts/test_epistemic_distillation.py
@@ -1,0 +1,91 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import (
+    EpistemicAxiomState,
+    EpistemicAxiomVerificationReceipt,
+    EpistemicChainGraphState,
+    EpistemicSeedInjectionPolicy,
+)
+
+
+def test_epistemic_chain_graph_state_determinism() -> None:
+    """
+    Prove EpistemicChainGraphState sorts its semantic_leaves deterministically
+    upon instantiation but preserves the order of syntactic_roots.
+    """
+    axiom1 = EpistemicAxiomState(source_concept_id="cid_A", directed_edge_type="causes", target_concept_id="cid_B")
+    axiom2 = EpistemicAxiomState(source_concept_id="cid_B", directed_edge_type="leads_to", target_concept_id="cid_C")
+    axiom3 = EpistemicAxiomState(source_concept_id="cid_A", directed_edge_type="inhibits", target_concept_id="cid_C")
+
+    # Initialize with unsorted semantic leaves and specifically ordered syntactic roots
+    graph = EpistemicChainGraphState(
+        chain_id="chain_1",
+        syntactic_roots=["root_Z", "root_A", "root_M"],
+        semantic_leaves=[axiom2, axiom3, axiom1],
+    )
+
+    # syntactic_roots should NOT be sorted
+    assert graph.syntactic_roots == ["root_Z", "root_A", "root_M"]
+
+    # semantic_leaves SHOULD be sorted deterministically
+    # Sort order: source_concept_id, then directed_edge_type, then target_concept_id
+    # axiom1: cid_A, causes, cid_B
+    # axiom3: cid_A, inhibits, cid_C
+    # axiom2: cid_B, leads_to, cid_C
+    assert graph.semantic_leaves == [axiom1, axiom3, axiom2]
+
+
+def test_epistemic_axiom_verification_receipt_fact_score() -> None:
+    """
+    Prove EpistemicAxiomVerificationReceipt successfully raises a ValueError
+    when fact_score_passed=False.
+    """
+    import re
+
+    with pytest.raises(
+        ValueError, match=re.escape("Epistemic Contagion Prevented: Axioms failing validation cannot be verified.")
+    ):
+        EpistemicAxiomVerificationReceipt(
+            verification_id="verif_1",
+            source_prediction_id="pred_1",
+            sequence_similarity_score=0.9,
+            fact_score_passed=False,
+        )
+
+    # Should pass when fact_score_passed is True
+    receipt = EpistemicAxiomVerificationReceipt(
+        verification_id="verif_2",
+        source_prediction_id="pred_2",
+        sequence_similarity_score=0.9,
+        fact_score_passed=True,
+    )
+    assert receipt.fact_score_passed is True
+
+
+def test_epistemic_seed_injection_policy_alpha_bounds() -> None:
+    """
+    Prove EpistemicSeedInjectionPolicy rejects alpha values > 1.0 or < 0.0.
+    """
+    # Should reject alpha < 0.0
+    with pytest.raises(ValidationError) as exc_info:
+        EpistemicSeedInjectionPolicy(
+            similarity_threshold_alpha=-0.1,
+            relation_diversity_bucket_size=5,
+        )
+    assert "Input should be greater than or equal to 0" in str(exc_info.value)
+
+    # Should reject alpha > 1.0
+    with pytest.raises(ValidationError) as exc_info2:
+        EpistemicSeedInjectionPolicy(
+            similarity_threshold_alpha=1.1,
+            relation_diversity_bucket_size=5,
+        )
+    assert "Input should be less than or equal to 1" in str(exc_info2.value)
+
+    # Should accept alpha between 0.0 and 1.0
+    policy = EpistemicSeedInjectionPolicy(
+        similarity_threshold_alpha=0.5,
+        relation_diversity_bucket_size=5,
+    )
+    assert policy.similarity_threshold_alpha == 0.5


### PR DESCRIPTION
Implemented Epistemic Distillation phase schemas into the coreason_manifest ontology, ensuring deterministic array sorting, preservation of sequence arrays, topological ordering, strict discriminator types, and adding corresponding pytest contracts to test these constraints.

---
*PR created automatically by Jules for task [5202051260395355934](https://jules.google.com/task/5202051260395355934) started by @gowthamrao*