### PR TITLE
docs(agents): enforce zensical for documentation builds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,10 @@ You are strictly forbidden from introducing "Active" or "Runtime" logic into thi
 
 ## **3. Technical Standards**
 
+### **Documentation**
+* **Generator:** `zensical`.
+* **Constraint:** You are strictly forbidden from reverting to, installing, or using `mkdocs` or any other legacy documentation generator. `zensical` is the mandatory tool for all documentation builds within this repository.
+
 ### **Environment & Package Management**
 * **Manager:** `uv`.
 * **Language:** Python 3.12+.


### PR DESCRIPTION
Update AGENTS.md to explicitly enforce `zensical` as the required tool for documentation and forbid using `mkdocs`.

---
*PR created automatically by Jules for task [4182138774415633275](https://jules.google.com/task/4182138774415633275) started by @gowthamrao*