### PR TITLE
Fix zensical documentation build config structure

### DIFF
--- a/zensical.toml
+++ b/zensical.toml
@@ -4,6 +4,7 @@ site_url = "https://coreason-ai.github.io/coreason_manifest/"
 repo_name = "CoReason-AI/coreason_manifest"
 repo_url = "https://github.com/CoReason-AI/coreason_manifest"
 
+[project.theme]
 features = [
     "navigation.instant",
     "navigation.tracking",
@@ -12,9 +13,11 @@ features = [
     "search.highlight"
 ]
 
+[project.plugins.search]
+
+[project.plugins.mkdocstrings]
 [project.plugins.mkdocstrings.handlers.python]
 paths = ["src/"]
-
 [project.plugins.mkdocstrings.handlers.python.options]
 show_root_heading = true
 show_bases = true


### PR DESCRIPTION
The `zensical.toml` configuration had incorrect table structure, specifically:
- `features` was placed under `[project]` instead of `[project.theme]`.
- Plugin maps `[project.plugins.search]` and `[project.plugins.mkdocstrings]` were not explicitly defined before appending their sub-tables (e.g. `handlers`), preventing them from being activated properly. 

This commit restructures `zensical.toml` to accurately define these tables. Zensical build passes and correctly parses the `::: coreason_manifest` mkdocstrings directives in the site documentation now.

---
*PR created automatically by Jules for task [258954328002522518](https://jules.google.com/task/258954328002522518) started by @gowthamrao*