### PR TITLE
feat: implement Epistemic Distillation schemas (Phase 1)

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -916,7 +916,9 @@
           "barge_in": "#/$defs/BargeInInterruptEvent",
           "belief_mutation": "#/$defs/BeliefMutationEvent",
           "budget_exhaustion": "#/$defs/BudgetExhaustionEvent",
+          "cognitive_prediction": "#/$defs/CognitivePredictionReceipt",
           "counterfactual_regret": "#/$defs/CounterfactualRegretEvent",
+          "epistemic_axiom_verification": "#/$defs/EpistemicAxiomVerificationReceipt",
           "epistemic_promotion": "#/$defs/EpistemicPromotionEvent",
           "epistemic_telemetry": "#/$defs/EpistemicTelemetryEvent",
           "hypothesis": "#/$defs/HypothesisGenerationEvent",
@@ -968,6 +970,12 @@
         },
         {
           "$ref": "#/$defs/EpistemicTelemetryEvent"
+        },
+        {
+          "$ref": "#/$defs/CognitivePredictionReceipt"
+        },
+        {
+          "$ref": "#/$defs/EpistemicAxiomVerificationReceipt"
         }
       ]
     },
@@ -2112,6 +2120,53 @@
         "epistemic_penalty_scalar"
       ],
       "title": "CognitiveCritiqueProfile",
+      "type": "object"
+    },
+    "CognitivePredictionReceipt": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "cognitive_prediction",
+          "default": "cognitive_prediction",
+          "title": "Type",
+          "type": "string"
+        },
+        "source_chain_id": {
+          "title": "Source Chain Id",
+          "type": "string"
+        },
+        "target_source_concept": {
+          "title": "Target Source Concept",
+          "type": "string"
+        },
+        "predicted_top_k_tokens": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Predicted Top K Tokens",
+          "type": "array"
+        }
+      },
+      "required": [
+        "event_id",
+        "timestamp",
+        "source_chain_id",
+        "target_source_concept",
+        "predicted_top_k_tokens"
+      ],
+      "title": "CognitivePredictionReceipt",
       "type": "object"
     },
     "CognitiveRoutingContract": {
@@ -4148,6 +4203,112 @@
       "title": "EpistemicArgumentGraphState",
       "type": "object"
     },
+    "EpistemicAxiomState": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "source_concept_id": {
+          "description": "CID of the origin node.",
+          "title": "Source Concept Id",
+          "type": "string"
+        },
+        "directed_edge_type": {
+          "description": "The topological relationship.",
+          "title": "Directed Edge Type",
+          "type": "string"
+        },
+        "target_concept_id": {
+          "description": "CID of destination node.",
+          "title": "Target Concept Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "source_concept_id",
+        "directed_edge_type",
+        "target_concept_id"
+      ],
+      "title": "EpistemicAxiomState",
+      "type": "object"
+    },
+    "EpistemicAxiomVerificationReceipt": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "epistemic_axiom_verification",
+          "default": "epistemic_axiom_verification",
+          "title": "Type",
+          "type": "string"
+        },
+        "source_prediction_id": {
+          "title": "Source Prediction Id",
+          "type": "string"
+        },
+        "sequence_similarity_score": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Sequence Similarity Score",
+          "type": "number"
+        },
+        "fact_score_passed": {
+          "title": "Fact Score Passed",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "event_id",
+        "timestamp",
+        "source_prediction_id",
+        "sequence_similarity_score",
+        "fact_score_passed"
+      ],
+      "title": "EpistemicAxiomVerificationReceipt",
+      "type": "object"
+    },
+    "EpistemicChainGraphState": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "chain_id": {
+          "minLength": 1,
+          "title": "Chain Id",
+          "type": "string"
+        },
+        "syntactic_roots": {
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Syntactic Roots",
+          "type": "array"
+        },
+        "semantic_leaves": {
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "title": "Semantic Leaves",
+          "type": "array"
+        }
+      },
+      "required": [
+        "chain_id",
+        "syntactic_roots",
+        "semantic_leaves"
+      ],
+      "title": "EpistemicChainGraphState",
+      "type": "object"
+    },
     "EpistemicCompressionSLA": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology",
@@ -4181,6 +4342,31 @@
         "required_grounding_density"
       ],
       "title": "EpistemicCompressionSLA",
+      "type": "object"
+    },
+    "EpistemicDomainGraphManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "graph_id": {
+          "minLength": 1,
+          "title": "Graph Id",
+          "type": "string"
+        },
+        "verified_axioms": {
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "minItems": 1,
+          "title": "Verified Axioms",
+          "type": "array"
+        }
+      },
+      "required": [
+        "graph_id",
+        "verified_axioms"
+      ],
+      "title": "EpistemicDomainGraphManifest",
       "type": "object"
     },
     "EpistemicEscalationContract": {
@@ -4575,6 +4761,29 @@
         "action_on_gap"
       ],
       "title": "EpistemicScanningPolicy",
+      "type": "object"
+    },
+    "EpistemicSeedInjectionPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "similarity_threshold_alpha": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Similarity Threshold Alpha",
+          "type": "number"
+        },
+        "relation_diversity_bucket_size": {
+          "exclusiveMinimum": 0,
+          "title": "Relation Diversity Bucket Size",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "similarity_threshold_alpha",
+        "relation_diversity_bucket_size"
+      ],
+      "title": "EpistemicSeedInjectionPolicy",
       "type": "object"
     },
     "EpistemicTelemetryEvent": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -5216,6 +5216,74 @@ class EpistemicTelemetryEvent(BaseStateEvent):
     )
 
 
+class EpistemicAxiomState(CoreasonBaseState):
+    source_concept_id: str = Field(description="CID of the origin node.")
+    directed_edge_type: str = Field(description="The topological relationship.")
+    target_concept_id: str = Field(description="CID of destination node.")
+
+
+class EpistemicSeedInjectionPolicy(CoreasonBaseState):
+    similarity_threshold_alpha: float = Field(ge=0.0, le=1.0)
+    relation_diversity_bucket_size: int = Field(gt=0)
+
+
+class EpistemicChainGraphState(CoreasonBaseState):
+    chain_id: str = Field(min_length=1)
+    syntactic_roots: list[str] = Field(min_length=1)
+    # Note: syntactic_roots is a structurally ordered sequence (Linguistic Syntax) and MUST NOT be sorted.
+    semantic_leaves: list[EpistemicAxiomState]
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(
+            self,
+            "semantic_leaves",
+            sorted(
+                self.semantic_leaves,
+                key=lambda x: (x.source_concept_id, x.directed_edge_type, x.target_concept_id),
+            ),
+        )
+        return self
+
+
+class CognitivePredictionReceipt(BaseStateEvent):
+    type: Literal["cognitive_prediction"] = Field(default="cognitive_prediction")
+    source_chain_id: str
+    target_source_concept: str
+    predicted_top_k_tokens: list[str] = Field(min_length=1)
+    # Note: predicted_top_k_tokens is a structurally ordered sequence (Probability Rank) and MUST NOT be sorted.
+
+
+class EpistemicAxiomVerificationReceipt(BaseStateEvent):
+    type: Literal["epistemic_axiom_verification"] = Field(default="epistemic_axiom_verification")
+    source_prediction_id: str
+    sequence_similarity_score: float = Field(ge=0.0, le=1.0)
+    fact_score_passed: bool
+
+    @model_validator(mode="after")
+    def enforce_epistemic_quarantine(self) -> Self:
+        if not self.fact_score_passed:
+            raise ValueError("Epistemic Contagion Prevented: Axioms failing validation cannot be verified.")
+        return self
+
+
+class EpistemicDomainGraphManifest(CoreasonBaseState):
+    graph_id: str = Field(min_length=1)
+    verified_axioms: list[EpistemicAxiomState] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(
+            self,
+            "verified_axioms",
+            sorted(
+                self.verified_axioms,
+                key=lambda x: (x.source_concept_id, x.directed_edge_type, x.target_concept_id),
+            ),
+        )
+        return self
+
+
 type AnyStateEvent = Annotated[
     ObservationEvent
     | BeliefMutationEvent
@@ -5229,7 +5297,9 @@ type AnyStateEvent = Annotated[
     | PersistenceCommitReceipt
     | TokenBurnReceipt
     | BudgetExhaustionEvent
-    | EpistemicTelemetryEvent,
+    | EpistemicTelemetryEvent
+    | CognitivePredictionReceipt
+    | EpistemicAxiomVerificationReceipt,
     Field(discriminator="type", description="A discriminated union of state events."),
 ]
 
@@ -5305,3 +5375,10 @@ TokenBurnReceipt.model_rebuild()
 BudgetExhaustionEvent.model_rebuild()
 
 LatentProjectionIntent.model_rebuild()
+
+EpistemicAxiomState.model_rebuild()
+EpistemicSeedInjectionPolicy.model_rebuild()
+EpistemicChainGraphState.model_rebuild()
+CognitivePredictionReceipt.model_rebuild()
+EpistemicAxiomVerificationReceipt.model_rebuild()
+EpistemicDomainGraphManifest.model_rebuild()

--- a/tests/contracts/test_epistemic_distillation.py
+++ b/tests/contracts/test_epistemic_distillation.py
@@ -1,0 +1,83 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import (
+    EpistemicAxiomState,
+    EpistemicAxiomVerificationReceipt,
+    EpistemicChainGraphState,
+    EpistemicSeedInjectionPolicy,
+)
+
+
+def test_epistemic_chain_graph_state_sorting() -> None:
+    axiom1 = EpistemicAxiomState(source_concept_id="B", directed_edge_type="type1", target_concept_id="A")
+    axiom2 = EpistemicAxiomState(source_concept_id="A", directed_edge_type="type2", target_concept_id="C")
+    axiom3 = EpistemicAxiomState(source_concept_id="A", directed_edge_type="type1", target_concept_id="C")
+
+    # Pass in a non-sorted list of axioms for semantic_leaves
+    state = EpistemicChainGraphState(
+        chain_id="chain-123",
+        syntactic_roots=["root2", "root1", "root3"],
+        semantic_leaves=[axiom1, axiom2, axiom3],
+    )
+
+    # Prove semantic_leaves is deterministically sorted by source, edge, then target
+    assert state.semantic_leaves == [axiom3, axiom2, axiom1]
+
+    # Prove syntactic_roots preserves order
+    assert state.syntactic_roots == ["root2", "root1", "root3"]
+
+
+def test_epistemic_axiom_verification_receipt_quarantine() -> None:
+    # Successful instantiation
+    receipt = EpistemicAxiomVerificationReceipt(
+        event_id="evt-123",
+        timestamp=1600000000.0,
+        source_prediction_id="pred-123",
+        sequence_similarity_score=0.9,
+        fact_score_passed=True,
+    )
+    assert receipt.fact_score_passed is True
+
+    # Failing instantiation raises ValueError (wrapped in ValidationError by Pydantic)
+    with pytest.raises(ValidationError) as excinfo:
+        EpistemicAxiomVerificationReceipt(
+            event_id="evt-124",
+            timestamp=1600000001.0,
+            source_prediction_id="pred-124",
+            sequence_similarity_score=0.9,
+            fact_score_passed=False,
+        )
+
+    # Check that the specific ValueError message is part of the ValidationError
+    assert "Epistemic Contagion Prevented: Axioms failing validation cannot be verified." in str(excinfo.value)
+
+
+def test_epistemic_seed_injection_policy_alpha_bounds() -> None:
+    # Valid alpha
+    policy = EpistemicSeedInjectionPolicy(
+        similarity_threshold_alpha=0.5,
+        relation_diversity_bucket_size=10,
+    )
+    assert policy.similarity_threshold_alpha == 0.5
+
+    # Alpha too low
+    with pytest.raises(ValidationError):
+        EpistemicSeedInjectionPolicy(
+            similarity_threshold_alpha=-0.1,
+            relation_diversity_bucket_size=10,
+        )
+
+    # Alpha too high
+    with pytest.raises(ValidationError):
+        EpistemicSeedInjectionPolicy(
+            similarity_threshold_alpha=1.1,
+            relation_diversity_bucket_size=10,
+        )
+
+    # Diversity bucket size too low
+    with pytest.raises(ValidationError):
+        EpistemicSeedInjectionPolicy(
+            similarity_threshold_alpha=0.5,
+            relation_diversity_bucket_size=0,
+        )


### PR DESCRIPTION
Implemented the six Epistemic Distillation schemas into `src/coreason_manifest/spec/ontology.py` and strictly enforced the Merkle Rule (cryptographic deterministic sorting vs. structural sequence exemptions). Contract tests were created and passed successfully locally via Ruff, Mypy, and Pytest.

---
*PR created automatically by Jules for task [2250278808727282266](https://jules.google.com/task/2250278808727282266) started by @gowthamrao*