### PR TITLE
feat: Implement Curriculum Synthesis ontology models and contract tests

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2122,6 +2122,32 @@
       "title": "CognitiveCritiqueProfile",
       "type": "object"
     },
+    "CognitiveDualVerificationReceipt": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "primary_verifier_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The DID of the primary evaluating agent."
+        },
+        "secondary_verifier_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The DID of the independent secondary evaluating agent."
+        },
+        "trace_factual_alignment": {
+          "description": "Strict Boolean indicating if BOTH agents mathematically agree on factual alignment.",
+          "title": "Trace Factual Alignment",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "primary_verifier_id",
+        "secondary_verifier_id",
+        "trace_factual_alignment"
+      ],
+      "title": "CognitiveDualVerificationReceipt",
+      "type": "object"
+    },
     "CognitivePredictionReceipt": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology",
@@ -2169,6 +2195,42 @@
       "title": "CognitivePredictionReceipt",
       "type": "object"
     },
+    "CognitiveReasoningTraceState": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "trace_id": {
+          "description": "CID of this specific non-monotonic reasoning trace.",
+          "minLength": 1,
+          "title": "Trace Id",
+          "type": "string"
+        },
+        "source_proof_id": {
+          "description": "The EpistemicTopologicalProofManifest CID this trace is mathematically anchored to.",
+          "title": "Source Proof Id",
+          "type": "string"
+        },
+        "token_length": {
+          "description": "The exact token consumption of the trace.",
+          "minimum": 0,
+          "title": "Token Length",
+          "type": "integer"
+        },
+        "trace_payload": {
+          "description": "The natural language reasoning steps bounded by structural tags.",
+          "title": "Trace Payload",
+          "type": "string"
+        }
+      },
+      "required": [
+        "trace_id",
+        "source_proof_id",
+        "token_length",
+        "trace_payload"
+      ],
+      "title": "CognitiveReasoningTraceState",
+      "type": "object"
+    },
     "CognitiveRoutingContract": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nHardware-level contract overriding MoE routing to enforce functional/specialist paths.",
@@ -2205,6 +2267,29 @@
         "routing_temperature"
       ],
       "title": "CognitiveRoutingContract",
+      "type": "object"
+    },
+    "CognitiveSamplingPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "max_complexity_hops": {
+          "description": "The absolute physical limit on path length N.",
+          "minimum": 1,
+          "title": "Max Complexity Hops",
+          "type": "integer"
+        },
+        "inverse_frequency_smoothing_epsilon": {
+          "default": 1.0,
+          "description": "The epsilon constant ensuring unsampled nodes are mathematically prioritized.",
+          "title": "Inverse Frequency Smoothing Epsilon",
+          "type": "number"
+        }
+      },
+      "required": [
+        "max_complexity_hops"
+      ],
+      "title": "CognitiveSamplingPolicy",
       "type": "object"
     },
     "CognitiveStateProfile": {
@@ -4344,6 +4429,33 @@
       "title": "EpistemicCompressionSLA",
       "type": "object"
     },
+    "EpistemicCurriculumManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "curriculum_id": {
+          "description": "Unique CID for this training epoch release.",
+          "minLength": 1,
+          "title": "Curriculum Id",
+          "type": "string"
+        },
+        "tasks": {
+          "description": "The array of fully verified task primitives.",
+          "items": {
+            "$ref": "#/$defs/EpistemicGroundedTaskManifest"
+          },
+          "minItems": 1,
+          "title": "Tasks",
+          "type": "array"
+        }
+      },
+      "required": [
+        "curriculum_id",
+        "tasks"
+      ],
+      "title": "EpistemicCurriculumManifest",
+      "type": "object"
+    },
     "EpistemicDomainGraphManifest": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology",
@@ -4398,6 +4510,44 @@
         "max_escalation_tiers"
       ],
       "title": "EpistemicEscalationContract",
+      "type": "object"
+    },
+    "EpistemicGroundedTaskManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "task_id": {
+          "description": "The cryptographic CID of the task.",
+          "minLength": 1,
+          "title": "Task Id",
+          "type": "string"
+        },
+        "topological_proof": {
+          "$ref": "#/$defs/EpistemicTopologicalProofManifest",
+          "description": "The underlying latent path."
+        },
+        "vignette_payload": {
+          "description": "The generated natural language scenario.",
+          "title": "Vignette Payload",
+          "type": "string"
+        },
+        "thinking_trace": {
+          "$ref": "#/$defs/CognitiveReasoningTraceState",
+          "description": "The verified reasoning path."
+        },
+        "verification_lock": {
+          "$ref": "#/$defs/CognitiveDualVerificationReceipt",
+          "description": "The cryptographic proof of dual-agent approval."
+        }
+      },
+      "required": [
+        "task_id",
+        "topological_proof",
+        "vignette_payload",
+        "thinking_trace",
+        "verification_lock"
+      ],
+      "title": "EpistemicGroundedTaskManifest",
       "type": "object"
     },
     "EpistemicLedgerState": {
@@ -4857,6 +5007,33 @@
         "target_node_id"
       ],
       "title": "EpistemicTelemetryEvent",
+      "type": "object"
+    },
+    "EpistemicTopologicalProofManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology",
+      "properties": {
+        "proof_id": {
+          "description": "A Content Identifier (CID) for this specific topological proof.",
+          "minLength": 1,
+          "title": "Proof Id",
+          "type": "string"
+        },
+        "axiomatic_chain": {
+          "description": "The strictly ordered sequence of axioms forming the reasoning path.",
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "minItems": 1,
+          "title": "Axiomatic Chain",
+          "type": "array"
+        }
+      },
+      "required": [
+        "proof_id",
+        "axiomatic_chain"
+      ],
+      "title": "EpistemicTopologicalProofManifest",
       "type": "object"
     },
     "EpistemicTransmutationTask": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -5284,6 +5284,77 @@ class EpistemicDomainGraphManifest(CoreasonBaseState):
         return self
 
 
+class EpistemicTopologicalProofManifest(CoreasonBaseState):
+    proof_id: str = Field(min_length=1, description="A Content Identifier (CID) for this specific topological proof.")
+    axiomatic_chain: list[EpistemicAxiomState] = Field(
+        min_length=1, description="The strictly ordered sequence of axioms forming the reasoning path."
+    )
+    # Note: axiomatic_chain is a structurally ordered sequence (Causal Path) and MUST NOT be sorted.
+
+
+class CognitiveSamplingPolicy(CoreasonBaseState):
+    max_complexity_hops: int = Field(ge=1, description="The absolute physical limit on path length N.")
+    inverse_frequency_smoothing_epsilon: float = Field(
+        default=1.0, description="The epsilon constant ensuring unsampled nodes are mathematically prioritized."
+    )
+
+
+class CognitiveReasoningTraceState(CoreasonBaseState):
+    trace_id: str = Field(min_length=1, description="CID of this specific non-monotonic reasoning trace.")
+    source_proof_id: str = Field(
+        description="The EpistemicTopologicalProofManifest CID this trace is mathematically anchored to."
+    )
+    token_length: int = Field(ge=0, description="The exact token consumption of the trace.")
+    trace_payload: str = Field(description="The natural language reasoning steps bounded by structural tags.")
+
+
+class CognitiveDualVerificationReceipt(CoreasonBaseState):
+    primary_verifier_id: NodeIdentifierState = Field(description="The DID of the primary evaluating agent.")
+    secondary_verifier_id: NodeIdentifierState = Field(
+        description="The DID of the independent secondary evaluating agent."
+    )
+    trace_factual_alignment: bool = Field(
+        description="Strict Boolean indicating if BOTH agents mathematically agree on factual alignment."
+    )
+
+    @model_validator(mode="after")
+    def enforce_dual_key_lock(self) -> Self:
+        if self.primary_verifier_id == self.secondary_verifier_id:
+            raise ValueError(
+                "Topological Contradiction: Dual verification requires two distinct and independent evaluator nodes."
+            )
+        return self
+
+
+class EpistemicGroundedTaskManifest(CoreasonBaseState):
+    task_id: str = Field(min_length=1, description="The cryptographic CID of the task.")
+    topological_proof: EpistemicTopologicalProofManifest = Field(description="The underlying latent path.")
+    vignette_payload: str = Field(description="The generated natural language scenario.")
+    thinking_trace: CognitiveReasoningTraceState = Field(description="The verified reasoning path.")
+    verification_lock: CognitiveDualVerificationReceipt = Field(
+        description="The cryptographic proof of dual-agent approval."
+    )
+
+
+class EpistemicCurriculumManifest(CoreasonBaseState):
+    curriculum_id: str = Field(min_length=1, description="Unique CID for this training epoch release.")
+    tasks: list[EpistemicGroundedTaskManifest] = Field(
+        min_length=1, description="The array of fully verified task primitives."
+    )
+
+    @model_validator(mode="after")
+    def sort_tasks(self) -> Self:
+        object.__setattr__(
+            self,
+            "tasks",
+            sorted(
+                self.tasks,
+                key=lambda task: task.task_id,
+            ),
+        )
+        return self
+
+
 type AnyStateEvent = Annotated[
     ObservationEvent
     | BeliefMutationEvent
@@ -5382,3 +5453,9 @@ EpistemicChainGraphState.model_rebuild()
 CognitivePredictionReceipt.model_rebuild()
 EpistemicAxiomVerificationReceipt.model_rebuild()
 EpistemicDomainGraphManifest.model_rebuild()
+EpistemicTopologicalProofManifest.model_rebuild()
+CognitiveSamplingPolicy.model_rebuild()
+CognitiveReasoningTraceState.model_rebuild()
+CognitiveDualVerificationReceipt.model_rebuild()
+EpistemicGroundedTaskManifest.model_rebuild()
+EpistemicCurriculumManifest.model_rebuild()

--- a/tests/contracts/test_curriculum_synthesis.py
+++ b/tests/contracts/test_curriculum_synthesis.py
@@ -1,0 +1,100 @@
+import re
+
+import pytest
+
+from coreason_manifest.spec.ontology import (
+    CognitiveDualVerificationReceipt,
+    CognitiveReasoningTraceState,
+    EpistemicAxiomState,
+    EpistemicCurriculumManifest,
+    EpistemicGroundedTaskManifest,
+    EpistemicTopologicalProofManifest,
+)
+
+
+def test_dual_verification_requires_distinct_evaluators() -> None:
+    """Prove dual verification receipt raises error for identical verifiers."""
+
+    # Should work fine
+    valid_receipt = CognitiveDualVerificationReceipt(
+        primary_verifier_id="did:coreason:evaluator-1",
+        secondary_verifier_id="did:coreason:evaluator-2",
+        trace_factual_alignment=True,
+    )
+
+    assert valid_receipt.primary_verifier_id == "did:coreason:evaluator-1"
+    assert valid_receipt.secondary_verifier_id == "did:coreason:evaluator-2"
+
+    # Should raise error
+    error_msg = "Topological Contradiction: Dual verification requires two distinct and independent evaluator nodes."
+    with pytest.raises(
+        ValueError,
+        match=re.escape(error_msg),
+    ):
+        CognitiveDualVerificationReceipt(
+            primary_verifier_id="did:coreason:same-evaluator",
+            secondary_verifier_id="did:coreason:same-evaluator",
+            trace_factual_alignment=True,
+        )
+
+
+def test_epistemic_curriculum_manifest_sorts_tasks() -> None:
+    """Prove EpistemicCurriculumManifest deterministically sorts its tasks array by task_id upon instantiation."""
+
+    proof = EpistemicTopologicalProofManifest(
+        proof_id="cid-proof-1",
+        axiomatic_chain=[
+            EpistemicAxiomState(source_concept_id="cid-1", directed_edge_type="causes", target_concept_id="cid-2")
+        ],
+    )
+
+    trace = CognitiveReasoningTraceState(
+        trace_id="cid-trace-1", source_proof_id="cid-proof-1", token_length=100, trace_payload="Thinking..."
+    )
+
+    lock = CognitiveDualVerificationReceipt(
+        primary_verifier_id="did:coreason:evaluator-1",
+        secondary_verifier_id="did:coreason:evaluator-2",
+        trace_factual_alignment=True,
+    )
+
+    task_2 = EpistemicGroundedTaskManifest(
+        task_id="task-b",
+        topological_proof=proof,
+        vignette_payload="Scenario B",
+        thinking_trace=trace,
+        verification_lock=lock,
+    )
+
+    task_1 = EpistemicGroundedTaskManifest(
+        task_id="task-a",
+        topological_proof=proof,
+        vignette_payload="Scenario A",
+        thinking_trace=trace,
+        verification_lock=lock,
+    )
+
+    # Pass in reverse alphabetical order
+    manifest = EpistemicCurriculumManifest(curriculum_id="cid-curriculum-1", tasks=[task_2, task_1])
+
+    # Assert they are sorted
+    assert manifest.tasks[0].task_id == "task-a"
+    assert manifest.tasks[1].task_id == "task-b"
+
+
+def test_epistemic_topological_proof_manifest_preserves_order() -> None:
+    """Prove EpistemicTopologicalProofManifest preserves the sequential order of its axiomatic_chain."""
+
+    axiom_1 = EpistemicAxiomState(source_concept_id="cid-a", directed_edge_type="causes", target_concept_id="cid-b")
+    axiom_2 = EpistemicAxiomState(source_concept_id="cid-b", directed_edge_type="causes", target_concept_id="cid-c")
+    axiom_3 = EpistemicAxiomState(source_concept_id="cid-c", directed_edge_type="causes", target_concept_id="cid-d")
+
+    # Pass in a specific order (not alphabetical or sorted by any standard)
+    axioms = [axiom_2, axiom_1, axiom_3]
+
+    proof = EpistemicTopologicalProofManifest(proof_id="cid-proof-order-test", axiomatic_chain=axioms)
+
+    # Assert they remain in that exact order
+    assert proof.axiomatic_chain[0] == axiom_2
+    assert proof.axiomatic_chain[1] == axiom_1
+    assert proof.axiomatic_chain[2] == axiom_3


### PR DESCRIPTION
This PR implements the Epic 2 / Session 2 Curriculum Synthesis schemas into the Coreason Shared Kernel Ontology.

**Key Additions:**
1.  **`EpistemicTopologicalProofManifest`**: Defines reasoning paths with strict sequence exemption for its `axiomatic_chain`.
2.  **`CognitiveSamplingPolicy`**: Establishes parameters bounding sampling complexity.
3.  **`CognitiveReasoningTraceState`**: Records natural language traces anchored to topological proofs.
4.  **`CognitiveDualVerificationReceipt`**: Cryptographic lock enforcing dual-agent factual alignment.
5.  **`EpistemicGroundedTaskManifest`**: Defines verified task primitives encapsulating the trace, proof, and lock.
6.  **`EpistemicCurriculumManifest`**: The top-level training release manifest that deterministically sorts its encapsulated tasks.

**Validations & Contracts:**
*   Implemented an `@model_validator` in `CognitiveDualVerificationReceipt` to raise a `ValueError` if `primary_verifier_id` and `secondary_verifier_id` are identical, explicitly preventing single-node topological contradictions.
*   Implemented an `@model_validator` in `EpistemicCurriculumManifest` to guarantee deterministic canonical hashing by actively sorting the `tasks` array using `task_id` during instantiation.
*   Preserved strict array ordering for `EpistemicTopologicalProofManifest.axiomatic_chain` utilizing the `# Note:` exemption rule.
*   Appended all necessary `.model_rebuild()` calls to the bottom of the Stratum to prevent `ForwardRef` collapse.

**Testing:**
*   Added `tests/contracts/test_curriculum_synthesis.py` to cryptographically prove the strict validation contracts (dual lock failure, task sorting, sequence preservation).
*   All mandatory local verification gates (`ruff format`, `ruff check`, `mypy`, `pytest`) have been executed and pass cleanly.

---
*PR created automatically by Jules for task [6009281976041999001](https://jules.google.com/task/6009281976041999001) started by @gowthamrao*