### PR TITLE
Refactor: Dead Code Elimination and Syntax Modernization

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1506,7 +1506,7 @@ class BrowserDOMState(CoreasonBaseState):
                     ip = ipaddress.ip_address(int(clean_hostname))
                 else:
                     raise ValueError("Cannot parse IP")
-            except (ValueError, OverflowError):
+            except ValueError, OverflowError:
                 return url
         if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
             raise ValueError(f"SSRF mathematical bound violation detected: {ip}")

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1506,7 +1506,7 @@ class BrowserDOMState(CoreasonBaseState):
                     ip = ipaddress.ip_address(int(clean_hostname))
                 else:
                     raise ValueError("Cannot parse IP")
-            except ValueError, OverflowError:
+            except (ValueError, OverflowError):
                 return url
         if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
             raise ValueError(f"SSRF mathematical bound violation detected: {ip}")
@@ -3368,11 +3368,7 @@ class NDimensionalTensorManifest(CoreasonBaseState):
         for dim in self.shape:
             if dim <= 0:
                 raise ValueError(f"Tensor dimensions must be strictly positive integers. Got: {self.shape}")
-        bytes_per_element = (
-            self.structural_type.bytes_per_element
-            if isinstance(self.structural_type, TensorStructuralFormatProfile)
-            else TensorStructuralFormatProfile(self.structural_type).bytes_per_element
-        )
+        bytes_per_element = self.structural_type.bytes_per_element
         calculated_bytes = math.prod(self.shape) * bytes_per_element
         if calculated_bytes != self.vram_footprint_bytes:
             raise ValueError(

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -171,7 +171,7 @@ def generate_correction_prompt(error: ValidationError, target_node_id: str, faul
     for err in error.errors():
         loc_path = "".join(f"/{item!s}" for item in err["loc"]) if err["loc"] else "/"
         failing_pointers.append(loc_path)
-        err_type = err.get("type", "unknown")
+        err_type = err["type"]
         if err_type == "missing":
             error_messages.append(
                 f"The required semantic boundary at '{loc_path}' is completely missing. You must project this missing dimension to satisfy the StateContract."  # noqa: E501
@@ -316,12 +316,8 @@ def verify_ast_safety(payload: str) -> bool:
         ast.operator,
         ast.unaryop,
         ast.Subscript,
+        ast.Slice,
     ]
-
-    if hasattr(ast, "Index"):
-        base_allowlist.append(ast.Index)
-    if hasattr(ast, "Slice"):
-        base_allowlist.append(ast.Slice)
 
     allowlist: tuple[type, ...] = tuple(base_allowlist)
 
@@ -469,8 +465,8 @@ def apply_state_differential(
 
         elif patch.op in ("copy", "move"):
             from_path = patch.from_path
-            if not isinstance(from_path, str):
-                raise ValueError(f"Invalid from_path: {from_path}")
+            if from_path is None:
+                raise ValueError("from_path is mathematically required for copy/move operations.")
             try:
                 from_target, from_last = resolve_from_path(from_path)
                 val = extract_from_target(from_target, from_last)

--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -389,6 +389,7 @@ def test_verify_merkle_proof_none_hash() -> None:
         ({"op": "test", "path": "/arr/0", "value": 99}, "Patch test operation failed"),
         ({"op": "copy", "path": "/nested/new_key", "from": "/arr/10"}, "Invalid from_path operation"),
         ({"op": "copy", "path": "/nested/new_key", "from": "/nested/key/invalid"}, "Invalid from_path"),
+        ({"op": "copy", "path": "/nested/new_key"}, "from_path is mathematically required for copy/move operations."),
     ],
 )
 def test_apply_state_differential_atomic_failures(patch_kwargs: dict[str, Any], match_str: str) -> None:


### PR DESCRIPTION
Executed the requested 5 atomic refactoring tasks targeting `src/coreason_manifest/utils/algebra.py` and `src/coreason_manifest/spec/ontology.py`.

1. **Task 1: Eliminate Legacy AST Bounding (Dead Code)**
   - Removed the `hasattr` checks for `ast.Index` and `ast.Slice` since they are obsolete in Python 3.14+. Appended `ast.Slice` directly to `base_allowlist`.
2. **Task 2: Fix Buggy Exception Shadowing**
   - Changed `except ValueError, OverflowError:` to `except (ValueError, OverflowError):` to prevent the built-in `OverflowError` from being shadowed as a variable in `BrowserDOMState._enforce_spatial_safety()`.
3. **Task 3: Prune Impossible Pydantic Type Coercions**
   - Removed the redundant `isinstance` check in `NDimensionalTensorManifest._enforce_physics_engine()` because `model_config = ConfigDict(strict=True)` guarantees the Enum instance. Simplified the assignment.
4. **Task 4: Remove Redundant Error Dictionary Fallbacks**
   - Removed the `.get("type", "unknown")` fallback in `generate_correction_prompt()` since Pydantic guarantees the presence of the `"type"` key.
5. **Task 5: Eliminate Over-Defensive Type Assertions**
   - Changed the `isinstance(from_path, str)` check in `apply_state_differential()` to check `from_path is None`, raising the exact requested ValueError since Pydantic freezes the type bounds to `str | None`.

Verified changes via local testing (`ruff format`, `ruff check`, `mypy`, `pytest`). All pass correctly.

---
*PR created automatically by Jules for task [15314298007240477990](https://jules.google.com/task/15314298007240477990) started by @gowthamrao*