### PR TITLE
chore: apply 2026 Prosperity Public License 3.0 header to all Python files

### DIFF
--- a/scripts/evaluate_architecture.py
+++ b/scripts/evaluate_architecture.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import re
 import sys
 

--- a/scripts/semantic_diff.py
+++ b/scripts/semantic_diff.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 import subprocess
 import sys

--- a/scripts/swarm_watchdog.py
+++ b/scripts/swarm_watchdog.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 import sys
 import urllib.request

--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -1,5 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
 # ruff: noqa: F405
-# Copyright (c) 2026 CoReason, Inc.. All Rights Reserved
 
 from coreason_manifest.spec.ontology import *  # noqa: F403
 from coreason_manifest.utils.algebra import (

--- a/src/coreason_manifest/spec/__init__.py
+++ b/src/coreason_manifest/spec/__init__.py
@@ -1,8 +1,11 @@
-# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+# Copyright (c) 2026 CoReason, Inc.
 #
-# This software is licensed under the Prosperity Public License 3.0.0.
-# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
 #
-# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 __all__ = []

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1,9 +1,12 @@
-# Copyright (c) 2025 CoReason, Inc.. All Rights Reserved
+# Copyright (c) 2026 CoReason, Inc.
 #
-# This software is licensed under the Prosperity Public License 3.0.0.
-# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
 #
-# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 from __future__ import annotations
 

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -1,9 +1,12 @@
-# Copyright (c) 2026 CoReason, Inc.. All Rights Reserved
+# Copyright (c) 2026 CoReason, Inc.
 #
-# This software is licensed under the Prosperity Public License 3.0.0.
-# The issuer of the Prosperity Public License for this software is CoReason, Inc..
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
 #
-# For a commercial version of this software, please contact us at gowtham.rao@coreason.ai.
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
 
 """AGENT INSTRUCTION: This module contains pure data transformations of the Hollow Data Plane."""
 

--- a/tests/contracts/__init__.py
+++ b/tests/contracts/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest

--- a/tests/contracts/test_advanced_neurosymbolic.py
+++ b/tests/contracts/test_advanced_neurosymbolic.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/contracts/test_adversarial_market_topology.py
+++ b/tests/contracts/test_adversarial_market_topology.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any
 
 import hypothesis.strategies as st

--- a/tests/contracts/test_algebra.py
+++ b/tests/contracts/test_algebra.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import base64
 import struct
 from copy import deepcopy

--- a/tests/contracts/test_bounded_json_rpc_intent.py
+++ b/tests/contracts/test_bounded_json_rpc_intent.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any
 
 import hypothesis.strategies as st

--- a/tests/contracts/test_browser_dom_state.py
+++ b/tests/contracts/test_browser_dom_state.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import ipaddress
 
 import hypothesis.strategies as st

--- a/tests/contracts/test_curriculum_synthesis.py
+++ b/tests/contracts/test_curriculum_synthesis.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import re
 
 import pytest

--- a/tests/contracts/test_document_layout_manifest.py
+++ b/tests/contracts/test_document_layout_manifest.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any
 
 import hypothesis.strategies as st

--- a/tests/contracts/test_domain_extensions.py
+++ b/tests/contracts/test_domain_extensions.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any
 
 import hypothesis.strategies as st

--- a/tests/contracts/test_epistemic_distillation.py
+++ b/tests/contracts/test_epistemic_distillation.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/contracts/test_execution_node_receipt.py
+++ b/tests/contracts/test_execution_node_receipt.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import json
 from typing import Any
 

--- a/tests/contracts/test_implicit_reward_rl.py
+++ b/tests/contracts/test_implicit_reward_rl.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from coreason_manifest.spec.ontology import (
     CognitiveFormatContract,
     CognitiveRewardEvaluationReceipt,

--- a/tests/contracts/test_latent_scratchpad_receipt.py
+++ b/tests/contracts/test_latent_scratchpad_receipt.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any
 
 import hypothesis.strategies as st

--- a/tests/contracts/test_n_dimensional_tensor_manifest.py
+++ b/tests/contracts/test_n_dimensional_tensor_manifest.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import math
 
 import hypothesis.strategies as st

--- a/tests/contracts/test_ontology_coverage.py
+++ b/tests/contracts/test_ontology_coverage.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import pytest
 from pydantic import ValidationError
 

--- a/tests/contracts/test_ontology_payload_bounds.py
+++ b/tests/contracts/test_ontology_payload_bounds.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any, cast
 
 import hypothesis.strategies as st

--- a/tests/contracts/test_ontology_validators.py
+++ b/tests/contracts/test_ontology_validators.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import hypothesis.strategies as st
 import pytest
 from hypothesis import HealthCheck, given, settings

--- a/tests/contracts/test_topology_manifests.py
+++ b/tests/contracts/test_topology_manifests.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import hypothesis.strategies as st
 import pytest
 from hypothesis import HealthCheck, given, settings

--- a/tests/fuzzing/__init__.py
+++ b/tests/fuzzing/__init__.py
@@ -1,0 +1,9 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any
 
 import hypothesis.strategies as st

--- a/tests/fuzzing/test_epistemology.py
+++ b/tests/fuzzing/test_epistemology.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any
 
 import hypothesis.strategies as st

--- a/tests/fuzzing/test_topologies.py
+++ b/tests/fuzzing/test_topologies.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 from typing import Any
 
 import hypothesis.strategies as st

--- a/tests/scripts/test_watchdog.py
+++ b/tests/scripts/test_watchdog.py
@@ -1,3 +1,13 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
 import os
 import sys
 


### PR DESCRIPTION
Replaced outdated/incomplete license headers in all `.py` files with the exact, verbatim 2026 CoReason, Inc. Prosperity Public License 3.0 header. Verified that linter directives and imports remain intact and that all CI tests, formatters, linters, and type-checkers pass perfectly.

---
*PR created automatically by Jules for task [10629817744348392720](https://jules.google.com/task/10629817744348392720) started by @gowthamrao*