### PR TITLE
Fix boundary failures in coreason_manifest

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1480,6 +1480,8 @@ class BrowserDOMState(CoreasonBaseState):
             raise ValueError("SSRF topological violation detected: file:// schema is forbidden")
         hostname = parsed.hostname
         if not hostname:
+            if parsed.scheme in ("http", "https"):
+                raise ValueError("SSRF topological violation detected: Invalid hostname in HTTP URI")
             return url
         hostname_lower = hostname.lower()
         if hostname_lower in {"localhost", "broadcasthost"} or hostname_lower.endswith(
@@ -2450,8 +2452,8 @@ class GenerativeManifoldSLA(CoreasonBaseState):
     @model_validator(mode="after")
     def enforce_geometric_bounds(self) -> Self:
         """Mathematically guarantees the configuration cannot authorize an OOM explosion."""
-        if self.max_topological_depth * self.max_node_fanout > 1000:
-            raise ValueError("Geometric explosion risk: max_topological_depth * max_node_fanout must be <= 1000.")
+        if self.max_node_fanout**self.max_topological_depth > 1000:
+            raise ValueError("Geometric explosion risk: max_node_fanout ** max_topological_depth must be <= 1000.")
         return self
 
 

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -471,6 +471,10 @@ def apply_state_differential(
             from_path = patch.from_path
             if from_path is None:
                 raise ValueError("from_path is mathematically required for copy/move operations.")
+
+            if path.startswith(from_path + "/"):
+                raise ValueError(f"The 'from' location MUST NOT be a proper prefix of the 'path' location: {path}")
+
             try:
                 from_target, from_last = resolve_from_path(from_path)
                 val = extract_from_target(from_target, from_last)
@@ -489,6 +493,15 @@ def apply_state_differential(
                 else:
                     try:
                         idx = int(last_part)
+
+                        if patch.op == "move" and from_target is target:
+                            try:
+                                from_idx = int(from_last)
+                                if from_idx < int(last_part):
+                                    idx -= 1
+                            except ValueError:
+                                pass
+
                         if idx < 0 or idx > len(target):
                             raise ValueError(f"Index out of bounds: {path}")
                         target.insert(idx, val)

--- a/tests/contracts/test_algebra_rfc.py
+++ b/tests/contracts/test_algebra_rfc.py
@@ -8,7 +8,7 @@ from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMuta
 from coreason_manifest.utils.algebra import apply_state_differential
 
 
-def test_move_down():
+def test_move_down() -> None:
     manifest = StateDifferentialManifest(
         diff_id="test",
         author_node_id="author",
@@ -21,7 +21,7 @@ def test_move_down():
     assert new_state == {"a": [3, 1, 2]}
 
 
-def test_prefix():
+def test_prefix() -> None:
     manifest = StateDifferentialManifest(
         diff_id="test",
         author_node_id="author",

--- a/tests/contracts/test_algebra_rfc.py
+++ b/tests/contracts/test_algebra_rfc.py
@@ -1,0 +1,34 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("src"))
+from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMutationIntent
+from coreason_manifest.utils.algebra import apply_state_differential
+
+
+def test_move_down():
+    manifest = StateDifferentialManifest(
+        diff_id="test",
+        author_node_id="author",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="move", path="/a/0", **{"from": "/a/2"})],
+    )
+    current_state = {"a": [1, 2, 3]}
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": [3, 1, 2]}
+
+
+def test_prefix():
+    manifest = StateDifferentialManifest(
+        diff_id="test",
+        author_node_id="author",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="move", path="/a/b", **{"from": "/a"})],
+    )
+    current_state = {"a": {"x": 1}}
+    with pytest.raises(ValueError, match="MUST NOT be a proper prefix"):
+        apply_state_differential(current_state, manifest)

--- a/tests/contracts/test_algebra_rfc2.py
+++ b/tests/contracts/test_algebra_rfc2.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("src"))
+from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMutationIntent
+from coreason_manifest.utils.algebra import apply_state_differential
+
+
+def test_move_exception():
+    manifest = StateDifferentialManifest(
+        diff_id="test",
+        author_node_id="author",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="move", path="/a/2", **{"from": "/a/x"})],
+    )
+    current_state = {"a": [1, 2, 3]}
+    with pytest.raises(ValueError):
+        apply_state_differential(current_state, manifest)
+
+
+test_move_exception()

--- a/tests/contracts/test_algebra_rfc2.py
+++ b/tests/contracts/test_algebra_rfc2.py
@@ -8,7 +8,7 @@ from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMuta
 from coreason_manifest.utils.algebra import apply_state_differential
 
 
-def test_move_exception():
+def test_move_exception() -> None:
     manifest = StateDifferentialManifest(
         diff_id="test",
         author_node_id="author",

--- a/tests/contracts/test_algebra_rfc2.py
+++ b/tests/contracts/test_algebra_rfc2.py
@@ -17,7 +17,7 @@ def test_move_exception():
         patches=[StateMutationIntent(op="move", path="/a/2", **{"from": "/a/x"})],
     )
     current_state = {"a": [1, 2, 3]}
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="Invalid from_path operation: Invalid index"):
         apply_state_differential(current_state, manifest)
 
 

--- a/tests/contracts/test_algebra_rfc3.py
+++ b/tests/contracts/test_algebra_rfc3.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath("src"))
+from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMutationIntent
+from coreason_manifest.utils.algebra import apply_state_differential
+
+
+def test_move_exception_value_error():
+    manifest = StateDifferentialManifest(
+        diff_id="test",
+        author_node_id="author",
+        lamport_timestamp=1,
+        vector_clock={},
+        patches=[StateMutationIntent(op="move", path="/a/x", **{"from": "/a/2"})],
+    )
+    current_state = {"a": [1, 2, 3]}
+    with pytest.raises(ValueError, match="Invalid index"):
+        apply_state_differential(current_state, manifest)
+
+
+test_move_exception_value_error()

--- a/tests/contracts/test_algebra_rfc_copy.py
+++ b/tests/contracts/test_algebra_rfc_copy.py
@@ -1,24 +1,19 @@
 import os
 import sys
 
-import pytest
-
 sys.path.insert(0, os.path.abspath("src"))
 from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMutationIntent
 from coreason_manifest.utils.algebra import apply_state_differential
 
 
-def test_move_exception_value_error() -> None:
+def test_copy() -> None:
     manifest = StateDifferentialManifest(
         diff_id="test",
         author_node_id="author",
         lamport_timestamp=1,
         vector_clock={},
-        patches=[StateMutationIntent(op="move", path="/a/x", **{"from": "/a/2"})],
+        patches=[StateMutationIntent(op="copy", path="/a/2", **{"from": "/a/0"})],
     )
     current_state = {"a": [1, 2, 3]}
-    with pytest.raises(ValueError, match="Invalid index"):
-        apply_state_differential(current_state, manifest)
-
-
-test_move_exception_value_error()
+    new_state = apply_state_differential(current_state, manifest)
+    assert new_state == {"a": [1, 2, 1, 3]}

--- a/tests/contracts/test_algebra_rfc_copy_move.py
+++ b/tests/contracts/test_algebra_rfc_copy_move.py
@@ -8,17 +8,17 @@ from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMuta
 from coreason_manifest.utils.algebra import apply_state_differential
 
 
-def test_move_exception_value_error() -> None:
+def test_copy_exception_value_error() -> None:
     manifest = StateDifferentialManifest(
         diff_id="test",
         author_node_id="author",
         lamport_timestamp=1,
         vector_clock={},
-        patches=[StateMutationIntent(op="move", path="/a/x", **{"from": "/a/2"})],
+        patches=[StateMutationIntent(op="copy", path="/a/x", **{"from": "/a/2"})],
     )
     current_state = {"a": [1, 2, 3]}
     with pytest.raises(ValueError, match="Invalid index"):
         apply_state_differential(current_state, manifest)
 
 
-test_move_exception_value_error()
+test_copy_exception_value_error()

--- a/tests/contracts/test_algebra_rfc_copy_prefix.py
+++ b/tests/contracts/test_algebra_rfc_copy_prefix.py
@@ -8,17 +8,17 @@ from coreason_manifest.spec.ontology import StateDifferentialManifest, StateMuta
 from coreason_manifest.utils.algebra import apply_state_differential
 
 
-def test_move_exception_value_error() -> None:
+def test_copy_prefix() -> None:
     manifest = StateDifferentialManifest(
         diff_id="test",
         author_node_id="author",
         lamport_timestamp=1,
         vector_clock={},
-        patches=[StateMutationIntent(op="move", path="/a/x", **{"from": "/a/2"})],
+        patches=[StateMutationIntent(op="copy", path="/a/b", **{"from": "/a"})],
     )
-    current_state = {"a": [1, 2, 3]}
-    with pytest.raises(ValueError, match="Invalid index"):
+    current_state = {"a": {"x": 1}}
+    with pytest.raises(ValueError, match="MUST NOT be a proper prefix"):
         apply_state_differential(current_state, manifest)
 
 
-test_move_exception_value_error()
+test_copy_prefix()

--- a/tests/contracts/test_ssrf_safety.py
+++ b/tests/contracts/test_ssrf_safety.py
@@ -1,0 +1,24 @@
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import BrowserDOMState
+
+
+def test_ssrf_safety_http():
+    with pytest.raises(ValidationError, match="Invalid hostname in HTTP URI"):
+        BrowserDOMState(
+            current_url="http:///169.254.169.254",
+            viewport_size=(800, 600),
+            dom_hash="a" * 64,
+            accessibility_tree_hash="b" * 64,
+        )
+
+
+def test_ssrf_safety_https():
+    with pytest.raises(ValidationError, match="Invalid hostname in HTTP URI"):
+        BrowserDOMState(
+            current_url="https:///127.0.0.1",
+            viewport_size=(800, 600),
+            dom_hash="a" * 64,
+            accessibility_tree_hash="b" * 64,
+        )

--- a/tests/contracts/test_ssrf_safety.py
+++ b/tests/contracts/test_ssrf_safety.py
@@ -4,7 +4,7 @@ from pydantic import ValidationError
 from coreason_manifest.spec.ontology import BrowserDOMState
 
 
-def test_ssrf_safety_http():
+def test_ssrf_safety_http() -> None:
     with pytest.raises(ValidationError, match="Invalid hostname in HTTP URI"):
         BrowserDOMState(
             current_url="http:///169.254.169.254",
@@ -14,7 +14,7 @@ def test_ssrf_safety_http():
         )
 
 
-def test_ssrf_safety_https():
+def test_ssrf_safety_https() -> None:
     with pytest.raises(ValidationError, match="Invalid hostname in HTTP URI"):
         BrowserDOMState(
             current_url="https:///127.0.0.1",

--- a/tests/fuzzing/test_topologies.py
+++ b/tests/fuzzing/test_topologies.py
@@ -88,7 +88,7 @@ def test_generative_manifold_geometric_explosion(depth: int, fanout: int) -> Non
     """Prove that GenerativeManifoldSLA mathematically rejects configurations that cause geometric explosion."""
     from hypothesis import assume
 
-    assume(fanout ** depth > 1000)
+    assume(fanout**depth > 1000)
 
     with pytest.raises(ValidationError, match="Geometric explosion risk"):
         GenerativeManifoldSLA(max_topological_depth=depth, max_node_fanout=fanout, max_synthetic_tokens=1000)

--- a/tests/fuzzing/test_topologies.py
+++ b/tests/fuzzing/test_topologies.py
@@ -88,7 +88,7 @@ def test_generative_manifold_geometric_explosion(depth: int, fanout: int) -> Non
     """Prove that GenerativeManifoldSLA mathematically rejects configurations that cause geometric explosion."""
     from hypothesis import assume
 
-    assume(depth * fanout > 1000)
+    assume(fanout ** depth > 1000)
 
     with pytest.raises(ValidationError, match="Geometric explosion risk"):
         GenerativeManifoldSLA(max_topological_depth=depth, max_node_fanout=fanout, max_synthetic_tokens=1000)


### PR DESCRIPTION
Fix boundary failures in coreason_manifest

- Fix OOM vulnerability in GenerativeManifoldSLA caused by linear growth calculation instead of exponential.
- Patch SSRF bypass in BrowserDOMState by enforcing strict checks for http/https schemes with missing hostnames.
- Enforce strict RFC 6902 compliance in apply_state_differential by adding prefix validation and fixing array shift bugs for move operations.

---
*PR created automatically by Jules for task [14306495620401625017](https://jules.google.com/task/14306495620401625017) started by @gowthamrao*