### PR TITLE
fix: Patch AST Immutability Lock and Inject Matrix Fuzzing Tripwires

### DIFF
--- a/scripts/evaluate_instantiation_bounds.py
+++ b/scripts/evaluate_instantiation_bounds.py
@@ -14,20 +14,21 @@ from pathlib import Path
 
 
 def is_forbidden_config(node: ast.expr) -> bool:
-    """Check if model_config assignment attempts to set forbidden properties to False."""
+    """Check if model_config assignment attempts to set forbidden properties to False or variable."""
     forbidden_keys = {"frozen", "strict", "validate_assignment"}
 
-    if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "ConfigDict":
+    if isinstance(node, ast.Call) and (
+        getattr(node.func, "id", None) == "ConfigDict" or getattr(node.func, "attr", None) == "ConfigDict"
+    ):
         for kw in node.keywords:
-            if kw.arg in forbidden_keys and isinstance(kw.value, ast.Constant) and kw.value.value is False:
+            if kw.arg in forbidden_keys and not (isinstance(kw.value, ast.Constant) and kw.value.value is True):
                 return True
     elif isinstance(node, ast.Dict):
         for key, value in zip(node.keys, node.values, strict=False):
             if (
                 isinstance(key, ast.Constant)
                 and key.value in forbidden_keys
-                and isinstance(value, ast.Constant)
-                and value.value is False
+                and not (isinstance(value, ast.Constant) and value.value is True)
             ):
                 return True
     return False

--- a/tests/fuzzing/test_instantiation_bounds.py
+++ b/tests/fuzzing/test_instantiation_bounds.py
@@ -23,6 +23,7 @@ from coreason_manifest.spec.ontology import (
     SpatialBoundingBoxProfile,
     StateHydrationManifest,
     SystemNodeProfile,
+    TaxonomicRoutingPolicy,
 )
 
 valid_node_id_st = st.from_regex(r"^did:[a-z0-9]+:[a-zA-Z0-9.\-_:]+$", fullmatch=True)
@@ -194,4 +195,31 @@ def test_payload_exhaustion_fuzzing(payload: dict[str, Any]) -> None:
             crystallized_ledger_cids=["a" * 64],
             working_context_variables=payload,
             max_retained_tokens=1000,
+        )
+
+
+@given(
+    target_heuristic=st.text().filter(
+        lambda x: x not in ["chronological", "entity_centric", "semantic_cluster", "confidence_decay"]
+    )
+)
+def test_categorical_hallucination_fuzzing(target_heuristic: str) -> None:
+    """Categorical Hallucination Fuzzing: Fuzz TaxonomyRoutingPolicy with invalid literal categories."""
+    with pytest.raises((ValidationError, ValueError)):
+        TaxonomicRoutingPolicy(
+            policy_id="test",
+            intent_to_heuristic_matrix={},
+            fallback_heuristic=target_heuristic,  # type: ignore
+        )
+
+
+@given(massive_key=st.text(min_size=10001))
+@pytest.mark.xfail(strict=False, reason="Epic 3 will handle the refactoring of the God Context")
+def test_dictionary_bombing_fuzzing(massive_key: str) -> None:
+    """Dictionary Bombing Fuzzing: Attempt to pass a massive key to intent_to_heuristic_matrix."""
+    with pytest.raises((ValidationError, ValueError)):
+        TaxonomicRoutingPolicy(
+            policy_id="test",
+            intent_to_heuristic_matrix={massive_key: "chronological"},
+            fallback_heuristic="chronological",
         )


### PR DESCRIPTION
This PR resolves the Hotfix 1.5 & 2.5 requirements by updating the AST parser logic for immutability locking and injecting matrix fuzzing tripwires for testing categorical hallucination and dictionary bombing.

---
*PR created automatically by Jules for task [12840092951351370497](https://jules.google.com/task/12840092951351370497) started by @gowthamrao*