### PR TITLE
Final Polish & Legacy Cleanup: Recursive extension validator and orphaned types

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -222,7 +222,6 @@ type FaultCategoryProfile = Literal[
     "temporal_dilation",
     "dependency_blackout",
 ]
-type CognitiveTierProfile = Literal["working", "episodic", "semantic"]
 type NodeIdentifierState = Annotated[
     str,
     Field(
@@ -370,23 +369,24 @@ class CoreasonBaseState(BaseModel):
     @model_validator(mode="after")
     def validate_global_domain_extensions(self, info: ValidationInfo) -> Self:
         """
-        Global mathematical boundary: Prove any 'ext:' string exists in the
-        active client's dynamically loaded vocabulary.
+        Global mathematical boundary: Recursively prove any 'ext:' string exists
+        in the active client's dynamically loaded vocabulary.
         """
         allowed_exts = (info.context or {}).get("allowed_ext_intents", set())
-        for k, v in self.__dict__.items():
-            if isinstance(v, str) and v.startswith("ext:") and v not in allowed_exts:
-                raise ValueError(f"Unauthorized extension string in field {k}: {v}")
-            if isinstance(v, dict):
-                for dk, dv in v.items():
-                    if isinstance(dk, str) and dk.startswith("ext:") and dk not in allowed_exts:
-                        raise ValueError(f"Unauthorized extension string in dict key of {k}: {dk}")
-                    if isinstance(dv, str) and dv.startswith("ext:") and dv not in allowed_exts:
-                        raise ValueError(f"Unauthorized extension string in dict value of {k}: {dv}")
-            if isinstance(v, list):
-                for item in v:
-                    if isinstance(item, str) and item.startswith("ext:") and item not in allowed_exts:
-                        raise ValueError(f"Unauthorized extension string in list of {k}: {item}")
+
+        def _walk_and_validate(obj: Any) -> None:
+            if isinstance(obj, str):
+                if obj.startswith("ext:") and obj not in allowed_exts:
+                    raise ValueError(f"Unauthorized domain extension string detected: '{obj}'")
+            elif isinstance(obj, dict):
+                for k, v in obj.items():
+                    _walk_and_validate(k)
+                    _walk_and_validate(v)
+            elif isinstance(obj, (list, tuple, set)):
+                for item in obj:
+                    _walk_and_validate(item)
+
+        _walk_and_validate(self.__dict__)
         return self
 
 
@@ -1662,7 +1662,6 @@ class AnchoringPolicy(CoreasonBaseState):
     )
 
 
-type AttackVectorProfile = Literal["rebuttal", "undercutter", "underminer"]
 type AttestationMechanismProfile = Literal["fido2_webauthn", "zk_snark_groth16", "pqc_ml_dsa"]
 
 
@@ -2210,7 +2209,7 @@ class DefeasibleAttackEvent(CoreasonBaseState):
         pattern="^[a-zA-Z0-9_.:-]+$",
         description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the claim being attacked.",  # noqa: E501
     )
-    attack_vector: AttackVectorProfile = Field(description="Geometric matrices of undercutting defeaters.")
+    attack_vector: DefeasibleEdgeType = Field(description="Geometric matrices of undercutting defeaters.")
 
 
 class DimensionalProjectionContract(CoreasonBaseState):
@@ -5484,7 +5483,7 @@ class SemanticNodeState(CoreasonBaseState):
     provenance: EpistemicProvenanceReceipt = Field(
         description="The cryptographic chain of custody for this semantic state."
     )
-    tier: CognitiveTierProfile = Field(
+    tier: CognitiveMemoryDomain = Field(
         default="semantic", description="The cognitive tier this latent state resides in."
     )
     temporal_bounds: TemporalBoundsProfile | None = Field(

--- a/tests/contracts/test_coverage_bump.py
+++ b/tests/contracts/test_coverage_bump.py
@@ -1,2 +1,2 @@
-def test_dummy_coverage():
+def test_dummy_coverage() -> None:
     pass

--- a/tests/contracts/test_coverage_bump.py
+++ b/tests/contracts/test_coverage_bump.py
@@ -1,0 +1,8 @@
+import pytest
+from coreason_manifest.spec.ontology import (
+    CognitiveMemoryDomain,
+    DefeasibleEdgeType,
+)
+
+def test_dummy_coverage():
+    pass

--- a/tests/contracts/test_coverage_bump.py
+++ b/tests/contracts/test_coverage_bump.py
@@ -1,8 +1,2 @@
-import pytest
-from coreason_manifest.spec.ontology import (
-    CognitiveMemoryDomain,
-    DefeasibleEdgeType,
-)
-
 def test_dummy_coverage():
     pass

--- a/tests/contracts/test_domain_extensions.py
+++ b/tests/contracts/test_domain_extensions.py
@@ -27,7 +27,7 @@ def test_taxonomic_routing_policy_extensions() -> None:
             intent_to_heuristic_matrix={"ext:custom_intent": "chronological"},
             fallback_heuristic="chronological",
         )
-    assert "Unauthorized extension string" in str(exc.value)
+    assert "Unauthorized domain extension string" in str(exc.value)
 
     # Test valid extension with context
     p3 = TaxonomicRoutingPolicy.model_validate(
@@ -168,7 +168,7 @@ def test_dict_validation_in_barge_in_event() -> None:
             },
             context={"allowed_ext_intents": set()},
         )
-    assert "Unauthorized extension string in dict key" in str(exc.value)
+    assert "Unauthorized domain extension string detected: 'ext:invalid_key'" in str(exc.value)
 
     # Invalid value
     with pytest.raises(ValidationError) as exc:
@@ -200,10 +200,19 @@ def test_dict_validation_in_taxonomic_routing_policy() -> None:
             },
             context={"allowed_ext_intents": set()},
         )
-    assert "Unauthorized extension string in dict key" in str(exc.value)
+    assert "Unauthorized domain extension string detected: 'ext:invalid_key'" in str(exc.value)
 
-    # To test an invalid value in dict, we'd need to bypass pydantic's typing or use a field that allows it.
-    # intent_to_heuristic_matrix values are Literal, so passing "ext:invalid" fails pydantic typing.
-    # Is there another dict in TaxonomicRoutingPolicy? No.
-    # The dv check branch is technically unreachable for normal validation.
-    # We can hit it by modifying the class __dict__.
+    # List extension tests
+    with pytest.raises(ValidationError) as exc:
+        BargeInInterruptEvent.model_validate(
+            {
+                "event_id": "e5",
+                "timestamp": 100.0,
+                "target_event_id": "t5",
+                "epistemic_disposition": "discard",
+                "disfluency_type": "repair",
+                "retained_partial_payload": {"k": ["ext:invalid_list_val"]},
+            },
+            context={"allowed_ext_intents": set()},
+        )
+    assert "Unauthorized domain extension string detected: 'ext:invalid_list_val'" in str(exc.value)


### PR DESCRIPTION
Fixes #1: Final Polish & Legacy Cleanup

This commit removes orphaned legacy types `CognitiveTierProfile` and `AttackVectorProfile` from `ontology.py` and updates `SemanticNodeState` and `DefeasibleAttackEvent` to use the new extensible types `CognitiveMemoryDomain` and `DefeasibleEdgeType`.

It also replaces the shallow `validate_global_domain_extensions` `@model_validator` in `CoreasonBaseState` with a rigorous recursive version to prevent malicious extension strings hidden inside nested collections from bypassing validation. Test cases have been updated to reflect the new validation exception error messages.

---
*PR created automatically by Jules for task [3328093107464991500](https://jules.google.com/task/3328093107464991500) started by @gowthamrao*