### PR TITLE
feat: I-POMDP epistemic logic and latent intent modeling patch

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -901,17 +901,17 @@ class CognitiveUncertaintyProfile(CoreasonBaseState):
         le=1000000000.0,
         description="The causal gap demanding Do-Calculus Interventions (P(y|do(x))), measured in bits/nats.",
     )
-    theory_of_mind_divergence: float | None = Field(
-        default=None,
-        ge=0.0,
-        le=1000000000.0,
-        description="The mathematical KL divergence between the agent's internal belief distribution and the explicitly modeled TheoryOfMindSnapshot.",  # noqa: E501
-    )
     semantic_consistency_score: float = Field(
         ge=0.0, le=1.0, description="Counterfactual Geometries representing alternative timeline vectors."
     )
     requires_abductive_escalation: bool = Field(
         description="True if epistemic_uncertainty breaches the safety threshold, requiring structural mandate escalation."  # noqa: E501
+    )
+    theory_of_mind_divergence: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1000000000.0,
+        description="The mathematical KL divergence between the agent's internal belief distribution and the explicitly modeled TheoryOfMindSnapshot.",  # noqa: E501
     )
 
 
@@ -1966,7 +1966,7 @@ class BrowserDOMState(CoreasonBaseState):
                     ip = ipaddress.ip_address(ip_int)
                 else:
                     raise ValueError
-            except (ValueError, OverflowError, IndexError):
+            except ValueError, OverflowError, IndexError:
                 return url
         if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
             raise ValueError(f"SSRF restricted IP detected: {hostname}")
@@ -5370,11 +5370,10 @@ type AnyToolchainState = Annotated[
 
 
 class TheoryOfMindSnapshot(CoreasonBaseState):
-    target_agent_id: NodeIdentifierState | Annotated[
-        str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")
-    ] = Field(
-        description="The strict DID of the swarm node, or CID of an external user, whose mind is being modeled."
-    )
+    target_agent_id: (
+        NodeIdentifierState
+        | Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    ) = Field(description="The strict DID of the swarm node, or CID of an external user, whose mind is being modeled.")
     assumed_shared_beliefs: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
         description="The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses.",  # noqa: E501
     )

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -892,10 +892,16 @@ class CognitiveUncertaintyProfile(CoreasonBaseState):
     """Structural Causal Models (SCMs) for active epistemic bounding."""
 
     aleatoric_entropy: float = Field(
-        ge=0.0, le=1.0, description="Irreducible ambiguity detected in the observational fields (P(y|x))."
+        ge=0.0, le=1000000000.0, description="Irreducible ambiguity detected in the observational fields (P(y|x)), measured in bits/nats."
     )
     epistemic_uncertainty: float = Field(
-        ge=0.0, le=1.0, description="The causal gap demanding Do-Calculus Interventions (P(y|do(x)))."
+        ge=0.0, le=1000000000.0, description="The causal gap demanding Do-Calculus Interventions (P(y|do(x))), measured in bits/nats."
+    )
+    theory_of_mind_divergence: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=1000000000.0,
+        description="The mathematical KL divergence between the agent's internal belief distribution and the explicitly modeled TheoryOfMindSnapshot.",
     )
     semantic_consistency_score: float = Field(
         ge=0.0, le=1.0, description="Counterfactual Geometries representing alternative timeline vectors."
@@ -1956,7 +1962,7 @@ class BrowserDOMState(CoreasonBaseState):
                     ip = ipaddress.ip_address(ip_int)
                 else:
                     raise ValueError
-            except ValueError, OverflowError, IndexError:
+            except (ValueError, OverflowError, IndexError):
                 return url
         if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast:
             raise ValueError(f"SSRF restricted IP detected: {hostname}")
@@ -5360,18 +5366,15 @@ type AnyToolchainState = Annotated[
 
 
 class TheoryOfMindSnapshot(CoreasonBaseState):
-    target_agent_id: str = Field(
-        max_length=128,
-        pattern="^[a-zA-Z0-9_.:-]+$",
-        min_length=1,
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the agent whose mind is being modeled.",  # noqa: E501
+    target_agent_id: NodeIdentifierState | Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        description="The strict DID of the swarm node, or CID of an external user, whose mind is being modeled."
     )
     assumed_shared_beliefs: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
         description="The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses.",  # noqa: E501
     )
-    identified_knowledge_gaps: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        max_length=1000000000,
-        description="Specific topics or logical premises the target agent is assumed to be missing.",
+    identified_knowledge_gaps: list[Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]] = Field(
+        default_factory=list,
+        description="The explicit array of CIDs/DIDs representing the exact coordinate spaces (SemanticNodeStates or Domain Extensions) the target is mathematically proven to lack."
     )
 
     @model_validator(mode="after")

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -892,16 +892,20 @@ class CognitiveUncertaintyProfile(CoreasonBaseState):
     """Structural Causal Models (SCMs) for active epistemic bounding."""
 
     aleatoric_entropy: float = Field(
-        ge=0.0, le=1000000000.0, description="Irreducible ambiguity detected in the observational fields (P(y|x)), measured in bits/nats."
+        ge=0.0,
+        le=1000000000.0,
+        description="Irreducible ambiguity detected in the observational fields (P(y|x)), measured in bits/nats.",
     )
     epistemic_uncertainty: float = Field(
-        ge=0.0, le=1000000000.0, description="The causal gap demanding Do-Calculus Interventions (P(y|do(x))), measured in bits/nats."
+        ge=0.0,
+        le=1000000000.0,
+        description="The causal gap demanding Do-Calculus Interventions (P(y|do(x))), measured in bits/nats.",
     )
     theory_of_mind_divergence: float | None = Field(
         default=None,
         ge=0.0,
         le=1000000000.0,
-        description="The mathematical KL divergence between the agent's internal belief distribution and the explicitly modeled TheoryOfMindSnapshot.",
+        description="The mathematical KL divergence between the agent's internal belief distribution and the explicitly modeled TheoryOfMindSnapshot.",  # noqa: E501
     )
     semantic_consistency_score: float = Field(
         ge=0.0, le=1.0, description="Counterfactual Geometries representing alternative timeline vectors."
@@ -5366,15 +5370,19 @@ type AnyToolchainState = Annotated[
 
 
 class TheoryOfMindSnapshot(CoreasonBaseState):
-    target_agent_id: NodeIdentifierState | Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+    target_agent_id: NodeIdentifierState | Annotated[
+        str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")
+    ] = Field(
         description="The strict DID of the swarm node, or CID of an external user, whose mind is being modeled."
     )
     assumed_shared_beliefs: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
         description="The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses.",  # noqa: E501
     )
-    identified_knowledge_gaps: list[Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]] = Field(
+    identified_knowledge_gaps: list[
+        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    ] = Field(
         default_factory=list,
-        description="The explicit array of CIDs/DIDs representing the exact coordinate spaces (SemanticNodeStates or Domain Extensions) the target is mathematically proven to lack."
+        description="The explicit array of CIDs/DIDs representing the exact coordinate spaces (SemanticNodeStates or Domain Extensions) the target is mathematically proven to lack.",  # noqa: E501
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
- Refactored `CognitiveUncertaintyProfile` to relax entropy bounds to 1e9 and allow bit/nats measurement. Added `theory_of_mind_divergence` metric to track KL divergence against the empathetic model.
- Refactored `TheoryOfMindSnapshot` types for `target_agent_id` and `identified_knowledge_gaps` to use `NodeIdentifierState` and bounded CIDs/DIDs to enable deterministic graph pruning.
- Fixed a syntax error in an exception block (`ValueError, OverflowError, IndexError` -> `(ValueError, OverflowError, IndexError)`).

---
*PR created automatically by Jules for task [17440567446563579137](https://jules.google.com/task/17440567446563579137) started by @gowthamrao*