### PR TITLE
feat: Implement ActionSpaceManifest to OpenAI tools compiler functor

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -232,6 +232,24 @@ def calculate_remaining_compute(ledger: ontology.EpistemicLedgerState, initial_e
     return remaining
 
 
+def compile_action_space_to_openai_tools(action_space: ontology.ActionSpaceManifest) -> list[dict[str, Any]]:
+    """
+    A pure algebraic functor that projects the internal ActionSpaceManifest
+    into the standardized OpenAI/Anthropic external tool array format.
+    """
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": tool.tool_name,
+                "description": tool.description,
+                "parameters": tool.input_schema,
+            },
+        }
+        for tool in action_space.native_tools
+    ]
+
+
 def calculate_latent_alignment(
     v1: VectorEmbeddingState, v2: VectorEmbeddingState, policy: OntologicalAlignmentPolicy
 ) -> float:

--- a/tests/contracts/test_action_space_compiler.py
+++ b/tests/contracts/test_action_space_compiler.py
@@ -1,0 +1,47 @@
+
+from coreason_manifest.spec.ontology import (
+    ActionSpaceManifest,
+    PermissionBoundaryPolicy,
+    SideEffectProfile,
+    ToolManifest,
+)
+from coreason_manifest.utils.algebra import compile_action_space_to_openai_tools
+
+
+def test_compile_action_space_to_openai_tools():
+    """Test the compilation of ActionSpaceManifest to OpenAI tool format."""
+    manifest = ActionSpaceManifest(
+        action_space_id="test-action-space",
+        native_tools=[
+            ToolManifest(
+                tool_name="test_tool",
+                description="A test tool",
+                input_schema={"type": "object", "properties": {"param1": {"type": "string"}}, "required": ["param1"]},
+                side_effects=SideEffectProfile(is_idempotent=True, mutates_state=False),
+                permissions=PermissionBoundaryPolicy(network_access=False, file_system_mutation_forbidden=True),
+            )
+        ],
+    )
+
+    tools_payload = compile_action_space_to_openai_tools(manifest)
+
+    assert isinstance(tools_payload, list)
+    assert len(tools_payload) == 1
+    assert tools_payload[0] == {
+        "type": "function",
+        "function": {
+            "name": "test_tool",
+            "description": "A test tool",
+            "parameters": {"type": "object", "properties": {"param1": {"type": "string"}}, "required": ["param1"]},
+        },
+    }
+
+
+def test_compile_action_space_to_openai_tools_empty():
+    """Test the compilation of an empty ActionSpaceManifest to OpenAI tool format."""
+    manifest = ActionSpaceManifest(action_space_id="test-action-space-empty", native_tools=[])
+
+    tools_payload = compile_action_space_to_openai_tools(manifest)
+
+    assert isinstance(tools_payload, list)
+    assert len(tools_payload) == 0

--- a/tests/contracts/test_algebra_more.py
+++ b/tests/contracts/test_algebra_more.py
@@ -1,39 +1,34 @@
-import pytest
-import ast
 import base64
-import struct
-from pydantic import ValidationError
+
+import pytest
 
 from coreason_manifest.spec.ontology import (
-    WorkflowManifest,
-    VectorEmbeddingState,
     OntologicalAlignmentPolicy,
+    VectorEmbeddingState,
 )
 from coreason_manifest.utils.algebra import (
-    project_manifest_to_markdown,
-    verify_ast_safety,
     calculate_latent_alignment,
+    verify_ast_safety,
 )
+
 
 def test_verify_ast_safety_slice():
     payload = "[1, 2, 3][0:2]"
-    assert verify_ast_safety(payload) == True
+    assert verify_ast_safety(payload)
+
 
 def test_verify_ast_safety_forbidden():
-    payload = "[x for x in range(10)]" # List comprehension isn't in base_allowlist
+    payload = "[x for x in range(10)]"  # List comprehension isn't in base_allowlist
     with pytest.raises(ValueError, match="Kinetic execution bleed detected"):
         verify_ast_safety(payload)
 
+
 def test_calculate_latent_alignment_struct_error():
     v1 = VectorEmbeddingState(
-        model_name="test-model",
-        dimensionality=1000,
-        vector_base64=base64.b64encode(b"not enough data").decode()
+        model_name="test-model", dimensionality=1000, vector_base64=base64.b64encode(b"not enough data").decode()
     )
     v2 = VectorEmbeddingState(
-        model_name="test-model",
-        dimensionality=1000,
-        vector_base64=base64.b64encode(b"not enough data").decode()
+        model_name="test-model", dimensionality=1000, vector_base64=base64.b64encode(b"not enough data").decode()
     )
     policy = OntologicalAlignmentPolicy(min_cosine_similarity=0.5, require_isometry_proof=False)
     with pytest.raises(ValueError, match="Byte length does not match declared dimensionality"):

--- a/tests/contracts/test_algebra_more.py
+++ b/tests/contracts/test_algebra_more.py
@@ -1,0 +1,40 @@
+import pytest
+import ast
+import base64
+import struct
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import (
+    WorkflowManifest,
+    VectorEmbeddingState,
+    OntologicalAlignmentPolicy,
+)
+from coreason_manifest.utils.algebra import (
+    project_manifest_to_markdown,
+    verify_ast_safety,
+    calculate_latent_alignment,
+)
+
+def test_verify_ast_safety_slice():
+    payload = "[1, 2, 3][0:2]"
+    assert verify_ast_safety(payload) == True
+
+def test_verify_ast_safety_forbidden():
+    payload = "[x for x in range(10)]" # List comprehension isn't in base_allowlist
+    with pytest.raises(ValueError, match="Kinetic execution bleed detected"):
+        verify_ast_safety(payload)
+
+def test_calculate_latent_alignment_struct_error():
+    v1 = VectorEmbeddingState(
+        model_name="test-model",
+        dimensionality=1000,
+        vector_base64=base64.b64encode(b"not enough data").decode()
+    )
+    v2 = VectorEmbeddingState(
+        model_name="test-model",
+        dimensionality=1000,
+        vector_base64=base64.b64encode(b"not enough data").decode()
+    )
+    policy = OntologicalAlignmentPolicy(min_cosine_similarity=0.5, require_isometry_proof=False)
+    with pytest.raises(ValueError, match="Byte length does not match declared dimensionality"):
+        calculate_latent_alignment(v1, v2, policy)

--- a/tests/contracts/test_coverage_bump.py
+++ b/tests/contracts/test_coverage_bump.py
@@ -1,2 +1,0 @@
-def test_dummy_coverage() -> None:
-    pass


### PR DESCRIPTION
This pull request completes Workstream A of Epic 4, introducing the `compile_action_space_to_openai_tools` pure functor in `src/coreason_manifest/utils/algebra.py`.

The function correctly maps `ActionSpaceManifest.native_tools` to a list of dictionaries following the OpenAI format. It operates as a pure algebraic functor without side effects.

Tests have also been added in `tests/contracts/test_action_space_compiler.py` and `tests/contracts/test_algebra_more.py` to ensure correctness and maintain the mandatory strict `95%` code coverage.

---
*PR created automatically by Jules for task [2836233966713076119](https://jules.google.com/task/2836233966713076119) started by @gowthamrao*