### PR TITLE
feat: implement deterministic extraction contracts for Visual OCR and DOM-less data extraction

### DIFF
--- a/src/coreason_manifest/__init__.py
+++ b/src/coreason_manifest/__init__.py
@@ -111,6 +111,7 @@ __all__ = [
     "DefeasibleAttackEvent",
     "DefeasibleCascadeEvent",
     "DelegatedCapabilityManifest",
+    "DeterministicExtractionContract",
     "DifferentiableLogicConstraint",
     "DigitalTwinTopologyManifest",
     "DimensionalProjectionContract",

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1034,6 +1034,36 @@ class ActivationSteeringContract(CoreasonBaseState):
         return self
 
 
+class DeterministicExtractionContract(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: The strict symbolic boundary forcing the probabilistic VLM output into a deterministic string
+    or schema via hard execution of Regex, XPath, or CSS Selectors.
+    """
+
+    contract_id: str = Field(
+        min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$"
+    )
+    extraction_type: Literal["regex", "xpath", "css_selector", "json_pointer"] = Field(
+        description="The exact deterministic engine to use."
+    )
+    query_string: str = Field(
+        max_length=2000, description="The actual Regex pattern or DOM selector."
+    )
+    strict_type_coercion: Literal["string", "integer", "float", "boolean", "date"] = Field(
+        description="The required final primitive type post-extraction."
+    )
+    fallback_value: JsonPrimitiveState | None = Field(
+        default=None, description="Optional default if the query yields a null set."
+    )
+
+    @field_validator("fallback_value", mode="before")
+    @classmethod
+    def validate_payload(cls, v: Any) -> Any:
+        if v is None:
+            return None
+        return _validate_payload_bounds(v)
+
+
 class SemanticSlicingPolicy(CoreasonBaseState):
     """
     AGENT INSTRUCTION: SemanticSlicingPolicy is a rigid mathematical boundary enforcing systemic constraints
@@ -1060,6 +1090,10 @@ class SemanticSlicingPolicy(CoreasonBaseState):
         le=2000000,
         gt=0,
         description="The mathematical physical limit of the active context partition to prevent VRAM exhaustion.",
+    )
+    spatial_crop_boundary: SpatialBoundingBoxProfile | None = Field(
+        default=None,
+        description="The strict Euclidean geometric coordinate bounds. The orchestrator must physically crop the visual tensor to this exact region before VLM evaluation to prevent attention dilution."  # noqa: E501
     )
 
     @model_validator(mode="after")
@@ -4152,6 +4186,14 @@ class EpistemicTransmutationTask(CoreasonBaseState):
         ge=0,
         description="Optional maximum economic expenditure authorized to run this VLM transmutation.",
     )
+    target_layout_region_ids: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] | None = Field(
+        default=None,
+        description="The explicit array of DocumentLayoutRegionState block_ids the VLM must constrain its extraction to."  # noqa: E501
+    )
+    extraction_contracts: list[DeterministicExtractionContract] = Field(
+        default_factory=list,
+        description="The strict array of deterministic Regex/Selector rules applied to the VLM output to sanitize the final payload."  # noqa: E501
+    )
 
     @model_validator(mode="after")
     def validate_grounding_density_for_visuals(self) -> Self:
@@ -4166,6 +4208,13 @@ class EpistemicTransmutationTask(CoreasonBaseState):
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
         object.__setattr__(self, "target_modalities", sorted(self.target_modalities))
+        if self.target_layout_region_ids is not None:
+            object.__setattr__(self, "target_layout_region_ids", sorted(self.target_layout_region_ids))
+        object.__setattr__(
+            self,
+            "extraction_contracts",
+            sorted(self.extraction_contracts, key=lambda x: x.contract_id)
+        )
         return self
 
 
@@ -10991,3 +11040,6 @@ WorkflowManifest.model_rebuild()
 ProgramSynthesisIntent.model_rebuild()
 SymbolicExecutionReceipt.model_rebuild()
 SemanticGapAnalysisProfile.model_rebuild()
+DeterministicExtractionContract.model_rebuild()
+SemanticSlicingPolicy.model_rebuild()
+EpistemicTransmutationTask.model_rebuild()

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1040,15 +1040,11 @@ class DeterministicExtractionContract(CoreasonBaseState):
     or schema via hard execution of Regex, XPath, or CSS Selectors.
     """
 
-    contract_id: str = Field(
-        min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$"
-    )
+    contract_id: str = Field(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")
     extraction_type: Literal["regex", "xpath", "css_selector", "json_pointer"] = Field(
         description="The exact deterministic engine to use."
     )
-    query_string: str = Field(
-        max_length=2000, description="The actual Regex pattern or DOM selector."
-    )
+    query_string: str = Field(max_length=2000, description="The actual Regex pattern or DOM selector.")
     strict_type_coercion: Literal["string", "integer", "float", "boolean", "date"] = Field(
         description="The required final primitive type post-extraction."
     )
@@ -1093,7 +1089,7 @@ class SemanticSlicingPolicy(CoreasonBaseState):
     )
     spatial_crop_boundary: SpatialBoundingBoxProfile | None = Field(
         default=None,
-        description="The strict Euclidean geometric coordinate bounds. The orchestrator must physically crop the visual tensor to this exact region before VLM evaluation to prevent attention dilution."  # noqa: E501
+        description="The strict Euclidean geometric coordinate bounds. The orchestrator must physically crop the visual tensor to this exact region before VLM evaluation to prevent attention dilution.",  # noqa: E501
     )
 
     @model_validator(mode="after")
@@ -4188,11 +4184,11 @@ class EpistemicTransmutationTask(CoreasonBaseState):
     )
     target_layout_region_ids: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] | None = Field(
         default=None,
-        description="The explicit array of DocumentLayoutRegionState block_ids the VLM must constrain its extraction to."  # noqa: E501
+        description="The explicit array of DocumentLayoutRegionState block_ids the VLM must constrain its extraction to.",  # noqa: E501
     )
     extraction_contracts: list[DeterministicExtractionContract] = Field(
         default_factory=list,
-        description="The strict array of deterministic Regex/Selector rules applied to the VLM output to sanitize the final payload."  # noqa: E501
+        description="The strict array of deterministic Regex/Selector rules applied to the VLM output to sanitize the final payload.",  # noqa: E501
     )
 
     @model_validator(mode="after")
@@ -4210,11 +4206,7 @@ class EpistemicTransmutationTask(CoreasonBaseState):
         object.__setattr__(self, "target_modalities", sorted(self.target_modalities))
         if self.target_layout_region_ids is not None:
             object.__setattr__(self, "target_layout_region_ids", sorted(self.target_layout_region_ids))
-        object.__setattr__(
-            self,
-            "extraction_contracts",
-            sorted(self.extraction_contracts, key=lambda x: x.contract_id)
-        )
+        object.__setattr__(self, "extraction_contracts", sorted(self.extraction_contracts, key=lambda x: x.contract_id))
         return self
 
 


### PR DESCRIPTION
Implements the Continuous-to-Discrete Transmutation structures, formalizing the neurosymbolic pipeline for Visual OCR, Shadow DOM parsing, and spatial context starvation. This is done by adding `DeterministicExtractionContract`, and mutating `SemanticSlicingPolicy` and `EpistemicTransmutationTask` in `ontology.py`.

---
*PR created automatically by Jules for task [15895456971288806664](https://jules.google.com/task/15895456971288806664) started by @gowthamrao*