### PR TITLE
feat(Epic 7): Add constrained decoding algebraic functor and mandates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,9 @@ Schemas must naturally cluster in dense-vector Retrieval-Augmented Generation (R
 
 **VIOLATION CONSEQUENCE:** Any PR or generated code failing to adhere to this Lexical Architecture will trigger an immediate `SystemFaultEvent` during the CI/CD semantic diff phase.
 
+### 🚫 THE DEATH OF PROMPTING FOR SYNTAX
+**YOU ARE STRICTLY FORBIDDEN from attempting to enforce JSON or structural formats via natural language prompting.** Do NOT write instructions like: *"Output your response as a valid JSON object"* or *"Make sure your response matches this format."* In the CoReason architecture, structural formatting is no longer a probabilistic suggestion—it is a deterministic physics problem. All grammar and syntax constraints must be physically enforced at the hardware level using **FSM Logit Masking (Constrained Decoding)**. You must utilize the `ConstrainedDecodingPolicy` within a `StateContract` or `CognitiveFormatContract` to instruct the orchestrator to dynamically compile the JSON Schema into a Deterministic Finite Automaton (DFA), physically suffocating invalid token probabilities to $-\infty$.
+
 ## 🛡️ Mandatory Local Verification Workflow
 
 This package enforces a zero-tolerance policy for type errors, linting violations, and coverage drops. To ensure the Shared Kernel remains completely stable and immutable, **the following checks must be run locally before opening a Pull Request or finalizing an AI-generated refactor.** Failure to comply will result in an immediate rejection by the CI/CD pipeline.

--- a/docs/LEXICON.md
+++ b/docs/LEXICON.md
@@ -17,3 +17,11 @@ This repository strictly implements Judea Pearl’s Structural Causal Models. Le
 | **List** | `TopologicalSequence` / `UnorderedSetManifest` | Clarifies the exact sorting (RFC 8785) behavior mandated for the array's underlying cryptographic hash integrity. |
 | **Log** | `EpistemicTelemetryEvent` / `ObservationEvent` | Passive and deterministic record generation reflecting systemic state evolution, stripped of imperative execution. |
 | **ID** | `ContentIdentifier (CID)` / `MerkleRoot` | Enforces cryptographic immutability rather than sequentially guessed database identities. |
+
+## Core Neurosymbolic Concepts
+
+### Constrained Decoding (FSM Logit Masking)
+The state-of-the-art (2026+) neurosymbolic mechanism that intercepts an LLM's forward pass at the vocabulary level. By compiling a Context-Free Grammar (CFG) or Regular Expression into a Deterministic Finite Automaton (DFA), the orchestrator checks valid state transitions before tokens are sampled. Any token that mathematically violates the grammar has its logit forcefully overwritten to $-\infty$, collapsing its probability to exactly $0.0\%$.
+
+### Outlines / XGrammar
+State-of-the-art C++/CUDA compilers and execution backends used by the orchestrator to translate declarative Pydantic schemas into highly optimized Pushdown Automatons (PDAs) for massive, concurrent batched inference logit masking.

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -247,6 +247,43 @@ def extract_mcp_tool_call(
     )
 
 
+def compile_constrained_decoding_intent(
+    contract: ontology.StateContract | ontology.CognitiveFormatContract,
+    target_node_id: str,
+    request_id: str | int,
+) -> ontology.BoundedJSONRPCIntent:
+    """
+    A pure algebraic functor that projects a strict structural contract into a
+    hardware-level execution instruction for an inference engine (e.g., vLLM/XGrammar).
+    Instructs the engine to compile a Deterministic Finite Automaton (DFA) to mask logits.
+    """
+    if not contract.decoding_policy:
+        raise ValueError("Cannot compile decoding intent: ConstrainedDecodingPolicy is missing or None.")
+
+    payload: dict[str, Any] = {
+        "target_node_id": target_node_id,
+        "enforcement_strategy": contract.decoding_policy.enforcement_strategy,
+        "compiler_backend": contract.decoding_policy.compiler_backend,
+        "terminate_on_eos_leak": contract.decoding_policy.terminate_on_eos_leak,
+    }
+
+    if isinstance(contract, ontology.StateContract):
+        payload["schema_definition"] = contract.schema_definition
+        method = "mcp.inference.compile_json_schema_mask"
+    elif isinstance(contract, ontology.CognitiveFormatContract):
+        payload["regex_pattern"] = contract.final_answer_regex
+        method = "mcp.inference.compile_regex_mask"
+    else:
+        raise TypeError("Unsupported contract type for constrained decoding projection.")
+
+    return ontology.BoundedJSONRPCIntent(
+        jsonrpc="2.0",
+        method=method,
+        params=payload,
+        id=request_id,
+    )
+
+
 def generate_correction_prompt(error: ValidationError, target_node_id: str, fault_id: str) -> System2RemediationIntent:
     """
     Pure functional adapter. Maps a raw Pythonic pydantic.ValidationError into a


### PR DESCRIPTION
Epic 7 (Workstream B) - The Grammar Enforcement Matrix

This PR physically bridges the gap between symbolic contracts and the neural inference engine by:
1. Building a pure algebraic functor `compile_constrained_decoding_intent` in `src/coreason_manifest/utils/algebra.py`.
2. Updating the repository's foundational architecture documents (`AGENTS.md`, `docs/LEXICON.md`) to strictly mandate FSM Logit Masking (Constrained Decoding) and explicitly outlaw probabilistic formatting (e.g., "prompting for JSON").

---
*PR created automatically by Jules for task [11777426935517443984](https://jules.google.com/task/11777426935517443984) started by @gowthamrao*