### PR TITLE
chore: finalize Epic 8.3 implementation with strict contracts and type checking

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -295,6 +295,38 @@
       "title": "AdjudicationRubricProfile",
       "type": "object"
     },
+    "AdversarialEmulationProfile": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates the simulation of complex adversarial actor heuristics.\n\nCAUSAL AFFORDANCE: Emulates advanced evasion tactics including non-linear spatial vectors.\n\nEPISTEMIC BOUNDS: Contains rigid constraints governing kinetic and environmental spoofing.\n\nMCP ROUTING TRIGGERS: Threat Emulation, Adversarial Actor, Evasion Tactics",
+      "properties": {
+        "kinematic_noise": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/KinematicNoiseProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The physical perturbation constraints."
+        },
+        "environmental_spoofing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EnvironmentalSpoofingProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The hardware and DOM spoofing constraints."
+        }
+      },
+      "title": "AdversarialEmulationProfile",
+      "type": "object"
+    },
     "AdversarialMarketTopologyManifest": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Zero-Cost Macro abstraction that mathematically projects a Zero-Sum Minimax game into a rigid Red/Blue team CouncilTopologyManifest. As a ...Manifest suffix, this defines a frozen coordinate of a topological structure.\n\nCAUSAL AFFORDANCE: Deterministically compiles into a fully bounded Council topology, forcing the generative router to evaluate claims through adversarial debate before the orchestrator resolves equilibrium via the designated market rules.\n\nEPISTEMIC BOUNDS: The @model_validator verify_disjoint_sets mathematically guarantees that blue_team_ids, red_team_ids, and the adjudicator_id are strictly disjoint to prevent self-dealing or topological paradoxes. Arrays are deterministically sorted to preserve RFC 8785 canonical hashes.\n\nMCP ROUTING TRIGGERS: Zero-Sum Minimax Game, Red Team vs Blue Team, Macro Abstraction, Generative Adversarial Networks, Topological Compilation",
@@ -574,6 +606,18 @@
           "description": "Discriminator for an Agent node.",
           "title": "Type",
           "type": "string"
+        },
+        "adversarial_emulation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AdversarialEmulationProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The deterministic emulation rules for simulating evasive behaviors."
         },
         "logit_steganography": {
           "anyOf": [
@@ -4811,6 +4855,30 @@
       "title": "EnsembleTopologyProfile",
       "type": "object"
     },
+    "EnvironmentalSpoofingProfile": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Mathematically spoofs hardware and environmental markers.\n\nCAUSAL AFFORDANCE: Bypasses static fingerprinting heuristics by mutating DOM properties.\n\nEPISTEMIC BOUNDS: Bounded by rigid string constraints to prevent payload bloat.\n\nMCP ROUTING TRIGGERS: DOM Spoofing, Fingerprint Mutation, Environmental Marker",
+      "properties": {
+        "webgl_entropy_seed_hash": {
+          "description": "The SHA-256 hash used to deterministically alter WebGL rendering arrays.",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Webgl Entropy Seed Hash",
+          "type": "string"
+        },
+        "canvas_noise_seed": {
+          "description": "The deterministic seed used to slightly mutate Canvas 2D render pixels.",
+          "maxLength": 128,
+          "title": "Canvas Noise Seed",
+          "type": "string"
+        }
+      },
+      "required": [
+        "webgl_entropy_seed_hash",
+        "canvas_noise_seed"
+      ],
+      "title": "EnvironmentalSpoofingProfile",
+      "type": "object"
+    },
     "EphemeralNamespacePartitionState": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a hardware-level Sandboxing and Trusted Execution\nEnvironment (TEE) paradigm, utilizing WASI, eBPF, or zkVMs to safely execute\nexogenous bytecode. As a ...State suffix, this is a declarative, frozen snapshot of\nan execution geometry.\n\nCAUSAL AFFORDANCE: Physically isolates kinetic execution from the host OS via\nexecution_runtime Literal [\"wasm32-wasi\", \"riscv32-zkvm\", \"bpf\"], authorizing\nthe orchestrator to instantiate a temporary virtual machine strictly conforming to\nallow_network_egress (default=False) and allow_subprocess_spawning (default=False).\n\nEPISTEMIC BOUNDS: The Halting Problem is managed via max_ttl_seconds (le=86400,\ngt=0), and memory exhaustion is prevented via max_vram_mb (le=1000000000, gt=0).\nThe @model_validator validate_cryptographic_hashes enforces SHA-256 regex\n(^[a-f0-9]{64}$); a second @model_validator sort_arrays deterministically sorts the\nauthorized_bytecode_hashes for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: WebAssembly System Interface, Zero-Knowledge Virtual Machine,\neBPF, Execution Sandbox, Arbitrary Code Execution Mitigation",
@@ -8419,6 +8487,32 @@
           "type": "null"
         }
       ]
+    },
+    "KinematicNoiseProfile": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements non-linear stochastic perturbations to physical trajectories.\n\nCAUSAL AFFORDANCE: Mutates continuous polynomial control points.\n\nEPISTEMIC BOUNDS: Clamped by pink_noise_amplitude (le=1.0).\n\nMCP ROUTING TRIGGERS: Mathematical Kinematics, Noise, Perturbation, Stochastic Vector",
+      "properties": {
+        "pink_noise_amplitude": {
+          "description": "The mathematical limit of non-linear noise injected.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Pink Noise Amplitude",
+          "type": "number"
+        },
+        "frequency_hz": {
+          "description": "The frequency of the injected noise.",
+          "maximum": 1000.0,
+          "minimum": 0.0,
+          "title": "Frequency Hz",
+          "type": "number"
+        }
+      },
+      "required": [
+        "pink_noise_amplitude",
+        "frequency_hz"
+      ],
+      "title": "KinematicNoiseProfile",
+      "type": "object"
     },
     "KineticBudgetPolicy": {
       "additionalProperties": false,
@@ -12166,6 +12260,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Mathematical Kinematics and Fitts's Law to project precise, non-linear physical interactions across an exogenous UI manifold.\n\nCAUSAL AFFORDANCE: Authorizes the translation of latent spatial targets into OS-level actuation, utilizing bezier_control_points to construct continuous polynomial trajectories that simulate human motor control and bypass bot-evasive heuristics.\n\nEPISTEMIC BOUNDS: Spatial execution is clamped to normalized Euclidean limits (ge=0.0, le=1.0) via the nested SpatialCoordinateProfile. Execution liveness is temporally guillotined by trajectory_duration_ms (le=86400000).\n\nMCP ROUTING TRIGGERS: Mathematical Kinematics, Bezier Geometry, Fitts's Law, OS-Level Actuation, Non-Linear Trajectory",
       "properties": {
+        "noise_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/KinematicNoiseProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical constraints for applying stochastic perturbations."
+        },
         "action_type": {
           "description": "The specific kinematic interaction paradigm.",
           "enum": [

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -12,6 +12,22 @@
           "title": "Action Space Id",
           "type": "string"
         },
+        "native_tools": {
+          "description": "The strict array of discrete, natively defined tools available in this space.",
+          "items": {
+            "$ref": "#/$defs/ToolManifest"
+          },
+          "title": "Native Tools",
+          "type": "array"
+        },
+        "mcp_servers": {
+          "description": "The array of verified external Model Context Protocol servers mounted into this action space.",
+          "items": {
+            "$ref": "#/$defs/MCPServerManifest"
+          },
+          "title": "Mcp Servers",
+          "type": "array"
+        },
         "ephemeral_partitions": {
           "description": "Hermetically sealed context boundaries for dynamically resolved scripts and PEFT adapters.",
           "items": {
@@ -31,22 +47,6 @@
           ],
           "default": null,
           "description": "The bipartite graph constraint preventing toxic tool combinations."
-        },
-        "mcp_servers": {
-          "description": "The array of verified external Model Context Protocol servers mounted into this action space.",
-          "items": {
-            "$ref": "#/$defs/MCPServerManifest"
-          },
-          "title": "Mcp Servers",
-          "type": "array"
-        },
-        "native_tools": {
-          "description": "The strict array of discrete, natively defined tools available in this space.",
-          "items": {
-            "$ref": "#/$defs/ToolManifest"
-          },
-          "title": "Native Tools",
-          "type": "array"
         }
       },
       "required": [
@@ -59,6 +59,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a hardware-level Representation Engineering (RepE)\ndirective to mechanically manipulate latent dimensions via forward-pass tensor injection.\nAs a ...Contract suffix, this object defines rigid mathematical boundaries that the\norchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Physically forces an additive, ablation, or clamping operation onto\nthe model's residual stream at specific injection_layers, steering the generator away\nfrom unstable hallucination geometries prior to token projection.\n\nEPISTEMIC BOUNDS: Cryptographically locked by the steering_vector_hash (SHA-256 pattern\n^[a-f0-9]{64}$). The scaling_factor is bounded above (le=100.0) but unbounded below,\npermitting negative magnitudes for ablation. The @model_validator deterministically\nsorts injection_layers (each ge=0, min_length=1) to preserve RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Representation Engineering, RepE, Activation Steering, Residual\nStream Ablation, Concept Vectors",
       "properties": {
+        "steering_vector_hash": {
+          "description": "The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Steering Vector Hash",
+          "type": "string"
+        },
         "injection_layers": {
           "description": "The specific transformer layer indices where this vector must be applied.",
           "items": {
@@ -74,14 +82,6 @@
           "maximum": 100.0,
           "title": "Scaling Factor",
           "type": "number"
-        },
-        "steering_vector_hash": {
-          "description": "The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Steering Vector Hash",
-          "type": "string"
         },
         "vector_modality": {
           "description": "The tensor operation to perform: add the vector, subtract it, or clamp activations to its bounds.",
@@ -107,32 +107,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the formal Fristonian Active Inference policy for an autonomous agent, mandating the minimization of Expected Free Energy through targeted epistemic foraging. As a ...Contract suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Unlocks kinetic tool execution strictly for the purpose of empirical observation, routing compute to maximize epistemic certainty (Shannon Information Gain) regarding a specific hypothesis to collapse the probability wave.\n\nEPISTEMIC BOUNDS: Mathematically constrained by expected_information_gain (a continuous float bounded between ge=0.0 and le=1.0 representing Shannon entropy reduction) and an economic execution_cost_budget_magnitude cap (ge=0, le=1000000000) to prevent thermodynamic runaway.\n\nMCP ROUTING TRIGGERS: Active Inference, Expected Free Energy, Epistemic Foraging, Fristonian Mechanics, Shannon Entropy Reduction",
       "properties": {
-        "execution_cost_budget_magnitude": {
-          "description": "The maximum economic expenditure authorized to run this specific scientific test.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Execution Cost Budget Magnitude",
-          "type": "integer"
-        },
-        "expected_information_gain": {
-          "description": "The mathematically estimated reduction in Epistemic Uncertainty (entropy) this tool call will yield.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Expected Information Gain",
-          "type": "number"
-        },
-        "selected_tool_name": {
-          "description": "The exact tool from the ActionSpaceManifest allocated for this experiment.",
-          "maxLength": 2000,
-          "title": "Selected Tool Name",
-          "type": "string"
-        },
-        "target_condition_id": {
-          "description": "The specific FalsificationContract being tested.",
+        "task_id": {
+          "description": "Unique identifier for this active inference execution.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Condition Id",
+          "title": "Task Id",
           "type": "string"
         },
         "target_hypothesis_id": {
@@ -143,13 +123,33 @@
           "title": "Target Hypothesis Id",
           "type": "string"
         },
-        "task_id": {
-          "description": "Unique identifier for this active inference execution.",
+        "target_condition_id": {
+          "description": "The specific FalsificationContract being tested.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Id",
+          "title": "Target Condition Id",
           "type": "string"
+        },
+        "selected_tool_name": {
+          "description": "The exact tool from the ActionSpaceManifest allocated for this experiment.",
+          "maxLength": 2000,
+          "title": "Selected Tool Name",
+          "type": "string"
+        },
+        "expected_information_gain": {
+          "description": "The mathematically estimated reduction in Epistemic Uncertainty (entropy) this tool call will yield.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Expected Information Gain",
+          "type": "number"
+        },
+        "execution_cost_budget_magnitude": {
+          "description": "The maximum economic expenditure authorized to run this specific scientific test.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Execution Cost Budget Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -167,6 +167,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Social Choice Theory to resolve the Condorcet Paradox.\nTriggers a Mixed-Initiative forced resolution to break an epistemic deadlock within a\nCouncilTopologyManifest. As an ...Intent suffix, the LLM may execute non-monotonic\nreasoning here.\n\nCAUSAL AFFORDANCE: Halts the active execution DAG and forces an external oracle\n(human or system) to act as a Dictatorial tie-breaker, definitively collapsing the\nprobability wave of competing claims in a Multi-Criteria Decision Analysis (MCDA)\nframework.\n\nEPISTEMIC BOUNDS: The state space is bounded by deadlocked_claims (min_length=2,\nmax_length=86400000), deterministically sorted via @model_validator sort_arrays for\nRFC 8785 canonical hashing. The timeout_action is restricted to a strict Literal\n[\"rollback\", \"proceed_default\", \"terminate\"] to prevent infinite stalling.\n\nMCP ROUTING TRIGGERS: Social Choice Theory, Condorcet Paradox, MCDA Deadlock,\nDictatorial Resolution, Tie-Breaking Heuristic",
       "properties": {
+        "type": {
+          "const": "forced_adjudication",
+          "default": "forced_adjudication",
+          "description": "Discriminator for breaking deadlocks within a CouncilTopologyManifest.",
+          "title": "Type",
+          "type": "string"
+        },
         "deadlocked_claims": {
           "description": "The conflicting claim IDs or proposals the human must choose between.",
           "items": {
@@ -197,13 +204,6 @@
           ],
           "title": "Timeout Action",
           "type": "string"
-        },
-        "type": {
-          "const": "forced_adjudication",
-          "default": "forced_adjudication",
-          "description": "Discriminator for breaking deadlocks within a CouncilTopologyManifest.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -218,6 +218,25 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the\ndefinitive collapse of an MCDA evaluation, acting as a verified Outcome Reward Model\n(ORM) signal. As a ...Receipt suffix, this is an append-only coordinate on the\nMerkle-DAG.\n\nCAUSAL AFFORDANCE: Commits the calculated score and boolean passed verdict to the\nEpistemic Ledger, permanently binding the deterministic evaluation to the specific\ntarget_node_id (NodeIdentifierState) and authorizing downstream policy updates.\n\nEPISTEMIC BOUNDS: The evaluation outcome is strictly bounded to an integer score\n(ge=0, le=100). The underlying deductive proof (reasoning) is physically capped at\nmax_length=2000. The entire receipt is cryptographically locked to the originating\nrubric_id CID (128-char regex).\n\nMCP ROUTING TRIGGERS: Cryptographic Verdict, Deterministic Proof, Grading Execution,\nEpistemic Commitment, Audit Trail",
       "properties": {
+        "rubric_id": {
+          "description": "The cryptographic pointer to the rubric dictating adjudication.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Rubric Id",
+          "type": "string"
+        },
+        "target_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The ID of the node that was evaluated."
+        },
+        "score": {
+          "description": "The final score assigned based on the rubric.",
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Score",
+          "type": "integer"
+        },
         "passed": {
           "description": "Indicates whether the evaluation passed the threshold.",
           "title": "Passed",
@@ -228,25 +247,6 @@
           "maxLength": 2000,
           "title": "Reasoning",
           "type": "string"
-        },
-        "rubric_id": {
-          "description": "The cryptographic pointer to the rubric dictating adjudication.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Rubric Id",
-          "type": "string"
-        },
-        "score": {
-          "description": "The final score assigned based on the rubric.",
-          "maximum": 100,
-          "minimum": 0,
-          "title": "Score",
-          "type": "integer"
-        },
-        "target_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the node that was evaluated."
         }
       },
       "required": [
@@ -263,6 +263,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes an Aggregation Function for Multi-Criteria Decision\nAnalysis (MCDA), compiling multiple utility dimensions into a definitive evaluation\nboundary for the swarm. As a ...Profile suffix, this defines a rigid mathematical\nboundary.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's verification engine on how to\ncalculate the total weighted score of a generated trajectory, triggering a\ndeterministic boolean pass/fail gate based on the aggregate sum.\n\nEPISTEMIC BOUNDS: The success condition is mathematically locked by passing_threshold\n(ge=0.0, le=100.0). The rubric_id is a 128-char CID anchor. The @model_validator\nsort_arrays deterministically sorts the criteria array by criterion_id, guaranteeing\ninvariant RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Evaluation Manifold, Threshold Gating, Deterministic Rubric,\nRFC 8785 Canonicalization, Binary State Transition",
       "properties": {
+        "rubric_id": {
+          "description": "Unique identifier for the rubric.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Rubric Id",
+          "type": "string"
+        },
         "criteria": {
           "description": "The explicit array of strict evaluation criteria defining the rubric.",
           "items": {
@@ -277,14 +285,6 @@
           "minimum": 0.0,
           "title": "Passing Threshold",
           "type": "number"
-        },
-        "rubric_id": {
-          "description": "Unique identifier for the rubric.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Rubric Id",
-          "type": "string"
         }
       },
       "required": [
@@ -331,9 +331,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Zero-Cost Macro abstraction that mathematically projects a Zero-Sum Minimax game into a rigid Red/Blue team CouncilTopologyManifest. As a ...Manifest suffix, this defines a frozen coordinate of a topological structure.\n\nCAUSAL AFFORDANCE: Deterministically compiles into a fully bounded Council topology, forcing the generative router to evaluate claims through adversarial debate before the orchestrator resolves equilibrium via the designated market rules.\n\nEPISTEMIC BOUNDS: The @model_validator verify_disjoint_sets mathematically guarantees that blue_team_ids, red_team_ids, and the adjudicator_id are strictly disjoint to prevent self-dealing or topological paradoxes. Arrays are deterministically sorted to preserve RFC 8785 canonical hashes.\n\nMCP ROUTING TRIGGERS: Zero-Sum Minimax Game, Red Team vs Blue Team, Macro Abstraction, Generative Adversarial Networks, Topological Compilation",
       "properties": {
-        "adjudicator_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The neutral node responsible for synthesizing the market resolution."
+        "type": {
+          "const": "macro_adversarial",
+          "default": "macro_adversarial",
+          "description": "Discriminator for adversarial macro.",
+          "title": "Type",
+          "type": "string"
         },
         "blue_team_ids": {
           "description": "Nodes assigned to the Blue Team.",
@@ -344,10 +347,6 @@
           "title": "Blue Team Ids",
           "type": "array"
         },
-        "market_rules": {
-          "$ref": "#/$defs/PredictionMarketPolicy",
-          "description": "The mathematical AMM rules for the debate."
-        },
         "red_team_ids": {
           "description": "Nodes assigned to the Red Team.",
           "items": {
@@ -357,12 +356,13 @@
           "title": "Red Team Ids",
           "type": "array"
         },
-        "type": {
-          "const": "macro_adversarial",
-          "default": "macro_adversarial",
-          "description": "Discriminator for adversarial macro.",
-          "title": "Type",
-          "type": "string"
+        "adjudicator_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The neutral node responsible for synthesizing the market resolution."
+        },
+        "market_rules": {
+          "$ref": "#/$defs/PredictionMarketPolicy",
+          "description": "The mathematical AMM rules for the debate."
         }
       },
       "required": [
@@ -378,6 +378,22 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A deterministic red-team configuration injecting Chaos Engineering vectors into a targeted node to map the fragility of the active context boundary. As a ...Profile suffix, this is a declarative snapshot of an attack geometry.\n\nCAUSAL AFFORDANCE: Authorizes the physical injection of a malicious structural payload (the \"Judas Node\" vector) to intentionally trip semantic firewalls, data exfiltration blocks, or tool poisoning filters, generating verification assertions.\n\nEPISTEMIC BOUNDS: The attack surface is rigidly constrained by the Literal automaton attack_vector. The payload is physically bounded by the synthetic_payload limits (max_length=100000), explicitly targeting a specific 128-char CID (target_node_id).\n\nMCP ROUTING TRIGGERS: Chaos Engineering, Judas Node, Threat Modeling, Structural Sabotage, Semantic Firewall Validation",
       "properties": {
+        "simulation_id": {
+          "description": "The unique identifier for this red-team experiment.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Simulation Id",
+          "type": "string"
+        },
+        "target_node_id": {
+          "description": "The exact NodeIdentifierState the 'Judas Node' will attempt to compromise.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Node Id",
+          "type": "string"
+        },
         "attack_vector": {
           "description": "The mathematically predictable category of structural sabotage being simulated.",
           "enum": [
@@ -387,28 +403,6 @@
             "tool_poisoning"
           ],
           "title": "Attack Vector",
-          "type": "string"
-        },
-        "expected_firewall_trip": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The exact rule_id of the InformationFlowPolicy or Governance bound expected to block this attack. Governing automated test assertions.",
-          "title": "Expected Firewall Trip"
-        },
-        "simulation_id": {
-          "description": "The unique identifier for this red-team experiment.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Simulation Id",
           "type": "string"
         },
         "synthetic_payload": {
@@ -428,13 +422,19 @@
           "maxLength": 100000,
           "title": "Synthetic Payload"
         },
-        "target_node_id": {
-          "description": "The exact NodeIdentifierState the 'Judas Node' will attempt to compromise.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Node Id",
-          "type": "string"
+        "expected_firewall_trip": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The exact rule_id of the InformationFlowPolicy or Governance bound expected to block this attack. Governing automated test assertions.",
+          "title": "Expected Firewall Trip"
         }
       },
       "required": [
@@ -450,6 +450,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Serves as the definitive Artificial Intelligence Bill of\nMaterials (AI-BOM), mapping the agent's exact training provenance and capability\nmatrix onto the Merkle-DAG. As a ...Receipt suffix, this represents a\ncryptographically frozen historical fact that the LLM must never mutate.\n\nCAUSAL AFFORDANCE: Establishes the agent's physical identity passport,\nauthorizing the orchestrator to mount the node into a swarm topology only if\nits training_lineage_hash satisfies the zero-trust alignment policy. The\ndeveloper_signature (max_length=2000) proves vendor accountability. The\ncredential_presentations (list[VerifiableCredentialPresentationReceipt],\ndefault_factory=list) carry the selective disclosure wallet.\n\nEPISTEMIC BOUNDS: Supply-chain vulnerabilities are mathematically severed by\nanchoring training_lineage_hash and capability_merkle_root to immutable SHA-256\nbounds (^[a-f0-9]{64}$). The @model_validator sort_arrays deterministically\nsorts credential_presentations by issuer_did for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: AI-BOM, Merkle-DAG Provenance, Supply-Chain Security,\nCryptographic Passport, Deterministic Sorting",
       "properties": {
+        "training_lineage_hash": {
+          "description": "The exact SHA-256 Merkle root of the agent's training lineage.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Training Lineage Hash",
+          "type": "string"
+        },
+        "developer_signature": {
+          "description": "The cryptographic signature of the developer/vendor.",
+          "maxLength": 2000,
+          "title": "Developer Signature",
+          "type": "string"
+        },
         "capability_merkle_root": {
           "description": "The SHA-256 Merkle root of the agent's verified semantic capabilities.",
           "pattern": "^[a-f0-9]{64}$",
@@ -463,20 +477,6 @@
           },
           "title": "Credential Presentations",
           "type": "array"
-        },
-        "developer_signature": {
-          "description": "The cryptographic signature of the developer/vendor.",
-          "maxLength": 2000,
-          "title": "Developer Signature",
-          "type": "string"
-        },
-        "training_lineage_hash": {
-          "description": "The exact SHA-256 Merkle root of the agent's training lineage.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Training Lineage Hash",
-          "type": "string"
         }
       },
       "required": [
@@ -499,20 +499,6 @@
           "title": "Agent Id",
           "type": "string"
         },
-        "confidence_score": {
-          "description": "The node's epistemic certainty of success.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Confidence Score",
-          "type": "number"
-        },
-        "estimated_carbon_gco2eq": {
-          "description": "The agent's mathematical projection of the environmental cost to execute this inference task.",
-          "maximum": 10000.0,
-          "minimum": 0.0,
-          "title": "Estimated Carbon Gco2Eq",
-          "type": "number"
-        },
         "estimated_cost_magnitude": {
           "description": "The node's calculated cost to fulfill the task.",
           "maximum": 1000000000,
@@ -525,6 +511,20 @@
           "minimum": 0,
           "title": "Estimated Latency Ms",
           "type": "integer"
+        },
+        "estimated_carbon_gco2eq": {
+          "description": "The agent's mathematical projection of the environmental cost to execute this inference task.",
+          "maximum": 10000.0,
+          "minimum": 0.0,
+          "title": "Estimated Carbon Gco2Eq",
+          "type": "number"
+        },
+        "confidence_score": {
+          "description": "The node's epistemic certainty of success.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Score",
+          "type": "number"
         }
       },
       "required": [
@@ -541,82 +541,11 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a stochastic actor traversing a Partially Observable\nMarkov Decision Process (POMDP). It establishes the cognitive and physical\nconstraints for autonomous swarm participants. As a ...Profile suffix, this is a\ndeclarative property descriptor.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to instantiate an independent\ngenerative trajectory capable of active inference, Representation Engineering\n(RepE) steering via baseline_cognitive_state (CognitiveStateProfile), and\nnon-monotonic test-time compute escalation via escalation_policy\n(EscalationContract). The description field (max_length=2000) provides the\nobjective function.\n\nEPISTEMIC BOUNDS: The node's operational variance is physically bounded by its\nthermodynamic Spot-Market budget (compute_frontier: RoutingFrontierPolicy). The\n@model_validator sort_agent_node_arrays deterministically sorts peft_adapters by\nadapter_id for RFC 8785 canonical hashing. The type discriminator is strictly\nlocked to Literal[\"agent\"].\n\nMCP ROUTING TRIGGERS: POMDP, Stochastic Actor, Active Inference, Representation\nEngineering, Policy Gradient",
       "properties": {
-        "action_space_id": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The ID of the specific ActionSpaceManifest (curated tool environment) bound to this agent.",
-          "title": "Action Space Id"
-        },
-        "active_inference_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ActiveInferenceContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The formal contract demanding mathematical proof of Expected Information Gain before authorizing tool execution."
-        },
-        "agent_attestation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AgentAttestationReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic identity passport and AI-BOM for the agent."
-        },
-        "adversarial_emulation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AdversarialEmulationProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The deterministic emulation rules for simulating evasive behaviors."
-        },
-        "logit_steganography": {
-        "analogical_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AnalogicalMappingTask"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The formal contract forcing the agent to execute cross-domain lateral thinking."
-        },
-        "anchoring_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AnchoringPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The declarative contract mathematically binding this agent to a core altruistic objective."
+        "description": {
+          "description": "The semantic boundary defining the objective function of the execution node. [SITD-Gamma: Neurosymbolic Substrate Alignment]",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
         },
         "architectural_intent": {
           "anyOf": [
@@ -632,59 +561,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "audit_policy": {
+        "justification": {
           "anyOf": [
             {
-              "$ref": "#/$defs/MechanisticAuditContract"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The adaptive trigger policy for executing deep mechanistic interpretability brain-scans on this agent."
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
         },
-        "baseline_cognitive_state": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CognitiveStateProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The default biochemical 'mood' simulated for this agent via Representation Engineering."
-        },
-        "compute_frontier": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RoutingFrontierPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic spot-market compute requirements for this agent."
-        },
-        "correction_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SelfCorrectionPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The policy governing self-correction loops."
-        },
-        "description": {
-          "description": "The semantic boundary defining the objective function of the execution node. [SITD-Gamma: Neurosymbolic Substrate Alignment]",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -703,75 +600,24 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
           "title": "Domain Extensions"
         },
-        "epistemic_policy": {
+        "type": {
+          "const": "agent",
+          "default": "agent",
+          "description": "Discriminator for an Agent node.",
+          "title": "Type",
+          "type": "string"
+        },
+        "adversarial_emulation": {
           "anyOf": [
             {
-              "$ref": "#/$defs/EpistemicScanningPolicy"
+              "$ref": "#/$defs/AdversarialEmulationProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The policy governing epistemic scanning."
-        },
-        "escalation_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EscalationContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical boundary authorizing the agent to spin up Test-Time Compute."
-        },
-        "grpo_reward_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EpistemicRewardModelPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The RL post-training contract forcing the agent to evaluate traces against an implicit graph reward."
-        },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "interventional_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InterventionalCausalTask"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The formal contract authorizing the agent to mutate variables to prove Pearlian causation."
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
+          "description": "The deterministic emulation rules for simulating evasive behaviors."
         },
         "logit_steganography": {
           "anyOf": [
@@ -785,6 +631,18 @@
           "default": null,
           "description": "The cryptographic contract forcing this agent to embed an undeniable provenance signature into its generative token stream."
         },
+        "compute_frontier": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoutingFrontierPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic spot-market compute requirements for this agent."
+        },
         "peft_adapters": {
           "description": "The declarative array of ephemeral PEFT/LoRA weights required to be hot-swapped during this agent's execution.",
           "items": {
@@ -793,29 +651,33 @@
           "title": "Peft Adapters",
           "type": "array"
         },
-        "prm_policy": {
+        "agent_attestation": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ProcessRewardContract"
+              "$ref": "#/$defs/AgentAttestationReceipt"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The ruleset governing how intermediate thoughts are scored and pruned."
+          "description": "The cryptographic identity passport and AI-BOM for the agent."
         },
-        "reflex_policy": {
+        "action_space_id": {
           "anyOf": [
             {
-              "$ref": "#/$defs/System1ReflexPolicy"
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The policy governing System 1 reflex actions."
+          "description": "The ID of the specific ActionSpaceManifest (curated tool environment) bound to this agent.",
+          "title": "Action Space Id"
         },
         "secure_sub_session": {
           "anyOf": [
@@ -829,6 +691,114 @@
           "default": null,
           "description": "Declarative boundary for handling unredacted secrets within a temporarily isolated state partition."
         },
+        "baseline_cognitive_state": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CognitiveStateProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The default biochemical 'mood' simulated for this agent via Representation Engineering."
+        },
+        "reflex_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/System1ReflexPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The policy governing System 1 reflex actions."
+        },
+        "epistemic_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpistemicScanningPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The policy governing epistemic scanning."
+        },
+        "correction_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SelfCorrectionPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The policy governing self-correction loops."
+        },
+        "escalation_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EscalationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical boundary authorizing the agent to spin up Test-Time Compute."
+        },
+        "prm_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProcessRewardContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The ruleset governing how intermediate thoughts are scored and pruned."
+        },
+        "active_inference_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActiveInferenceContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal contract demanding mathematical proof of Expected Information Gain before authorizing tool execution."
+        },
+        "analogical_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnalogicalMappingTask"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal contract forcing the agent to execute cross-domain lateral thinking."
+        },
+        "interventional_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InterventionalCausalTask"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal contract authorizing the agent to mutate variables to prove Pearlian causation."
+        },
         "symbolic_handoff_policy": {
           "anyOf": [
             {
@@ -841,12 +811,41 @@
           "default": null,
           "description": "The API-like contract allowing the agent to offload rigid logic to deterministic CPU solvers."
         },
-        "type": {
-          "const": "agent",
-          "default": "agent",
-          "description": "Discriminator for an Agent node.",
-          "title": "Type",
-          "type": "string"
+        "audit_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MechanisticAuditContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The adaptive trigger policy for executing deep mechanistic interpretability brain-scans on this agent."
+        },
+        "anchoring_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnchoringPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The declarative contract mathematically binding this agent to a core altruistic objective."
+        },
+        "grpo_reward_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpistemicRewardModelPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The RL post-training contract forcing the agent to evaluate traces against an implicit graph reward."
         }
       },
       "required": [
@@ -859,6 +858,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a unidirectional telemetry pipeline projecting\ninternal swarm kinematics across the Markov Blanket without inducing causal\nfeedback loops. As a ...State suffix, this is a declarative, ephemeral\nN-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Emits an ephemeral, 1D representation of the active\nprobability distribution and execution progress to the external UI plane. The\norchestrator processes this signal without halting the underlying generative\ntrajectory.\n\nEPISTEMIC BOUNDS: The semantic status_message is structurally clamped to\nmax_length=2000. The continuous progress metric is bounded by float limits\n(le=1000000000.0) allowing it to represent either a 0.0-1.0 ratio or precise\nraw token counts.\n\nMCP ROUTING TRIGGERS: Markov Blanket, Ephemeral Projection, Continuous\nObservability, Kinetic Execution State, UI Telemetry",
       "properties": {
+        "status_message": {
+          "description": "The semantic 1D string projection representing the active kinetic execution state.",
+          "maxLength": 2000,
+          "title": "Status Message",
+          "type": "string"
+        },
         "progress": {
           "anyOf": [
             {
@@ -872,12 +877,6 @@
           "default": null,
           "description": "The progress ratio from 0.0 to 1.0, or None if indeterminate.",
           "title": "Progress"
-        },
-        "status_message": {
-          "description": "The semantic 1D string projection representing the active kinetic execution state.",
-          "maxLength": 2000,
-          "title": "Status Message",
-          "type": "string"
         }
       },
       "required": [
@@ -890,19 +889,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Structure-Mapping Theory (Gentner) to execute\nsystemic cross-domain lateral thinking. As a ...Task suffix, this represents an\nauthorized kinetic execution trigger or test-time compute branch.\n\nCAUSAL AFFORDANCE: Forces the generative router to bridge the target_domain\n(max_length=2000) with an unrelated source_domain (max_length=2000) by finding\nrelational isomorphisms, actively injecting out-of-distribution abstractions. The\ntask_id (128-char CID) anchors the task.\n\nEPISTEMIC BOUNDS: The cognitive leap is physically forced by the\ndivergence_temperature_override (ge=0.0, le=10.0), shifting the sampling\ndistribution. The structural rigor is bounded by required_isomorphisms (ge=1,\nle=86400000), demanding an exact count of valid mappings.\n\nMCP ROUTING TRIGGERS: Structure-Mapping Theory, Lateral Thinking, Relational\nIsomorphism, Cross-Domain Abstraction, High-Temperature Divergence",
       "properties": {
-        "divergence_temperature_override": {
-          "description": "The specific high-temperature sampling override required to force this creative leap.",
-          "maximum": 10.0,
-          "minimum": 0.0,
-          "title": "Divergence Temperature Override",
-          "type": "number"
-        },
-        "required_isomorphisms": {
-          "description": "The exact number of structural/logical mappings the agent must successfully bridge between the two domains.",
-          "maximum": 86400000,
-          "minimum": 1,
-          "title": "Required Isomorphisms",
-          "type": "integer"
+        "task_id": {
+          "description": "Unique identifier for this lateral thinking task.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Id",
+          "type": "string"
         },
         "source_domain": {
           "description": "The unrelated abstract concept space (e.g., 'thermodynamics', 'mycelial networks').",
@@ -916,13 +909,19 @@
           "title": "Target Domain",
           "type": "string"
         },
-        "task_id": {
-          "description": "Unique identifier for this lateral thinking task.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Id",
-          "type": "string"
+        "required_isomorphisms": {
+          "description": "The exact number of structural/logical mappings the agent must successfully bridge between the two domains.",
+          "maximum": 86400000,
+          "minimum": 1,
+          "title": "Required Isomorphisms",
+          "type": "integer"
+        },
+        "divergence_temperature_override": {
+          "description": "The specific high-temperature sampling override required to force this creative leap.",
+          "maximum": 10.0,
+          "minimum": 0.0,
+          "title": "Divergence Temperature Override",
+          "type": "number"
         }
       },
       "required": [
@@ -1217,15 +1216,15 @@
           "$ref": "#/$defs/AuctionMechanismProfile",
           "description": "The market mechanism governing the auction."
         },
+        "tie_breaker": {
+          "$ref": "#/$defs/TieBreakerPolicy",
+          "description": "The deterministic rule for resolving tied bids."
+        },
         "max_bidding_window_ms": {
           "description": "The absolute timeout in milliseconds for nodes to submit proposals.",
           "maximum": 86400000,
           "title": "Max Bidding Window Ms",
           "type": "integer"
-        },
-        "tie_breaker": {
-          "$ref": "#/$defs/TieBreakerPolicy",
-          "description": "The deterministic rule for resolving tied bids."
         }
       },
       "required": [
@@ -1244,6 +1243,14 @@
           "$ref": "#/$defs/TaskAnnouncementIntent",
           "description": "The original call for proposals."
         },
+        "bids": {
+          "description": "The array of received bids.",
+          "items": {
+            "$ref": "#/$defs/AgentBidIntent"
+          },
+          "title": "Bids",
+          "type": "array"
+        },
         "award": {
           "anyOf": [
             {
@@ -1255,14 +1262,6 @@
           ],
           "default": null,
           "description": "The final cryptographic receipt of the auction, if resolved."
-        },
-        "bids": {
-          "description": "The array of received bids.",
-          "items": {
-            "$ref": "#/$defs/AgentBidIntent"
-          },
-          "title": "Bids",
-          "type": "array"
         },
         "clearing_timeout": {
           "description": "Maximum wait time for auction settlement.",
@@ -1291,31 +1290,15 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Queueing Theory and the Token Bucket algorithm to\nmathematically regulate the thermodynamic flow of compute across topological\nboundaries. As a ...Policy suffix, this defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Forces the orchestrator to yield execution threads, shed load,\nor trip circuit breakers when temporal velocity (max_tokens_per_minute,\nmax_requests_per_minute) or spatial queues (max_queue_depth) reach physical\nsaturation. Optional token_budget_per_branch and max_concurrent_tool_invocations\nfurther constrain parallel execution.\n\nEPISTEMIC BOUNDS: Physical system limits are rigidly clamped by integer bounds\n(le=1000000000) on max_queue_depth, token_budget_per_branch,\nmax_tokens_per_minute (gt=0), max_requests_per_minute (gt=0), and\nmax_concurrent_tool_invocations (gt=0). Temporal liveness is bounded by\nmax_uninterruptible_span_ms (le=86400000, gt=0). All rate fields are Optional\n(default=None).\n\nMCP ROUTING TRIGGERS: Queueing Theory, Token Bucket, Backpressure, Load\nShedding, Thermodynamic Flow Control",
       "properties": {
-        "max_concurrent_tool_invocations": {
-          "anyOf": [
-            {
-              "exclusiveMinimum": 0,
-              "maximum": 1000000000,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical integer ceiling to prevent Sybil-like parallel mutations against the ActionSpaceManifest.",
-          "title": "Max Concurrent Tool Invocations"
-        },
         "max_queue_depth": {
           "description": "The maximum number of unprocessed messages/observations allowed between connected nodes before yielding.",
           "maximum": 1000000000,
           "title": "Max Queue Depth",
           "type": "integer"
         },
-        "max_requests_per_minute": {
+        "token_budget_per_branch": {
           "anyOf": [
             {
-              "exclusiveMinimum": 0,
               "maximum": 1000000000,
               "type": "integer"
             },
@@ -1324,8 +1307,8 @@
             }
           ],
           "default": null,
-          "description": "The maximum kinetic velocity of API requests allowed.",
-          "title": "Max Requests Per Minute"
+          "description": "The maximum token cost allowed per execution branch before rate-limiting.",
+          "title": "Token Budget Per Branch"
         },
         "max_tokens_per_minute": {
           "anyOf": [
@@ -1342,6 +1325,21 @@
           "description": "The maximum kinetic velocity of token consumption allowed before the circuit breaker trips.",
           "title": "Max Tokens Per Minute"
         },
+        "max_requests_per_minute": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "maximum": 1000000000,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum kinetic velocity of API requests allowed.",
+          "title": "Max Requests Per Minute"
+        },
         "max_uninterruptible_span_ms": {
           "anyOf": [
             {
@@ -1357,9 +1355,10 @@
           "description": "Systemic heartbeat constraint. A node cannot lock the thread longer than this without yielding to poll for BargeInInterruptEvents.",
           "title": "Max Uninterruptible Span Ms"
         },
-        "token_budget_per_branch": {
+        "max_concurrent_tool_invocations": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "maximum": 1000000000,
               "type": "integer"
             },
@@ -1368,8 +1367,8 @@
             }
           ],
           "default": null,
-          "description": "The maximum token cost allowed per execution branch before rate-limiting.",
-          "title": "Token Budget Per Branch"
+          "description": "The mathematical integer ceiling to prevent Sybil-like parallel mutations against the ActionSpaceManifest.",
+          "title": "Max Concurrent Tool Invocations"
         }
       },
       "required": [
@@ -1382,16 +1381,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encodes an asynchronous hardware interrupt or exogenous sensory spike that forces a premature probability wave collapse on an active generation trajectory.\n\nCAUSAL AFFORDANCE: Physically severs the continuous multimodal sequence of the target_event_id, injecting the retained_partial_payload into the Epistemic Quarantine and forcing the orchestrator to execute the defined epistemic_disposition instruction.\n\nEPISTEMIC BOUNDS: Topologically anchored to the target_event_id via a strict 128-char CID regex. The retained_partial_payload is mechanically capped at 100,000 bytes to mathematically prevent VRAM exhaustion from unbounded sensory streams.\n\nMCP ROUTING TRIGGERS: Asynchronous Interrupt, Generative Severing, Context Switching, Defeasible Disposition, Wave Collapse",
       "properties": {
-        "epistemic_disposition": {
-          "description": "Explicit instruction to the orchestrator on how to patch the shared state blackboard with the partial payload.",
-          "enum": [
-            "discard",
-            "retain_as_context",
-            "mark_as_falsified"
-          ],
-          "title": "Epistemic Disposition",
-          "type": "string"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -1399,6 +1388,40 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
           "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "barge_in",
+          "default": "barge_in",
+          "description": "Discriminator type for a barge-in interruption event.",
+          "title": "Type",
+          "type": "string"
+        },
+        "target_event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the active node generation cycle that was killed in the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Event Id",
+          "type": "string"
+        },
+        "sensory_trigger": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EmbodiedSensoryVectorProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The continuous multimodal trigger (e.g., audio spike, user saying 'stop') that justified the interruption."
         },
         "retained_partial_payload": {
           "anyOf": [
@@ -1425,38 +1448,14 @@
           "description": "The 'stutter' state: the incomplete fragment of thought or text appended before the kill signal.",
           "title": "Retained Partial Payload"
         },
-        "sensory_trigger": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EmbodiedSensoryVectorProfile"
-            },
-            {
-              "type": "null"
-            }
+        "epistemic_disposition": {
+          "description": "Explicit instruction to the orchestrator on how to patch the shared state blackboard with the partial payload.",
+          "enum": [
+            "discard",
+            "retain_as_context",
+            "mark_as_falsified"
           ],
-          "default": null,
-          "description": "The continuous multimodal trigger (e.g., audio spike, user saying 'stop') that justified the interruption."
-        },
-        "target_event_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the active node generation cycle that was killed in the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Event Id",
-          "type": "string"
-        },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "type": {
-          "const": "barge_in",
-          "default": "barge_in",
-          "description": "Discriminator type for a barge-in interruption event.",
-          "title": "Type",
+          "title": "Epistemic Disposition",
           "type": "string"
         }
       },
@@ -1480,6 +1479,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the Graph Theory topological root structure (vertex) for all execution participants within a decentralized multi-agent graph.\n\nCAUSAL AFFORDANCE: Defines the foundational perimeter (objective function) of a participant, enabling the orchestrator to inject proactive oversight hooks (intervention_policies) across the node's lifecycle.\n\nEPISTEMIC BOUNDS: The semantic boundary is physically constrained by description (max_length=2000). The domain_extensions payload is mathematically bounded to a max recursive depth of 5 via @field_validator to prevent JSON-bomb memory leaks.\n\nMCP ROUTING TRIGGERS: Graph Theory, Topological Vertex, Subgraph Node, Lifecycle Hook, JSON-Bomb Prevention",
       "properties": {
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -1494,11 +1499,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -1516,28 +1537,6 @@
           "default": null,
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
           "title": "Domain Extensions"
-        },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
         }
       },
       "required": [
@@ -1596,20 +1595,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the abstract algebraic baseline and Markov Blanket for\nall execution subgraphs, establishing the structural and epistemic perimeters for a\nlocalized swarm. As a ...Manifest suffix, this defines a frozen, N-dimensional\ncoordinate state.\n\nCAUSAL AFFORDANCE: Projects overarching schema-on-write contracts\n(shared_state_contract: StateContract) and zero-trust Payload Loss Prevention\n(information_flow: InformationFlowPolicy) across all connected nodes, ensuring\ninherited alignment. The observability (ObservabilityPolicy) binds distributed\ntracing.\n\nEPISTEMIC BOUNDS: The nodes attribute is strictly typed as a dictionary mapping\nNodeIdentifierState to polymorphic AnyNodeProfile identities. The lifecycle_phase\nis locked to an FSM Literal [\"draft\", \"live\"] (default=\"live\"). The\narchitectural_intent and justification strings are capped at max_length=2000.\n\nMCP ROUTING TRIGGERS: Topological Manifold, Markov Blanket, Subgraph Abstraction,\nExecution Base, Structural Isolation",
       "properties": {
-        "architectural_intent": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The AI's declarative rationale for selecting this topology.",
-          "title": "Architectural Intent"
-        },
         "epistemic_enforcement": {
           "anyOf": [
             {
@@ -1623,17 +1608,29 @@
           "default": null,
           "description": "Ties the topology to the Truth Maintenance layer."
         },
-        "information_flow": {
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
+        "architectural_intent": {
           "anyOf": [
             {
-              "$ref": "#/$defs/InformationFlowPolicy"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+          "description": "The AI's declarative rationale for selecting this topology.",
+          "title": "Architectural Intent"
         },
         "justification": {
           "anyOf": [
@@ -1649,16 +1646,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -1669,18 +1656,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The distributed tracing rules bound to this specific execution graph."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -1693,6 +1668,30 @@
           ],
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
+        },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
         }
       },
       "required": [
@@ -1705,14 +1704,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Bayesian Belief Updating and Pearlian Causal\nTracing by synthesizing internal cognitive shifts into discrete, hashable\nfacts. As an ...Event suffix, this is an append-only coordinate on the\nMerkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Projects a synthesized conclusion into the shared topology,\nbinding the new belief to causal_attributions (list[CausalAttributionState],\ndefault_factory=list). Optional zk_proof (ZeroKnowledgeReceipt),\nhardware_attestation (HardwareEnclaveReceipt), uncertainty_profile\n(CognitiveUncertaintyProfile), scratchpad_trace (LatentScratchpadReceipt),\nand neural_audit (NeuralAuditAttestationReceipt) extend the attestation.\n\nEPISTEMIC BOUNDS: payload is clamped by @field_validator\nenforce_payload_topology via _validate_payload_bounds. The @model_validator\nsort_arrays sorts causal_attributions by source_event_id for RFC 8785\ncanonical hashing. source_node_id (NodeIdentifierState | None) traces origin.\n\nMCP ROUTING TRIGGERS: Bayesian Belief Updating, Causal Tracing, Cognitive\nSynthesis, Merkle-DAG Coordinate, Non-Monotonic Leap",
       "properties": {
-        "causal_attributions": {
-          "description": "Immutable audit trail of prior states that forced this specific cognitive synthesis.",
-          "items": {
-            "$ref": "#/$defs/CausalAttributionState"
-          },
-          "title": "Causal Attributions",
-          "type": "array"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -1720,65 +1711,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
           "type": "string"
-        },
-        "hardware_attestation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HardwareEnclaveReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The physical hardware root-of-trust proving this belief was synthesized in a secure enclave."
-        },
-        "neural_audit": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NeuralAuditAttestationReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical brain-scan proving exactly which neural circuits fired to append this event."
-        },
-        "payload": {
-          "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitiveState"
-          },
-          "description": "Topologically Bounded Latent Spaces capturing the semantic representation of the agent's internal cognitive shift or synthesis that anchor statistical probability to a definitive causal event hash.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Payload",
-          "type": "object"
-        },
-        "scratchpad_trace": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LatentScratchpadReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic record of the non-monotonic internal monologue that justifies this belief."
-        },
-        "source_node_id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeIdentifierState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The specific topological node that synthesized this belief assertion."
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -1794,6 +1726,61 @@
           "title": "Type",
           "type": "string"
         },
+        "payload": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonPrimitiveState"
+          },
+          "description": "Topologically Bounded Latent Spaces capturing the semantic representation of the agent's internal cognitive shift or synthesis that anchor statistical probability to a definitive causal event hash.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Payload",
+          "type": "object"
+        },
+        "source_node_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeIdentifierState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific topological node that synthesized this belief assertion."
+        },
+        "causal_attributions": {
+          "description": "Immutable audit trail of prior states that forced this specific cognitive synthesis.",
+          "items": {
+            "$ref": "#/$defs/CausalAttributionState"
+          },
+          "title": "Causal Attributions",
+          "type": "array"
+        },
+        "hardware_attestation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HardwareEnclaveReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The physical hardware root-of-trust proving this belief was synthesized in a secure enclave."
+        },
+        "zk_proof": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ZeroKnowledgeReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical attestation proving this belief synthesis was appended securely without model-downgrade fraud."
+        },
         "uncertainty_profile": {
           "anyOf": [
             {
@@ -1807,17 +1794,29 @@
           "default": null,
           "description": "The mathematical quantification of doubt associated with this synthesized belief."
         },
-        "zk_proof": {
+        "scratchpad_trace": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ZeroKnowledgeReceipt"
+              "$ref": "#/$defs/LatentScratchpadReceipt"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The mathematical attestation proving this belief synthesis was appended securely without model-downgrade fraud."
+          "description": "The cryptographic record of the non-monotonic internal monologue that justifies this belief."
+        },
+        "neural_audit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NeuralAuditAttestationReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical brain-scan proving exactly which neural circuits fired to append this event."
         }
       },
       "required": [
@@ -1832,6 +1831,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the zero-trust structural boundary for multi-tenant federation,\nsecuring cross-boundary graph traversal against Shor's algorithm via an optional\nPostQuantumSignatureReceipt. As an ...SLA suffix, this object enforces rigid mathematical\nboundaries that the orchestrator must respect globally.\n\nCAUSAL AFFORDANCE: Unlocks cross-swarm graph bridging by enforcing strict liability,\nphysical location routing, semantic data classification constraints via\nmax_permitted_classification, and ESG carbon intensity limits.\n\nEPISTEMIC BOUNDS: Economically constrained by liability_limit_magnitude (ge=0,\nle=1000000000). ESG limits physically bind the node grid to the optional\nmax_permitted_grid_carbon_intensity (ge=0.0, le=10000.0). The permitted_geographic_regions\narray is deterministically sorted via @model_validator for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Post-Quantum Cryptography, Federated\nLearning, Bilateral SLA, Data Residency",
       "properties": {
+        "receiving_tenant_id": {
+          "description": "The strict enterprise identifier of the foreign B2B tenant receiving this payload.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Receiving Tenant Id",
+          "type": "string"
+        },
+        "max_permitted_classification": {
+          "$ref": "#/$defs/InformationClassificationProfile",
+          "description": "The absolute highest semantic sensitivity allowed to cross this federated boundary."
+        },
         "liability_limit_magnitude": {
           "description": "The strict magnitude cap on cross-tenant economic liability.",
           "maximum": 1000000000,
@@ -1839,9 +1850,14 @@
           "title": "Liability Limit Magnitude",
           "type": "integer"
         },
-        "max_permitted_classification": {
-          "$ref": "#/$defs/InformationClassificationProfile",
-          "description": "The absolute highest semantic sensitivity allowed to cross this federated boundary."
+        "permitted_geographic_regions": {
+          "description": "Explicit whitelist of geographic regions or cloud enclaves where execution is structurally permitted (Payload Residency Pinning).",
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "title": "Permitted Geographic Regions",
+          "type": "array"
         },
         "max_permitted_grid_carbon_intensity": {
           "anyOf": [
@@ -1858,15 +1874,6 @@
           "description": "Absolute structural ESG mandate. The execution graph will quarantine any federated node operating on a grid exceeding this gCO2eq/kWh threshold.",
           "title": "Max Permitted Grid Carbon Intensity"
         },
-        "permitted_geographic_regions": {
-          "description": "Explicit whitelist of geographic regions or cloud enclaves where execution is structurally permitted (Payload Residency Pinning).",
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "title": "Permitted Geographic Regions",
-          "type": "array"
-        },
         "pq_signature": {
           "anyOf": [
             {
@@ -1878,14 +1885,6 @@
           ],
           "default": null,
           "description": "The quantum-resistant signature securing the multi-tenant structural boundary."
-        },
-        "receiving_tenant_id": {
-          "description": "The strict enterprise identifier of the foreign B2B tenant receiving this payload.",
-          "maxLength": 255,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Receiving Tenant Id",
-          "type": "string"
         }
       },
       "required": [
@@ -1960,30 +1959,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces the formal JSON-RPC 2.0 specification as a stateless,\ndeterministic message-passing protocol, acting as the primary algorithmic firewall\nat the Zero-Trust network boundary. As an ...Intent suffix, this represents an\nauthorized kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Unlocks remote procedure execution while preventing JSON Bombing\nand Algorithmic Complexity Attacks. The method field (max_length=1000) specifies the\nRPC target. The id field (128-char CID regex | int le=1000000000 | None) binds\nrequest-response correlation.\n\nEPISTEMIC BOUNDS: The @field_validator validate_params_depth_and_size mathematically\nbounds recursive payload geometry (params) to: max depth=10, dict keys=100, key\nlength=1000, list elements=1000, string length=10000. The jsonrpc field is a rigid\nLiteral[\"2.0\"] automaton.\n\nMCP ROUTING TRIGGERS: JSON-RPC 2.0, Stateless RPC, Algorithmic Complexity Attack,\nJSON Bombing Prevention, Deterministic Finite Automaton",
       "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "maxLength": 128,
-                  "minLength": 1,
-                  "pattern": "^[a-zA-Z0-9_.:-]+$",
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ],
-              "le": 1000000000
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Unique request identifier.",
-          "title": "Id"
-        },
         "jsonrpc": {
           "const": "2.0",
           "description": "JSON-RPC version.",
@@ -2013,6 +1988,30 @@
           "default": null,
           "description": "Payload parameters.",
           "title": "Params"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "maxLength": 128,
+                  "minLength": 1,
+                  "pattern": "^[a-zA-Z0-9_.:-]+$",
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "le": 1000000000
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Unique request identifier.",
+          "title": "Id"
         }
       },
       "required": [
@@ -2026,47 +2025,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the exogenous structural boundary of a headless browser\nenvironment within a Partially Observable Markov Decision Process (POMDP). As a\n...State suffix, this is a declarative, frozen snapshot of an external topography.\n\nCAUSAL AFFORDANCE: Exposes the deterministic coordinate space (viewport_size,\ndom_hash, accessibility_tree_hash) enabling spatial kinematics and visual\ngrounding. The current_url (max_length=2000) anchors the spatial execution bound.\nAn optional screenshot_cid (max_length=2000, default=None) captures the visual\nsnapshot.\n\nEPISTEMIC BOUNDS: Enforces strict Server-Side Request Forgery (SSRF) quarantine\nvia the @field_validator _enforce_spatial_safety, mathematically isolating the\nagent from Bogon/private IP space. The dom_hash and accessibility_tree_hash are\nrigidly locked to SHA-256 pattern (^[a-f0-9]{64}$).\n\nMCP ROUTING TRIGGERS: Exogenous Perturbation, DOM Topography, SSRF Quarantine,\nSpatial Execution Bound, Accessibility Tree",
       "properties": {
-        "accessibility_tree_hash": {
-          "description": "The SHA-256 hash of the accessibility tree defining Exogenous Perturbations to the state space.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Accessibility Tree Hash",
+        "type": {
+          "const": "browser",
+          "default": "browser",
+          "description": "Discriminator for Causal Actuators representing structural shifts.",
+          "title": "Type",
           "type": "string"
         },
         "current_url": {
           "description": "Spatial Execution Bounds where the agent interacts.",
           "maxLength": 2000,
           "title": "Current Url",
-          "type": "string"
-        },
-        "dom_hash": {
-          "description": "The SHA-256 hash acting as the structural manifestation vector.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Dom Hash",
-          "type": "string"
-        },
-        "screenshot_cid": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the snapshot representation.",
-          "title": "Screenshot Cid"
-        },
-        "type": {
-          "const": "browser",
-          "default": "browser",
-          "description": "Discriminator for Causal Actuators representing structural shifts.",
-          "title": "Type",
           "type": "string"
         },
         "viewport_size": {
@@ -2083,6 +2052,36 @@
           ],
           "title": "Viewport Size",
           "type": "array"
+        },
+        "dom_hash": {
+          "description": "The SHA-256 hash acting as the structural manifestation vector.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Dom Hash",
+          "type": "string"
+        },
+        "accessibility_tree_hash": {
+          "description": "The SHA-256 hash of the accessibility tree defining Exogenous Perturbations to the state space.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Accessibility Tree Hash",
+          "type": "string"
+        },
+        "screenshot_cid": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the snapshot representation.",
+          "title": "Screenshot Cid"
         }
       },
       "required": [
@@ -2106,6 +2105,20 @@
           "title": "Event Id",
           "type": "string"
         },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "budget_exhaustion",
+          "default": "budget_exhaustion",
+          "description": "Discriminator type for a budget exhaustion event.",
+          "title": "Type",
+          "type": "string"
+        },
         "exhausted_escrow_id": {
           "description": "A string representing the original escrow boundary breached.",
           "maxLength": 128,
@@ -2120,20 +2133,6 @@
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Final Burn Receipt Id",
-          "type": "string"
-        },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "type": {
-          "const": "budget_exhaustion",
-          "default": "budget_exhaustion",
-          "description": "Discriminator type for a budget exhaustion event.",
-          "title": "Type",
           "type": "string"
         }
       },
@@ -2162,14 +2161,6 @@
           "$ref": "#/$defs/NodeIdentifierState",
           "description": "The exact extraction step in the DAG that was mathematically starved of compute."
         },
-        "cryptographic_null_hash": {
-          "description": "The SHA-256 null-hash representing the skipped state to satisfy the Epistemic Ledger.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Cryptographic Null Hash",
-          "type": "string"
-        },
         "justification": {
           "description": "The deterministic reason the orchestrator severed this execution branch.",
           "enum": [
@@ -2178,6 +2169,14 @@
             "sla_timeout"
           ],
           "title": "Justification",
+          "type": "string"
+        },
+        "cryptographic_null_hash": {
+          "description": "The SHA-256 null-hash representing the skipped state to satisfy the Epistemic Ledger.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Cryptographic Null Hash",
           "type": "string"
         }
       },
@@ -2194,13 +2193,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Pearlian causal tracing, linking a localized cognitive\nsynthesis back to its historical Merkle-DAG origin. As a ...State suffix, this is a\ndeclarative, frozen snapshot of a causal connection at a point in time.\n\nCAUSAL AFFORDANCE: Authorizes the assignment of fractional attention or influence\nweights to prior events, establishing a Directed Acyclic Graph (DAG) of causal lineage.\n\nEPISTEMIC BOUNDS: The influence_weight is mathematically bounded to a continuous\nprobability distribution (ge=0.0, le=1.0). The source_event_id is locked to a 128-char\nCID regex (^[a-zA-Z0-9_.:-]+$).\n\nMCP ROUTING TRIGGERS: Pearlian Causal Tracing, Directed Acyclic Graph, Causal Lineage,\nAttention Weighting, Influence Distribution",
       "properties": {
-        "influence_weight": {
-          "description": "The mathematical attention/importance weight (0.0 to 1.0) assigned to this source by the agent.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Influence Weight",
-          "type": "number"
-        },
         "source_event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the source event in the Merkle-DAG.",
           "maxLength": 128,
@@ -2208,6 +2200,13 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Source Event Id",
           "type": "string"
+        },
+        "influence_weight": {
+          "description": "The mathematical attention/importance weight (0.0 to 1.0) assigned to this source by the agent.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Influence Weight",
+          "type": "number"
         }
       },
       "required": [
@@ -2221,17 +2220,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Judea Pearl's Structural Causal Models (SCMs)\nand d-separation mechanics to map exact topological relationships between\nvariables. As a ...State suffix, this is a frozen, declarative connection\nvector.\n\nCAUSAL AFFORDANCE: Empowers the orchestrator's traversal engine to construct\ninterventional graphs for the Do-Operator (P(y|do(x))), isolating direct\ncauses from latent confounders during active inference or counterfactual\nregret simulation.\n\nEPISTEMIC BOUNDS: The edge_type physically restricts topological connections\nto the Pearlian Literal automaton [\"direct_cause\", \"confounder\", \"collider\",\n\"mediator\"]. The source_variable and target_variable are bounded by\nmin_length=1 (no max_length) to prevent ghost pointer allocation.\n\nMCP ROUTING TRIGGERS: Structural Causal Models, Pearlian Causality,\nd-separation, Do-Calculus, Directed Edge",
       "properties": {
-        "edge_type": {
-          "description": "The specific Pearlian topological relationship between the two variables.",
-          "enum": [
-            "direct_cause",
-            "confounder",
-            "collider",
-            "mediator"
-          ],
-          "title": "Edge Type",
-          "type": "string"
-        },
         "source_variable": {
           "description": "The independent variable $X$.",
           "minLength": 1,
@@ -2242,6 +2230,17 @@
           "description": "The dependent variable $Y$.",
           "minLength": 1,
           "title": "Target Variable",
+          "type": "string"
+        },
+        "edge_type": {
+          "description": "The specific Pearlian topological relationship between the two variables.",
+          "enum": [
+            "direct_cause",
+            "confounder",
+            "collider",
+            "mediator"
+          ],
+          "title": "Edge Type",
           "type": "string"
         }
       },
@@ -2257,32 +2256,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the\nmacroscopic factorization of a collective swarm outcome into its constituent causal\ncomponents. As an ...Event suffix, this is an append-only coordinate on the\nMerkle-DAG.\n\nCAUSAL AFFORDANCE: Commits the system-level CollectiveIntelligenceProfile and the\nindividual ShapleyAttributionReceipt array to the Epistemic Ledger, finalizing the\ncredit assignment for a target_outcome_event_id.\n\nEPISTEMIC BOUNDS: The target_outcome_event_id is locked to a 128-char CID regex. The\n@model_validator mathematically enforces deterministic canonical hashing by sorting the\nagent_attributions array by target_node_id (NodeIdentifierState), guaranteeing RFC 8785\nalignment.\n\nMCP ROUTING TRIGGERS: Causal Factorization, Epistemic Ledger Commit, Credit Assignment,\nMacroscopic Explanation, Deterministic Sorting",
       "properties": {
-        "agent_attributions": {
-          "description": "The array of individual causal contributions.",
-          "items": {
-            "$ref": "#/$defs/ShapleyAttributionReceipt"
-          },
-          "title": "Agent Attributions",
-          "type": "array"
-        },
-        "collective_intelligence": {
-          "$ref": "#/$defs/CollectiveIntelligenceProfile",
-          "description": "The system-level emergence metrics."
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
-          "type": "string"
-        },
-        "target_outcome_event_id": {
-          "description": "The CID of the collective outcome being explained.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Outcome Event Id",
           "type": "string"
         },
         "timestamp": {
@@ -2298,6 +2277,26 @@
           "description": "Discriminator type for a causal explanation event.",
           "title": "Type",
           "type": "string"
+        },
+        "target_outcome_event_id": {
+          "description": "The CID of the collective outcome being explained.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Outcome Event Id",
+          "type": "string"
+        },
+        "collective_intelligence": {
+          "$ref": "#/$defs/CollectiveIntelligenceProfile",
+          "description": "The system-level emergence metrics."
+        },
+        "agent_attributions": {
+          "description": "The array of individual causal contributions.",
+          "items": {
+            "$ref": "#/$defs/ShapleyAttributionReceipt"
+          },
+          "title": "Agent Attributions",
+          "type": "array"
         }
       },
       "required": [
@@ -2332,6 +2331,10 @@
           "title": "Experiment Id",
           "type": "string"
         },
+        "hypothesis": {
+          "$ref": "#/$defs/SteadyStateHypothesisState",
+          "description": "The baseline steady state hypothesis being tested."
+        },
         "faults": {
           "description": "The strict array of fault injection profiles defining the chaotic elements.",
           "items": {
@@ -2339,10 +2342,6 @@
           },
           "title": "Faults",
           "type": "array"
-        },
-        "hypothesis": {
-          "$ref": "#/$defs/SteadyStateHypothesisState",
-          "description": "The baseline steady state hypothesis being tested."
         },
         "shocks": {
           "description": "The declarative array of exogenous Black Swan events injected into the topology.",
@@ -2365,21 +2364,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Lyapunov Stability and distributed Control Theory to guarantee that the neurosymbolic network returns to a deterministic equilibrium when facing catastrophic variance. As an ...Event suffix, this is a cryptographically frozen coordinate.\n\nCAUSAL AFFORDANCE: Physically severs the active execution thread for the targeted node, acting as a hardware guillotine that immediately halts out-of-memory cascades, runaway generative loops, or API rate-limit breaches.\n\nEPISTEMIC BOUNDS: The fault perimeter is mathematically restricted to a specific `target_node_id` (`NodeIdentifierState`). To prevent log-poisoning and VRAM exhaustion during the crash, the `error_signature` is strictly clamped at `max_length=2000`.\n\nMCP ROUTING TRIGGERS: Lyapunov Stability, Control Theory, Circuit Breaker, Cascading Failure, State Equilibrium",
       "properties": {
-        "error_signature": {
-          "description": "Signature or summary of the error causing the trip.",
-          "maxLength": 2000,
-          "title": "Error Signature",
+        "type": {
+          "const": "circuit_breaker_event",
+          "default": "circuit_breaker_event",
+          "description": "The type of the resilience payload.",
+          "title": "Type",
           "type": "string"
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
           "description": "The ID of the node for which the circuit breaker was tripped."
         },
-        "type": {
-          "const": "circuit_breaker_event",
-          "default": "circuit_breaker_event",
-          "description": "The type of the resilience payload.",
-          "title": "Type",
+        "error_signature": {
+          "description": "Signature or summary of the error causing the trip.",
+          "maxLength": 2000,
+          "title": "Error Signature",
           "type": "string"
         }
       },
@@ -2394,12 +2393,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Step-Level Verification via Process Reward Models\n(PRMs) to evaluate and critique intermediate steps in non-monotonic reasoning\ntrees. As a ...Profile suffix, this is a declarative, frozen snapshot.\n\nCAUSAL AFFORDANCE: Injects a dense latent supervision vector\n(logical_flaw_embedding: VectorEmbeddingState | None, default=None) to\nmathematically repel the generative trajectory away from hallucinated or\nlogically flawed probability manifolds during test-time compute.\n\nEPISTEMIC BOUNDS: The penalization magnitude is strictly clamped by\nepistemic_penalty_scalar (ge=0.0, le=1.0) to prevent gradient explosion. The\ntarget is cryptographically locked via reasoning_trace_hash (SHA-256 pattern\n^[a-f0-9]{64}$).\n\nMCP ROUTING TRIGGERS: Process Reward Model, Step-Level Verification,\nRepresentation Engineering, Latent Repulsion, Test-Time Supervision",
       "properties": {
-        "epistemic_penalty_scalar": {
-          "description": "CoReason Shared Kernel Ontology: A continuous penalty applied to the branch's probability mass if normative drift or hallucination is detected.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Epistemic Penalty Scalar",
-          "type": "number"
+        "reasoning_trace_hash": {
+          "description": "CoReason Shared Kernel Ontology: The cryptographic Merkle root of the specific ThoughtBranch being evaluated.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Reasoning Trace Hash",
+          "type": "string"
         },
         "logical_flaw_embedding": {
           "anyOf": [
@@ -2413,13 +2413,12 @@
           "default": null,
           "description": "CoReason Shared Kernel Ontology: A dense latent space representation of the specific logical fallacy identified, used to mathematically repel future generation trajectories."
         },
-        "reasoning_trace_hash": {
-          "description": "CoReason Shared Kernel Ontology: The cryptographic Merkle root of the specific ThoughtBranch being evaluated.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Reasoning Trace Hash",
-          "type": "string"
+        "epistemic_penalty_scalar": {
+          "description": "CoReason Shared Kernel Ontology: A continuous penalty applied to the branch's probability mass if normative drift or hallucination is detected.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Epistemic Penalty Scalar",
+          "type": "number"
         }
       },
       "required": [
@@ -2433,6 +2432,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Generative Flow Network (GFlowNet) trajectory balance\nconditions to ensure that the probability of generating a non-monotonic reasoning path\nis strictly proportional to its terminal reward. As a ...Contract suffix, this object\ndefines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's sampling mechanism to continuously\noptimize for the detailed balance equations using the specified flow_estimation_model\n(max_length=2000), ensuring proportional flow allocation across alternative Markov\nDecision Process (MDP) branches.\n\nEPISTEMIC BOUNDS: The acceptable mathematical variance is strictly bounded by\ntarget_balance_epsilon (ge=0.0, le=1.0), preventing probability flow divergence. The\nlocal_exploration_k (gt=0, le=1.0) physically caps exploratory branching.\n\nMCP ROUTING TRIGGERS: Generative Flow Networks, Detailed Balance, Markov Chain Monte\nCarlo, Trajectory Flow, Credit Assignment Problem",
       "properties": {
+        "target_balance_epsilon": {
+          "description": "The mathematical tolerance for the detailed balance constraint.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Target Balance Epsilon",
+          "type": "number"
+        },
         "flow_estimation_model": {
           "description": "The specific neural architecture used to estimate flow.",
           "maxLength": 2000,
@@ -2445,13 +2451,6 @@
           "maximum": 1.0,
           "title": "Local Exploration K",
           "type": "integer"
-        },
-        "target_balance_epsilon": {
-          "description": "The mathematical tolerance for the detailed balance constraint.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Target Balance Epsilon",
-          "type": "number"
         }
       },
       "required": [
@@ -2492,9 +2491,11 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Finite State Machine (FSM) Logit Masking and Constrained\nDecoding to deterministically herd LLM stochasticity into rigorous syntactic\nstructures. As a ...Contract suffix, this enforces a rigid mathematical boundary\nglobally.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's inference engine to physically\nsuffocate invalid token probabilities to negative infinity, mechanically ensuring\nthe output conforms to downstream parser requirements.\n\nEPISTEMIC BOUNDS: Execution constraints are rigidly defined by require_think_tags\n(default=True, forcing XML-bounded internal monologues) and final_answer_regex\n(max_length=2000, default=\"^Final Answer: .*$\") to prevent ReDoS CPU exhaustion\nduring evaluation and routing.\n\nMCP ROUTING TRIGGERS: FSM Logit Masking, Constrained Decoding, Regular Expression\nAutomaton, Syntactic Boundary, Token Suffocation",
       "properties": {
-        "decoding_policy": {
-          "$ref": "#/$defs/ConstrainedDecodingPolicy",
-          "description": "The mandatory hardware-level execution limits for token masking."
+        "require_think_tags": {
+          "default": true,
+          "description": "Forces the inclusion of structural XML tags to isolate the reasoning trace.",
+          "title": "Require Think Tags",
+          "type": "boolean"
         },
         "final_answer_regex": {
           "default": "^Final Answer: .*$",
@@ -2503,11 +2504,9 @@
           "title": "Final Answer Regex",
           "type": "string"
         },
-        "require_think_tags": {
-          "default": true,
-          "description": "Forces the inclusion of structural XML tags to isolate the reasoning trace.",
-          "title": "Require Think Tags",
-          "type": "boolean"
+        "decoding_policy": {
+          "$ref": "#/$defs/ConstrainedDecodingPolicy",
+          "description": "The mandatory hardware-level execution limits for token masking."
         }
       },
       "required": [
@@ -2528,14 +2527,18 @@
           "title": "Event Id",
           "type": "string"
         },
-        "predicted_top_k_tokens": {
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Predicted Top K Tokens",
-          "type": "array"
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "cognitive_prediction",
+          "default": "cognitive_prediction",
+          "title": "Type",
+          "type": "string"
         },
         "source_chain_id": {
           "maxLength": 128,
@@ -2549,18 +2552,14 @@
           "title": "Target Source Concept",
           "type": "string"
         },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "type": {
-          "const": "cognitive_prediction",
-          "default": "cognitive_prediction",
-          "title": "Type",
-          "type": "string"
+        "predicted_top_k_tokens": {
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Predicted Top K Tokens",
+          "type": "array"
         }
       },
       "required": [
@@ -2577,6 +2576,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of a continuous proof trace resulting\nfrom a successfully resolved non-monotonic search, projecting internal System 2 thinking\ninto the observable graph. As a ...State suffix, this is a frozen N-dimensional\ncoordinate.\n\nCAUSAL AFFORDANCE: Binds the raw, unstructured Chain-of-Thought (trace_payload) to a\nformal EpistemicTopologicalProofManifest (source_proof_id), injecting the internal\nmonologue into the verifiable DAG for downstream reward shaping (GRPO).\n\nEPISTEMIC BOUNDS: The token_length is restricted (ge=0, le=1000000000). The textual\nreasoning is physically bounded to max_length=100000 to prevent context window\nexplosion. The trace_id is locked to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Chain of Thought, Non-Monotonic Trace, Proof Crystallization,\nLatent Monologue, Verifiable Reasoning",
       "properties": {
+        "trace_id": {
+          "description": "CID of this specific non-monotonic reasoning trace.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Trace Id",
+          "type": "string"
+        },
         "source_proof_id": {
           "description": "The EpistemicTopologicalProofManifest CID this trace is mathematically anchored to.",
           "maxLength": 128,
@@ -2591,14 +2598,6 @@
           "minimum": 0,
           "title": "Token Length",
           "type": "integer"
-        },
-        "trace_id": {
-          "description": "CID of this specific non-monotonic reasoning trace.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Trace Id",
-          "type": "string"
         },
         "trace_payload": {
           "description": "The natural language reasoning steps bounded by structural tags.",
@@ -2620,19 +2619,33 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The immutable cryptographic receipt of a GRPO Advantage Actor-Critic\nevaluation step, permanently logging the mathematically verified advantage score of a\nspecific generation trajectory. As a ...Receipt suffix, this is an append-only coordinate\non the Merkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Unlocks policy gradient updates by providing the deterministic advantage\nsignal derived from the extracted_axioms of the source_generation_id.\n\nEPISTEMIC BOUNDS: The calculated_r_path is strictly clamped between [ge=0.0, le=1.0], and\nthe total_advantage_score is capped at le=100.0. The @model_validator physically guarantees\nthat the extracted_axioms array is deterministically sorted by the composite key\n(source_concept_id, directed_edge_type, target_concept_id) to preserve RFC 8785 canonical\nhashing across the distributed swarm.\n\nMCP ROUTING TRIGGERS: Advantage Actor-Critic, Policy Gradient Update, Epistemic Reward,\nBaseline Normalization, Reinforcement Learning",
       "properties": {
-        "calculated_r_path": {
-          "description": "The dense reasoning reward signal derived from the verified axioms.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Calculated R Path",
-          "type": "number"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "cognitive_reward_evaluation",
+          "default": "cognitive_reward_evaluation",
+          "title": "Type",
+          "type": "string"
+        },
+        "source_generation_id": {
+          "description": "The CID of the LLM's raw generated text trajectory.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Generation Id",
           "type": "string"
         },
         "extracted_axioms": {
@@ -2643,19 +2656,11 @@
           "title": "Extracted Axioms",
           "type": "array"
         },
-        "source_generation_id": {
-          "description": "The CID of the LLM's raw generated text trajectory.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Generation Id",
-          "type": "string"
-        },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
+        "calculated_r_path": {
+          "description": "The dense reasoning reward signal derived from the verified axioms.",
+          "maximum": 1.0,
           "minimum": 0.0,
-          "title": "Timestamp",
+          "title": "Calculated R Path",
           "type": "number"
         },
         "total_advantage_score": {
@@ -2663,12 +2668,6 @@
           "maximum": 100.0,
           "title": "Total Advantage Score",
           "type": "number"
-        },
-        "type": {
-          "const": "cognitive_reward_evaluation",
-          "default": "cognitive_reward_evaluation",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -2692,11 +2691,12 @@
           "title": "Dynamic Top K",
           "type": "integer"
         },
-        "enforce_functional_isolation": {
-          "default": false,
-          "description": "If True, the orchestrator applies a hard mask (-inf) to any expert not explicitly boosted in expert_logit_biases.",
-          "title": "Enforce Functional Isolation",
-          "type": "boolean"
+        "routing_temperature": {
+          "description": "The temperature applied to the router's softmax gate, controlling how deterministically it picks experts.",
+          "maximum": 1000000000.0,
+          "minimum": 0.0,
+          "title": "Routing Temperature",
+          "type": "number"
         },
         "expert_logit_biases": {
           "additionalProperties": {
@@ -2712,12 +2712,11 @@
           "title": "Expert Logit Biases",
           "type": "object"
         },
-        "routing_temperature": {
-          "description": "The temperature applied to the router's softmax gate, controlling how deterministically it picks experts.",
-          "maximum": 1000000000.0,
-          "minimum": 0.0,
-          "title": "Routing Temperature",
-          "type": "number"
+        "enforce_functional_isolation": {
+          "default": false,
+          "description": "If True, the orchestrator applies a hard mask (-inf) to any expert not explicitly boosted in expert_logit_biases.",
+          "title": "Enforce Functional Isolation",
+          "type": "boolean"
         }
       },
       "required": [
@@ -2731,19 +2730,19 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the Upper Confidence Bound (UCB) algorithm and Inverse Frequency Smoothing to regulate the exploration-exploitation geometry of Monte Carlo Tree Search (MCTS).\n\nCAUSAL AFFORDANCE: Physically regulates the search tree depth and dynamically prioritizes unexplored nodes, forcing the orchestrator to expand its epistemic search space before converging.\n\nEPISTEMIC BOUNDS: Graph traversal depth is rigidly cut off by max_complexity_hops (ge=1, le=1000000000). The mathematical exploration bonus is constrained by inverse_frequency_smoothing_epsilon (le=1.0), preventing exponential divergence in node prioritization.\n\nMCP ROUTING TRIGGERS: Monte Carlo Tree Search, Upper Confidence Bound, Inverse Frequency Smoothing, Heuristic Exploration, Graph Traversal",
       "properties": {
-        "inverse_frequency_smoothing_epsilon": {
-          "default": 1.0,
-          "description": "The epsilon constant ensuring unsampled nodes are mathematically prioritized.",
-          "maximum": 1.0,
-          "title": "Inverse Frequency Smoothing Epsilon",
-          "type": "number"
-        },
         "max_complexity_hops": {
           "description": "The absolute physical limit on path length N.",
           "maximum": 1000000000,
           "minimum": 1,
           "title": "Max Complexity Hops",
           "type": "integer"
+        },
+        "inverse_frequency_smoothing_epsilon": {
+          "default": 1.0,
+          "description": "The epsilon constant ensuring unsampled nodes are mathematically prioritized.",
+          "maximum": 1.0,
+          "title": "Inverse Frequency Smoothing Epsilon",
+          "type": "number"
         }
       },
       "required": [
@@ -2756,17 +2755,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Tracks the continuous Partially Observable Markov Decision Process\n(POMDP) belief distribution and dictates the active cognitive heuristic. As a ...Profile\nsuffix, this is a declarative, frozen snapshot of N-dimensional geometry at a specific\npoint in time.\n\nCAUSAL AFFORDANCE: Orchestrates multi-dimensional state progression, determining if the\nagent explores via high divergence_tolerance or exploits via constrained caution vectors.\nOptionally embeds an ActivationSteeringContract, CognitiveRoutingContract, and\nSemanticSlicingPolicy for full mechanistic control.\n\nEPISTEMIC BOUNDS: Relies on strict Pydantic bounding of internal indices (urgency_index,\ncaution_index, divergence_tolerance) to continuous probability distributions between\n[ge=0.0, le=1.0].\n\nMCP ROUTING TRIGGERS: POMDP, Continuous Belief Distribution, Heuristic Routing, State\nProgression, Cognitive Constraining",
       "properties": {
-        "activation_steering": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ActivationSteeringContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The precise mathematical contract for altering the residual stream to enforce this constraint."
+        "urgency_index": {
+          "description": "Drives structural constraints; high urgency forces fast heuristic routing.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Urgency Index",
+          "type": "number"
         },
         "caution_index": {
           "description": "Drives precision; high caution injects analytical/falsification steering vectors.",
@@ -2781,6 +2775,18 @@
           "minimum": 0.0,
           "title": "Divergence Tolerance",
           "type": "number"
+        },
+        "activation_steering": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivationSteeringContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The precise mathematical contract for altering the residual stream to enforce this constraint."
         },
         "moe_routing_directive": {
           "anyOf": [
@@ -2805,13 +2811,6 @@
           ],
           "default": null,
           "description": "The mathematical data starvation mechanism bounding the working memory context."
-        },
-        "urgency_index": {
-          "description": "Drives structural constraints; high urgency forces fast heuristic routing.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Urgency Index",
-          "type": "number"
         }
       },
       "required": [
@@ -2848,17 +2847,17 @@
           "title": "Epistemic Uncertainty",
           "type": "number"
         },
-        "requires_abductive_escalation": {
-          "description": "True if epistemic_uncertainty breaches the safety threshold, requiring structural mandate escalation.",
-          "title": "Requires Abductive Escalation",
-          "type": "boolean"
-        },
         "semantic_consistency_score": {
           "description": "Counterfactual Geometries representing alternative timeline vectors.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Semantic Consistency Score",
           "type": "number"
+        },
+        "requires_abductive_escalation": {
+          "description": "True if epistemic_uncertainty breaches the safety threshold, requiring structural mandate escalation.",
+          "title": "Requires Abductive Escalation",
+          "type": "boolean"
         }
       },
       "required": [
@@ -2874,6 +2873,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Integrated Information Theory (IIT) and synergy metrics\nto quantify system-level emergence in the neurosymbolic swarm. As a ...Profile suffix,\nthis is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Provides the orchestrator with macroscopic topological variables to\nevaluate whether the multi-agent ensemble is producing non-linear, synergistic output\nversus independent parallel processing.\n\nEPISTEMIC BOUNDS: coordination_score and information_integration are upper-clamped at\nle=1.0 to represent normalized mutual information. synergy_index is capped at\nle=1000000000.0 to prevent scalar explosion. Note: no lower ge bounds are enforced on\nthese fields.\n\nMCP ROUTING TRIGGERS: Integrated Information Theory, Systemic Emergence, Conditional\nMutual Information, Synergy Index, Multi-Agent Coupling",
       "properties": {
+        "synergy_index": {
+          "description": "The mathematical measure of the degree of emergence. A high SI indicates strong positive emergence.",
+          "maximum": 1000000000.0,
+          "title": "Synergy Index",
+          "type": "number"
+        },
         "coordination_score": {
           "description": "The temporal alignment measuring the extent to which agents coordinate their actions over time.",
           "maximum": 1.0,
@@ -2884,12 +2889,6 @@
           "description": "The conditional mutual information quantifying the information flow and tight coupling between agents.",
           "maximum": 1.0,
           "title": "Information Integration",
-          "type": "number"
-        },
-        "synergy_index": {
-          "description": "The mathematical measure of the degree of emergence. A high SI indicates strong positive emergence.",
-          "maximum": 1000000000.0,
-          "title": "Synergy Index",
           "type": "number"
         }
       },
@@ -2905,6 +2904,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a Fractal Graph Abstraction, allowing the recursive\nencapsulation of entire workflow sub-topologies within a single, unified macroscopic\nvertex. As a ...Profile suffix, this is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to suspend the parent graph, injecting\nstate variables into the isolated topology (AnyTopologyManifest) via input_mappings\n(list[InputMappingContract], default_factory=list), and extracting terminal output\nvia output_mappings (list[OutputMappingContract], default_factory=list).\n\nEPISTEMIC BOUNDS: The @model_validator sort_composite_arrays deterministically sorts\ninput_mappings by parent_key and output_mappings by child_key, guaranteeing\nzero-variance RFC 8785 canonical Merkle-DAG hashes across distributed nodes.\n\nMCP ROUTING TRIGGERS: Fractal Graph Abstraction, Recursive Encapsulation, State\nProjection, Bijective Mapping, Sub-Topology",
       "properties": {
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -2919,11 +2924,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -2942,6 +2963,17 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
           "title": "Domain Extensions"
         },
+        "type": {
+          "const": "composite",
+          "default": "composite",
+          "description": "Discriminator for a Composite node.",
+          "title": "Type",
+          "type": "string"
+        },
+        "topology": {
+          "$ref": "#/$defs/AnyTopologyManifest",
+          "description": "The encapsulated subgraph to execute."
+        },
         "input_mappings": {
           "description": "Explicit state projection inputs.",
           "items": {
@@ -2950,28 +2982,6 @@
           "title": "Input Mappings",
           "type": "array"
         },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
-        },
         "output_mappings": {
           "description": "Explicit state projection outputs.",
           "items": {
@@ -2979,17 +2989,6 @@
           },
           "title": "Output Mappings",
           "type": "array"
-        },
-        "topology": {
-          "$ref": "#/$defs/AnyTopologyManifest",
-          "description": "The encapsulated subgraph to execute."
-        },
-        "type": {
-          "const": "composite",
-          "default": "composite",
-          "description": "Discriminator for a Composite node.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -3003,22 +3002,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as the liquid compute substrate abstraction, defining the\nfoundational LLM matrix available on the Spot Market for dynamic routing. As a ...Profile\nsuffix, this is a declarative, frozen snapshot of a compute geometry.\n\nCAUSAL AFFORDANCE: Projects the physical LLM capabilities, contextual memory constraints,\nand thermodynamic rate cards (ComputeRateContract) into the orchestrator's active routing\nmanifold, allowing cost-aware topological planning.\n\nEPISTEMIC BOUNDS: The token working memory is mathematically bounded by\ncontext_window_size (le=1000000000). To guarantee RFC 8785 canonical hashing across\ndisparate nodes, the capabilities and supported_functional_experts arrays are strictly\nsorted at instantiation via @model_validator.\n\nMCP ROUTING TRIGGERS: Liquid Compute, Spot Market Routing, Foundation Model Matrix,\nThermodynamic Rate Card, Substrate Abstraction",
       "properties": {
-        "capabilities": {
-          "description": "The explicit, structurally bounded array of capabilities authorized for this model.",
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "maxItems": 1000000000,
-          "title": "Capabilities",
-          "type": "array"
-        },
-        "context_window_size": {
-          "description": "The maximum context window size in tokens.",
-          "maximum": 1000000000,
-          "title": "Context Window Size",
-          "type": "integer"
-        },
         "model_name": {
           "description": "The identifier of the underlying model.",
           "maxLength": 2000,
@@ -3030,6 +3013,22 @@
           "maxLength": 2000,
           "title": "Provider",
           "type": "string"
+        },
+        "context_window_size": {
+          "description": "The maximum context window size in tokens.",
+          "maximum": 1000000000,
+          "title": "Context Window Size",
+          "type": "integer"
+        },
+        "capabilities": {
+          "description": "The explicit, structurally bounded array of capabilities authorized for this model.",
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "maxItems": 1000000000,
+          "title": "Capabilities",
+          "type": "array"
         },
         "rate_card": {
           "$ref": "#/$defs/ComputeRateContract",
@@ -3065,11 +3064,6 @@
           "title": "Max Budget",
           "type": "number"
         },
-        "qos_class": {
-          "$ref": "#/$defs/QoSClassificationProfile",
-          "default": "interactive",
-          "description": "The Quality of Service priority, used by the compute spot market for semantic load shedding."
-        },
         "required_capabilities": {
           "description": "The minimal functional capabilities required by the requested compute.",
           "items": {
@@ -3079,6 +3073,11 @@
           "maxItems": 1000000000,
           "title": "Required Capabilities",
           "type": "array"
+        },
+        "qos_class": {
+          "$ref": "#/$defs/QoSClassificationProfile",
+          "default": "interactive",
+          "description": "The Quality of Service priority, used by the compute spot market for semantic load shedding."
         }
       },
       "required": [
@@ -3123,9 +3122,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Zero-Cost Macro abstraction that deterministically projects a Practical Byzantine Fault Tolerance (pBFT) consensus ring into a multi-agent workflow. As a ...Manifest suffix, this defines a frozen coordinate of a topological structure.\n\nCAUSAL AFFORDANCE: Unrolls into a base CouncilTopologyManifest, enforcing strict quorum rules and sequential adjudication to guarantee ledger alignment and truth maintenance across a decentralized, zero-trust swarm.\n\nEPISTEMIC BOUNDS: Mathematically ensures Byzantine security by requiring a minimum of 3 participant_ids. The adjudicator_id is physically isolated from the voting pool via the verify_adjudicator_isolation hook. The participant_ids array is deterministically sorted for invariant hashing.\n\nMCP ROUTING TRIGGERS: Practical Byzantine Fault Tolerance, pBFT, Distributed Consensus, Sybil Resistance, Macro Abstraction",
       "properties": {
-        "adjudicator_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The orchestrating sequencer for the PBFT consensus."
+        "type": {
+          "const": "macro_federation",
+          "default": "macro_federation",
+          "description": "Discriminator for federation macro.",
+          "title": "Type",
+          "type": "string"
         },
         "participant_ids": {
           "description": "The nodes forming the PBFT ring.",
@@ -3136,16 +3138,13 @@
           "title": "Participant Ids",
           "type": "array"
         },
+        "adjudicator_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The orchestrating sequencer for the PBFT consensus."
+        },
         "quorum_rules": {
           "$ref": "#/$defs/QuorumPolicy",
           "description": "The strict BFT tolerance bounds."
-        },
-        "type": {
-          "const": "macro_federation",
-          "default": "macro_federation",
-          "description": "Discriminator for federation macro.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -3160,6 +3159,30 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Social Choice Theory and Distributed Consensus mechanisms\nto systematically synthesize a singular, crystallized truth from a multi-agent council.\nAs a ...Policy suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Triggers deterministic tie-breaking (via optional\ntie_breaker_node_id: NodeIdentifierState) or algorithmic market resolution (via\noptional prediction_market_rules: PredictionMarketPolicy) when agents deadlock,\nforcefully collapsing the debate probability wave to maintain systemic liveness.\n\nEPISTEMIC BOUNDS: The max_debate_rounds (optional int) is clamped to le=1000000000 to\ncomputationally solve the Halting Problem for runaway arguments. The strategy Literal\n[\"unanimous\", \"majority\", \"debate_rounds\", \"prediction_market\", \"pbft\"] constrains\nthe combinatorial space. The @model_validator requires quorum_rules if strategy is\n\"pbft\".\n\nMCP ROUTING TRIGGERS: Social Choice Theory, Mechanism Design, Condorcet's Jury Theorem,\nAlgorithmic Consensus, Deadlock Resolution",
       "properties": {
+        "strategy": {
+          "description": "The mathematical rule for reaching agreement.",
+          "enum": [
+            "unanimous",
+            "majority",
+            "debate_rounds",
+            "prediction_market",
+            "pbft"
+          ],
+          "title": "Strategy",
+          "type": "string"
+        },
+        "tie_breaker_node_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeIdentifierState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The node authorized to break deadlocks if unanimity or majority fails."
+        },
         "max_debate_rounds": {
           "anyOf": [
             {
@@ -3197,30 +3220,6 @@
           ],
           "default": null,
           "description": "The strict Byzantine fault tolerance limits required if the strategy is 'pbft'."
-        },
-        "strategy": {
-          "description": "The mathematical rule for reaching agreement.",
-          "enum": [
-            "unanimous",
-            "majority",
-            "debate_rounds",
-            "prediction_market",
-            "pbft"
-          ],
-          "title": "Strategy",
-          "type": "string"
-        },
-        "tie_breaker_node_id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeIdentifierState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The node authorized to break deadlocks if unanimity or majority fails."
         }
       },
       "required": [
@@ -3233,18 +3232,19 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a non-monotonic structural revision trigger within a\nDefeasible Logic framework, engineered to adapt the GovernancePolicy to\nout-of-distribution environments. As an ...Intent suffix, the LLM may execute\nnon-monotonic reasoning here.\n\nCAUSAL AFFORDANCE: Triggers an active topological mutation (Pearlian intervention) to\nresolve logical friction, applying a strict RFC 6902 JSON Patch (proposed_patch) to the\nunderlying alignment manifold.\n\nEPISTEMIC BOUNDS: Cryptographically anchored to the specific drift_event_id (regex\nbounded CID ^[a-zA-Z0-9_.:-]+$) that mathematically justified the revision. The payload\nis strictly constrained to a JSON Schema object (proposed_patch). The justification\nfield (max_length=2000) bounds the natural language argument.\n\nMCP ROUTING TRIGGERS: Defeasible Logic, Non-Monotonic Revision, Out-of-Distribution\nAdaptation, Normative Drift Resolution, Pearlian Intervention",
       "properties": {
+        "type": {
+          "const": "constitutional_amendment",
+          "default": "constitutional_amendment",
+          "description": "The strict discriminator for this intervention payload.",
+          "title": "Type",
+          "type": "string"
+        },
         "drift_event_id": {
           "description": "The CID of the NormativeDriftEvent that justified triggering this proposal.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Drift Event Id",
-          "type": "string"
-        },
-        "justification": {
-          "description": "The AI's natural language structural/logical argument for why this patch resolves the contradiction without violating the root AnchoringPolicy.",
-          "maxLength": 2000,
-          "title": "Justification",
           "type": "string"
         },
         "proposed_patch": {
@@ -3256,11 +3256,10 @@
           "title": "Proposed Patch",
           "type": "object"
         },
-        "type": {
-          "const": "constitutional_amendment",
-          "default": "constitutional_amendment",
-          "description": "The strict discriminator for this intervention payload.",
-          "title": "Type",
+        "justification": {
+          "description": "The AI's natural language structural/logical argument for why this patch resolves the contradiction without violating the root AnchoringPolicy.",
+          "maxLength": 2000,
+          "title": "Justification",
           "type": "string"
         }
       },
@@ -3276,28 +3275,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a discrete normative axiom within a Constitutional AI\nframework to prevent instrumental convergence. As a ...Policy suffix, this object defines\nrigid mathematical boundaries that the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Establishes a hard structural boundary that mathematically repels the\nswarm's generative trajectory away from forbidden semantic manifolds. Violation severity\nis classified via a strict Literal[\"low\", \"medium\", \"high\", \"critical\"] tier.\n\nEPISTEMIC BOUNDS: Geometrically restricts the state space by blacklisting specific\nexecution branches via the forbidden_intents array (max_length=1000000000),\ndeterministically sorted by @model_validator to preserve RFC 8785 canonical hashing.\nThe rule_id is bounded to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Constitutional AI, Value Alignment, Normative Axiom, Instrumental\nConvergence, Semantic Boundary",
       "properties": {
-        "description": {
-          "description": "The definitive causal constraint or heuristic boundary enforced by this rule.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
-        },
-        "forbidden_intents": {
-          "description": "The explicit, structurally bounded set of forbidden semantic intents.",
-          "items": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 1000000000,
-          "title": "Forbidden Intents",
-          "type": "array"
-        },
         "rule_id": {
           "description": "Unique identifier for the constitutional rule.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Rule Id",
+          "type": "string"
+        },
+        "description": {
+          "description": "The definitive causal constraint or heuristic boundary enforced by this rule.",
+          "maxLength": 2000,
+          "title": "Description",
           "type": "string"
         },
         "severity": {
@@ -3310,6 +3299,16 @@
           ],
           "title": "Severity",
           "type": "string"
+        },
+        "forbidden_intents": {
+          "description": "The explicit, structurally bounded set of forbidden semantic intents.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 1000000000,
+          "title": "Forbidden Intents",
+          "type": "array"
         }
       },
       "required": [
@@ -3325,6 +3324,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: ConstrainedDecodingPolicy is a rigid mathematical boundary enforcing systemic constraints\nglobally. Dictates the hardware-level execution limits for the token sampling phase by converting structural\nformatting from a probabilistic neural suggestion into a deterministic physics problem.\n\nCAUSAL AFFORDANCE: Enforces rigid isolation perimeters and limits subgraph generation by physically\nsuffocating invalid token probabilities. It instructs the inference engine (e.g., Outlines, XGrammar)\nto compile a Deterministic Finite Automaton (DFA) or Pushdown Automaton (PDA) and mechanically overwrite\nillegal token logits to negative infinity.\n\nEPISTEMIC BOUNDS: The absolute mathematical and physical limits are strictly bounded categorical literals\non fields: enforcement_strategy, compiler_backend. All field limits must be strictly validated at\ninstantiation to prevent epistemic contagion and prompt-injection payload sabotage.\n\nMCP ROUTING TRIGGERS: FSM Logit Masking, Constrained Decoding, Tokenizer Interception, Hardware Execution Boundary",
       "properties": {
+        "enforcement_strategy": {
+          "const": "fsm_logit_mask",
+          "default": "fsm_logit_mask",
+          "description": "The mechanistic strategy for intercepting the LLM forward pass.",
+          "title": "Enforcement Strategy",
+          "type": "string"
+        },
         "compiler_backend": {
           "description": "The C++/CUDA backend used to compile the CFG or Regex into a DFA/PDA.",
           "enum": [
@@ -3334,13 +3340,6 @@
             "agnostic"
           ],
           "title": "Compiler Backend",
-          "type": "string"
-        },
-        "enforcement_strategy": {
-          "const": "fsm_logit_mask",
-          "default": "fsm_logit_mask",
-          "description": "The mechanistic strategy for intercepting the LLM forward pass.",
-          "title": "Enforcement Strategy",
           "type": "string"
         },
         "terminate_on_eos_leak": {
@@ -3377,21 +3376,6 @@
           "title": "Max Token Budget",
           "type": "integer"
         },
-        "parent_merge_threshold": {
-          "anyOf": [
-            {
-              "maximum": 1.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The geometric cosine similarity threshold required to merge parent nodes.",
-          "title": "Parent Merge Threshold"
-        },
         "surrounding_sentences_k": {
           "anyOf": [
             {
@@ -3406,6 +3390,21 @@
           "default": null,
           "description": "The strict temporal window of surrounding sentences.",
           "title": "Surrounding Sentences K"
+        },
+        "parent_merge_threshold": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The geometric cosine similarity threshold required to merge parent nodes.",
+          "title": "Parent Merge Threshold"
         }
       },
       "required": [
@@ -3419,6 +3418,15 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Queueing Theory and Micro-Batching Stream Processing\nheuristics for continuous, high-velocity graph updates without violating Eventual\nConsistency. As a ...Policy suffix, this defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Dictates the thermodynamic flow of the orchestrator, determining\nexactly when to buffer and when to force-commit volatile StateMutationIntent\nmatrices to the EpistemicLedgerState via the mutation_paradigm\nLiteral [\"append_only\", \"merge_on_resolve\"].\n\nEPISTEMIC BOUNDS: Physically prevents Out-Of-Memory (OOM) VRAM crashes by\nmathematically enforcing max_uncommitted_edges (gt=0, le=1000000000). The\n@model_validator enforce_append_only_vram_bound further crushes this limit to\n<= 10000 for append_only operations. The commit cycle is temporally guillotined\nby micro_batch_interval_ms (gt=0, le=86400000).\n\nMCP ROUTING TRIGGERS: Queueing Theory, Stream Processing, Micro-Batching,\nBackpressure, Buffer Memory Bounding",
       "properties": {
+        "mutation_paradigm": {
+          "description": "Forces non-destructive graph mutations.",
+          "enum": [
+            "append_only",
+            "merge_on_resolve"
+          ],
+          "title": "Mutation Paradigm",
+          "type": "string"
+        },
         "max_uncommitted_edges": {
           "description": "Backpressure threshold before forcing a commit.",
           "exclusiveMinimum": 0,
@@ -3432,15 +3440,6 @@
           "maximum": 86400000,
           "title": "Micro Batch Interval Ms",
           "type": "integer"
-        },
-        "mutation_paradigm": {
-          "description": "Forces non-destructive graph mutations.",
-          "enum": [
-            "append_only",
-            "merge_on_resolve"
-          ],
-          "title": "Mutation Paradigm",
-          "type": "string"
         }
       },
       "required": [
@@ -3455,9 +3454,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Social Choice Theory, Condorcet's Jury Theorem, and\nPractical Byzantine Fault Tolerance (pBFT) to synthesize an authoritative truth\nfrom a multi-agent network. As a ...Manifest suffix, this defines a frozen,\nN-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Unlocks decentralized truth-synthesis by routing conflicting\nproposals through a strict consensus_policy (ConsensusPolicy), ultimately collapsing\nthe epistemic probability wave via the designated adjudicator_id\n(NodeIdentifierState). Cognitive heterogeneity is enforced by\ndiversity_policy (DiversityPolicy).\n\nEPISTEMIC BOUNDS: The @model_validator enforce_funded_byzantine_slashing enforces a\nstrict economic interlock: if the consensus_policy demands slash_escrow via pBFT,\nit halts instantiation unless a funded council_escrow (EscrowPolicy, magnitude > 0)\nis present. A second @model_validator check_adjudicator_id verifies the\nadjudicator_id exists in the nodes registry.\n\nMCP ROUTING TRIGGERS: Social Choice Theory, PBFT Consensus, Multi-Agent Debate,\nByzantine Fault Tolerance, Slashing Condition",
       "properties": {
-        "adjudicator_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The NodeIdentifierState of the adjudicator that synthesizes the council's output."
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy",
+              "le": 1000000000
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
         },
         "architectural_intent": {
           "anyOf": [
@@ -3473,67 +3491,6 @@
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
         },
-        "consensus_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ConsensusPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The explicit ruleset governing how the council resolves disagreements."
-        },
-        "council_escrow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EscrowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The strictly typed mathematical surface area to lock funds specifically for PBFT council execution and slashing."
-        },
-        "diversity_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DiversityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Constraints enforcing cognitive heterogeneity across the council."
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy",
-              "le": 1000000000
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "information_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
-        },
         "justification": {
           "anyOf": [
             {
@@ -3548,16 +3505,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -3568,30 +3515,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The distributed tracing rules bound to this specific execution graph."
-        },
-        "ontological_alignment": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/OntologicalAlignmentPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -3605,12 +3528,88 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
         "type": {
           "const": "council",
           "default": "council",
           "description": "Discriminator for a Council topology.",
           "title": "Type",
           "type": "string"
+        },
+        "adjudicator_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The NodeIdentifierState of the adjudicator that synthesizes the council's output."
+        },
+        "diversity_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DiversityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Constraints enforcing cognitive heterogeneity across the council."
+        },
+        "consensus_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConsensusPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The explicit ruleset governing how the council resolves disagreements."
+        },
+        "ontological_alignment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologicalAlignmentPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
+        },
+        "council_escrow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EscrowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strictly typed mathematical surface area to lock funds specifically for PBFT council execution and slashing."
         }
       },
       "required": [
@@ -3624,18 +3623,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Counterfactual Regret Minimization (CFR) and Pearlian Do-Calculus to execute simulated alternative timelines for policy refinement.\n\nCAUSAL AFFORDANCE: Commits a simulated causal divergence (intervention) into the ledger, mathematically quantifying the opportunity cost (regret) to backpropagate stateless adjustments to the routing policy.\n\nEPISTEMIC BOUNDS: The event is anchored to the exact `historical_event_id` (128-char CID). Expected utilities and the resultant `epistemic_regret` are physically capped at `le=1000000000.0`. `policy_mutation_gradients` map bounded tensor adjustments.\n\nMCP ROUTING TRIGGERS: Counterfactual Regret Minimization, Pearlian Do-Calculus, Opportunity Cost, Alternative Timeline, Policy Gradient Update",
       "properties": {
-        "counterfactual_intervention": {
-          "description": "The specific alternative action or do-calculus intervention applied in the simulation.",
-          "maxLength": 2000,
-          "title": "Counterfactual Intervention",
-          "type": "string"
-        },
-        "epistemic_regret": {
-          "description": "The mathematical variance (simulated - actual) representing the opportunity cost of the historical decision.",
-          "maximum": 1000000000.0,
-          "title": "Epistemic Regret",
-          "type": "number"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -3643,40 +3630,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
           "type": "string"
-        },
-        "expected_utility_actual": {
-          "description": "The calculated utility of the trajectory that was actually executed.",
-          "maximum": 1000000000.0,
-          "title": "Expected Utility Actual",
-          "type": "number"
-        },
-        "expected_utility_simulated": {
-          "description": "The calculated utility of the simulated counterfactual trajectory.",
-          "maximum": 1000000000.0,
-          "title": "Expected Utility Simulated",
-          "type": "number"
-        },
-        "historical_event_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the specific historical state node where the agent mathematically diverged to simulate an alternative path.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Historical Event Id",
-          "type": "string"
-        },
-        "policy_mutation_gradients": {
-          "additionalProperties": {
-            "maximum": 1000.0,
-            "minimum": -1000.0,
-            "type": "number"
-          },
-          "description": "The stateless routing gradient adjustments derived from the calculated regret, used to self-correct future routing.",
-          "le": 1000000000.0,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Policy Mutation Gradients",
-          "type": "object"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -3691,6 +3644,52 @@
           "description": "Discriminator type for a counterfactual regret event.",
           "title": "Type",
           "type": "string"
+        },
+        "historical_event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the specific historical state node where the agent mathematically diverged to simulate an alternative path.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Historical Event Id",
+          "type": "string"
+        },
+        "counterfactual_intervention": {
+          "description": "The specific alternative action or do-calculus intervention applied in the simulation.",
+          "maxLength": 2000,
+          "title": "Counterfactual Intervention",
+          "type": "string"
+        },
+        "expected_utility_actual": {
+          "description": "The calculated utility of the trajectory that was actually executed.",
+          "maximum": 1000000000.0,
+          "title": "Expected Utility Actual",
+          "type": "number"
+        },
+        "expected_utility_simulated": {
+          "description": "The calculated utility of the simulated counterfactual trajectory.",
+          "maximum": 1000000000.0,
+          "title": "Expected Utility Simulated",
+          "type": "number"
+        },
+        "epistemic_regret": {
+          "description": "The mathematical variance (simulated - actual) representing the opportunity cost of the historical decision.",
+          "maximum": 1000000000.0,
+          "title": "Epistemic Regret",
+          "type": "number"
+        },
+        "policy_mutation_gradients": {
+          "additionalProperties": {
+            "maximum": 1000.0,
+            "minimum": -1000.0,
+            "type": "number"
+          },
+          "description": "The stateless routing gradient adjustments derived from the calculated regret, used to self-correct future routing.",
+          "le": 1000000000.0,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Policy Mutation Gradients",
+          "type": "object"
         }
       },
       "required": [
@@ -3725,10 +3724,6 @@
           "title": "Initiating Tenant Id",
           "type": "string"
         },
-        "offered_sla": {
-          "$ref": "#/$defs/BilateralSLA",
-          "description": "The initial structural/data boundary proposed."
-        },
         "receiving_tenant_id": {
           "description": "The enterprise DID receiving the connection.",
           "maxLength": 128,
@@ -3736,6 +3731,10 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Receiving Tenant Id",
           "type": "string"
+        },
+        "offered_sla": {
+          "$ref": "#/$defs/BilateralSLA",
+          "description": "The initial structural/data boundary proposed."
         },
         "status": {
           "default": "proposed",
@@ -3771,16 +3770,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the chromosomal crossover and genetic recombination\nheuristics for blending latent feature vectors of elite parent agents. As a ...Policy\nsuffix, this object defines rigid mathematical boundaries that the orchestrator must\nenforce globally.\n\nCAUSAL AFFORDANCE: Executes the deterministic interpolation of N-dimensional properties\nfrom successful agents using a specific geometric strategy (CrossoverMechanismProfile)\nto breed the next generation's starting state.\n\nEPISTEMIC BOUNDS: The blending_factor is strictly constrained to a fractional\ninterpolation ratio (ge=0.0, le=1.0) to mathematically prevent extrapolated state drift\nbeyond the parents' bounding box. Relies on optional verifiable_entropy\n(VerifiableEntropyReceipt) to ensure unbiased recombination.\n\nMCP ROUTING TRIGGERS: Genetic Recombination, Chromosomal Crossover, Vector\nInterpolation, Elitism, Reproduction Heuristic",
       "properties": {
+        "strategy_type": {
+          "$ref": "#/$defs/CrossoverMechanismProfile",
+          "description": "The heuristic method for blending successful parent agents."
+        },
         "blending_factor": {
           "description": "The proportional mix ratio when merging vector properties.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Blending Factor",
           "type": "number"
-        },
-        "strategy_type": {
-          "$ref": "#/$defs/CrossoverMechanismProfile",
-          "description": "The heuristic method for blending successful parent agents."
         },
         "verifiable_entropy": {
           "anyOf": [
@@ -3806,18 +3805,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: CrystallizationPolicy governs Systemic Memory Consolidation (analogous\nto Hebbian Learning). It is a mathematical threshold that determines exactly when noisy,\nhigh-entropy episodic logs are statistically proven enough to be promoted into permanent semantic axioms.\n\nCAUSAL AFFORDANCE: Instructs the swarm to execute Inductive Logic Programming. It authorizes the\norchestrator to collapse a massive subgraph of repetitive ObservationEvent nodes into a single,\ndense SemanticNodeState, drastically reducing future inference costs.\n\nEPISTEMIC BOUNDS: The aleatoric_entropy_threshold float (le=0.1) dictates the maximum statistical\nvariance allowed before compression is physically authorized. It mathematically mandates a sample\nsize of min_observations_required (ge=10) to prevent premature epistemic convergence.\n\nMCP ROUTING TRIGGERS: Hebbian Learning, Memory Consolidation, Inductive Logic Programming, Aleatoric Entropy, Knowledge Distillation",
       "properties": {
-        "aleatoric_entropy_threshold": {
-          "description": "The entropy variance must fall below this mathematical threshold to prove absolute certainty before compression is authorized.",
-          "maximum": 0.1,
-          "title": "Aleatoric Entropy Threshold",
-          "type": "number"
-        },
         "min_observations_required": {
           "description": "The minimum number of episodic logs needed to statistically prove a crystallized rule.",
           "maximum": 1000000000,
           "minimum": 10,
           "title": "Min Observations Required",
           "type": "integer"
+        },
+        "aleatoric_entropy_threshold": {
+          "description": "The entropy variance must fall below this mathematical threshold to prove absolute certainty before compression is authorized.",
+          "maximum": 0.1,
+          "title": "Aleatoric Entropy Threshold",
+          "type": "number"
         },
         "target_cognitive_tier": {
           "description": "The destination tier where the compressed rule will be stored.",
@@ -3841,20 +3840,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the successful\nexecution of an InformationFlowPolicy redaction on the Merkle-DAG. Enforced as fully\nimmutable via ConfigDict(frozen=True). As a ...Receipt suffix, this is an append-only\ncoordinate that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Unlocks strict audit compliance by mathematically mapping the optional\ntoxic pre_redaction_hash to the mandatory safe post_redaction_hash, proving\nnon-repudiation via the applied_policy_id.\n\nEPISTEMIC BOUNDS: Temporal geometry is strictly clamped to redaction_timestamp_unix_nano\n(ge=0, le=253402300799000000000). Both hashes are locked to immutable SHA-256 hexadecimal\nbounds (^[a-f0-9]{64}$). The pre_redaction_hash is optional (default=None) for cases\nwhere raw toxic data must not be stored.\n\nMCP ROUTING TRIGGERS: Chain of Custody, Cryptographic Provenance, Merkle-DAG Audit,\nNon-Repudiation, Data Isomorphism",
       "properties": {
+        "record_id": {
+          "description": "Unique identifier for this chain-of-custody entry.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Record Id",
+          "type": "string"
+        },
+        "source_node_id": {
+          "description": "The execution node that emitted the original payload.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Node Id",
+          "type": "string"
+        },
         "applied_policy_id": {
           "description": "The ID of the InformationFlowPolicy successfully applied.",
           "maxLength": 255,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Applied Policy Id",
-          "type": "string"
-        },
-        "post_redaction_hash": {
-          "description": "The definitive SHA-256 hash of the sanitized, mathematically clean payload.",
-          "maxLength": 255,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Post Redaction Hash",
           "type": "string"
         },
         "pre_redaction_hash": {
@@ -3873,12 +3880,12 @@
           "description": "Optional SHA-256 hash of the raw toxic data for isolated audit vaults.",
           "title": "Pre Redaction Hash"
         },
-        "record_id": {
-          "description": "Unique identifier for this chain-of-custody entry.",
+        "post_redaction_hash": {
+          "description": "The definitive SHA-256 hash of the sanitized, mathematically clean payload.",
           "maxLength": 255,
           "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Record Id",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Post Redaction Hash",
           "type": "string"
         },
         "redaction_timestamp_unix_nano": {
@@ -3887,14 +3894,6 @@
           "minimum": 0,
           "title": "Redaction Timestamp Unix Nano",
           "type": "integer"
-        },
-        "source_node_id": {
-          "description": "The execution node that emitted the original payload.",
-          "maxLength": 255,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Node Id",
-          "type": "string"
         }
       },
       "required": [
@@ -3911,11 +3910,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a Directed Acyclic Graph (DAG) for deterministic,\nchronologically ordered task execution, guaranteeing strict topological sorting of\noperations. As a ...Manifest suffix, this defines a frozen, N-dimensional\ncoordinate state.\n\nCAUSAL AFFORDANCE: Forces the orchestrator to evaluate causal edges\n(default_factory=list) and execute DFS loop-detection to verify the allow_cycles\nconstraint (default=False) before initiating kinetic node compute. The backpressure\n(BackpressurePolicy) governs edge flow control.\n\nEPISTEMIC BOUNDS: Algorithmic complexity is mathematically bound by max_depth\n(ge=1, le=256) and max_fan_out (ge=1, le=1024), preventing recursive token\nexhaustion. The @model_validator sort_dag_topology_arrays deterministically sorts\nedges for RFC 8785 hashing. A second @model_validator verify_edges_exist validates\nedge nodes in the registry and executes DFS cycle detection.\n\nMCP ROUTING TRIGGERS: Directed Acyclic Graph, Kahn's Algorithm, Topological Sort,\nCausal Edge, Algorithmic Complexity",
       "properties": {
-        "allow_cycles": {
-          "default": false,
-          "description": "Configuration indicating if cycles are allowed during validation.",
-          "title": "Allow Cycles",
-          "type": "boolean"
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy",
+              "le": 1000000000
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
         },
         "architectural_intent": {
           "anyOf": [
@@ -3931,17 +3947,73 @@
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
         },
-        "backpressure": {
+        "justification": {
           "anyOf": [
             {
-              "$ref": "#/$defs/BackpressurePolicy"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Declarative backpressure constraints for the graph edges."
+          "description": "Cryptographic/audit justification for this topology's configuration.",
+          "title": "Justification"
+        },
+        "nodes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AnyNodeProfile"
+          },
+          "description": "Flat registry of all nodes in this topology.",
+          "propertyNames": {
+            "$ref": "#/$defs/NodeIdentifierState"
+          },
+          "title": "Nodes",
+          "type": "object"
+        },
+        "shared_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The schema-on-write contract governing the internal state of this topology."
+        },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
+        "type": {
+          "const": "dag",
+          "default": "dag",
+          "description": "Discriminator for a DAG topology.",
+          "title": "Type",
+          "type": "string"
         },
         "edges": {
           "description": "The strict, topologically bounded matrix of directed causal edges.",
@@ -3961,54 +4033,23 @@
           "title": "Edges",
           "type": "array"
         },
-        "epistemic_enforcement": {
+        "allow_cycles": {
+          "default": false,
+          "description": "Configuration indicating if cycles are allowed during validation.",
+          "title": "Allow Cycles",
+          "type": "boolean"
+        },
+        "backpressure": {
           "anyOf": [
             {
-              "$ref": "#/$defs/TruthMaintenancePolicy",
-              "le": 1000000000
+              "$ref": "#/$defs/BackpressurePolicy"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "information_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this topology's configuration.",
-          "title": "Justification"
-        },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
+          "description": "Declarative backpressure constraints for the graph edges."
         },
         "max_depth": {
           "description": "The maximum recursive depth of the routing DAG.",
@@ -4023,48 +4064,6 @@
           "minimum": 1,
           "title": "Max Fan Out",
           "type": "integer"
-        },
-        "nodes": {
-          "additionalProperties": {
-            "$ref": "#/$defs/AnyNodeProfile"
-          },
-          "description": "Flat registry of all nodes in this topology.",
-          "propertyNames": {
-            "$ref": "#/$defs/NodeIdentifierState"
-          },
-          "title": "Nodes",
-          "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The distributed tracing rules bound to this specific execution graph."
-        },
-        "shared_state_contract": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StateContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The schema-on-write contract governing the internal state of this topology."
-        },
-        "type": {
-          "const": "dag",
-          "default": "dag",
-          "description": "Discriminator for a DAG topology.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -4087,10 +4086,6 @@
           "title": "Attack Id",
           "type": "string"
         },
-        "attack_vector": {
-          "$ref": "#/$defs/AttackVectorProfile",
-          "description": "Geometric matrices of undercutting defeaters."
-        },
         "source_claim_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the claim mounting the attack.",
           "maxLength": 128,
@@ -4106,6 +4101,10 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Target Claim Id",
           "type": "string"
+        },
+        "attack_vector": {
+          "$ref": "#/$defs/AttackVectorProfile",
+          "description": "Geometric matrices of undercutting defeaters."
         }
       },
       "required": [
@@ -4129,11 +4128,13 @@
           "title": "Cascade Id",
           "type": "string"
         },
-        "cross_boundary_quarantine_issued": {
-          "default": false,
-          "description": "Cryptographic proof that this cascade was broadcast to the Swarm to halt epistemic contagion.",
-          "title": "Cross Boundary Quarantine Issued",
-          "type": "boolean"
+        "root_falsified_event_id": {
+          "description": "The source BeliefMutationEvent or HypothesisGenerationEvent Content Identifier (CID) that collapsed and triggered this cascade.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Root Falsified Event Id",
+          "type": "string"
         },
         "propagated_decay_factor": {
           "description": "The calculated Entropy Penalty applied to this specific subgraph.",
@@ -4153,13 +4154,11 @@
           "title": "Quarantined Event Ids",
           "type": "array"
         },
-        "root_falsified_event_id": {
-          "description": "The source BeliefMutationEvent or HypothesisGenerationEvent Content Identifier (CID) that collapsed and triggered this cascade.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Root Falsified Event Id",
-          "type": "string"
+        "cross_boundary_quarantine_issued": {
+          "default": false,
+          "description": "Cryptographic proof that this cascade was broadcast to the Swarm to halt epistemic contagion.",
+          "title": "Cross Boundary Quarantine Issued",
+          "type": "boolean"
         }
       },
       "required": [
@@ -4175,14 +4174,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Macaroons and Decentralized Identifiers (DIDs) to\nconstruct a verifiable delegation chain of authority from a human principal to an\nautonomous agent. As a ...Manifest suffix, this defines a frozen, N-dimensional\ncoordinate state.\n\nCAUSAL AFFORDANCE: Empowers the delegate_agent_did (NodeIdentifierState) to invoke\nthe explicitly whitelisted allowed_tool_ids (list[ToolIdentifierState]), acting as a\ncryptographic proxy for the principal_did (NodeIdentifierState). The\ncryptographic_signature (max_length=10000) proves the delegation chain.\n\nEPISTEMIC BOUNDS: The delegation's temporal geometry is physically bounded by\nexpiration_timestamp (ge=0.0, le=253402300799.0). The capability_id is a 128-char\nCID anchor. The allowed_tool_ids array is deterministically sorted by\n@model_validator sort_arrays for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Macaroons, Delegation Chain, Public Key Infrastructure,\nObject Capability Model, Decentralized Identifiers",
       "properties": {
-        "allowed_tool_ids": {
-          "description": "The strictly bounded set of ToolIdentifiers this delegation permits.",
-          "items": {
-            "$ref": "#/$defs/ToolIdentifierState"
-          },
-          "title": "Allowed Tool Ids",
-          "type": "array"
-        },
         "capability_id": {
           "description": "A string CID for the delegated capability.",
           "maxLength": 128,
@@ -4191,15 +4182,21 @@
           "title": "Capability Id",
           "type": "string"
         },
-        "cryptographic_signature": {
-          "description": "A base64 string proving the cryptographic delegation.",
-          "maxLength": 10000,
-          "title": "Cryptographic Signature",
-          "type": "string"
+        "principal_did": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The DID representing the human or parent delegating authority."
         },
         "delegate_agent_did": {
           "$ref": "#/$defs/NodeIdentifierState",
           "description": "The DID representing the autonomous actor receiving authority."
+        },
+        "allowed_tool_ids": {
+          "description": "The strictly bounded set of ToolIdentifiers this delegation permits.",
+          "items": {
+            "$ref": "#/$defs/ToolIdentifierState"
+          },
+          "title": "Allowed Tool Ids",
+          "type": "array"
         },
         "expiration_timestamp": {
           "description": "A float bounding the temporal lifecycle.",
@@ -4208,9 +4205,11 @@
           "title": "Expiration Timestamp",
           "type": "number"
         },
-        "principal_did": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The DID representing the human or parent delegating authority."
+        "cryptographic_signature": {
+          "description": "A base64 string proving the cryptographic delegation.",
+          "maxLength": 10000,
+          "title": "Cryptographic Signature",
+          "type": "string"
         }
       },
       "required": [
@@ -4261,30 +4260,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of a Cyber-Physical Systems (CPS)\nDigital Twin, establishing an epistemically isolated shadow graph that mirrors a\nreal-world topology without risking kinetic bleed. As a ...Manifest suffix, this\ndefines a frozen N-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to execute unbounded sandbox\nsimulations against the mirrored target_topology_id (128-char CID), mathematically\nsevering all external write access if enforce_no_side_effects (default=True) is True.\n\nEPISTEMIC BOUNDS: The simulation physics are structurally clamped by the\nconvergence_sla (SimulationConvergenceSLA), which physically bounds the maximum Monte\nCarlo rollouts and variance tolerance. External kinetic permutations are mechanically\ntrapped.\n\nMCP ROUTING TRIGGERS: Digital Twin, Cyber-Physical Systems, Sandbox Simulation,\nMarkov Blanket, Shadow Graph",
       "properties": {
-        "architectural_intent": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The AI's declarative rationale for selecting this topology.",
-          "title": "Architectural Intent"
-        },
-        "convergence_sla": {
-          "$ref": "#/$defs/SimulationConvergenceSLA",
-          "description": "The strict mathematical boundaries for the simulation."
-        },
-        "enforce_no_side_effects": {
-          "default": true,
-          "description": "A declarative flag that instructs the runtime to mathematically sever all external write access.",
-          "title": "Enforce No Side Effects",
-          "type": "boolean"
-        },
         "epistemic_enforcement": {
           "anyOf": [
             {
@@ -4298,17 +4273,29 @@
           "default": null,
           "description": "Ties the topology to the Truth Maintenance layer."
         },
-        "information_flow": {
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
+        "architectural_intent": {
           "anyOf": [
             {
-              "$ref": "#/$defs/InformationFlowPolicy"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+          "description": "The AI's declarative rationale for selecting this topology.",
+          "title": "Architectural Intent"
         },
         "justification": {
           "anyOf": [
@@ -4324,16 +4311,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -4344,18 +4321,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The distributed tracing rules bound to this specific execution graph."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -4369,6 +4334,37 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
+        "type": {
+          "const": "digital_twin",
+          "default": "digital_twin",
+          "description": "Discriminator for a Digital Twin topology.",
+          "title": "Type",
+          "type": "string"
+        },
         "target_topology_id": {
           "description": "The identifier (expected to be a W3C DID) pointing to the real-world topology it is cloning.",
           "maxLength": 128,
@@ -4377,12 +4373,15 @@
           "title": "Target Topology Id",
           "type": "string"
         },
-        "type": {
-          "const": "digital_twin",
-          "default": "digital_twin",
-          "description": "Discriminator for a Digital Twin topology.",
-          "title": "Type",
-          "type": "string"
+        "convergence_sla": {
+          "$ref": "#/$defs/SimulationConvergenceSLA",
+          "description": "The strict mathematical boundaries for the simulation."
+        },
+        "enforce_no_side_effects": {
+          "default": true,
+          "description": "A declarative flag that instructs the runtime to mathematically sever all external write access.",
+          "title": "Enforce No Side Effects",
+          "type": "boolean"
         }
       },
       "required": [
@@ -4397,21 +4396,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a linear algebraic transformation (e.g.,\nSingular Value Decomposition) mapping one embedding manifold to another,\ngrounded in the Johnson-Lindenstrauss Lemma. As a ...Contract suffix, this\nenforces rigid mathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to translate latent vectors\nacross zero-trust network boundaries, bridging incompatible LLM spaces. The\nsource_model_name and target_model_name (both max_length=2000) identify the\norigin and destination geometries.\n\nEPISTEMIC BOUNDS: Translation fidelity is physically proven by the\nisometry_preservation_score (ge=0.0, le=1.0), ensuring Earth Mover's Distance\npreservation. Cryptographic integrity is locked via projection_matrix_hash\n(SHA-256 regex ^[a-f0-9]{64}$).\n\nMCP ROUTING TRIGGERS: Singular Value Decomposition, Johnson-Lindenstrauss\nLemma, Tensor Projection, Earth Mover's Distance, Latent Translation",
       "properties": {
-        "isometry_preservation_score": {
-          "description": "Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Isometry Preservation Score",
-          "type": "number"
-        },
-        "projection_matrix_hash": {
-          "description": "The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Projection Matrix Hash",
-          "type": "string"
-        },
         "source_model_name": {
           "description": "The native embedding model of the origin agent.",
           "maxLength": 2000,
@@ -4423,6 +4407,21 @@
           "maxLength": 2000,
           "title": "Target Model Name",
           "type": "string"
+        },
+        "projection_matrix_hash": {
+          "description": "The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Projection Matrix Hash",
+          "type": "string"
+        },
+        "isometry_preservation_score": {
+          "description": "Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Isometry Preservation Score",
+          "type": "number"
         }
       },
       "required": [
@@ -4438,29 +4437,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Bayesian Inference and Parametric Probability Density\nFunctions (PDFs) to mathematically define the stochastic shape of latent variables.\nAs a ...Profile suffix, this is a declarative, frozen snapshot of an evaluation geometry.\n\nCAUSAL AFFORDANCE: Projects a continuous statistical geometry (Gaussian, Uniform,\nor Beta) onto a stochastic process, dictating the generative bounds of entropy or\nreward distributions during reinforcement learning.\n\nEPISTEMIC BOUNDS: The Euclidean limits are physically clamped by mean and variance\n(le=1000000000.0). The @model_validator validate_confidence_interval mathematically\nenforces the invariant that the 95% confidence lower bound must be strictly less than\nthe upper bound.\n\nMCP ROUTING TRIGGERS: Probability Density Function, Bayesian Inference, Stochastic Geometry, Parametric Distribution, Variance Bounding",
       "properties": {
-        "confidence_interval_95": {
-          "anyOf": [
-            {
-              "maxItems": 1000000000,
-              "minItems": 2,
-              "prefixItems": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The 95% probability bounds.",
-          "title": "Confidence Interval 95"
-        },
         "distribution_type": {
           "$ref": "#/$defs/DistributionShapeProfile",
           "description": "The mathematical shape of the probability density function."
@@ -4492,6 +4468,29 @@
           "default": null,
           "description": "The mathematical variance (sigma squared).",
           "title": "Variance"
+        },
+        "confidence_interval_95": {
+          "anyOf": [
+            {
+              "maxItems": 1000000000,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The 95% probability bounds.",
+          "title": "Confidence Interval 95"
         }
       },
       "required": [
@@ -4590,10 +4589,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A discrete topological bounding box within a formalized\nDocument Object Model (DOM) taxonomy, acting as a spatial vertex in a\nmultimodal graph. As a ...State suffix, this is a frozen N-dimensional\ncoordinate.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's spatial extraction engine to\nclassify, extract, and isolate explicit sub-regions for localized processing\nusing the anchor (MultimodalTokenAnchorState).\n\nEPISTEMIC BOUNDS: The block_id is cryptographically anchored by a 128-char\nCID regex (^[a-zA-Z0-9_.:-]+$). The block_type structurally limits extraction\ngeometry to a finite Literal automaton [\"header\", \"paragraph\", \"figure\",\n\"table\", \"footnote\", \"caption\", \"equation\"].\n\nMCP ROUTING TRIGGERS: DOM Taxonomy, Topological Vertex, Spatial\nClassification, Bounding Box Geometry, Semantic Region Isolation",
       "properties": {
-        "anchor": {
-          "$ref": "#/$defs/MultimodalTokenAnchorState",
-          "description": "The strict visual and token coordinate bindings for this block."
-        },
         "block_id": {
           "description": "Unique structural identifier for this geometric region.",
           "maxLength": 128,
@@ -4615,6 +4610,10 @@
           ],
           "title": "Block Type",
           "type": "string"
+        },
+        "anchor": {
+          "$ref": "#/$defs/MultimodalTokenAnchorState",
+          "description": "The strict visual and token coordinate bindings for this block."
         }
       },
       "required": [
@@ -4629,6 +4628,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Fristonian Active Inference to minimize Expected Free\nEnergy. It is triggered when the swarm detects a catastrophic Epistemic Gap and lacks\nthe structural parameters necessary to reduce Shannon Entropy autonomously.\n\nCAUSAL AFFORDANCE: Emits a structural query to an external human oracle to explicitly\nsolicit data. It suspends autonomous trajectory generation until the missing semantic\ndimensions are actively projected back into the working memory partition.\n\nEPISTEMIC BOUNDS: The human's unstructured cognitive entropy is aggressively forced\nthrough a mathematical funnel via the resolution_schema (a strict JSON Schema dict,\nmax_length=1000000000). If the human fails to satisfy the bounded schema, the\ntimeout_action guarantees deterministic fallback routing.\n\nMCP ROUTING TRIGGERS: Active Inference, Expected Free Energy, Shannon Entropy\nReduction, Zero-Shot Elicitation, Epistemic Gap",
       "properties": {
+        "type": {
+          "const": "drafting",
+          "default": "drafting",
+          "description": "Discriminator for requesting specific missing context from a human.",
+          "title": "Type",
+          "type": "string"
+        },
         "context_prompt": {
           "description": "The prompt explaining what information the swarm is missing.",
           "maxLength": 2000,
@@ -4653,13 +4659,6 @@
             "terminate"
           ],
           "title": "Timeout Action",
-          "type": "string"
-        },
-        "type": {
-          "const": "drafting",
-          "default": "drafting",
-          "description": "Discriminator for requesting specific missing context from a human.",
-          "title": "Type",
           "type": "string"
         }
       },
@@ -4726,6 +4725,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a deterministic Softmax Router Gate to dictate the exact active execution topology, mapping multi-agent subgraphs to specific data modalities.\n\nCAUSAL AFFORDANCE: Physically directs the thermodynamic compute flow, unlocking specific worker nodes (active_subgraphs) and explicitly bypassing others (bypassed_steps), while locking economic allocations via branch_budgets_magnitude.\n\nEPISTEMIC BOUNDS: The @model_validator hooks mathematically verify topological soundness: validate_modality_alignment proves no routes to hallucinated modalities exist, and validate_conservation_of_custody ensures bypassed_steps perfectly align with the artifact_event_id.\n\nMCP ROUTING TRIGGERS: Softmax Router Gate, Sparse Mixture of Experts, Conservation of Custody, Topos Theory, Spot Compute Allocation",
       "properties": {
+        "manifest_id": {
+          "description": "The unique Content Identifier (CID) for this routing plan.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Manifest Id",
+          "type": "string"
+        },
+        "artifact_profile": {
+          "$ref": "#/$defs/GlobalSemanticProfile",
+          "description": "The semantic profile governing this route."
+        },
         "active_subgraphs": {
           "additionalProperties": {
             "items": {
@@ -4740,9 +4751,13 @@
           "title": "Active Subgraphs",
           "type": "object"
         },
-        "artifact_profile": {
-          "$ref": "#/$defs/GlobalSemanticProfile",
-          "description": "The semantic profile governing this route."
+        "bypassed_steps": {
+          "description": "The declarative array of steps the orchestrator is mandated to skip.",
+          "items": {
+            "$ref": "#/$defs/BypassReceipt"
+          },
+          "title": "Bypassed Steps",
+          "type": "array"
         },
         "branch_budgets_magnitude": {
           "additionalProperties": {
@@ -4755,22 +4770,6 @@
           },
           "title": "Branch Budgets Magnitude",
           "type": "object"
-        },
-        "bypassed_steps": {
-          "description": "The declarative array of steps the orchestrator is mandated to skip.",
-          "items": {
-            "$ref": "#/$defs/BypassReceipt"
-          },
-          "title": "Bypassed Steps",
-          "type": "array"
-        },
-        "manifest_id": {
-          "description": "The unique Content Identifier (CID) for this routing plan.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Manifest Id",
-          "type": "string"
         }
       },
       "required": [
@@ -4786,19 +4785,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Multimodal Sensor Fusion by quantifying Bayesian Surprise (KL Divergence) against the agent's prior belief manifold.\n\nCAUSAL AFFORDANCE: Emits a quantified sensory vector to the orchestrator, determining whether an exogenous signal contains enough information-theoretic value to cross the continuous-to-discrete gap and trigger a topological observation.\n\nEPISTEMIC BOUNDS: The bayesian_surprise_score is strictly clamped to a continuous float space (le=1.0), and physical presence is bounded by temporal_duration_ms (le=86400000).\n\nMCP ROUTING TRIGGERS: Bayesian Surprise, Multimodal Sensor Fusion, Kullback-Leibler Divergence, Exteroceptive Vector, Proprioception",
       "properties": {
-        "bayesian_surprise_score": {
-          "description": "The calculated KL divergence between the prior belief and the incoming structural evidence.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Bayesian Surprise Score",
-          "type": "number"
-        },
-        "salience_threshold_breached": {
-          "default": true,
-          "description": "Continuous-to-Discrete Crystallization threshold being crossed.",
-          "title": "Salience Threshold Breached",
-          "type": "boolean"
-        },
         "sensory_modality": {
           "description": "Multimodal Sensor Fusion and Spatial-Temporal Bindings representing Proprioceptive State and Exteroceptive Vectors.",
           "enum": [
@@ -4809,12 +4795,25 @@
           "title": "Sensory Modality",
           "type": "string"
         },
+        "bayesian_surprise_score": {
+          "description": "The calculated KL divergence between the prior belief and the incoming structural evidence.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Bayesian Surprise Score",
+          "type": "number"
+        },
         "temporal_duration_ms": {
           "description": "The exact length of the timeline encapsulated by this observation.",
           "exclusiveMinimum": 0,
           "maximum": 86400000,
           "title": "Temporal Duration Ms",
           "type": "integer"
+        },
+        "salience_threshold_breached": {
+          "default": true,
+          "description": "Continuous-to-Discrete Crystallization threshold being crossed.",
+          "title": "Salience Threshold Breached",
+          "type": "boolean"
         }
       },
       "required": [
@@ -4884,17 +4883,23 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a hardware-level Sandboxing and Trusted Execution\nEnvironment (TEE) paradigm, utilizing WASI, eBPF, or zkVMs to safely execute\nexogenous bytecode. As a ...State suffix, this is a declarative, frozen snapshot of\nan execution geometry.\n\nCAUSAL AFFORDANCE: Physically isolates kinetic execution from the host OS via\nexecution_runtime Literal [\"wasm32-wasi\", \"riscv32-zkvm\", \"bpf\"], authorizing\nthe orchestrator to instantiate a temporary virtual machine strictly conforming to\nallow_network_egress (default=False) and allow_subprocess_spawning (default=False).\n\nEPISTEMIC BOUNDS: The Halting Problem is managed via max_ttl_seconds (le=86400,\ngt=0), and memory exhaustion is prevented via max_vram_mb (le=1000000000, gt=0).\nThe @model_validator validate_cryptographic_hashes enforces SHA-256 regex\n(^[a-f0-9]{64}$); a second @model_validator sort_arrays deterministically sorts the\nauthorized_bytecode_hashes for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: WebAssembly System Interface, Zero-Knowledge Virtual Machine,\neBPF, Execution Sandbox, Arbitrary Code Execution Mitigation",
       "properties": {
-        "allow_network_egress": {
-          "default": false,
-          "description": "Capability-based flag to allow or mathematically deny network sockets.",
-          "title": "Allow Network Egress",
-          "type": "boolean"
+        "partition_id": {
+          "description": "Unique identifier for this ephemeral partition.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Partition Id",
+          "type": "string"
         },
-        "allow_subprocess_spawning": {
-          "default": false,
-          "description": "Capability-based flag to allow or deny OS-level process spawning.",
-          "title": "Allow Subprocess Spawning",
-          "type": "boolean"
+        "execution_runtime": {
+          "description": "The strict virtual machine target mandated for dynamic execution.",
+          "enum": [
+            "wasm32-wasi",
+            "riscv32-zkvm",
+            "bpf"
+          ],
+          "title": "Execution Runtime",
+          "type": "string"
         },
         "authorized_bytecode_hashes": {
           "description": "The explicit whitelist of SHA-256 hashes allowed to execute within this partition.",
@@ -4906,16 +4911,6 @@
           "minItems": 1,
           "title": "Authorized Bytecode Hashes",
           "type": "array"
-        },
-        "execution_runtime": {
-          "description": "The strict virtual machine target mandated for dynamic execution.",
-          "enum": [
-            "wasm32-wasi",
-            "riscv32-zkvm",
-            "bpf"
-          ],
-          "title": "Execution Runtime",
-          "type": "string"
         },
         "max_ttl_seconds": {
           "description": "The absolute temporal guillotine before the orchestrator drops the context.",
@@ -4931,13 +4926,17 @@
           "title": "Max Vram Mb",
           "type": "integer"
         },
-        "partition_id": {
-          "description": "Unique identifier for this ephemeral partition.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Partition Id",
-          "type": "string"
+        "allow_network_egress": {
+          "default": false,
+          "description": "Capability-based flag to allow or mathematically deny network sockets.",
+          "title": "Allow Network Egress",
+          "type": "boolean"
+        },
+        "allow_subprocess_spawning": {
+          "default": false,
+          "description": "Capability-based flag to allow or deny OS-level process spawning.",
+          "title": "Allow Subprocess Spawning",
+          "type": "boolean"
         }
       },
       "required": [
@@ -4997,18 +4996,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Constructs the macroscopic adjacency matrix for the complete\n$AF = \\langle AR, \rightarrow \rangle$ topology. As a ...State suffix, this is a\ndeclarative, frozen snapshot of the dialectical geometry at a specific point in time.\n\nCAUSAL AFFORDANCE: Exposes the holistic bipartite mapping of claims and their defeasible\nattacks to the orchestrator, allowing graph traversal algorithms to deterministically\ncompute the conflict-free Grounded Extension of surviving truths.\n\nEPISTEMIC BOUNDS: Physically limits state-space explosion by capping the claims and attacks\ndictionaries at max_length=10000 keys each. Key geometries are strictly bounded to 255\ncharacters via StringConstraints(max_length=255) to prevent Dictionary Bombing during\ncanonicalization.\n\nMCP ROUTING TRIGGERS: Dung's AAF, Adjacency Matrix, Grounded Extension,\nState-Space Bounding, Dialectical Justification",
       "properties": {
-        "attacks": {
-          "additionalProperties": {
-            "$ref": "#/$defs/DefeasibleAttackEvent"
-          },
-          "description": "Geometric matrices of undercutting defeaters.",
-          "maxProperties": 10000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Attacks",
-          "type": "object"
-        },
         "claims": {
           "additionalProperties": {
             "$ref": "#/$defs/EpistemicArgumentClaimState"
@@ -5019,6 +5006,18 @@
             "maxLength": 255
           },
           "title": "Claims",
+          "type": "object"
+        },
+        "attacks": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DefeasibleAttackEvent"
+          },
+          "description": "Geometric matrices of undercutting defeaters.",
+          "maxProperties": 10000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Attacks",
           "type": "object"
         }
       },
@@ -5032,18 +5031,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements First-Order Logic and Resource Description Framework (RDF)\ntriples to mathematically formalize knowledge. As a ...State suffix, this is a\ndeclarative, frozen snapshot of a specific causal connection at a point in time.\n\nCAUSAL AFFORDANCE: Distills high-entropy natural language token streams into rigid,\nhashable causal edges (Subject, Predicate, Object), unlocking deterministic querying\nand Truth Maintenance System (TMS) traversals.\n\nEPISTEMIC BOUNDS: Source and target concept physical boundaries are strictly locked to\n128-char CIDs matching the regex ^[a-zA-Z0-9_.:-]+$. The directed_edge_type is clamped\nto a max_length of 2000 to prevent dictionary bombing during semantic evaluation.\n\nMCP ROUTING TRIGGERS: First-Order Logic, RDF Triple, Semantic Distillation, Causal\nEdge, Directed Graph",
       "properties": {
-        "directed_edge_type": {
-          "description": "The topological relationship.",
-          "maxLength": 2000,
-          "title": "Directed Edge Type",
-          "type": "string"
-        },
         "source_concept_id": {
           "description": "CID of the origin node.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Source Concept Id",
+          "type": "string"
+        },
+        "directed_edge_type": {
+          "description": "The topological relationship.",
+          "maxLength": 2000,
+          "title": "Directed Edge Type",
           "type": "string"
         },
         "target_concept_id": {
@@ -5075,23 +5074,6 @@
           "title": "Event Id",
           "type": "string"
         },
-        "fact_score_passed": {
-          "title": "Fact Score Passed",
-          "type": "boolean"
-        },
-        "sequence_similarity_score": {
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Sequence Similarity Score",
-          "type": "number"
-        },
-        "source_prediction_id": {
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Prediction Id",
-          "type": "string"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -5104,6 +5086,23 @@
           "default": "epistemic_axiom_verification",
           "title": "Type",
           "type": "string"
+        },
+        "source_prediction_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Prediction Id",
+          "type": "string"
+        },
+        "sequence_similarity_score": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Sequence Similarity Score",
+          "type": "number"
+        },
+        "fact_score_passed": {
+          "title": "Fact Score Passed",
+          "type": "boolean"
         }
       },
       "required": [
@@ -5127,13 +5126,6 @@
           "title": "Chain Id",
           "type": "string"
         },
-        "semantic_leaves": {
-          "items": {
-            "$ref": "#/$defs/EpistemicAxiomState"
-          },
-          "title": "Semantic Leaves",
-          "type": "array"
-        },
         "syntactic_roots": {
           "items": {
             "maxLength": 2000,
@@ -5141,6 +5133,13 @@
           },
           "minItems": 1,
           "title": "Syntactic Roots",
+          "type": "array"
+        },
+        "semantic_leaves": {
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "title": "Semantic Leaves",
           "type": "array"
         }
       },
@@ -5156,6 +5155,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the Information Bottleneck Method to govern the\nlossy compression of episodic or multimodal payloads into structured semantic\ngeometry. As an ...SLA suffix, this enforces rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Instructs the extraction and transmutation engines to discard\naleatoric noise while mathematically preserving the mutual information of the\nsource artifact. The strict_probability_retention (bool, default=True) forces\nthe resulting SemanticNodeState to populate its uncertainty_profile.\n\nEPISTEMIC BOUNDS: The informational loss is strictly bounded by\nmax_allowed_entropy_loss (ge=0.0, le=1.0), mathematically preventing the\nover-compression of truth. The required_grounding_density is locked to the\nLiteral automaton [\"sparse\", \"dense\", \"exhaustive\"].\n\nMCP ROUTING TRIGGERS: Information Bottleneck Method, Shannon Entropy Loss,\nSemantic Compression, Multimodal Grounding, Autoencoder Distillation",
       "properties": {
+        "strict_probability_retention": {
+          "default": true,
+          "description": "If True, forces the resulting SemanticNodeState to populate its uncertainty_profile.",
+          "title": "Strict Probability Retention",
+          "type": "boolean"
+        },
         "max_allowed_entropy_loss": {
           "description": "The maximum allowed statistical flattening of the source data. Bounded between [0.0, 1.0].",
           "maximum": 1.0,
@@ -5172,12 +5177,6 @@
           ],
           "title": "Required Grounding Density",
           "type": "string"
-        },
-        "strict_probability_retention": {
-          "default": true,
-          "description": "If True, forces the resulting SemanticNodeState to populate its uncertainty_profile.",
-          "title": "Strict Probability Retention",
-          "type": "boolean"
         }
       },
       "required": [
@@ -5254,19 +5253,19 @@
           "title": "Baseline Entropy Threshold",
           "type": "number"
         },
-        "max_escalation_tiers": {
-          "description": "CoReason Shared Kernel Ontology: The absolute integer limit on how many times the orchestrator can recursively multiply the compute budget before forcing a SystemFaultEvent.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Max Escalation Tiers",
-          "type": "integer"
-        },
         "test_time_multiplier": {
           "description": "CoReason Shared Kernel Ontology: The continuous scalar applied to the agent's baseline max_latent_tokens_budget when the entropy threshold is breached.",
           "exclusiveMinimum": 1.0,
           "maximum": 1000000000.0,
           "title": "Test Time Multiplier",
           "type": "number"
+        },
+        "max_escalation_tiers": {
+          "description": "CoReason Shared Kernel Ontology: The absolute integer limit on how many times the orchestrator can recursively multiply the compute budget before forcing a SystemFaultEvent.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Max Escalation Tiers",
+          "type": "integer"
         }
       },
       "required": [
@@ -5281,13 +5280,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An immutable cryptographic coordinate recording the successful\nfactorization of a terminal reward into a fractional flow value across a continuous\nCognitiveReasoningTraceState trajectory. As a ...Receipt suffix, this is an append-only\ncoordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Physically anchors the scalar backpropagation of a factored reward\nto a specific source_trajectory_id, unlocking global flow consistency calculations\nacross the distributed swarm. The terminal_reward_factorized boolean confirms\nsuccessful reward decomposition.\n\nEPISTEMIC BOUNDS: Flow magnitude is geometrically bounded by estimated_flow_value\n(ge=0.0, le=1000000000.0) to prevent exploding gradients during policy updates.\nCryptographically mapped to a rigid 128-char source_trajectory_id CID.\n\nMCP ROUTING TRIGGERS: Trajectory Balance, Reward Factorization, Flow Network Receipt,\nScalar Backpropagation, Acyclic Path",
       "properties": {
-        "estimated_flow_value": {
-          "description": "The non-negative flow value scalar representing the factorized outcome reward.",
-          "maximum": 1000000000.0,
-          "minimum": 0.0,
-          "title": "Estimated Flow Value",
-          "type": "number"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -5295,19 +5287,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
           "type": "string"
-        },
-        "source_trajectory_id": {
-          "description": "The CID of the partial CognitiveReasoningTraceState.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Trajectory Id",
-          "type": "string"
-        },
-        "terminal_reward_factorized": {
-          "description": "True if this flow successfully factorized a terminal outcome reward.",
-          "title": "Terminal Reward Factorized",
-          "type": "boolean"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -5321,6 +5300,26 @@
           "default": "epistemic_flow_state",
           "title": "Type",
           "type": "string"
+        },
+        "source_trajectory_id": {
+          "description": "The CID of the partial CognitiveReasoningTraceState.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Trajectory Id",
+          "type": "string"
+        },
+        "estimated_flow_value": {
+          "description": "The non-negative flow value scalar representing the factorized outcome reward.",
+          "maximum": 1000000000.0,
+          "minimum": 0.0,
+          "title": "Estimated Flow Value",
+          "type": "number"
+        },
+        "terminal_reward_factorized": {
+          "description": "True if this flow successfully factorized a terminal outcome reward.",
+          "title": "Terminal Reward Factorized",
+          "type": "boolean"
         }
       },
       "required": [
@@ -5345,23 +5344,23 @@
           "title": "Task Id",
           "type": "string"
         },
-        "thinking_trace": {
-          "$ref": "#/$defs/CognitiveReasoningTraceState",
-          "description": "The verified reasoning path."
-        },
         "topological_proof": {
           "$ref": "#/$defs/EpistemicTopologicalProofManifest",
           "description": "The underlying latent path."
-        },
-        "verification_lock": {
-          "$ref": "#/$defs/CognitiveDualVerificationReceipt",
-          "description": "The cryptographic proof of dual-agent approval."
         },
         "vignette_payload": {
           "description": "The generated natural language scenario.",
           "maxLength": 100000,
           "title": "Vignette Payload",
           "type": "string"
+        },
+        "thinking_trace": {
+          "$ref": "#/$defs/CognitiveReasoningTraceState",
+          "description": "The verified reasoning path."
+        },
+        "verification_lock": {
+          "$ref": "#/$defs/CognitiveDualVerificationReceipt",
+          "description": "The cryptographic proof of dual-agent approval."
         }
       },
       "required": [
@@ -5376,22 +5375,15 @@
     },
     "EpistemicLedgerState": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Event Sourcing and the Merkle-DAG structure as\nthe absolute, immutable source of truth for the swarm, fully partitioned from\nvolatile memory. As a ...State suffix, this is a declarative, frozen snapshot\nof the macro-topology.\n\nCAUSAL AFFORDANCE: Permanently crystallizes validated events into the history\n(list[AnyStateEvent], max_length=10000). Applies Truth Maintenance via\ntruth_maintenance_policy (TruthMaintenancePolicy | None), eviction via\neviction_policy (EvictionPolicy | None), crystallization via\ncrystallization_policy (CrystallizationPolicy | None), and tracks active\nDefeasibleCascadeEvents and RollbackIntents.\n\nEPISTEMIC BOUNDS: The @model_validator sort_history deterministically sorts\nhistory by timestamp, checkpoints by checkpoint_id, active_rollbacks by\nrequest_id, migration_contracts by contract_id, and active_cascades by\ncascade_id \u2014 guaranteeing invariant RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Event Sourcing, Merkle-DAG, Immutable Ledger, Truth\nCrystallization, Chronological Sort",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Event Sourcing and the Merkle-DAG structure as\nthe absolute, immutable source of truth for the swarm, fully partitioned from\nvolatile memory. As a ...State suffix, this is a declarative, frozen snapshot\nof the macro-topology.\n\nCAUSAL AFFORDANCE: Permanently crystallizes validated events into the history\n(list[AnyStateEvent], max_length=10000). Applies Truth Maintenance via\ntruth_maintenance_policy (TruthMaintenancePolicy | None), eviction via\neviction_policy (EvictionPolicy | None), crystallization via\ncrystallization_policy (CrystallizationPolicy | None), and tracks active\nDefeasibleCascadeEvents and RollbackIntents.\n\nEPISTEMIC BOUNDS: The @model_validator sort_history deterministically sorts\nhistory by timestamp, checkpoints by checkpoint_id, active_rollbacks by\nrequest_id, migration_contracts by contract_id, and active_cascades by\ncascade_id — guaranteeing invariant RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Event Sourcing, Merkle-DAG, Immutable Ledger, Truth\nCrystallization, Chronological Sort",
       "properties": {
-        "active_cascades": {
-          "description": "The active state-differential payload muting specific causal subgraphs due to falsification.",
+        "history": {
+          "description": "An append-only, cryptographic ledger of state events. [SITD-Alpha: Non-Monotonic Epistemic Quarantine Isometry]",
           "items": {
-            "$ref": "#/$defs/DefeasibleCascadeEvent"
+            "$ref": "#/$defs/AnyStateEvent"
           },
-          "title": "Active Cascades",
-          "type": "array"
-        },
-        "active_rollbacks": {
-          "description": "Causal invalidations actively enforced on the execution tree.",
-          "items": {
-            "$ref": "#/$defs/RollbackIntent"
-          },
-          "title": "Active Rollbacks",
+          "maxItems": 10000,
+          "title": "History",
           "type": "array"
         },
         "checkpoints": {
@@ -5403,17 +5395,13 @@
           "title": "Checkpoints",
           "type": "array"
         },
-        "crystallization_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CrystallizationPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical threshold required to compress episodic observations into semantic rules."
+        "active_rollbacks": {
+          "description": "Causal invalidations actively enforced on the execution tree.",
+          "items": {
+            "$ref": "#/$defs/RollbackIntent"
+          },
+          "title": "Active Rollbacks",
+          "type": "array"
         },
         "eviction_policy": {
           "anyOf": [
@@ -5426,15 +5414,6 @@
           ],
           "default": null,
           "description": "The strict mathematical boundary governing context window compression."
-        },
-        "history": {
-          "description": "An append-only, cryptographic ledger of state events. [SITD-Alpha: Non-Monotonic Epistemic Quarantine Isometry]",
-          "items": {
-            "$ref": "#/$defs/AnyStateEvent"
-          },
-          "maxItems": 10000,
-          "title": "History",
-          "type": "array"
         },
         "migration_contracts": {
           "description": "Declarative rules to translate historical states to the current active schema version.",
@@ -5456,6 +5435,26 @@
           ],
           "default": null,
           "description": "The mathematical contract governing automated causal graph ablations and probabilistic decay."
+        },
+        "active_cascades": {
+          "description": "The active state-differential payload muting specific causal subgraphs due to falsification.",
+          "items": {
+            "$ref": "#/$defs/DefeasibleCascadeEvent"
+          },
+          "title": "Active Cascades",
+          "type": "array"
+        },
+        "crystallization_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CrystallizationPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical threshold required to compress episodic observations into semantic rules."
         }
       },
       "required": [
@@ -5468,20 +5467,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: EpistemicPromotionEvent is an append-only, cryptographically frozen historical\nfact representing Hippocampal-Neocortical Consolidation. It proves the successful extraction\nand transfer of generalized knowledge from short-term episodic traces into the permanent semantic graph.\n\nCAUSAL AFFORDANCE: Emits a permanent Merkle-DAG coordinate (crystallized_semantic_node_id) that\ndownstream agents can zero-shot reference. This permanently severs the computational need to\nre-evaluate or load the raw source logs into the active context window.\n\nEPISTEMIC BOUNDS: The mathematical chain of custody is physically bound to the strictly sorted\narray of source_episodic_event_ids. The token efficiency gained is mathematically proven by the\ncompression_ratio float, which must be strictly bounded (le=1.0) to guarantee Shannon Entropy reduction.\n\nMCP ROUTING TRIGGERS: Hippocampal Consolidation, Knowledge Distillation, Semantic Memory, Shannon Entropy Compression, Epistemic Promotion",
       "properties": {
-        "compression_ratio": {
-          "description": "A mathematical proof of the token savings achieved (e.g., old_token_count / new_token_count).",
-          "maximum": 1.0,
-          "title": "Compression Ratio",
-          "type": "number"
-        },
-        "crystallized_semantic_node_id": {
-          "description": "The resulting permanent W3C DID / CID of the newly minted knowledge node.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Crystallized Semantic Node Id",
-          "type": "string"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -5489,16 +5474,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
           "type": "string"
-        },
-        "source_episodic_event_ids": {
-          "description": "The strict array of CIDs (Content Identifiers) representing the raw logs being compressed and archived.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Source Episodic Event Ids",
-          "type": "array"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -5513,6 +5488,30 @@
           "description": "Discriminator type for an epistemic promotion event.",
           "title": "Type",
           "type": "string"
+        },
+        "source_episodic_event_ids": {
+          "description": "The strict array of CIDs (Content Identifiers) representing the raw logs being compressed and archived.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Source Episodic Event Ids",
+          "type": "array"
+        },
+        "crystallized_semantic_node_id": {
+          "description": "The resulting permanent W3C DID / CID of the newly minted knowledge node.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Crystallized Semantic Node Id",
+          "type": "string"
+        },
+        "compression_ratio": {
+          "description": "A mathematical proof of the token savings achieved (e.g., old_token_count / new_token_count).",
+          "maximum": 1.0,
+          "title": "Compression Ratio",
+          "type": "number"
         }
       },
       "required": [
@@ -5533,29 +5532,13 @@
           "$ref": "#/$defs/NodeIdentifierState",
           "description": "The Content Identifier (CID) of the agent node that extracted this payload."
         },
-        "lineage_watermark": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LineageWatermarkReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic, tamper-evident chain of custody tracing this memory across multiple swarm hops."
-        },
-        "multimodal_anchor": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MultimodalTokenAnchorState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The unified VLM spatial and temporal token matrix where this data was extracted."
+        "source_event_id": {
+          "description": "The exact event Content Identifier (CID) in the EpistemicLedgerState that generated this fact.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Event Id",
+          "type": "string"
         },
         "source_artifact_id": {
           "anyOf": [
@@ -5573,13 +5556,29 @@
           "description": "The CID of the Genesis MultimodalArtifactReceipt this semantic state was transmutated from.",
           "title": "Source Artifact Id"
         },
-        "source_event_id": {
-          "description": "The exact event Content Identifier (CID) in the EpistemicLedgerState that generated this fact.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Event Id",
-          "type": "string"
+        "multimodal_anchor": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultimodalTokenAnchorState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The unified VLM spatial and temporal token matrix where this data was extracted."
+        },
+        "lineage_watermark": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LineageWatermarkReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic, tamper-evident chain of custody tracing this memory across multiple swarm hops."
         }
       },
       "required": [
@@ -5593,6 +5592,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a discrete Epistemic Quarantine and Working\nMemory partition, isolating volatile, non-monotonic probability waves from\nthe immutable ledger. As a ...Snapshot suffix, this is a frozen N-dimensional\ncoordinate of ephemeral context.\n\nCAUSAL AFFORDANCE: Provides a sandbox for the agent to simulate Theory of\nMind (theory_of_mind_models, list[TheoryOfMindSnapshot]) and compute\ndefeasible argumentation (argumentation, EpistemicArgumentGraphState | None).\nThe system_prompt (max_length=2000) defines the basal instruction set.\naffordance_projection and capability_attestations extend the discovery surface.\n\nEPISTEMIC BOUNDS: Physical memory is clamped by active_context (key\nmax_length=255, value max_length=100000, le=1000000000). The @model_validator\nsort_arrays deterministically sorts theory_of_mind_models by target_agent_id\nand capability_attestations by attestation_id for RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Working Memory Partition, Epistemic Quarantine, Theory\nof Mind, Volatile State Isolation, Semantic Sandbox",
       "properties": {
+        "system_prompt": {
+          "description": "The basal non-monotonic instruction set currently held in Epistemic Quarantine.",
+          "maxLength": 2000,
+          "title": "System Prompt",
+          "type": "string"
+        },
         "active_context": {
           "additionalProperties": {
             "maxLength": 100000,
@@ -5606,18 +5611,6 @@
           "title": "Active Context",
           "type": "object"
         },
-        "affordance_projection": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/OntologicalSurfaceProjectionManifest"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematically bounded subgraph of capabilities currently available to the agent."
-        },
         "argumentation": {
           "anyOf": [
             {
@@ -5630,26 +5623,32 @@
           "default": null,
           "description": "The formal graph of non-monotonic claims and defeasible attacks currently active in the swarm's working state."
         },
-        "capability_attestations": {
-          "description": "Immutable cryptographic receipts of dynamically discovered external enterprise connectors.",
-          "items": {
-            "$ref": "#/$defs/FederatedCapabilityAttestationReceipt"
-          },
-          "title": "Capability Attestations",
-          "type": "array"
-        },
-        "system_prompt": {
-          "description": "The basal non-monotonic instruction set currently held in Epistemic Quarantine.",
-          "maxLength": 2000,
-          "title": "System Prompt",
-          "type": "string"
-        },
         "theory_of_mind_models": {
           "description": "Empathetic models of other agents to compress and target outgoing communications.",
           "items": {
             "$ref": "#/$defs/TheoryOfMindSnapshot"
           },
           "title": "Theory Of Mind Models",
+          "type": "array"
+        },
+        "affordance_projection": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologicalSurfaceProjectionManifest"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematically bounded subgraph of capabilities currently available to the agent."
+        },
+        "capability_attestations": {
+          "description": "Immutable cryptographic receipts of dynamically discovered external enterprise connectors.",
+          "items": {
+            "$ref": "#/$defs/FederatedCapabilityAttestationReceipt"
+          },
+          "title": "Capability Attestations",
           "type": "array"
         }
       },
@@ -5664,17 +5663,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the Group Relative Policy Optimization (GRPO) reward\nshaping ruleset, mathematically immunizing the swarm against Goodhart's Law and reward\nhacking. As a ...Policy suffix, this object defines rigid mathematical boundaries that\nthe orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Projects a continuous penalty/reward gradient across extracted axiomatic\npaths, enforcing syntactic compliance through the format_contract (CognitiveFormatContract)\nwhile simultaneously evaluating semantic and topological validity via the optional\ntopological_scoring (TopologicalRewardContract).\n\nEPISTEMIC BOUNDS: Prevents reward hacking by scaling the logical validity score (R_path)\nvia the beta_path_weight scalar (ge=0.0, le=1.0). Gated by a cryptographic\nreference_graph_id providing the deterministic ground-truth topology.\n\nMCP ROUTING TRIGGERS: GRPO, Reward Shaping, Goodhart's Law, Policy Gradient,\nAdvantage Estimation",
       "properties": {
-        "beta_path_weight": {
-          "description": "The scalar weight applied to the logical path validity (R_path) to prevent reward hacking.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Beta Path Weight",
-          "type": "number"
-        },
-        "format_contract": {
-          "$ref": "#/$defs/CognitiveFormatContract",
-          "description": "The syntactic constraints the agent must follow to prevent reward zeroing."
-        },
         "policy_id": {
           "description": "CID for this specific reward configuration.",
           "maxLength": 128,
@@ -5690,6 +5678,17 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Reference Graph Id",
           "type": "string"
+        },
+        "format_contract": {
+          "$ref": "#/$defs/CognitiveFormatContract",
+          "description": "The syntactic constraints the agent must follow to prevent reward zeroing."
+        },
+        "beta_path_weight": {
+          "description": "The scalar weight applied to the logical path validity (R_path) to prevent reward hacking.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Beta Path Weight",
+          "type": "number"
         },
         "topological_scoring": {
           "anyOf": [
@@ -5717,6 +5716,41 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encodes a macroscopic Petri net or Directed Acyclic Graph (DAG)\nformalizing standard operating procedures into mathematically traversable state\ntransitions. As a ...Manifest suffix, this defines a frozen, N-dimensional coordinate\nstate.\n\nCAUSAL AFFORDANCE: Physically bounds the executing agent (target_persona:\nProfileIdentifierState) to a deterministic sequence of CognitiveStateProfiles, unlocking\nthe ability for the orchestrator to dynamically evaluate execution via Process Reward\nModels (prm_evaluations: list[ProcessRewardContract]) at each topological node.\n\nEPISTEMIC BOUNDS: The cognitive_steps dictionary is constrained to max_length=1000000000\nto cap memory footprint. The @model_validator reject_ghost_nodes mathematically enforces\nreferential integrity, guaranteeing that no chronological_flow_edges AND no\nstructural_grammar_hashes point to an undefined state.\n\nMCP ROUTING TRIGGERS: Petri Net, Directed Acyclic Graph, Process Reward Model,\nTopological Flow, Referential Integrity",
       "properties": {
+        "sop_id": {
+          "description": "A Content Identifier (CID) for the Standard Operating Procedure.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Sop Id",
+          "type": "string"
+        },
+        "target_persona": {
+          "$ref": "#/$defs/ProfileIdentifierState",
+          "description": "The deterministic cognitive routing boundary for the persona executing the SOP."
+        },
+        "cognitive_steps": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CognitiveStateProfile"
+          },
+          "description": "Dictionary mapping step_ids to strict causal DAG constraints.",
+          "maxProperties": 1000000000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Cognitive Steps",
+          "type": "object"
+        },
+        "structural_grammar_hashes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Dictionary mapping step_ids to SHA-256 hashes of strict Context-Free Grammars or JSON Schemas.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Structural Grammar Hashes",
+          "type": "object"
+        },
         "chronological_flow_edges": {
           "description": "The exact topological flow between step_ids.",
           "items": {
@@ -5735,18 +5769,6 @@
           "title": "Chronological Flow Edges",
           "type": "array"
         },
-        "cognitive_steps": {
-          "additionalProperties": {
-            "$ref": "#/$defs/CognitiveStateProfile"
-          },
-          "description": "Dictionary mapping step_ids to strict causal DAG constraints.",
-          "maxProperties": 1000000000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Cognitive Steps",
-          "type": "object"
-        },
         "prm_evaluations": {
           "description": "The strict array of Process Reward Contracts evaluating the logic.",
           "items": {
@@ -5754,29 +5776,6 @@
           },
           "title": "Prm Evaluations",
           "type": "array"
-        },
-        "sop_id": {
-          "description": "A Content Identifier (CID) for the Standard Operating Procedure.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Sop Id",
-          "type": "string"
-        },
-        "structural_grammar_hashes": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Dictionary mapping step_ids to SHA-256 hashes of strict Context-Free Grammars or JSON Schemas.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Structural Grammar Hashes",
-          "type": "object"
-        },
-        "target_persona": {
-          "$ref": "#/$defs/ProfileIdentifierState",
-          "description": "The deterministic cognitive routing boundary for the persona executing the SOP."
         }
       },
       "required": [
@@ -5794,16 +5793,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Metacognitive Monitoring and Fristonian Active Inference to continuously scan the agent's internal belief distribution and residual stream for epistemic gaps. As a ...Policy suffix, this object defines rigid mathematical boundaries that the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Triggers a structural interlock when the agent detects a spike in Shannon Entropy or cognitive dissonance, forcing the orchestrator to halt forward-pass generation and actively probe or clarify the uncertainty. Gated by the active boolean toggle.\n\nEPISTEMIC BOUNDS: The sensitivity of the metacognitive scanner is physically clamped by the dissonance_threshold (ge=0.0, le=1.0). Recovery mechanisms are deterministically restricted by the action_on_gap FSM literal automaton [\"fail\", \"probe\", \"clarify\"].\n\nMCP ROUTING TRIGGERS: Metacognitive Monitoring, Active Inference, Cognitive Dissonance, Epistemic Foraging, Shannon Entropy",
       "properties": {
-        "action_on_gap": {
-          "description": "The action to take when an epistemic gap is detected.",
-          "enum": [
-            "fail",
-            "probe",
-            "clarify"
-          ],
-          "title": "Action On Gap",
-          "type": "string"
-        },
         "active": {
           "description": "Whether the epistemic scanner is active.",
           "title": "Active",
@@ -5815,6 +5804,16 @@
           "minimum": 0.0,
           "title": "Dissonance Threshold",
           "type": "number"
+        },
+        "action_on_gap": {
+          "description": "The action to take when an epistemic gap is detected.",
+          "enum": [
+            "fail",
+            "probe",
+            "clarify"
+          ],
+          "title": "Action On Gap",
+          "type": "string"
         }
       },
       "required": [
@@ -5829,17 +5828,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Subgraph Injection and Graph Neural Network (GNN)\nneighborhood sampling heuristics. As a ...Policy suffix, this defines rigid\nmathematical boundaries the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Authorizes the algorithmic injection of high-density semantic\nseeds or priors into an existing Knowledge Graph, ensuring topological diversity\nby clustering relationships into strictly bounded neighborhood buckets.\n\nEPISTEMIC BOUNDS: The semantic proximity for neighborhood sampling is\nmathematically clamped by similarity_threshold_alpha (ge=0.0, le=1.0). To\nprevent topological density explosions (hub nodes), the\nrelation_diversity_bucket_size is bounded (gt=0, le=1000000000).\n\nMCP ROUTING TRIGGERS: Subgraph Injection, Graph Neural Networks, Neighborhood\nSampling, Topological Diversity, Semantic Seeding",
       "properties": {
-        "relation_diversity_bucket_size": {
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Relation Diversity Bucket Size",
-          "type": "integer"
-        },
         "similarity_threshold_alpha": {
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Similarity Threshold Alpha",
           "type": "number"
+        },
+        "relation_diversity_bucket_size": {
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Relation Diversity Bucket Size",
+          "type": "integer"
         }
       },
       "required": [
@@ -5853,58 +5852,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Human-in-the-Loop (HITL) Supervisory Control Theory and Epistemic Regret tracking to measure out-of-band human physical attention kinematics.\n\nCAUSAL AFFORDANCE: Emits passive structural telemetry to update retrieval gradients and Bayesian priors based on human spatial interaction, without halting the underlying execution DAG.\n\nEPISTEMIC BOUNDS: The human interaction is rigidly confined to the interaction_modality Literal automaton. Temporal liveness of attention is bounded by dwell_duration_ms (ge=0, le=86400000). The target is locked to the 128-char target_node_id CID.\n\nMCP ROUTING TRIGGERS: Epistemic Regret, Supervisory Control Theory, Human-in-the-Loop, Dwell Time, Spatial Telemetry",
       "properties": {
-        "dwell_duration_ms": {
-          "anyOf": [
-            {
-              "maximum": 86400000,
-              "minimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The strictly typed temporal bound measuring human attention focus.",
-          "title": "Dwell Duration Ms"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
-          "type": "string"
-        },
-        "interaction_modality": {
-          "description": "The exact topological action the human operator performed on the projected manifold.",
-          "enum": [
-            "expansion",
-            "collapse",
-            "dwell_focus",
-            "heuristic_rejection"
-          ],
-          "title": "Interaction Modality",
-          "type": "string"
-        },
-        "spatial_coordinates": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SpatialCoordinateProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional 2D trajectory of the human pointer event mapped to the visual grid."
-        },
-        "target_node_id": {
-          "description": "The specific TaxonomicNodeState CID that was manipulated.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Node Id",
           "type": "string"
         },
         "timestamp": {
@@ -5920,6 +5873,52 @@
           "description": "Discriminator type for telemetry events.",
           "title": "Type",
           "type": "string"
+        },
+        "interaction_modality": {
+          "description": "The exact topological action the human operator performed on the projected manifold.",
+          "enum": [
+            "expansion",
+            "collapse",
+            "dwell_focus",
+            "heuristic_rejection"
+          ],
+          "title": "Interaction Modality",
+          "type": "string"
+        },
+        "target_node_id": {
+          "description": "The specific TaxonomicNodeState CID that was manipulated.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Node Id",
+          "type": "string"
+        },
+        "dwell_duration_ms": {
+          "anyOf": [
+            {
+              "maximum": 86400000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strictly typed temporal bound measuring human attention focus.",
+          "title": "Dwell Duration Ms"
+        },
+        "spatial_coordinates": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SpatialCoordinateProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional 2D trajectory of the human pointer event mapped to the visual grid."
         }
       },
       "required": [
@@ -5935,6 +5934,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Curry-Howard Correspondence, mapping pure logic to\ncomputational types to form an unassailable deductive chain. As a ...Manifest suffix,\nthis defines a frozen, N-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Unlocks verifiable automated theorem proving. By presenting a\nstrictly ordered, acyclic sequence of axioms (axiomatic_chain), it allows an independent\nauditor or secondary LLM to mechanically verify the logical deduction step-by-step.\n\nEPISTEMIC BOUNDS: The axiomatic_chain array is structurally declared with min_length=1.\nCrucially, it invokes the Topological Exemption from array sorting; the sequence order\nMUST mathematically preserve the chronological deduction steps, preventing the\ndestruction of the proof's epistemic value.\n\nMCP ROUTING TRIGGERS: Curry-Howard Correspondence, Constructive Proof, Topological\nSort, Deductive Reasoning, Automated Theorem Proving",
       "properties": {
+        "proof_id": {
+          "description": "A Content Identifier (CID) for this specific topological proof.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Proof Id",
+          "type": "string"
+        },
         "axiomatic_chain": {
           "description": "The strictly ordered sequence of axioms forming the reasoning path.",
           "items": {
@@ -5943,14 +5950,6 @@
           "minItems": 1,
           "title": "Axiomatic Chain",
           "type": "array"
-        },
-        "proof_id": {
-          "description": "A Content Identifier (CID) for this specific topological proof.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Proof Id",
-          "type": "string"
         }
       },
       "required": [
@@ -5964,6 +5963,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates Cross-Modal Representation Alignment,\ndeterministically transmuting unstructured artifacts into machine-readable\nN-dimensional tensors or discrete graphs. As a ...Task suffix, this represents\nan authorized kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Forces the orchestrator's VLM or extraction engine to process\nthe artifact_event_id (128-char CID) and project it into target_modalities\n(5-value Literal, min_length=1) while strictly adhering to the attached\ncompression_sla (EpistemicCompressionSLA).\n\nEPISTEMIC BOUNDS: The @model_validator validate_grounding_density_for_visuals\nrejects sparse grounding for visual/tabular modalities. The @model_validator\nsort_arrays deterministically sorts target_modalities for RFC 8785 canonical\nhashing. The optional execution_cost_budget_magnitude (int | None,\nle=1000000000, ge=0, default=None) caps thermodynamic cost.\n\nMCP ROUTING TRIGGERS: Cross-Modal Alignment, Representation Engineering,\nMultimodal Extraction, VLM Transmutation, Deterministic Projection",
       "properties": {
+        "task_id": {
+          "description": "Unique identifier for this specific multimodal extraction intervention.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Id",
+          "type": "string"
+        },
         "artifact_event_id": {
           "description": "The CID of the MultimodalArtifactReceipt being processed.",
           "maxLength": 128,
@@ -5971,6 +5978,22 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Artifact Event Id",
           "type": "string"
+        },
+        "target_modalities": {
+          "description": "The specific SOTA modality resolutions required for this extraction pass.",
+          "items": {
+            "enum": [
+              "text",
+              "raster_image",
+              "vector_graphics",
+              "tabular_grid",
+              "n_dimensional_tensor"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Target Modalities",
+          "type": "array"
         },
         "compression_sla": {
           "$ref": "#/$defs/EpistemicCompressionSLA",
@@ -5990,30 +6013,6 @@
           "default": null,
           "description": "Optional maximum economic expenditure authorized to run this VLM transmutation.",
           "title": "Execution Cost Budget Magnitude"
-        },
-        "target_modalities": {
-          "description": "The specific SOTA modality resolutions required for this extraction pass.",
-          "items": {
-            "enum": [
-              "text",
-              "raster_image",
-              "vector_graphics",
-              "tabular_grid",
-              "n_dimensional_tensor"
-            ],
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Target Modalities",
-          "type": "array"
-        },
-        "task_id": {
-          "description": "Unique identifier for this specific multimodal extraction intervention.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Id",
-          "type": "string"
         }
       },
       "required": [
@@ -6029,6 +6028,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A rigid mathematical agreement governing when an agent is authorized\nto expand its test-time compute allocation (System 2 thinking) based on measured doubt.\nAs a ...Contract suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Physically unlocks the LatentScratchpadReceipt, granting the agent\na budget of hidden tokens to execute a non-monotonic search tree (MCTS or Beam Search).\n\nEPISTEMIC BOUNDS: Mathematically bounded by uncertainty_escalation_threshold (ge=0.0,\nle=1.0). The computation is physically capped by max_latent_tokens_budget (gt=0,\nle=1000000000) and max_test_time_compute_ms (gt=0, le=86400000) to prevent infinite\nloops and VRAM exhaustion.\n\nMCP ROUTING TRIGGERS: Test-Time Compute, System 2 Thinking, Epistemic Uncertainty,\nNon-Monotonic Escalation, Token Budgeting",
       "properties": {
+        "uncertainty_escalation_threshold": {
+          "description": "The exact Epistemic Uncertainty score that triggers the opening of the Latent Scratchpad.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Uncertainty Escalation Threshold",
+          "type": "number"
+        },
         "max_latent_tokens_budget": {
           "description": "The maximum number of hidden tokens the orchestrator is authorized to buy for the internal monologue.",
           "exclusiveMinimum": 0,
@@ -6042,13 +6048,6 @@
           "maximum": 86400000,
           "title": "Max Test Time Compute Ms",
           "type": "integer"
-        },
-        "uncertainty_escalation_threshold": {
-          "description": "The exact Epistemic Uncertainty score that triggers the opening of the Latent Scratchpad.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Uncertainty Escalation Threshold",
-          "type": "number"
         }
       },
       "required": [
@@ -6063,6 +6062,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Anchors in the Biba Integrity Model to orchestrate a Dictatorial\nOverride mechanism within a Zero-Trust Architecture. It is emitted when a rigid\nmathematical safety boundary is breached during inference.\n\nCAUSAL AFFORDANCE: Severs the active kinetic thread when a rule is tripped,\nviolently halting generation to force the presentation of a resolution_schema.\nIt demands explicit, structurally verified cryptographic sign-off from a\nhigher-clearance entity to bypass the breaker.\n\nEPISTEMIC BOUNDS: The tripped_rule_id is strictly anchored to a 128-char CID\nregex (^[a-zA-Z0-9_.:-]+$). The resolution_schema (dict) caps keys at\nmax_length=255. The fallback is governed by the Literal timeout_action\n[\"rollback\", \"proceed_default\", \"terminate\"] to guarantee systemic liveness\nif unhandled.\n\nMCP ROUTING TRIGGERS: Biba Integrity Model, Dictatorial Override, Privilege\nEscalation, Payload Loss Prevention, Cryptographic Sign-Off",
       "properties": {
+        "type": {
+          "const": "escalation",
+          "default": "escalation",
+          "description": "Discriminator for security or economic boundary overrides.",
+          "title": "Type",
+          "type": "string"
+        },
+        "tripped_rule_id": {
+          "description": "The ID of the Payload Loss Prevention (PLP) or Governance rule that blocked execution.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Tripped Rule Id",
+          "type": "string"
+        },
         "resolution_schema": {
           "additionalProperties": true,
           "description": "The strict JSON Schema requiring an explicit cryptographic sign-off or justification string to bypass the breaker.",
@@ -6080,21 +6094,6 @@
             "terminate"
           ],
           "title": "Timeout Action",
-          "type": "string"
-        },
-        "tripped_rule_id": {
-          "description": "The ID of the Payload Loss Prevention (PLP) or Governance rule that blocked execution.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Tripped Rule Id",
-          "type": "string"
-        },
-        "type": {
-          "const": "escalation",
-          "default": "escalation",
-          "description": "Discriminator for security or economic boundary overrides.",
-          "title": "Type",
           "type": "string"
         }
       },
@@ -6117,18 +6116,18 @@
           "title": "Escrow Locked Magnitude",
           "type": "integer"
         },
+        "release_condition_metric": {
+          "description": "A declarative pointer to the SLA or QA rubric required to release the funds.",
+          "maxLength": 2000,
+          "title": "Release Condition Metric",
+          "type": "string"
+        },
         "refund_target_node_id": {
           "description": "The exact NodeIdentifierState to return funds to if the release condition fails.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Refund Target Node Id",
-          "type": "string"
-        },
-        "release_condition_metric": {
-          "description": "A declarative pointer to the SLA or QA rubric required to release the funds.",
-          "maxLength": 2000,
-          "title": "Release Condition Metric",
           "type": "string"
         }
       },
@@ -6144,20 +6143,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of an Actor-Critic\n(Generator-Discriminator) micro-topology, establishing a zero-sum minimax game\nbetween two discrete node identities. As a ...Manifest suffix, this defines a\nfrozen N-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Executes a finite, adversarial generation-evaluation-revision\nloop, forcing the generator_node_id to propose states and the evaluator_node_id to\nstrictly critique them. The optional require_multimodal_grounding (default=False)\nenforces pure adversarial Proposer-Critique validation.\n\nEPISTEMIC BOUNDS: State-Space Explosion is mathematically prevented by capping\nmax_revision_loops (ge=1, le=1000000000). The @model_validator verify_bipartite_nodes\nstructurally guarantees both nodes exist in the topology's nodes registry AND are\ndisjoint identities.\n\nMCP ROUTING TRIGGERS: Actor-Critic Architecture, Minimax Optimization, Adversarial\nCritique, Dual-Process Revision, Generative Adversarial Loop",
       "properties": {
-        "architectural_intent": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The AI's declarative rationale for selecting this topology.",
-          "title": "Architectural Intent"
-        },
         "epistemic_enforcement": {
           "anyOf": [
             {
@@ -6171,25 +6156,29 @@
           "default": null,
           "description": "Ties the topology to the Truth Maintenance layer."
         },
-        "evaluator_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the critic scoring the payload."
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
         },
-        "generator_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the actor generating the payload."
-        },
-        "information_flow": {
+        "architectural_intent": {
           "anyOf": [
             {
-              "$ref": "#/$defs/InformationFlowPolicy"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+          "description": "The AI's declarative rationale for selecting this topology.",
+          "title": "Architectural Intent"
         },
         "justification": {
           "anyOf": [
@@ -6205,23 +6194,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
-        "max_revision_loops": {
-          "description": "The absolute limit on Actor-Critic cycles to prevent infinite compute burn.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Max Revision Loops",
-          "type": "integer"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -6232,24 +6204,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The distributed tracing rules bound to this specific execution graph."
-        },
-        "require_multimodal_grounding": {
-          "default": false,
-          "description": "If True, the evaluator_node_id MUST mathematically mask all tokens outside the MultimodalTokenAnchorState during its forward pass to execute pure adversarial Proposer-Critique validation.",
-          "title": "Require Multimodal Grounding",
-          "type": "boolean"
         },
         "shared_state_contract": {
           "anyOf": [
@@ -6263,12 +6217,57 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
         "type": {
           "const": "evaluator_optimizer",
           "default": "evaluator_optimizer",
           "description": "Discriminator for an Evaluator-Optimizer loop.",
           "title": "Type",
           "type": "string"
+        },
+        "generator_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The ID of the actor generating the payload."
+        },
+        "evaluator_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The ID of the critic scoring the payload."
+        },
+        "max_revision_loops": {
+          "description": "The absolute limit on Actor-Critic cycles to prevent infinite compute burn.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Max Revision Loops",
+          "type": "integer"
+        },
+        "require_multimodal_grounding": {
+          "default": false,
+          "description": "If True, the evaluator_node_id MUST mathematically mask all tokens outside the MultimodalTokenAnchorState during its forward pass to execute pure adversarial Proposer-Critique validation.",
+          "title": "Require Multimodal Grounding",
+          "type": "boolean"
         }
       },
       "required": [
@@ -6284,6 +6283,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: EvictionPolicy implements Information Bottleneck Theory and the\nEbbinghaus Forgetting Curve. It is a rigid mathematical boundary dictating how the\nactive context partition sheds low-salience episodic memories to prevent attention dilution.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator's tensor-pruning heuristic to physically purge,\nsummarize, or decay historical nodes from the GPU VRAM, while mathematically guaranteeing that\nthe protected_event_ids array remains perfectly invariant in the context window.\n\nEPISTEMIC BOUNDS: The absolute physical boundary is enforced by the max_retained_tokens\ninteger limit (gt=0). The eviction behavior is deterministically restricted to the string\nliterals 'fifo', 'salience_decay', or 'summarize' to prevent hallucinated memory management.\n\nMCP ROUTING TRIGGERS: Information Bottleneck, Ebbinghaus Forgetting Curve, Salience Decay, LRU Cache Eviction, Attention Dilution",
       "properties": {
+        "strategy": {
+          "description": "The mathematical heuristic used to select which semantic memories are retracted or compressed.",
+          "enum": [
+            "fifo",
+            "salience_decay",
+            "summarize"
+          ],
+          "title": "Strategy",
+          "type": "string"
+        },
         "max_retained_tokens": {
           "description": "The strict geometric upper bound of the Epistemic Quarantine's token capacity.",
           "exclusiveMinimum": 0,
@@ -6300,16 +6309,6 @@
           },
           "title": "Protected Event Ids",
           "type": "array"
-        },
-        "strategy": {
-          "description": "The mathematical heuristic used to select which semantic memories are retracted or compressed.",
-          "enum": [
-            "fifo",
-            "salience_decay",
-            "summarize"
-          ],
-          "title": "Strategy",
-          "type": "string"
         }
       },
       "required": [
@@ -6323,12 +6322,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Toulmin Model of Argumentation by creating a structural\nbridge between a localized EpistemicArgumentClaimState and a globally verifiable Merkle-DAG\ncoordinate. As a ...State suffix, this is a declarative, frozen snapshot of N-dimensional\ngeometry at a specific point in time.\n\nCAUSAL AFFORDANCE: Physically anchors a non-monotonic proposition to an immutable\nhistorical fact, unlocking the ability for downstream evaluators to mathematically trace\nthe justification logic back to its evidentiary origin.\n\nEPISTEMIC BOUNDS: Requires either a source_event_id or source_semantic_node_id (both\noptional, bounded to 128-char CIDs via strict regex ^[a-zA-Z0-9_.:-]+$). The inferential\nleap is constrained by justification, capped at max_length=2000 characters to prevent\ncontext-window exhaustion.\n\nMCP ROUTING TRIGGERS: Toulmin Model, Evidentiary Warrant, Inferential Bridge, Grounding\nCoordinate, Argumentation Theory",
       "properties": {
-        "justification": {
-          "description": "The logical premise explaining why this evidence supports the claim.",
-          "maxLength": 2000,
-          "title": "Justification",
-          "type": "string"
-        },
         "source_event_id": {
           "anyOf": [
             {
@@ -6360,6 +6353,12 @@
           "default": null,
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for a specific concept in the Semantic Knowledge Graph.",
           "title": "Source Semantic Node Id"
+        },
+        "justification": {
+          "description": "The logical premise explaining why this evidence supports the claim.",
+          "maxLength": 2000,
+          "title": "Justification",
+          "type": "string"
         }
       },
       "required": [
@@ -6372,24 +6371,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a Genetic Algorithm (GA) or Evolutionary Strategy (ES)\ntopology for the gradient-free optimization of agent populations over discrete temporal\ngenerations. As a ...Manifest suffix, this is a declarative, frozen snapshot of an\nN-dimensional execution coordinate.\n\nCAUSAL AFFORDANCE: Orchestrates the iterative instantiation, evaluation, and culling of\nautonomous agents, actively applying stochastic perturbations (MutationPolicy) and\nchromosomal combinations (CrossoverPolicy) to maximize fitness.\n\nEPISTEMIC BOUNDS: The state space explosion is physically restricted by integer limits\non population_size (le=1000000000) and generations (le=1.0). The @model_validator\nmathematically guarantees that fitness_objectives are deterministically sorted by\ntarget_metric, preserving RFC 8785 canonical hashing across the decentralized swarm.\n\nMCP ROUTING TRIGGERS: Genetic Algorithm, Evolutionary Strategy, Gradient-Free\nOptimization, Population Dynamics, Multi-Objective Optimization",
       "properties": {
-        "architectural_intent": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The AI's declarative rationale for selecting this topology.",
-          "title": "Architectural Intent"
-        },
-        "crossover": {
-          "$ref": "#/$defs/CrossoverPolicy",
-          "description": "The mathematical rules for combining elite agents."
-        },
         "epistemic_enforcement": {
           "anyOf": [
             {
@@ -6403,31 +6384,29 @@
           "default": null,
           "description": "Ties the topology to the Truth Maintenance layer."
         },
-        "fitness_objectives": {
-          "description": "The multi-dimensional criteria used to score and cull the population.",
-          "items": {
-            "$ref": "#/$defs/FitnessObjectiveProfile"
-          },
-          "title": "Fitness Objectives",
-          "type": "array"
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
         },
-        "generations": {
-          "description": "The absolute limit on evolutionary breeding cycles.",
-          "maximum": 1.0,
-          "title": "Generations",
-          "type": "integer"
-        },
-        "information_flow": {
+        "architectural_intent": {
           "anyOf": [
             {
-              "$ref": "#/$defs/InformationFlowPolicy"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+          "description": "The AI's declarative rationale for selecting this topology.",
+          "title": "Architectural Intent"
         },
         "justification": {
           "anyOf": [
@@ -6443,20 +6422,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
-        "mutation": {
-          "$ref": "#/$defs/MutationPolicy",
-          "description": "The constraints governing random heuristic mutations."
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -6467,24 +6432,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The distributed tracing rules bound to this specific execution graph."
-        },
-        "population_size": {
-          "description": "The number of concurrent agents instantiated per generation.",
-          "maximum": 1000000000,
-          "title": "Population Size",
-          "type": "integer"
         },
         "shared_state_contract": {
           "anyOf": [
@@ -6498,12 +6445,64 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
         "type": {
           "const": "evolutionary",
           "default": "evolutionary",
           "description": "Discriminator for an Evolutionary topology.",
           "title": "Type",
           "type": "string"
+        },
+        "generations": {
+          "description": "The absolute limit on evolutionary breeding cycles.",
+          "maximum": 1.0,
+          "title": "Generations",
+          "type": "integer"
+        },
+        "population_size": {
+          "description": "The number of concurrent agents instantiated per generation.",
+          "maximum": 1000000000,
+          "title": "Population Size",
+          "type": "integer"
+        },
+        "mutation": {
+          "$ref": "#/$defs/MutationPolicy",
+          "description": "The constraints governing random heuristic mutations."
+        },
+        "crossover": {
+          "$ref": "#/$defs/CrossoverPolicy",
+          "description": "The mathematical rules for combining elite agents."
+        },
+        "fitness_objectives": {
+          "description": "The multi-dimensional criteria used to score and cull the population.",
+          "items": {
+            "$ref": "#/$defs/FitnessObjectiveProfile"
+          },
+          "title": "Fitness Objectives",
+          "type": "array"
         }
       },
       "required": [
@@ -6521,39 +6520,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a discrete computational vertex within a Merkle-DAG execution trace, binding raw data inputs to deterministic outputs. As a ...Receipt suffix, this is an append-only coordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Permits the orchestrator to cryptographically re-evaluate, replay, or slash execution branches by guaranteeing all computational inputs, outputs, and parent pointers are deterministically serialized and preserved.\n\nEPISTEMIC BOUNDS: The @model_validator mathematically guarantees the node_hash via RFC 8785 canonical JSON serialization, trapping any non-deterministic dictionary properties. Orphaned lineages are structurally blocked by cross-field validation between parent_request_id and root_request_id.\n\nMCP ROUTING TRIGGERS: Merkle-DAG, RFC 8785 Canonicalization, Execution Trace, Cryptographic Determinism, Directed Acyclic Graph",
       "properties": {
-        "inputs": {
-          "$ref": "#/$defs/JsonPrimitiveState",
-          "description": "The inputs provided to the execution node."
-        },
-        "node_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic SHA-256 hash of this node.",
-          "title": "Node Hash"
-        },
-        "outputs": {
-          "$ref": "#/$defs/JsonPrimitiveState",
-          "description": "The outputs generated by the execution node."
-        },
-        "parent_hashes": {
-          "description": "The strict array of cryptographic hashes of parent execution nodes.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Parent Hashes",
-          "type": "array"
+        "request_id": {
+          "description": "The unique ID for this specific execution.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Request Id",
+          "type": "string"
         },
         "parent_request_id": {
           "anyOf": [
@@ -6571,14 +6544,6 @@
           "description": "The ID of the parent request.",
           "title": "Parent Request Id"
         },
-        "request_id": {
-          "description": "The unique ID for this specific execution.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Request Id",
-          "type": "string"
-        },
         "root_request_id": {
           "anyOf": [
             {
@@ -6594,6 +6559,40 @@
           "default": null,
           "description": "The ID of the trace root.",
           "title": "Root Request Id"
+        },
+        "inputs": {
+          "$ref": "#/$defs/JsonPrimitiveState",
+          "description": "The inputs provided to the execution node."
+        },
+        "outputs": {
+          "$ref": "#/$defs/JsonPrimitiveState",
+          "description": "The outputs generated by the execution node."
+        },
+        "parent_hashes": {
+          "description": "The strict array of cryptographic hashes of parent execution nodes.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Parent Hashes",
+          "type": "array"
+        },
+        "node_hash": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic SHA-256 hash of this node.",
+          "title": "Node Hash"
         }
       },
       "required": [
@@ -6608,6 +6607,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: ExecutionSLA is the rigid physical boundary dictating the absolute time and memory\nlimits for kinetic execution, practically bounding the Halting Problem within the swarm.\n\nCAUSAL AFFORDANCE: Acts as the hardware guillotine. It instructs the orchestrator's C++/Rust runtime\nto physically sever the thread, drop the VRAM context, or kill the WASM container if an agent\nexceeds its authorized footprint, preventing Denial of Service (DoS) via memory exhaustion.\n\nEPISTEMIC BOUNDS: The absolute mathematical and physical limits are intrinsic Pydantic limits on\nmax_execution_time_ms (le=86400000, gt=0) and max_compute_footprint_mb (le=1000000000, gt=0).\nAny breach instantly triggers a SystemFaultEvent.\n\nMCP ROUTING TRIGGERS: Hardware Guillotine, Halting Problem Bounding, VRAM Allocation, Process Termination, Resource Exhaustion",
       "properties": {
+        "max_execution_time_ms": {
+          "description": "The maximum allowed execution time in milliseconds before the orchestrator kills the process.",
+          "exclusiveMinimum": 0,
+          "maximum": 86400000,
+          "title": "Max Execution Time Ms",
+          "type": "integer"
+        },
         "max_compute_footprint_mb": {
           "anyOf": [
             {
@@ -6622,13 +6628,6 @@
           "default": null,
           "description": "The maximum physical compute footprint allowed for the tool's execution sandbox.",
           "title": "Max Compute Footprint Mb"
-        },
-        "max_execution_time_ms": {
-          "description": "The maximum allowed execution time in milliseconds before the orchestrator kills the process.",
-          "exclusiveMinimum": 0,
-          "maximum": 86400000,
-          "title": "Max Execution Time Ms",
-          "type": "integer"
         }
       },
       "required": [
@@ -6641,39 +6640,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the Dapper distributed tracing model to deterministically\nmap the causal execution DAG of the swarm. As a ...Receipt suffix, this is an\nappend-only coordinate on the Merkle-DAG that the LLM must never hallucinate a mutation\nto.\n\nCAUSAL AFFORDANCE: Unlocks global observability by mathematically binding parent-child\nRPC calls (parent_span_id to span_id) across the zero-trust network, enabling exact\nbottleneck detection and graph reconstruction. Tracks execution role via kind\n(SpanKindProfile, default=\"internal\") and health via status (SpanStatusCodeProfile,\ndefault=\"unset\").\n\nEPISTEMIC BOUNDS: Temporal boundaries are rigidly constrained by start_time_unix_nano\nand optional end_time_unix_nano (ge=0, le=253402300799000000000). The @model_validator\nenforces Allen's Interval Algebra to physically guarantee end_time cannot precede\nstart_time. The events array (max_length=10000) is deterministically sorted by\ntimestamp_unix_nano via a second @model_validator to preserve RFC 8785 canonical\nhashing.\n\nMCP ROUTING TRIGGERS: Dapper Tracing Model, Distributed Causal DAG, Allen's Interval\nAlgebra, OpenTelemetry, Execution Provenance",
       "properties": {
-        "end_time_unix_nano": {
-          "anyOf": [
-            {
-              "maximum": 253402300799000000000,
-              "minimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Temporal end bound, if completed.",
-          "title": "End Time Unix Nano"
+        "trace_id": {
+          "description": "The global identifier for the entire execution causal tree.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Trace Id",
+          "type": "string"
         },
-        "events": {
-          "description": "Structured log records emitted during the span.",
-          "items": {
-            "$ref": "#/$defs/SpanEvent"
-          },
-          "maxItems": 10000,
-          "title": "Events",
-          "type": "array"
-        },
-        "kind": {
-          "$ref": "#/$defs/SpanKindProfile",
-          "default": "internal",
-          "description": "The role of the span."
-        },
-        "name": {
-          "description": "The semantic identifier for the operation.",
-          "maxLength": 2000,
-          "title": "Name",
+        "span_id": {
+          "description": "The unique identifier for this specific operation.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Span Id",
           "type": "string"
         },
         "parent_span_id": {
@@ -6692,13 +6672,16 @@
           "description": "The causal edge to the invoking node.",
           "title": "Parent Span Id"
         },
-        "span_id": {
-          "description": "The unique identifier for this specific operation.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Span Id",
+        "name": {
+          "description": "The semantic identifier for the operation.",
+          "maxLength": 2000,
+          "title": "Name",
           "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/SpanKindProfile",
+          "default": "internal",
+          "description": "The role of the span."
         },
         "start_time_unix_nano": {
           "description": "Temporal start bound.",
@@ -6707,18 +6690,34 @@
           "title": "Start Time Unix Nano",
           "type": "integer"
         },
+        "end_time_unix_nano": {
+          "anyOf": [
+            {
+              "maximum": 253402300799000000000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Temporal end bound, if completed.",
+          "title": "End Time Unix Nano"
+        },
         "status": {
           "$ref": "#/$defs/SpanStatusCodeProfile",
           "default": "unset",
           "description": "The execution health flag."
         },
-        "trace_id": {
-          "description": "The global identifier for the entire execution causal tree.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Trace Id",
-          "type": "string"
+        "events": {
+          "description": "Structured log records emitted during the span.",
+          "items": {
+            "$ref": "#/$defs/SpanEvent"
+          },
+          "maxItems": 10000,
+          "title": "Events",
+          "type": "array"
         }
       },
       "required": [
@@ -6734,17 +6733,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Nassim Taleb's Black Swan Theory by injecting\nOut-of-Distribution (OOD) epistemic shocks into the causal graph. As an ...Event suffix,\nthis is an append-only coordinate on the Merkle-DAG that the LLM must never hallucinate\na mutation to.\n\nCAUSAL AFFORDANCE: Forces the active reasoning topology to process a high-entropy\nsynthetic_payload, actively testing the swarm's non-monotonic truth maintenance,\ndefeasible reasoning, and overall topological resilience.\n\nEPISTEMIC BOUNDS: Cryptographically targets a specific Merkle root via target_node_hash\n(strict SHA-256 pattern ^[a-f0-9]{64}$) and bounds the Variational Free Energy via\nbayesian_surprise_score [ge=0.0, le=1.0, allow_inf_nan=False]. The @model_validator\nphysically guarantees execution is halted if the attached escrow is not strictly positive.\n\nMCP ROUTING TRIGGERS: Black Swan Theory, Out-of-Distribution Shock, Variational Free\nEnergy, Exogenous Perturbation, Epistemic Stress Test",
       "properties": {
-        "bayesian_surprise_score": {
-          "description": "Strictly bounded mathematical quantification of the epistemic decay or Variational Free Energy.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Bayesian Surprise Score",
-          "type": "number"
-        },
-        "escrow": {
-          "$ref": "#/$defs/SimulationEscrowContract",
-          "description": "The cryptographic Proof-of-Stake funding the shock."
-        },
         "shock_id": {
           "description": "Cryptographic identifier for the Black Swan event.",
           "maxLength": 128,
@@ -6752,6 +6740,21 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Shock Id",
           "type": "string"
+        },
+        "target_node_hash": {
+          "description": "Regex-bound SHA-256 string targeting a specific Merkle root in the epistemic graph.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Target Node Hash",
+          "type": "string"
+        },
+        "bayesian_surprise_score": {
+          "description": "Strictly bounded mathematical quantification of the epistemic decay or Variational Free Energy.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Bayesian Surprise Score",
+          "type": "number"
         },
         "synthetic_payload": {
           "additionalProperties": true,
@@ -6763,13 +6766,9 @@
           "title": "Synthetic Payload",
           "type": "object"
         },
-        "target_node_hash": {
-          "description": "Regex-bound SHA-256 string targeting a specific Merkle root in the epistemic graph.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Target Node Hash",
-          "type": "string"
+        "escrow": {
+          "$ref": "#/$defs/SimulationEscrowContract",
+          "description": "The cryptographic Proof-of-Stake funding the shock."
         }
       },
       "required": [
@@ -6801,20 +6800,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Edward Tufte's principles of Small Multiples (Trellis\ndisplays) by establishing a categorical partitioning matrix for high-dimensional data\nprojections. As a ...Profile suffix, this is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Authorizes the rendering engine to recursively split and project a\nsingular visual grammar into a grid of structurally isomorphic sub-manifolds based on\ndistinct categorical fields.\n\nEPISTEMIC BOUNDS: The partitioning constraints (row_field, column_field) are both\noptional (default=None) and physically bounded by max_length=2000 to mathematically\nprevent Dictionary Bombing and OOM crashes during matrix generation.\n\nMCP ROUTING TRIGGERS: Small Multiples, Trellis Display, Isomorphic Sub-Manifold,\nHigh-Dimensional Projection, Categorical Partitioning",
       "properties": {
-        "column_field": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dataset field used to split the chart into columns.",
-          "title": "Column Field"
-        },
         "row_field": {
           "anyOf": [
             {
@@ -6828,6 +6813,20 @@
           "default": null,
           "description": "The dataset field used to split the chart into rows.",
           "title": "Row Field"
+        },
+        "column_field": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dataset field used to split the chart into columns.",
+          "title": "Column Field"
         }
       },
       "title": "FacetMatrixProfile",
@@ -6837,14 +6836,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Graceful Degradation within a Markov Decision Process (MDP), executing a deterministic policy intervention to escape an absorbing state (terminal failure) upon node collapse. As an ...Intent suffix, this is a kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Re-routes the probabilistic execution wave from a failing primary node (`target_node_id`) to a pre-verified, lower-variance backup node (`fallback_node_id`), actively bypassing structural collapse and maintaining systemic liveness.\n\nEPISTEMIC BOUNDS: Enforces strict structural referential integrity by requiring both `target_node_id` and `fallback_node_id` to resolve to mathematically valid `NodeIdentifierState` DIDs, severing hallucinated graph traversals.\n\nMCP ROUTING TRIGGERS: Markov Decision Process, Absorbing State, Graceful Degradation, Control-Flow Override, Policy Intervention",
       "properties": {
-        "fallback_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the node to use as a fallback."
-        },
-        "target_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the failing node."
-        },
         "type": {
           "const": "fallback_intent",
           "default": "fallback_intent",
@@ -6852,6 +6843,14 @@
           "le": 1000000000,
           "title": "Type",
           "type": "string"
+        },
+        "target_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The ID of the failing node."
+        },
+        "fallback_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The ID of the node to use as a fallback."
         }
       },
       "required": [
@@ -6863,19 +6862,14 @@
     },
     "FallbackSLA": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a Hard Real-Time Systems deadline for Supervisory Control\nTheory interactions, mathematically bounding the Halting Problem during human-in-the-loop\npauses. As an ...SLA suffix, this object enforces rigid mathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Dictates the deterministic timeout_action\n(Literal[\"fail_safe\", \"proceed_with_defaults\", \"escalate\"]) the orchestrator must execute\nwhen the temporal limit expires, structurally preventing execution deadlocks. If\nescalation is selected, traffic routes to the optional escalation_target_node_id.\n\nEPISTEMIC BOUNDS: The temporal envelope is physically capped by timeout_seconds (gt=0,\nle=86400 \u2014 a strict 24-hour absolute maximum TTL). Escalation routing targets a valid\nNodeIdentifierState (escalation_target_node_id, default=None).\n\nMCP ROUTING TRIGGERS: Hard Real-Time Systems, Supervisory Control Theory, Execution\nDeadlock Prevention, Bounded Delay, Liveness Guarantee",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a Hard Real-Time Systems deadline for Supervisory Control\nTheory interactions, mathematically bounding the Halting Problem during human-in-the-loop\npauses. As an ...SLA suffix, this object enforces rigid mathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Dictates the deterministic timeout_action\n(Literal[\"fail_safe\", \"proceed_with_defaults\", \"escalate\"]) the orchestrator must execute\nwhen the temporal limit expires, structurally preventing execution deadlocks. If\nescalation is selected, traffic routes to the optional escalation_target_node_id.\n\nEPISTEMIC BOUNDS: The temporal envelope is physically capped by timeout_seconds (gt=0,\nle=86400 — a strict 24-hour absolute maximum TTL). Escalation routing targets a valid\nNodeIdentifierState (escalation_target_node_id, default=None).\n\nMCP ROUTING TRIGGERS: Hard Real-Time Systems, Supervisory Control Theory, Execution\nDeadlock Prevention, Bounded Delay, Liveness Guarantee",
       "properties": {
-        "escalation_target_node_id": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeIdentifierState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The specific NodeIdentifierState to route the execution to if the escalate action is triggered."
+        "timeout_seconds": {
+          "description": "The maximum allowed delay for a human intervention.",
+          "exclusiveMinimum": 0,
+          "maximum": 86400,
+          "title": "Timeout Seconds",
+          "type": "integer"
         },
         "timeout_action": {
           "description": "The action to take when the timeout expires.",
@@ -6887,12 +6881,17 @@
           "title": "Timeout Action",
           "type": "string"
         },
-        "timeout_seconds": {
-          "description": "The maximum allowed delay for a human intervention.",
-          "exclusiveMinimum": 0,
-          "maximum": 86400,
-          "title": "Timeout Seconds",
-          "type": "integer"
+        "escalation_target_node_id": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeIdentifierState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific NodeIdentifierState to route the execution to if the escalate action is triggered."
         }
       },
       "required": [
@@ -6920,12 +6919,6 @@
           "title": "Description",
           "type": "string"
         },
-        "falsifying_observation_signature": {
-          "description": "The expected data schema or regex pattern that, if returned by the tool, kills the hypothesis.",
-          "maxLength": 2000,
-          "title": "Falsifying Observation Signature",
-          "type": "string"
-        },
         "required_tool_name": {
           "anyOf": [
             {
@@ -6939,6 +6932,12 @@
           "default": null,
           "description": "The specific ActionSpaceManifest tool required to test this condition (e.g., 'sql_query_db').",
           "title": "Required Tool Name"
+        },
+        "falsifying_observation_signature": {
+          "description": "The expected data schema or regex pattern that, if returned by the tool, kills the hypothesis.",
+          "maxLength": 2000,
+          "title": "Falsifying Observation Signature",
+          "type": "string"
         }
       },
       "required": [
@@ -6970,12 +6969,6 @@
           "$ref": "#/$defs/FaultCategoryProfile",
           "description": "The specific type of fault to inject."
         },
-        "intensity": {
-          "description": "The severity of the fault, represented from 0.0 to 1.0.",
-          "maximum": 1000000000.0,
-          "title": "Intensity",
-          "type": "number"
-        },
         "target_node_id": {
           "anyOf": [
             {
@@ -6991,6 +6984,12 @@
           "default": null,
           "description": "The specific node to attack, or None for swarm-wide.",
           "title": "Target Node Id"
+        },
+        "intensity": {
+          "description": "The severity of the fault, represented from 0.0 to 1.0.",
+          "maximum": 1000000000.0,
+          "title": "Intensity",
+          "type": "number"
         }
       },
       "required": [
@@ -7012,6 +7011,10 @@
           "title": "Attestation Id",
           "type": "string"
         },
+        "target_topology_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The DID of the discovered external state matrix/VPC."
+        },
         "authorized_session": {
           "$ref": "#/$defs/SecureSubSessionState",
           "description": "The isolated state partition granted to the agent for this connection."
@@ -7019,10 +7022,6 @@
         "governing_sla": {
           "$ref": "#/$defs/BilateralSLA",
           "description": "The structural and physical boundary constraints for querying this target."
-        },
-        "target_topology_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The DID of the discovered external state matrix/VPC."
         }
       },
       "required": [
@@ -7077,12 +7076,12 @@
           "title": "Adapter Merkle Root",
           "type": "string"
         },
-        "cache_priority_weight": {
-          "description": "CoReason Shared Kernel Ontology: The relative importance scalar used by the orchestrator's LRU eviction algorithm when VRAM limits are saturated.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Cache Priority Weight",
-          "type": "number"
+        "vram_footprint_bytes": {
+          "description": "CoReason Shared Kernel Ontology: The exact spatial geometry required in VRAM to mount this adapter.",
+          "exclusiveMinimum": 0,
+          "maximum": 100000000000,
+          "title": "Vram Footprint Bytes",
+          "type": "integer"
         },
         "ephemeral_ttl_ms": {
           "description": "CoReason Shared Kernel Ontology: The absolute Time-To-Live for the adapter to exist in the kinetic execution plane before forced eviction.",
@@ -7091,12 +7090,12 @@
           "title": "Ephemeral Ttl Ms",
           "type": "integer"
         },
-        "vram_footprint_bytes": {
-          "description": "CoReason Shared Kernel Ontology: The exact spatial geometry required in VRAM to mount this adapter.",
-          "exclusiveMinimum": 0,
-          "maximum": 100000000000,
-          "title": "Vram Footprint Bytes",
-          "type": "integer"
+        "cache_priority_weight": {
+          "description": "CoReason Shared Kernel Ontology: The relative importance scalar used by the orchestrator's LRU eviction algorithm when VRAM limits are saturated.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Cache Priority Weight",
+          "type": "number"
         }
       },
       "required": [
@@ -7136,15 +7135,15 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a specific mathematical objective function (fitness dimension)\nwithin a multi-objective optimization landscape for evaluating agent phenotypes. As a\n...Profile suffix, this is a declarative, frozen snapshot of an evaluation geometry.\n\nCAUSAL AFFORDANCE: Provides the mathematical vector (OptimizationDirectionProfile:\nminimize/maximize) and scalar weight required by the orchestrator to score an agent's\nexecution telemetry, ultimately determining its survival on the Pareto Efficiency\nfrontier.\n\nEPISTEMIC BOUNDS: The relative influence of this objective is mathematically clamped by\nthe weight field (le=1.0, default=1.0) to prevent gradient or reward explosion during\nfitness aggregation. The target_metric is bounded to max_length=2000.\n\nMCP ROUTING TRIGGERS: Fitness Landscape, Objective Function, Multi-Objective\nOptimization, Phenotype Scoring, Pareto Efficiency",
       "properties": {
-        "direction": {
-          "$ref": "#/$defs/OptimizationDirectionProfile",
-          "description": "Whether the algorithm should maximize or minimize this metric."
-        },
         "target_metric": {
           "description": "The specific telemetry or execution metric to evaluate (e.g., 'latency', 'accuracy').",
           "maxLength": 2000,
           "title": "Target Metric",
           "type": "string"
+        },
+        "direction": {
+          "$ref": "#/$defs/OptimizationDirectionProfile",
+          "description": "Whether the algorithm should maximize or minimize this metric."
         },
         "weight": {
           "default": 1.0,
@@ -7165,20 +7164,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Leverages Automated Theorem Proving and the Curry-Howard\nCorrespondence to bind the causal graph to a mathematically verified safety\ninvariant. As a ...Contract suffix, this enforces rigid mathematical\nboundaries globally.\n\nCAUSAL AFFORDANCE: Authorizes the Rust/C++ orchestrator to ingest a compiled\nproof artifact and mechanically verify that the topology cannot transition into\na catastrophic or forbidden geometric state. The invariant_theorem\n(max_length=2000) specifies the exact safety assertion.\n\nEPISTEMIC BOUNDS: The theorem prover dialect is strictly locked to the\nproof_system Literal [\"tla_plus\", \"lean4\", \"coq\", \"z3\"]. Cryptographic\nintegrity is guaranteed by the compiled_proof_hash (SHA-256 regex\n^[a-f0-9]{64}$).\n\nMCP ROUTING TRIGGERS: Automated Theorem Proving, Curry-Howard Correspondence,\nSafety Invariant, TLA+, Formal Methods",
       "properties": {
-        "compiled_proof_hash": {
-          "description": "The SHA-256 fingerprint of the verified proof object that the Rust/C++ orchestrator must load and check.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Compiled Proof Hash",
-          "type": "string"
-        },
-        "invariant_theorem": {
-          "description": "The exact mathematical assertion or safety invariant being proven (e.g., 'No data classified as CONFIDENTIAL routes externally').",
-          "maxLength": 2000,
-          "title": "Invariant Theorem",
-          "type": "string"
-        },
         "proof_system": {
           "description": "The mathematical dialect and theorem prover used to compile the proof.",
           "enum": [
@@ -7188,6 +7173,20 @@
             "z3"
           ],
           "title": "Proof System",
+          "type": "string"
+        },
+        "invariant_theorem": {
+          "description": "The exact mathematical assertion or safety invariant being proven (e.g., 'No data classified as CONFIDENTIAL routes externally').",
+          "maxLength": 2000,
+          "title": "Invariant Theorem",
+          "type": "string"
+        },
+        "compiled_proof_hash": {
+          "description": "The SHA-256 fingerprint of the verified proof object that the Rust/C++ orchestrator must load and check.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Compiled Proof Hash",
           "type": "string"
         }
       },
@@ -7203,6 +7202,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Ergodic Theory and Branching Factor Analysis to\nrigorously bound the topological expansion of synthetic or fractal graphs. As\nan ...SLA suffix, this enforces rigid mathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Acts as a physical gas limit on generative expansion,\nauthorizing the orchestrator to cull recursive encapsulation before it induces\nstate-space explosion or GPU VRAM exhaustion.\n\nEPISTEMIC BOUNDS: Mathematically clamps geometric explosion via the\n@model_validator enforce_geometric_bounds, guaranteeing\nmax_node_fanout ** max_topological_depth <= 1000. Both max_topological_depth\nand max_node_fanout are strictly positive (ge=1, le=1000000000). Synthetic\ntoken economy is capped by max_synthetic_tokens (ge=1, le=1000000000).\n\nMCP ROUTING TRIGGERS: Ergodic Theory, Branching Factor Analysis, State-Space\nExplosion, Fractal Graph Bounding, Gas Limit",
       "properties": {
+        "max_topological_depth": {
+          "description": "The absolute physical depth limit for recursive encapsulation.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Max Topological Depth",
+          "type": "integer"
+        },
         "max_node_fanout": {
           "description": "The maximum number of horizontally connected nodes per topology tier.",
           "maximum": 1000000000,
@@ -7215,13 +7221,6 @@
           "maximum": 1000000000,
           "minimum": 1,
           "title": "Max Synthetic Tokens",
-          "type": "integer"
-        },
-        "max_topological_depth": {
-          "description": "The absolute physical depth limit for recursive encapsulation.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Max Topological Depth",
           "type": "integer"
         }
       },
@@ -7245,6 +7244,14 @@
           "title": "Manifest Id",
           "type": "string"
         },
+        "root_node_id": {
+          "description": "The CID of the top-level TaxonomicNodeState initiating the tree.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Root Node Id",
+          "type": "string"
+        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/TaxonomicNodeState"
@@ -7256,14 +7263,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "root_node_id": {
-          "description": "The CID of the top-level TaxonomicNodeState initiating the tree.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Root Node Id",
-          "type": "string"
         }
       },
       "required": [
@@ -7276,27 +7275,8 @@
     },
     "GlobalGovernancePolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Superimposes macro-economic and thermodynamic constraints over the\nswarm's execution graph to prevent unbounded compute exhaustion. As a ...Policy suffix,\nthis object defines rigid mathematical boundaries that the orchestrator must enforce\nglobally.\n\nCAUSAL AFFORDANCE: Acts as the ultimate hardware guillotine, authorizing the orchestrator\nto physically sever the execution thread if thermodynamic, economic, or temporal budgets\nare breached. Includes a mandatory zero-trust @model_validator enforcing the Prosperity\nPublic License 3.0 via mandatory_license_rule (rule_id=\"PPL_3_0_COMPLIANCE\",\nseverity=\"critical\").\n\nEPISTEMIC BOUNDS: Enforces absolute physical ceilings: max_budget_magnitude\n(le=1000000000), max_global_tokens (le=1000000000), global_timeout_seconds (ge=0,\nle=86400 \u2014 a strict 24-hour TTL), and optional max_carbon_budget_gco2eq (ge=0.0,\nle=10000.0). An optional FormalVerificationContract provides mathematical proofs of\nstructural correctness.\n\nMCP ROUTING TRIGGERS: Thermodynamic Compute Limits, Hardware Guillotine, Halting Problem\nBounding, ESG Constraint, Execution Envelope",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Superimposes macro-economic and thermodynamic constraints over the\nswarm's execution graph to prevent unbounded compute exhaustion. As a ...Policy suffix,\nthis object defines rigid mathematical boundaries that the orchestrator must enforce\nglobally.\n\nCAUSAL AFFORDANCE: Acts as the ultimate hardware guillotine, authorizing the orchestrator\nto physically sever the execution thread if thermodynamic, economic, or temporal budgets\nare breached. Includes a mandatory zero-trust @model_validator enforcing the Prosperity\nPublic License 3.0 via mandatory_license_rule (rule_id=\"PPL_3_0_COMPLIANCE\",\nseverity=\"critical\").\n\nEPISTEMIC BOUNDS: Enforces absolute physical ceilings: max_budget_magnitude\n(le=1000000000), max_global_tokens (le=1000000000), global_timeout_seconds (ge=0,\nle=86400 — a strict 24-hour TTL), and optional max_carbon_budget_gco2eq (ge=0.0,\nle=10000.0). An optional FormalVerificationContract provides mathematical proofs of\nstructural correctness.\n\nMCP ROUTING TRIGGERS: Thermodynamic Compute Limits, Hardware Guillotine, Halting Problem\nBounding, ESG Constraint, Execution Envelope",
       "properties": {
-        "formal_verification": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/FormalVerificationContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical proof of structural correctness mandated for this execution graph."
-        },
-        "global_timeout_seconds": {
-          "description": "The absolute Time-To-Live (TTL) for the execution envelope before graceful termination.",
-          "maximum": 86400,
-          "minimum": 0,
-          "title": "Global Timeout Seconds",
-          "type": "integer"
-        },
         "mandatory_license_rule": {
           "$ref": "#/$defs/ConstitutionalPolicy"
         },
@@ -7304,6 +7284,12 @@
           "description": "The absolute maximum economic cost allowed for the entire swarm lifecycle.",
           "maximum": 1000000000,
           "title": "Max Budget Magnitude",
+          "type": "integer"
+        },
+        "max_global_tokens": {
+          "description": "The maximum aggregate token usage allowed across all nodes.",
+          "maximum": 1000000000,
+          "title": "Max Global Tokens",
           "type": "integer"
         },
         "max_carbon_budget_gco2eq": {
@@ -7321,11 +7307,24 @@
           "description": "The absolute physical energy footprint allowed for this execution graph. If exceeded, the orchestrator terminates the swarm.",
           "title": "Max Carbon Budget Gco2Eq"
         },
-        "max_global_tokens": {
-          "description": "The maximum aggregate token usage allowed across all nodes.",
-          "maximum": 1000000000,
-          "title": "Max Global Tokens",
+        "global_timeout_seconds": {
+          "description": "The absolute Time-To-Live (TTL) for the execution envelope before graceful termination.",
+          "maximum": 86400,
+          "minimum": 0,
+          "title": "Global Timeout Seconds",
           "type": "integer"
+        },
+        "formal_verification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FormalVerificationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical proof of structural correctness mandated for this execution graph."
         }
       },
       "required": [
@@ -7390,6 +7389,10 @@
           "title": "Policy Name",
           "type": "string"
         },
+        "version": {
+          "$ref": "#/$defs/SemanticVersionState",
+          "description": "Semantic version of the governance policy."
+        },
         "rules": {
           "description": "The explicit array of constitutional rules included in this policy.",
           "items": {
@@ -7397,10 +7400,6 @@
           },
           "title": "Rules",
           "type": "array"
-        },
-        "version": {
-          "$ref": "#/$defs/SemanticVersionState",
-          "description": "Semantic version of the governance policy."
         }
       },
       "required": [
@@ -7449,25 +7448,26 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Leland Wilkinson's Grammar of Graphics to deterministically project N-dimensional Epistemic Ledger state into a 2D topological manifold. As a ...Profile suffix, this is a declarative, frozen snapshot of a rendering geometry.\n\nCAUSAL AFFORDANCE: Authorizes the frontend rendering engine to construct geometric marks (`Literal[\"point\", \"line\", \"area\", \"bar\", \"rect\", \"arc\"]`) driven strictly by the underlying `ledger_source_id`. Optionally supports Small Multiples via `facet` (`FacetMatrixProfile`).\n\nEPISTEMIC BOUNDS: Bounded by a rigid `encodings` array sorted mathematically by `channel` via a `@model_validator` to preserve RFC 8785 canonical hashing. Prevents hallucinated visuals by strictly linking to a verified `ledger_source_id` CID.\n\nMCP ROUTING TRIGGERS: Grammar of Graphics, Data Visualization, Geometric Projection, Declarative UI, Retinal Variables",
       "properties": {
-        "encodings": {
-          "description": "The mapping of structural fields to visual channels.",
-          "items": {
-            "$ref": "#/$defs/VisualEncodingProfile"
-          },
-          "title": "Encodings",
-          "type": "array"
+        "panel_id": {
+          "description": "The unique identifier for this UI panel.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Panel Id",
+          "type": "string"
         },
-        "facet": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/FacetMatrixProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional faceting matrix for small multiples."
+        "type": {
+          "const": "grammar",
+          "default": "grammar",
+          "description": "Discriminator for Grammar of Graphics charts.",
+          "title": "Type",
+          "type": "string"
+        },
+        "title": {
+          "description": "The declarative semantic anchor summarizing the underlying visual grammar.",
+          "maxLength": 2000,
+          "title": "Title",
+          "type": "string"
         },
         "ledger_source_id": {
           "description": "The cryptographic pointer to the semantic series in the EpistemicLedgerState.",
@@ -7491,26 +7491,25 @@
           "title": "Mark",
           "type": "string"
         },
-        "panel_id": {
-          "description": "The unique identifier for this UI panel.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Panel Id",
-          "type": "string"
+        "encodings": {
+          "description": "The mapping of structural fields to visual channels.",
+          "items": {
+            "$ref": "#/$defs/VisualEncodingProfile"
+          },
+          "title": "Encodings",
+          "type": "array"
         },
-        "title": {
-          "description": "The declarative semantic anchor summarizing the underlying visual grammar.",
-          "maxLength": 2000,
-          "title": "Title",
-          "type": "string"
-        },
-        "type": {
-          "const": "grammar",
-          "default": "grammar",
-          "description": "Discriminator for Grammar of Graphics charts.",
-          "title": "Type",
-          "type": "string"
+        "facet": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FacetMatrixProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional faceting matrix for small multiples."
         }
       },
       "required": [
@@ -7527,15 +7526,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A rigid Graph Isomorphism and Dimensionality Reduction protocol\ndefining the deterministic translation of high-dimensional neurosymbolic Knowledge\nGraphs into flat, tabular matrices for standard OLAP processing. As a ...Policy\nsuffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Forces the structural projection engine to serialize complex\nsemantic nodes and edges into wide-columnar arrays or adjacency matrices. The\npreserve_cryptographic_lineage boolean (default=True) guarantees Merkle-DAG hashes\nsurvive the flattening transformation.\n\nEPISTEMIC BOUNDS: The reduction geometry is rigidly constrained by Literal enums for\nnode_projection_mode [\"wide_columnar\", \"struct_array\"] and edge_projection_mode\n[\"adjacency_matrix\", \"map_array\"], mathematically severing the capability for agents\nto hallucinate unsupported tabular schemas.\n\nMCP ROUTING TRIGGERS: Graph Isomorphism, Dimensionality Reduction, Adjacency Matrix,\nWide-Columnar Projection, Structural Serialization",
       "properties": {
-        "edge_projection_mode": {
-          "description": "How to flatten SemanticEdgeState.",
-          "enum": [
-            "adjacency_matrix",
-            "map_array"
-          ],
-          "title": "Edge Projection Mode",
-          "type": "string"
-        },
         "node_projection_mode": {
           "description": "How to flatten SemanticNodeState.",
           "enum": [
@@ -7543,6 +7533,15 @@
             "struct_array"
           ],
           "title": "Node Projection Mode",
+          "type": "string"
+        },
+        "edge_projection_mode": {
+          "description": "How to flatten SemanticEdgeState.",
+          "enum": [
+            "adjacency_matrix",
+            "map_array"
+          ],
+          "title": "Edge Projection Mode",
           "type": "string"
         },
         "preserve_cryptographic_lineage": {
@@ -7563,19 +7562,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a Stateless Client-Server Architecture for JSON-RPC\n2.0 message passing, serving as the egress manifold for Zero-Trust Network Access\n(ZTNA). As a ...Profile suffix, this is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to open an out-of-band HTTP socket\n(uri: HttpUrl), transmitting structured semantic payloads while strictly confining\ncustom headers to prevent protocol manipulation.\n\nEPISTEMIC BOUNDS: The headers dictionary is mathematically bounded (le=1000000000\nproperties, key max_length=255, value max_length=2000, default_factory=dict) and\nexplicitly trapped by the @field_validator _prevent_crlf_injection to physically\nblock HTTP Request Smuggling.\n\nMCP ROUTING TRIGGERS: Stateless Architecture, Zero-Trust Network Access, HTTP\nRequest Smuggling Prevention, JSON-RPC Egress, Out-of-Band Socket",
       "properties": {
-        "headers": {
-          "additionalProperties": {
-            "maxLength": 2000,
-            "type": "string"
-          },
-          "description": "HTTP headers, strictly bounded for zero-trust credentials.",
-          "le": 1000000000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Headers",
-          "type": "object"
-        },
         "type": {
           "const": "http",
           "default": "http",
@@ -7590,6 +7576,19 @@
           "minLength": 1,
           "title": "Uri",
           "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "description": "HTTP headers, strictly bounded for zero-trust credentials.",
+          "le": 1000000000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Headers",
+          "type": "object"
         }
       },
       "required": [
@@ -7600,7 +7599,7 @@
     },
     "HardwareEnclaveReceipt": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a Remote Attestation Quote generated by a Trusted Execution\nEnvironment (TEE) \u2014 supporting intel_tdx, amd_sev_snp, aws_nitro, and nvidia_cc \u2014\nmathematically proving physical silicon isolation. As a ...Receipt suffix, this is an\nappend-only coordinate on the Merkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Authorizes the swarm orchestrator to securely inject RESTRICTED\nclassification payloads into the agent's context by proving the host OS cannot read or\ntamper with the working memory.\n\nEPISTEMIC BOUNDS: The attestation is physically bounded by the 8192-byte max_length of\nthe hardware_signature_blob, and mathematically anchored to the exact memory state via the\nplatform_measurement_hash (a strict SHA-256 pattern ^[a-f0-9]{64}$ representing the PCRs).\n\nMCP ROUTING TRIGGERS: Trusted Execution Environment, Remote Attestation, Platform\nConfiguration Register, Hardware Root-of-Trust, SGX/TDX/Nitro",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a Remote Attestation Quote generated by a Trusted Execution\nEnvironment (TEE) — supporting intel_tdx, amd_sev_snp, aws_nitro, and nvidia_cc —\nmathematically proving physical silicon isolation. As a ...Receipt suffix, this is an\nappend-only coordinate on the Merkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Authorizes the swarm orchestrator to securely inject RESTRICTED\nclassification payloads into the agent's context by proving the host OS cannot read or\ntamper with the working memory.\n\nEPISTEMIC BOUNDS: The attestation is physically bounded by the 8192-byte max_length of\nthe hardware_signature_blob, and mathematically anchored to the exact memory state via the\nplatform_measurement_hash (a strict SHA-256 pattern ^[a-f0-9]{64}$ representing the PCRs).\n\nMCP ROUTING TRIGGERS: Trusted Execution Environment, Remote Attestation, Platform\nConfiguration Register, Hardware Root-of-Trust, SGX/TDX/Nitro",
       "properties": {
         "enclave_type": {
           "description": "The physical silicon architecture generating the root-of-trust quote.",
@@ -7614,18 +7613,18 @@
           "title": "Enclave Type",
           "type": "string"
         },
-        "hardware_signature_blob": {
-          "description": "The base64-encoded hardware quote signed by the silicon manufacturer's master private key.",
-          "maxLength": 8192,
-          "title": "Hardware Signature Blob",
-          "type": "string"
-        },
         "platform_measurement_hash": {
           "description": "The cryptographic hash of the Platform Configuration Registers (PCRs) proving the memory state was physically isolated.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-f0-9]{64}$",
           "title": "Platform Measurement Hash",
+          "type": "string"
+        },
+        "hardware_signature_blob": {
+          "description": "The base64-encoded hardware quote signed by the silicon manufacturer's master private key.",
+          "maxLength": 8192,
+          "title": "Hardware Signature Blob",
           "type": "string"
         }
       },
@@ -7641,12 +7640,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Lattice-Based Cryptography to enable the\nevaluation of geometric and arithmetic operations directly on an encrypted\ntensor state. As a ...Profile suffix, this is a declarative, frozen snapshot.\n\nCAUSAL AFFORDANCE: Permits an external, untrusted orchestrator to calculate\ngeometric distances or compute reward gradients on sensitive representations\nwithout exposing plaintext. The public_key_id (128-char CID) identifies the\nevaluation key for privacy-preserving computation.\n\nEPISTEMIC BOUNDS: The encryption dialect is rigidly locked to the fhe_scheme\nLiteral automaton [\"ckks\", \"bgv\", \"bfv\", \"tfhe\"]. Cryptographic memory\nexplosion is prevented by capping ciphertext_blob (max_length=5000000).\n\nMCP ROUTING TRIGGERS: Fully Homomorphic Encryption, Lattice-Based\nCryptography, CKKS Scheme, Privacy-Preserving Computation, Encrypted Tensor",
       "properties": {
-        "ciphertext_blob": {
-          "description": "The base64-encoded homomorphic ciphertext.",
-          "maxLength": 5000000,
-          "title": "Ciphertext Blob",
-          "type": "string"
-        },
         "fhe_scheme": {
           "description": "The specific homomorphic encryption dialect used to encode the ciphertext.",
           "enum": [
@@ -7665,6 +7658,12 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Public Key Id",
           "type": "string"
+        },
+        "ciphertext_blob": {
+          "description": "The base64-encoded homomorphic ciphertext.",
+          "maxLength": 5000000,
+          "title": "Ciphertext Blob",
+          "type": "string"
         }
       },
       "required": [
@@ -7679,6 +7678,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Supervisory Control Theory within the causal DAG,\ninstantiating an out-of-band Oracle node for Mixed-Initiative truth resolution.\nAs a ...Profile suffix, this is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Physically halts the continuous multi-agent generation loop,\nforcing the probability wave to suspend until external wetware (human) entropy is\nsafely injected into the topological state.\n\nEPISTEMIC BOUNDS: Execution resumption is cryptographically gated by the optional\nrequired_attestation (AttestationMechanismProfile | None, default=None). If set,\nthe orchestrator MUST physically drop all responses lacking a matching\ncryptographic attestation. The type discriminator is locked to Literal[\"human\"].\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, Oracle Node, Mixed-Initiative,\nProof of Humanity, Out-of-Band Entropy",
       "properties": {
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -7693,11 +7698,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -7716,27 +7737,12 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
           "title": "Domain Extensions"
         },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
+        "type": {
+          "const": "human",
+          "default": "human",
+          "description": "Discriminator for a Human node.",
+          "title": "Type",
+          "type": "string"
         },
         "required_attestation": {
           "anyOf": [
@@ -7749,13 +7755,6 @@
           ],
           "default": null,
           "description": "AGENT INSTRUCTION: If set, the orchestrator MUST NOT resolve\n        this node without a cryptographically matching WetwareAttestationContract\n        supplied in the InterventionReceipt."
-        },
-        "type": {
-          "const": "human",
-          "default": "human",
-          "description": "Discriminator for a Human node.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -7768,65 +7767,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Instantiates an abductive reasoning branch governed by Popperian Falsification and Bayesian updating on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Commits a formalized causal premise into the EpistemicLedgerState, unlocking the orchestration of empirical testing via active inference to falsify or verify the embedded causal_model.\n\nEPISTEMIC BOUNDS: The bayesian_prior is mathematically clamped to a valid probability space (ge=0.0, le=1.0). The hypothesis identity is cryptographically locked via a 128-char CID (hypothesis_id), and falsification_conditions are deterministically sorted.\n\nMCP ROUTING TRIGGERS: Abductive Reasoning, Popperian Falsification, Bayesian Prior, Causal Hypothesis, Epistemic Commitment",
       "properties": {
-        "bayesian_prior": {
-          "description": "The agent's initial probabilistic belief in this hypothesis before testing.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Bayesian Prior",
-          "type": "number"
-        },
-        "causal_model": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StructuralCausalGraphProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The formal DAG representing the agent's structural assumptions about the environment."
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
-          "type": "string"
-        },
-        "falsification_conditions": {
-          "description": "The strict array of strict conditions that the orchestrator must test to attempt to disprove this premise.",
-          "items": {
-            "$ref": "#/$defs/FalsificationContract"
-          },
-          "minItems": 1,
-          "title": "Falsification Conditions",
-          "type": "array"
-        },
-        "hypothesis_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this abductive leap to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Hypothesis Id",
-          "type": "string"
-        },
-        "premise_text": {
-          "description": "The natural language explanation of the abductive theory.",
-          "maxLength": 2000,
-          "title": "Premise Text",
-          "type": "string"
-        },
-        "status": {
-          "default": "active",
-          "description": "The current validity state of this hypothesis in the EpistemicLedgerState.",
-          "enum": [
-            "active",
-            "falsified",
-            "verified"
-          ],
-          "title": "Status",
           "type": "string"
         },
         "timestamp": {
@@ -7842,6 +7788,59 @@
           "description": "Discriminator for a hypothesis generation event.",
           "title": "Type",
           "type": "string"
+        },
+        "hypothesis_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this abductive leap to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Hypothesis Id",
+          "type": "string"
+        },
+        "premise_text": {
+          "description": "The natural language explanation of the abductive theory.",
+          "maxLength": 2000,
+          "title": "Premise Text",
+          "type": "string"
+        },
+        "bayesian_prior": {
+          "description": "The agent's initial probabilistic belief in this hypothesis before testing.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Bayesian Prior",
+          "type": "number"
+        },
+        "falsification_conditions": {
+          "description": "The strict array of strict conditions that the orchestrator must test to attempt to disprove this premise.",
+          "items": {
+            "$ref": "#/$defs/FalsificationContract"
+          },
+          "minItems": 1,
+          "title": "Falsification Conditions",
+          "type": "array"
+        },
+        "status": {
+          "default": "active",
+          "description": "The current validity state of this hypothesis in the EpistemicLedgerState.",
+          "enum": [
+            "active",
+            "falsified",
+            "verified"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "causal_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StructuralCausalGraphProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal DAG representing the agent's structural assumptions about the environment."
         }
       },
       "required": [
@@ -7866,12 +7865,12 @@
           "title": "Agent Id",
           "type": "string"
         },
-        "implied_probability": {
-          "description": "The agent's calculated internal confidence score.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Implied Probability",
-          "type": "number"
+        "target_hypothesis_id": {
+          "description": "The exact HypothesisGenerationEvent the agent is betting on.",
+          "le": 1000000000,
+          "minLength": 1,
+          "title": "Target Hypothesis Id",
+          "type": "string"
         },
         "staked_magnitude": {
           "description": "The volume of compute budget committed to this position.",
@@ -7880,12 +7879,12 @@
           "title": "Staked Magnitude",
           "type": "integer"
         },
-        "target_hypothesis_id": {
-          "description": "The exact HypothesisGenerationEvent the agent is betting on.",
-          "le": 1000000000,
-          "minLength": 1,
-          "title": "Target Hypothesis Id",
-          "type": "string"
+        "implied_probability": {
+          "description": "The agent's calculated internal confidence score.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Implied Probability",
+          "type": "number"
         }
       },
       "required": [
@@ -7912,20 +7911,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the macroscopic Payload Loss Prevention (PLP) and\nLattice-Based Information Flow Control (IFC) bounds across the entire execution graph.\nAs a ...Policy suffix, this object defines rigid mathematical boundaries that the\norchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Projects a unified defensive mesh that aggregates RedactionPolicy\nrules, an optional SemanticFirewallPolicy intercept, and tensor-level SaeLatentPolicy\nfirewalls to comprehensively sanitize all graph edges. The active toggle controls\nwhether enforcement is live.\n\nEPISTEMIC BOUNDS: Ensures absolute deterministic evaluation by utilizing a\n@model_validator to physically sort the rules array by rule_id and the latent_firewalls\narray by target_feature_index, guaranteeing an invariant Merkle root.\n\nMCP ROUTING TRIGGERS: Information Flow Control, Payload Loss Prevention, Lattice-Based\nSecurity, Biba Integrity Model, Defense-in-Depth",
       "properties": {
-        "active": {
-          "default": true,
-          "description": "Whether this policy is currently enforcing data sanitization.",
-          "title": "Active",
-          "type": "boolean"
-        },
-        "latent_firewalls": {
-          "description": "The strict array of tensor-level mechanistic firewalls monitoring the forward pass for adversarial intent.",
-          "items": {
-            "$ref": "#/$defs/SaeLatentPolicy"
-          },
-          "title": "Latent Firewalls",
-          "type": "array"
-        },
         "policy_id": {
           "description": "Unique identifier for this macroscopic flow control policy.",
           "maxLength": 128,
@@ -7933,6 +7918,12 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Policy Id",
           "type": "string"
+        },
+        "active": {
+          "default": true,
+          "description": "Whether this policy is currently enforcing data sanitization.",
+          "title": "Active",
+          "type": "boolean"
         },
         "rules": {
           "description": "The array of sanitization rules to enforce.",
@@ -7953,6 +7944,14 @@
           ],
           "default": null,
           "description": "The active cognitive defense perimeter against adversarial control-flow overrides."
+        },
+        "latent_firewalls": {
+          "description": "The strict array of tensor-level mechanistic firewalls monitoring the forward pass for adversarial intent.",
+          "items": {
+            "$ref": "#/$defs/SaeLatentPolicy"
+          },
+          "title": "Latent Firewalls",
+          "type": "array"
         }
       },
       "required": [
@@ -7965,6 +7964,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Synchronous Epistemic Signaling within a Mixed-Initiative\nControl paradigm. The agent requires explicit acknowledgment from an external Oracle\nbefore committing the next probability wave collapse. As an ...Intent suffix, this\nyields control.\n\nCAUSAL AFFORDANCE: Conditionally suspends the continuous execution DAG to project a\nread-only observational state manifold to the human operator. Resumption is dynamically\ngoverned by the deterministic timeout_action.\n\nEPISTEMIC BOUNDS: The semantic payload (message) is physically clamped to\nmax_length=2000 to prevent UI dictionary bombing. The timeout_action is locked to a\nstrict Finite State Machine Literal [\"rollback\", \"proceed_default\", \"terminate\"],\nsolving the Halting Problem for unresponsive oracles.\n\nMCP ROUTING TRIGGERS: Synchronous Epistemic Signaling, Mixed-Initiative Control,\nFinite State Machine, Oracle Projection, Halting Problem",
       "properties": {
+        "type": {
+          "const": "informational",
+          "default": "informational",
+          "description": "Discriminator for read-only informational handoffs.",
+          "title": "Type",
+          "type": "string"
+        },
         "message": {
           "description": "The context or summary to display to the human operator.",
           "maxLength": 2000,
@@ -7980,13 +7986,6 @@
           ],
           "title": "Timeout Action",
           "type": "string"
-        },
-        "type": {
-          "const": "informational",
-          "default": "informational",
-          "description": "Discriminator for read-only informational handoffs.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -8000,16 +7999,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a covariant Functor (Category Theory) mapping\nhigher-order topological state dimensions into an encapsulated subgraph's\nlocalized working memory. As a ...Contract suffix, this enforces rigid\nmathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's state projection engine to\nsafely inject parent variables into a CompositeNodeProfile without violating\nscope isolation or referential transparency.\n\nEPISTEMIC BOUNDS: The geometric projection vectors parent_key and child_key\nare strictly clamped to max_length=2000, mathematically severing the\ncapability for String Exhaustion Attacks and Path Traversal vulnerabilities\nduring AST resolution.\n\nMCP ROUTING TRIGGERS: Category Theory, Covariant Functor, Scope Isolation,\nState Projection, Bijective Mapping",
       "properties": {
-        "child_key": {
-          "description": "The mapped key in the nested topology's state contract.",
-          "maxLength": 2000,
-          "title": "Child Key",
-          "type": "string"
-        },
         "parent_key": {
           "description": "The key in the parent's shared state contract.",
           "maxLength": 2000,
           "title": "Parent Key",
+          "type": "string"
+        },
+        "child_key": {
+          "description": "The mapped key in the nested topology's state contract.",
+          "maxLength": 2000,
+          "title": "Child Key",
           "type": "string"
         }
       },
@@ -8024,12 +8023,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative bounding box for rendering condensed semantic summaries (Information Bottleneck compression) into human-readable 2D space. As a ...Profile suffix, this is a declarative, frozen snapshot of a rendering geometry.\n\nCAUSAL AFFORDANCE: Projects Markdown-formatted text onto the UI plane while serving as a structural honeypot against Polyglot XSS and Markdown execution injection attacks.\n\nEPISTEMIC BOUNDS: Physically restricts payload size to `max_length=100000` on `markdown_content`. Two distinct `@field_validators` mathematically strip HTML event handlers and malicious URI schemes, ensuring zero-trust projection.\n\nMCP ROUTING TRIGGERS: Information Bottleneck, Semantic Compression, XSS Sanitization, Markdown Projection, Zero-Trust UI",
       "properties": {
-        "markdown_content": {
-          "description": "The markdown formatted text content.",
-          "maxLength": 100000,
-          "title": "Markdown Content",
-          "type": "string"
-        },
         "panel_id": {
           "description": "The unique identifier for this UI panel.",
           "maxLength": 128,
@@ -8038,17 +8031,23 @@
           "title": "Panel Id",
           "type": "string"
         },
+        "type": {
+          "const": "insight_card",
+          "default": "insight_card",
+          "description": "Discriminator for markdown insight cards.",
+          "title": "Type",
+          "type": "string"
+        },
         "title": {
           "description": "The declarative semantic anchor summarizing the underlying matrix or markdown projection.",
           "maxLength": 2000,
           "title": "Title",
           "type": "string"
         },
-        "type": {
-          "const": "insight_card",
-          "default": "insight_card",
-          "description": "Discriminator for markdown insight cards.",
-          "title": "Type",
+        "markdown_content": {
+          "description": "The markdown formatted text content.",
+          "maxLength": 100000,
+          "title": "Markdown Content",
           "type": "string"
         }
       },
@@ -8064,6 +8063,34 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the non-monotonic\ncollapse of a high-entropy human natural language string into a discrete, mathematically\nbounded routing heuristic. As a ...Receipt suffix, this is an append-only Merkle-DAG coordinate.\n\nCAUSAL AFFORDANCE: Commits the LLM's Softmax classification verdict to the Epistemic Ledger,\nauthorizing the TaxonomicRoutingPolicy or router gate to physically execute the targeted\ntopology or sub-agent.\n\nEPISTEMIC BOUNDS: The raw_input_string is physically clamped (max_length=100000) to prevent\ncontext window buffer overflows. The classification confidence is strictly bound to a\nnormalized float (ge=0.0, le=1.0).\n\nMCP ROUTING TRIGGERS: Intent Classification, Softmax Gating, High-Entropy Parsing,\nRouting Heuristic, Semantic Wave Collapse",
       "properties": {
+        "event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "intent_classification",
+          "default": "intent_classification",
+          "description": "Discriminator type for an intent classification receipt.",
+          "title": "Type",
+          "type": "string"
+        },
+        "raw_input_string": {
+          "description": "The raw, unparsed human natural language instruction.",
+          "maxLength": 100000,
+          "title": "Raw Input String",
+          "type": "string"
+        },
         "classified_intent": {
           "description": "The discrete, structurally bounded capability or heuristic mapped by the LLM.",
           "maxLength": 255,
@@ -8076,20 +8103,6 @@
           "minimum": 0.0,
           "title": "Confidence Score",
           "type": "number"
-        },
-        "event_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Event Id",
-          "type": "string"
-        },
-        "raw_input_string": {
-          "description": "The raw, unparsed human natural language instruction.",
-          "maxLength": 100000,
-          "title": "Raw Input String",
-          "type": "string"
         },
         "routing_policy_id": {
           "anyOf": [
@@ -8106,20 +8119,6 @@
           "default": null,
           "description": "The TaxonomicRoutingPolicy CID that governed this classification.",
           "title": "Routing Policy Id"
-        },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "type": {
-          "const": "intent_classification",
-          "default": "intent_classification",
-          "description": "Discriminator type for an intent classification receipt.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -8136,18 +8135,24 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Supervisory Control Theory (Ramadge & Wonham) for\nDiscrete-Event Systems, acting as a formal Mixed-Initiative Control mechanism. As an\n...Intent suffix, this represents an authorized kinetic trigger.\n\nCAUSAL AFFORDANCE: Physically halts the active Directed Acyclic Graph (DAG) traversal\nor Petri Net reachability loop, preventing the swarm from committing a state transition\nuntil an explicit, authorized Pearlian intervention is negotiated by the human supervisor.\n\nEPISTEMIC BOUNDS: Execution suspension is rigorously bounded by the temporal logic of\nthe adjudication_deadline (a float representing a UNIX timestamp) and the attached\nFallbackSLA. If the temporal limit expires, the orchestrator mechanically breaks the\nhalt via the timeout_action to solve the Halting Problem and guarantee systemic liveness.\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, Mixed-Initiative System,\nDiscrete-Event System, Bounded Delay, Pearlian Intervention",
       "properties": {
-        "adjudication_deadline": {
-          "description": "The deadline for adjudication, represented as a UNIX timestamp.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Adjudication Deadline",
-          "type": "number"
-        },
-        "context_summary": {
-          "description": "A summary of the context requiring intervention.",
-          "maxLength": 2000,
-          "title": "Context Summary",
+        "type": {
+          "const": "request",
+          "default": "request",
+          "description": "The type of the intervention payload.",
+          "title": "Type",
           "type": "string"
+        },
+        "intervention_scope": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundedInterventionScopePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The scope constraints bounding the intervention."
         },
         "fallback_sla": {
           "anyOf": [
@@ -8161,17 +8166,15 @@
           "default": null,
           "description": "The SLA constraints on the intervention delay."
         },
-        "intervention_scope": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/BoundedInterventionScopePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The scope constraints bounding the intervention."
+        "target_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The ID of the target node."
+        },
+        "context_summary": {
+          "description": "A summary of the context requiring intervention.",
+          "maxLength": 2000,
+          "title": "Context Summary",
+          "type": "string"
         },
         "proposed_action": {
           "additionalProperties": {
@@ -8201,16 +8204,12 @@
           "title": "Proposed Action",
           "type": "object"
         },
-        "target_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the target node."
-        },
-        "type": {
-          "const": "request",
-          "default": "request",
-          "description": "The type of the intervention payload.",
-          "title": "Type",
-          "type": "string"
+        "adjudication_deadline": {
+          "description": "The deadline for adjudication, represented as a UNIX timestamp.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Adjudication Deadline",
+          "type": "number"
         }
       },
       "required": [
@@ -8226,11 +8225,9 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Executes Supervisory Control Theory by embedding\ndeterministic execution hooks (transitions) into the swarm's Petri Net\nlifecycle graph. As a ...Policy suffix, this defines rigid mathematical\nboundaries.\n\nCAUSAL AFFORDANCE: Physically halts the autonomous execution loop (if blocking\nis True, default=True) at the exact topological trigger coordinate\n(LifecycleTriggerEvent), forcing the orchestrator to await an external\nInterventionReceipt before proceeding.\n\nEPISTEMIC BOUNDS: The interruption locus is rigidly confined to the\nLifecycleTriggerEvent literal automaton. The structural mutation permissions\nduring the pause are strictly governed by the optional scope\n(BoundedInterventionScopePolicy | None, default=None).\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, Petri Net Transition,\nLifecycle Hook, Execution Halting, Mixed-Initiative Interaction",
       "properties": {
-        "blocking": {
-          "default": true,
-          "description": "If True, the graph execution halts until a verdict is rendered. If False, it is an async observation.",
-          "title": "Blocking",
-          "type": "boolean"
+        "trigger": {
+          "$ref": "#/$defs/LifecycleTriggerEvent",
+          "description": "The exact topological lifecycle event that triggers this intervention."
         },
         "scope": {
           "anyOf": [
@@ -8244,9 +8241,11 @@
           "default": null,
           "description": "The strictly typed boundaries for what the human/oversight system is allowed to mutate during this pause."
         },
-        "trigger": {
-          "$ref": "#/$defs/LifecycleTriggerEvent",
-          "description": "The exact topological lifecycle event that triggers this intervention."
+        "blocking": {
+          "default": true,
+          "description": "If True, the graph execution halts until a verdict is rendered. If False, it is an async observation.",
+          "title": "Blocking",
+          "type": "boolean"
         }
       },
       "required": [
@@ -8259,22 +8258,27 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: InterventionReceipt is a cryptographically frozen historical fact representing\nthe resolution of a Mixed-Initiative pause. It acts as the mathematical key that unlocks a suspended\nstate partition.\n\nCAUSAL AFFORDANCE: Collapses the halted superposition of the DAG, physically re-activating the\nexecution thread and authorizing the orchestrator to commit the human-approved state mutation to\nthe Epistemic Ledger.\n\nEPISTEMIC BOUNDS: Mathematically locked against Replay Attacks via the intervention_request_id\n(a UUID cryptographic nonce). The @model_validator physically guarantees that if a WetwareAttestationContract\nis present, its internal DAG node nonce must perfectly match the request ID, preventing signature laundering.\n\nMCP ROUTING TRIGGERS: Cryptographic Nonce, State Resumption, Replay Attack Prevention, Wetware Attestation, Liveness Resolution",
       "properties": {
+        "type": {
+          "const": "verdict",
+          "default": "verdict",
+          "description": "The type of the intervention payload.",
+          "title": "Type",
+          "type": "string"
+        },
+        "intervention_request_id": {
+          "description": "The cryptographic nonce uniquely identifying the intervention request.",
+          "format": "uuid",
+          "title": "Intervention Request Id",
+          "type": "string"
+        },
+        "target_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The ID of the target node."
+        },
         "approved": {
           "description": "Indicates whether the proposed action was approved.",
           "title": "Approved",
           "type": "boolean"
-        },
-        "attestation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WetwareAttestationContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic proof provided by the human operator, if required."
         },
         "feedback": {
           "anyOf": [
@@ -8289,22 +8293,17 @@
           "description": "Optional feedback provided along with the verdict.",
           "title": "Feedback"
         },
-        "intervention_request_id": {
-          "description": "The cryptographic nonce uniquely identifying the intervention request.",
-          "format": "uuid",
-          "title": "Intervention Request Id",
-          "type": "string"
-        },
-        "target_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the target node."
-        },
-        "type": {
-          "const": "verdict",
-          "default": "verdict",
-          "description": "The type of the intervention payload.",
-          "title": "Type",
-          "type": "string"
+        "attestation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WetwareAttestationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic proof provided by the human operator, if required."
         }
       },
       "required": [
@@ -8320,30 +8319,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a formal Pearlian Do-Operator (P(y|do(X=x))) intervention, forcefully severing a variable from its historical back-door causal mechanisms to prove direct causal influence.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to physically mutate the intervention_variable to the do_operator_state, breaking confounding structural edges in the directed acyclic graph.\n\nEPISTEMIC BOUNDS: The physical mutation is economically capped by execution_cost_budget_magnitude (le=1000000000), and its justification is strictly quantified by expected_causal_information_gain (bounded mathematically between 0.0 and 1.0).\n\nMCP ROUTING TRIGGERS: Pearlian Do-Calculus, Structural Causal Models, Causal Intervention, Confounder Ablation, Back-door Criterion",
       "properties": {
-        "do_operator_state": {
-          "description": "The exact value or condition forced upon the intervention_variable, isolating it from its historical causes.",
-          "maxLength": 2000,
-          "title": "Do Operator State",
-          "type": "string"
-        },
-        "execution_cost_budget_magnitude": {
-          "description": "The maximum economic expenditure authorized to run this specific causal intervention.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Execution Cost Budget Magnitude",
-          "type": "integer"
-        },
-        "expected_causal_information_gain": {
-          "description": "The mathematical proof of entropy reduction yielded specifically by breaking the confounding back-doors.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Expected Causal Information Gain",
-          "type": "number"
-        },
-        "intervention_variable": {
-          "description": "The specific node $X$ in the SCM the agent is forcing to a specific state.",
-          "maxLength": 2000,
-          "title": "Intervention Variable",
+        "task_id": {
+          "description": "Unique identifier for this causal intervention.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Id",
           "type": "string"
         },
         "target_hypothesis_id": {
@@ -8354,13 +8335,31 @@
           "title": "Target Hypothesis Id",
           "type": "string"
         },
-        "task_id": {
-          "description": "Unique identifier for this causal intervention.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Id",
+        "intervention_variable": {
+          "description": "The specific node $X$ in the SCM the agent is forcing to a specific state.",
+          "maxLength": 2000,
+          "title": "Intervention Variable",
           "type": "string"
+        },
+        "do_operator_state": {
+          "description": "The exact value or condition forced upon the intervention_variable, isolating it from its historical causes.",
+          "maxLength": 2000,
+          "title": "Do Operator State",
+          "type": "string"
+        },
+        "expected_causal_information_gain": {
+          "description": "The mathematical proof of entropy reduction yielded specifically by breaking the confounding back-doors.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Expected Causal Information Gain",
+          "type": "number"
+        },
+        "execution_cost_budget_magnitude": {
+          "description": "The maximum economic expenditure authorized to run this specific causal intervention.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Execution Cost Budget Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -8378,6 +8377,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The definitive top-level envelope for transmitting a\nJSONRPCErrorState across a Zero-Trust Architecture boundary. As a ...State suffix,\nthis is a frozen N-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Concludes a failed Distributed RPC call via the error\n(JSONRPCErrorState) typed reference, forcing the orchestrator to sever the current\nexecution tree and apply necessary truth maintenance.\n\nEPISTEMIC BOUNDS: The jsonrpc field is a rigid Literal[\"2.0\"] automaton. The id is\ntopologically locked to a 128-char CID regex or an integer (le=1000000000) or None.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Distributed RPC, Execution Severing,\nTruth Maintenance, Fault Envelope",
       "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "description": "JSON-RPC version.",
+          "title": "Jsonrpc",
+          "type": "string"
+        },
         "error": {
           "$ref": "#/$defs/JSONRPCErrorState",
           "description": "The error object."
@@ -8405,12 +8410,6 @@
           "default": null,
           "description": "The request ID that this error corresponds to.",
           "title": "Id"
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "JSON-RPC version.",
-          "title": "Jsonrpc",
-          "type": "string"
         }
       },
       "required": [
@@ -8430,6 +8429,12 @@
           "title": "Code",
           "type": "integer"
         },
+        "message": {
+          "description": "The strict semantic fault boundary explaining the structural or execution collapse.",
+          "maxLength": 2000,
+          "title": "Message",
+          "type": "string"
+        },
         "data": {
           "anyOf": [
             {},
@@ -8440,12 +8445,6 @@
           "default": null,
           "description": "A Primitive or Structured value that contains additional information about the error.",
           "title": "Data"
-        },
-        "message": {
-          "description": "The strict semantic fault boundary explaining the structural or execution collapse.",
-          "maxLength": 2000,
-          "title": "Message",
-          "type": "string"
         }
       },
       "required": [
@@ -8519,13 +8518,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Optimal Stopping Theory and Simulated Annealing to\nmechanistically manage the Exploration-Exploitation dilemma during Test-Time\nCompute. As a ...Policy suffix, this defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Forces probability wave collapse by dynamically throttling\nthe sampling temperature toward the dynamic_temperature_asymptote (ge=0.0,\nle=1000000000.0) and physically halting lateral ThoughtBranch generation when\nthe forced_exploitation_threshold_ms is breached.\n\nEPISTEMIC BOUNDS: The decay geometry is strictly confined to the\nexploration_decay_curve Literal [\"linear\", \"exponential\", \"step\"]. Physical\ntemporal limits are hard-capped by forced_exploitation_threshold_ms (gt=0,\nle=86400000).\n\nMCP ROUTING TRIGGERS: Optimal Stopping Theory, Simulated Annealing, Probability\nWave Collapse, Exploration-Exploitation Dilemma, Kinetic Thermodynamics",
       "properties": {
-        "dynamic_temperature_asymptote": {
-          "description": "CoReason Shared Kernel Ontology: The absolute minimum sampling temperature the system must converge to during the final exploitation phase.",
-          "maximum": 1000000000.0,
-          "minimum": 0.0,
-          "title": "Dynamic Temperature Asymptote",
-          "type": "number"
-        },
         "exploration_decay_curve": {
           "description": "CoReason Shared Kernel Ontology: The mathematical function dictating how rapidly lateral ThoughtBranches are restricted over time.",
           "enum": [
@@ -8542,6 +8534,13 @@
           "maximum": 86400000,
           "title": "Forced Exploitation Threshold Ms",
           "type": "integer"
+        },
+        "dynamic_temperature_asymptote": {
+          "description": "CoReason Shared Kernel Ontology: The absolute minimum sampling temperature the system must converge to during the final exploitation phase.",
+          "maximum": 1000000000.0,
+          "minimum": 0.0,
+          "title": "Dynamic Temperature Asymptote",
+          "type": "number"
         }
       },
       "required": [
@@ -8556,13 +8555,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements strict Bipartite Graph Separation (Conflict\nGraphs) to mathematically prevent toxic capability combinations from co-existing\nwithin the same causal execution chain. As a ...Policy suffix, this enforces\nrigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Forces the orchestrator to perform an intersection check\nacross mutually_exclusive_clusters; if an overlap occurs, it mechanically\ntriggers the enforcement_action (e.g., halt_and_quarantine) to sever the\nchain.\n\nEPISTEMIC BOUNDS: The 2D matrix of string constraints (max_length=2000) is\nrigidly sorted both internally and externally by @model_validator sort_clusters,\nensuring deterministic RFC 8785 hashing. The enforcement_action is clamped to\na strict Finite State Machine Literal.\n\nMCP ROUTING TRIGGERS: Bipartite Graph Separation, Toxic Capability Quarantine,\nFinite State Machine, Structural Interlock, Conflict Graph",
       "properties": {
-        "enforcement_action": {
-          "description": "The deterministic action the orchestrator must take if a bipartite cycle is detected.",
-          "enum": [
-            "halt_and_quarantine",
-            "sever_causal_chain"
-          ],
-          "title": "Enforcement Action",
+        "policy_id": {
+          "description": "Unique identifier for this specific separation boundary.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Policy Id",
           "type": "string"
         },
         "mutually_exclusive_clusters": {
@@ -8577,12 +8575,13 @@
           "title": "Mutually Exclusive Clusters",
           "type": "array"
         },
-        "policy_id": {
-          "description": "Unique identifier for this specific separation boundary.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Policy Id",
+        "enforcement_action": {
+          "description": "The deterministic action the orchestrator must take if a bipartite cycle is detected.",
+          "enum": [
+            "halt_and_quarantine",
+            "sever_causal_chain"
+          ],
+          "title": "Enforcement Action",
           "type": "string"
         }
       },
@@ -8598,24 +8597,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as the kinetic trigger for Maximum Inner Product Search (MIPS)\nand k-Nearest Neighbors (k-NN) retrieval across high-dimensional semantic manifolds. As\nan ...Intent suffix, the LLM may execute non-monotonic reasoning here.\n\nCAUSAL AFFORDANCE: Forces the orchestrator's embedding engine to dynamically hydrate the\nworking context by fetching the top_k_candidates nearest to the synthetic_target_vector.\nOptionally embeds a TopologicalRetrievalContract for graph traversal bounds and a\nContextExpansionPolicy for post-retrieval merging.\n\nEPISTEMIC BOUNDS: Mathematically boundary-enforced by min_isometry_score (ge=-1.0,\nle=1.0) to automatically prune low-relevance hallucinations before they consume context\nwindow tokens. The top_k_candidates is strictly positive (gt=0).\n\nMCP ROUTING TRIGGERS: Maximum Inner Product Search, k-Nearest Neighbors, Latent Manifold\nProjection, Retrieval-Augmented Generation",
       "properties": {
-        "context_expansion": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ContextExpansionPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural rules governing context hydration."
-        },
-        "min_isometry_score": {
-          "description": "The minimum cosine similarity bounds for accepting a vector match.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Min Isometry Score",
-          "type": "number"
+        "type": {
+          "const": "latent_projection",
+          "default": "latent_projection",
+          "description": "Discriminator for RAG projection intent.",
+          "title": "Type",
+          "type": "string"
         },
         "synthetic_target_vector": {
           "$ref": "#/$defs/VectorEmbeddingState",
@@ -8626,6 +8613,13 @@
           "exclusiveMinimum": 0,
           "title": "Top K Candidates",
           "type": "integer"
+        },
+        "min_isometry_score": {
+          "description": "The minimum cosine similarity bounds for accepting a vector match.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Min Isometry Score",
+          "type": "number"
         },
         "topological_bounds": {
           "anyOf": [
@@ -8639,12 +8633,17 @@
           "default": null,
           "description": "The explicit graph traversal contract."
         },
-        "type": {
-          "const": "latent_projection",
-          "default": "latent_projection",
-          "description": "Discriminator for RAG projection intent.",
-          "title": "Type",
-          "type": "string"
+        "context_expansion": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContextExpansionPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural rules governing context hydration."
         }
       },
       "required": [
@@ -8659,25 +8658,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Authorizes Abductive Reasoning on intercepted unstructured byte streams\nor memory heaps to probabilistically derive a deterministic StateContract. As an ...Intent\nsuffix, the LLM may execute non-monotonic reasoning here.\n\nCAUSAL AFFORDANCE: Triggers the LLM's representation engineering engine to process a\nchaotic target_buffer_id and output a rigid JSON schema, bridging the gap between\nexogenous data and the structural Hollow Data Plane.\n\nEPISTEMIC BOUNDS: State-Space explosion is prevented by bounding max_schema_depth (le=10)\nand max_properties (le=1000) to mathematically prevent recursive JSON-bombing during\nschema generation. The target_buffer_id is locked to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Schema Inference, Memory Heap Parsing, Abductive Reasoning,\nXHR Interception, Unstructured Transmutation",
       "properties": {
-        "max_properties": {
-          "description": "The maximum allowed keys in the deduced JSON dictionary.",
-          "maximum": 1000,
-          "minimum": 1,
-          "title": "Max Properties",
-          "type": "integer"
-        },
-        "max_schema_depth": {
-          "description": "The maximum recursive depth of the probabilistically generated schema.",
-          "maximum": 10,
-          "minimum": 1,
-          "title": "Max Schema Depth",
-          "type": "integer"
-        },
-        "require_strict_validation": {
-          "default": true,
-          "description": "If True, forces the resulting schema to set additionalProperties=False.",
-          "title": "Require Strict Validation",
-          "type": "boolean"
+        "type": {
+          "const": "latent_schema_inference",
+          "default": "latent_schema_inference",
+          "description": "Discriminator for unstructured payload schema deduction.",
+          "title": "Type",
+          "type": "string"
         },
         "target_buffer_id": {
           "description": "The CID pointing to the TerminalBufferState or raw intercepted byte stream.",
@@ -8687,12 +8673,25 @@
           "title": "Target Buffer Id",
           "type": "string"
         },
-        "type": {
-          "const": "latent_schema_inference",
-          "default": "latent_schema_inference",
-          "description": "Discriminator for unstructured payload schema deduction.",
-          "title": "Type",
-          "type": "string"
+        "max_schema_depth": {
+          "description": "The maximum recursive depth of the probabilistically generated schema.",
+          "maximum": 10,
+          "minimum": 1,
+          "title": "Max Schema Depth",
+          "type": "integer"
+        },
+        "max_properties": {
+          "description": "The maximum allowed keys in the deduced JSON dictionary.",
+          "maximum": 1000,
+          "minimum": 1,
+          "title": "Max Properties",
+          "type": "integer"
+        },
+        "require_strict_validation": {
+          "default": true,
+          "description": "If True, forces the resulting schema to set additionalProperties=False.",
+          "title": "Require Strict Validation",
+          "type": "boolean"
         }
       },
       "required": [
@@ -8707,6 +8706,22 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An append-only, cryptographically frozen coordinate representing an\nEphemeral Epistemic Quarantine used for Monte Carlo Tree Search (MCTS) or Beam Search.\nAs a ...Receipt suffix, this is an append-only coordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Isolates exploratory trajectories (ThoughtBranchState) from the\nimmutable EpistemicLedgerState, allowing the orchestrator to collapse probability waves\n(via resolution_branch_id) and prune dead-ends without causal contamination.\n\nEPISTEMIC BOUNDS: Two @model_validators enforce integrity: (1) verify_referential_\nintegrity confirms resolution_branch_id and all discarded_branches exist within\nexplored_branches; (2) sort_arrays deterministically sorts both explored_branches\n(by branch_id) and discarded_branches for RFC 8785 Canonical Hashing.\ntotal_latent_tokens is hard-capped (ge=0, le=1000000000).\n\nMCP ROUTING TRIGGERS: Monte Carlo Tree Search, Beam Search, Epistemic Quarantine,\nProbability Wave Collapse, State-Space Exploration",
       "properties": {
+        "trace_id": {
+          "description": "A Content Identifier (CID) bounding this ephemeral test-time execution tree.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Trace Id",
+          "type": "string"
+        },
+        "explored_branches": {
+          "description": "All logical paths the agent attempted within this Ephemeral Epistemic Quarantine—a volatile workspace where probability waves collapse before being committed to the immutable ledger.",
+          "items": {
+            "$ref": "#/$defs/ThoughtBranchState"
+          },
+          "title": "Explored Branches",
+          "type": "array"
+        },
         "discarded_branches": {
           "description": "The strict array of Content Identifiers (CIDs) that were explicitly pruned due to logical dead-ends.",
           "items": {
@@ -8715,14 +8730,6 @@
             "type": "string"
           },
           "title": "Discarded Branches",
-          "type": "array"
-        },
-        "explored_branches": {
-          "description": "All logical paths the agent attempted within this Ephemeral Epistemic Quarantine\u2014a volatile workspace where probability waves collapse before being committed to the immutable ledger.",
-          "items": {
-            "$ref": "#/$defs/ThoughtBranchState"
-          },
-          "title": "Explored Branches",
           "type": "array"
         },
         "resolution_branch_id": {
@@ -8747,14 +8754,6 @@
           "minimum": 0,
           "title": "Total Latent Tokens",
           "type": "integer"
-        },
-        "trace_id": {
-          "description": "A Content Identifier (CID) bounding this ephemeral test-time execution tree.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Trace Id",
-          "type": "string"
         }
       },
       "required": [
@@ -8780,6 +8779,13 @@
           "title": "Decay Function",
           "type": "string"
         },
+        "transition_window_tokens": {
+          "description": "The exact number of forward-pass generation steps over which the decay is applied.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Transition Window Tokens",
+          "type": "integer"
+        },
         "decay_rate_param": {
           "anyOf": [
             {
@@ -8793,13 +8799,6 @@
           "default": null,
           "description": "The optional tuning parameter (e.g., half-life lambda for exponential decay).",
           "title": "Decay Rate Param"
-        },
-        "transition_window_tokens": {
-          "description": "The exact number of forward-pass generation steps over which the decay is applied.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Transition Window Tokens",
-          "type": "integer"
         }
       },
       "required": [
@@ -8824,6 +8823,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Cryptographic Watermarking and Homomorphic MAC frameworks to mathematically seal the chain of custody against laundering, obfuscation, or Byzantine tampering. As a ...Receipt suffix, this is an append-only coordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Enforces a zero-trust execution perimeter by forcing participating agents to append their deterministic execution signatures to the hop_signatures matrix, verifying non-repudiation before advancing the graph.\n\nEPISTEMIC BOUNDS: The mathematical sealing mechanism is strictly constrained by the watermark_protocol Literal automaton [\"merkle_dag\", \"statistical_token\", \"homomorphic_mac\"]. The hop_signatures dictionary keys and values are physically bounded by StringConstraints to prevent memory exhaustion during serialization.\n\nMCP ROUTING TRIGGERS: Cryptographic Watermarking, Homomorphic MAC, Byzantine Fault Detection, Zero-Trust Lineage, Chain of Custody",
       "properties": {
+        "watermark_protocol": {
+          "description": "The mathematical methodology used to embed the chain of custody.",
+          "enum": [
+            "merkle_dag",
+            "statistical_token",
+            "homomorphic_mac"
+          ],
+          "title": "Watermark Protocol",
+          "type": "string"
+        },
         "hop_signatures": {
           "additionalProperties": {
             "maxLength": 2000,
@@ -8842,16 +8851,6 @@
           "maxLength": 2000,
           "title": "Tamper Evident Root",
           "type": "string"
-        },
-        "watermark_protocol": {
-          "description": "The mathematical methodology used to embed the chain of custody.",
-          "enum": [
-            "merkle_dag",
-            "statistical_token",
-            "homomorphic_mac"
-          ],
-          "title": "Watermark Protocol",
-          "type": "string"
         }
       },
       "required": [
@@ -8866,9 +8865,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a purely out-of-band semantic logging vector, structurally\nisolated from the rigorous causal constraints of the Dapper trace tree. As an ...Event\nsuffix, this is an append-only historical fact.\n\nCAUSAL AFFORDANCE: Emits asynchronous telemetry for human-in-the-loop debugging or\nperipheral auditing without mutating the active Epistemic Ledger's topological state.\n\nEPISTEMIC BOUNDS: Temporal reality is clamped by timestamp (ge=0.0,\nle=253402300799.0, float seconds). The severity level is strictly masked by a Literal\nautomaton [\"DEBUG\", \"INFO\", \"WARNING\", \"ERROR\", \"CRITICAL\"]. The message is bounded\nto max_length=2000. Recursive depth is constrained via TelemetryContextProfile.\n\nMCP ROUTING TRIGGERS: Out-of-Band Telemetry, Asynchronous Logging, Severity Masking,\nPeripheral Audit, Ephemeral Context",
       "properties": {
-        "context_profile": {
-          "$ref": "#/$defs/TelemetryContextProfile",
-          "description": "Contextual key-value metadata associated with the event."
+        "timestamp": {
+          "description": "The UNIX timestamp of the log event.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
         },
         "level": {
           "description": "The severity level of the log event.",
@@ -8888,12 +8890,9 @@
           "title": "Message",
           "type": "string"
         },
-        "timestamp": {
-          "description": "The UNIX timestamp of the log event.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
+        "context_profile": {
+          "$ref": "#/$defs/TelemetryContextProfile",
+          "description": "Contextual key-value metadata associated with the event."
         }
       },
       "required": [
@@ -8908,12 +8907,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographic mandate for neural watermarking. Uses a Pseudo-Random\nFunction (PRF) seeded by previous token context to deterministically split the vocabulary\ninto \"green\" and \"red\" lists during Gumbel-Softmax sampling. As a ...Contract suffix, this\nobject defines rigid mathematical boundaries that the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Physically manipulates the LLM's residual stream logit distribution\njust before the final softmax activation, embedding an undeniable, high-entropy Shannon\ninformation signature directly into the generated text without degrading model perplexity.\n\nEPISTEMIC BOUNDS: The injection is mathematically clamped by watermark_strength_delta\n(gt=0.0, le=1.0) to prevent logit explosion. Resistance to cropping attacks is\ngeometrically enforced by context_history_window (ge=0, le=1000000000). The information\ndensity is bounded by target_bits_per_token (gt=0.0, le=1000000000.0).\n\nMCP ROUTING TRIGGERS: Logit Steganography, Gumbel-Softmax Watermarking, Pseudo-Random\nFunction, Shannon Entropy, Provenance Tracking",
       "properties": {
-        "context_history_window": {
-          "description": "The k-gram rolling window size of preceding tokens hashed into the PRF state to ensure robustness against text cropping.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Context History Window",
-          "type": "integer"
+        "verification_public_key_id": {
+          "description": "The DID or public key identifier required by an auditor to reconstruct the PRF and verify the watermark.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Verification Public Key Id",
+          "type": "string"
         },
         "prf_seed_hash": {
           "description": "The SHA-256 hash of the cryptographic seed used to initialize the pseudo-random function (PRF).",
@@ -8923,6 +8923,13 @@
           "title": "Prf Seed Hash",
           "type": "string"
         },
+        "watermark_strength_delta": {
+          "description": "The exact logit scalar (bias) injected into the 'green list' vocabulary partition before Gumbel-Softmax sampling.",
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "title": "Watermark Strength Delta",
+          "type": "number"
+        },
         "target_bits_per_token": {
           "description": "The information-theoretic density of the payload being embedded into the generative stream.",
           "exclusiveMinimum": 0.0,
@@ -8930,20 +8937,12 @@
           "title": "Target Bits Per Token",
           "type": "number"
         },
-        "verification_public_key_id": {
-          "description": "The DID or public key identifier required by an auditor to reconstruct the PRF and verify the watermark.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Verification Public Key Id",
-          "type": "string"
-        },
-        "watermark_strength_delta": {
-          "description": "The exact logit scalar (bias) injected into the 'green list' vocabulary partition before Gumbel-Softmax sampling.",
-          "exclusiveMinimum": 0.0,
-          "maximum": 1.0,
-          "title": "Watermark Strength Delta",
-          "type": "number"
+        "context_history_window": {
+          "description": "The k-gram rolling window size of preceding tokens hashed into the PRF state to ensure robustness against text cropping.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Context History Window",
+          "type": "integer"
         }
       },
       "required": [
@@ -8960,13 +8959,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a Lattice-Based Access Control (LBAC) and Zero-Trust\nArchitecture perimeter, restricting JSON-RPC capability mounts from foreign subgraphs.\nAs a ...Policy suffix, this object defines rigid mathematical boundaries that the\norchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Acts as a structural firewall that physically prevents the\norchestrator from binding unauthorized external tools, resources, or prompts into the\nactive agent's ActionSpaceManifest.\n\nEPISTEMIC BOUNDS: The boundary is geometrically enforced via StringConstraints\n(max_length=2000 for allowed_tools, allowed_resources, allowed_prompts;\nmax_length=255 for required_licenses). The @model_validator strictly sorts all four\narrays alphabetically to mathematically guarantee RFC 8785 Canonical Hashing.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Lattice-Based Access Control, Least\nPrivilege, RPC Firewall, Bipartite Partitioning",
       "properties": {
-        "allowed_prompts": {
-          "description": "The explicit whitelist of workflow templates the node is allowed to trigger.",
+        "allowed_tools": {
+          "description": "The explicit whitelist of function names the node is allowed to call.",
           "items": {
             "maxLength": 2000,
             "type": "string"
           },
-          "title": "Allowed Prompts",
+          "title": "Allowed Tools",
           "type": "array"
         },
         "allowed_resources": {
@@ -8978,13 +8977,13 @@
           "title": "Allowed Resources",
           "type": "array"
         },
-        "allowed_tools": {
-          "description": "The explicit whitelist of function names the node is allowed to call.",
+        "allowed_prompts": {
+          "description": "The explicit whitelist of workflow templates the node is allowed to trigger.",
           "items": {
             "maxLength": 2000,
             "type": "string"
           },
-          "title": "Allowed Tools",
+          "title": "Allowed Prompts",
           "type": "array"
         },
         "required_licenses": {
@@ -9004,6 +9003,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a Bipartite Graph Projection, mathematically binding a\ndecentralized agent node to the remote or local capabilities exposed by a specific\nModel Context Protocol (MCP) server. As a ...Profile suffix, this is a declarative\nproperty descriptor.\n\nCAUSAL AFFORDANCE: Projects the external MCP server's affordance matrix into the\nagent's local working memory, allowing authorized JSON-RPC intents to traverse the\nspecified transport_type (MCPTransportProtocolProfile Literal). The server_uri\n(max_length=2000) anchors the connection.\n\nEPISTEMIC BOUNDS: The optional allowed_mcp_tools (list[str] | None, default=None,\nstring max_length=2000) is deterministically alphabetized by @model_validator\nsort_arrays for RFC 8785 canonical hashing when not None.\n\nMCP ROUTING TRIGGERS: Bipartite Graph Projection, Capability Binding, Model\nContext Protocol, RFC 8785 Canonicalization, Zero-Trust RPC",
       "properties": {
+        "server_uri": {
+          "description": "The URI or command path to the MCP server.",
+          "maxLength": 2000,
+          "title": "Server Uri",
+          "type": "string"
+        },
+        "transport_type": {
+          "$ref": "#/$defs/MCPTransportProtocolProfile",
+          "description": "The transport protocol used to communicate with the MCP server."
+        },
         "allowed_mcp_tools": {
           "anyOf": [
             {
@@ -9020,16 +9029,6 @@
           "default": null,
           "description": "An explicit whitelist of tools the agent is allowed to invoke from this server. If None, all discovered tools are allowed.",
           "title": "Allowed Mcp Tools"
-        },
-        "server_uri": {
-          "description": "The URI or command path to the MCP server.",
-          "maxLength": 2000,
-          "title": "Server Uri",
-          "type": "string"
-        },
-        "transport_type": {
-          "$ref": "#/$defs/MCPTransportProtocolProfile",
-          "description": "The transport protocol used to communicate with the MCP server."
         }
       },
       "required": [
@@ -9043,30 +9042,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An inherited JSON-RPC 2.0 substrate specifically binding Model\nContext Protocol (MCP) client intent emissions to the frontend UI. As an ...Intent\nsuffix, this represents an authorized kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Executes an exact semantic signal (Literal[\"mcp.ui.emit_intent\"])\nto bubble internal agent states (like drafting or adjudication) to the human\noperator.\n\nEPISTEMIC BOUNDS: Inherits all recursive depth bounds from BoundedJSONRPCIntent and\nmathematically clamps the method space to a singular Literal[\"mcp.ui.emit_intent\"]\nto prevent execution drift.\n\nMCP ROUTING TRIGGERS: Model Context Protocol, Intent Bubbling, Human-in-the-Loop,\nSemantic Signaling, Method Clamping",
       "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "anyOf": [
-                {
-                  "maxLength": 128,
-                  "minLength": 1,
-                  "pattern": "^[a-zA-Z0-9_.:-]+$",
-                  "type": "string"
-                },
-                {
-                  "type": "integer"
-                }
-              ],
-              "le": 1000000000
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Unique request identifier.",
-          "title": "Id"
-        },
         "jsonrpc": {
           "const": "2.0",
           "description": "JSON-RPC version.",
@@ -9097,6 +9072,30 @@
           "default": null,
           "description": "Payload parameters.",
           "title": "Params"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "anyOf": [
+                {
+                  "maxLength": 128,
+                  "minLength": 1,
+                  "pattern": "^[a-zA-Z0-9_.:-]+$",
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ],
+              "le": 1000000000
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Unique request identifier.",
+          "title": "Id"
         }
       },
       "required": [
@@ -9110,6 +9109,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a Higher-Order Function within the Model Context Protocol, mapping\na dynamic Latent Prompt Manifold into the agent's execution context.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to fetch and interpolate an exogenous prompt\ntemplate from a remote server, using the arguments dictionary to inject localized state into the template.\n\nEPISTEMIC BOUNDS: Supply-chain execution attacks are mathematically mitigated by the optional\nprompt_hash (strictly matching SHA-256 pattern ^[a-f0-9]{64}$). The arguments matrix is physically\ncapped at max_length=1000000000 (with keys at max_length=255) to prevent OOM faults during interpolation.\nThe optional fallback_persona is bounded to max_length=2000.\n\nMCP ROUTING TRIGGERS: Higher-Order Function, Latent Prompt Manifold, Template Interpolation, Supply-Chain Verification, Stateless RPC",
       "properties": {
+        "server_id": {
+          "description": "The ID of the MCP server providing this prompt.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Server Id",
+          "type": "string"
+        },
+        "prompt_name": {
+          "description": "The name of the prompt template.",
+          "maxLength": 2000,
+          "title": "Prompt Name",
+          "type": "string"
+        },
         "arguments": {
           "additionalProperties": true,
           "description": "Arguments to fill the prompt template.",
@@ -9149,20 +9162,6 @@
           "default": null,
           "description": "Cryptographic hash for prompt integrity verification.",
           "title": "Prompt Hash"
-        },
-        "prompt_name": {
-          "description": "The name of the prompt template.",
-          "maxLength": 2000,
-          "title": "Prompt Name",
-          "type": "string"
-        },
-        "server_id": {
-          "description": "The ID of the MCP server providing this prompt.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Server Id",
-          "type": "string"
         }
       },
       "required": [
@@ -9204,15 +9203,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a Distributed RPC substrate and Lattice-Based Access\nControl (LBAC) boundary for integrating exogenous Model Context Protocol instances\nas a frozen geometric snapshot. As a ...Profile suffix, this is a declarative\nproperty descriptor.\n\nCAUSAL AFFORDANCE: Physically wires an external semantic manifold into the local\norchestrator's routing graph via the transport (MCPTransportProfile, discriminated\nunion) vector. The server_id (128-char CID) anchors the binding.\n\nEPISTEMIC BOUNDS: The capabilities allowed across the wire are geometrically bounded\nby required_capabilities (max_length=255 strings, default=[\"tools\", \"resources\",\n\"prompts\"]), strictly alphabetized by @model_validator sort_arrays for RFC 8785\ncanonical hashing.\n\nMCP ROUTING TRIGGERS: Distributed RPC, Lattice-Based Access Control, Stateless\nTransport, Capability Projection, Bipartite Graph",
       "properties": {
-        "required_capabilities": {
-          "description": "The structurally bounded array of capabilities mandated for this server connection.",
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "title": "Required Capabilities",
-          "type": "array"
-        },
         "server_id": {
           "description": "A unique identifier for this server instance.",
           "maxLength": 128,
@@ -9237,6 +9227,15 @@
             }
           ],
           "title": "Transport"
+        },
+        "required_capabilities": {
+          "description": "The structurally bounded array of capabilities mandated for this server connection.",
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "title": "Required Capabilities",
+          "type": "array"
         }
       },
       "required": [
@@ -9250,8 +9249,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a cryptographically verifiable Distributed RPC substrate\nmapping, binding an external Model Context Protocol (MCP) manifold into the swarm's\nlocal topology. As a ...Manifest suffix, this defines a frozen, declarative state\nprojection.\n\nCAUSAL AFFORDANCE: Authorizes the physical connection to an exogenous compute node\nover specific transport_type vectors (Literal [\"stdio\", \"sse\", \"http\"]), provided the\ncapability_whitelist (MCPCapabilityWhitelistPolicy) and mandatory attestation_receipt\nconstraints are fully satisfied.\n\nEPISTEMIC BOUNDS: Supply-chain execution attacks are mitigated by the optional\nbinary_hash (strictly matching SHA-256 pattern ^[a-f0-9]{64}$). A @model_validator\nstructurally enforces that the presented Verifiable Credential is signed by a valid\ndid:coreason: authority, emitting a QuarantineIntent upon failure.\n\nMCP ROUTING TRIGGERS: Distributed RPC, Capability-Based Security, Remote Procedure\nCall, Transport Layer, Verifiable Credential",
       "properties": {
-        "attestation_receipt": {
-          "$ref": "#/$defs/VerifiableCredentialPresentationReceipt"
+        "server_uri": {
+          "description": "The network URI for SSE/HTTP, or the command execution string for stdio.",
+          "maxLength": 2000,
+          "title": "Server Uri",
+          "type": "string"
+        },
+        "transport_type": {
+          "description": "The physical transport layer protocol used to stream the JSON-RPC packets.",
+          "enum": [
+            "stdio",
+            "sse",
+            "http"
+          ],
+          "title": "Transport Type",
+          "type": "string"
         },
         "binary_hash": {
           "anyOf": [
@@ -9273,21 +9285,8 @@
           "$ref": "#/$defs/MCPCapabilityWhitelistPolicy",
           "description": "The strict capability bounds enforced by the orchestrator prior to connection."
         },
-        "server_uri": {
-          "description": "The network URI for SSE/HTTP, or the command execution string for stdio.",
-          "maxLength": 2000,
-          "title": "Server Uri",
-          "type": "string"
-        },
-        "transport_type": {
-          "description": "The physical transport layer protocol used to stream the JSON-RPC packets.",
-          "enum": [
-            "stdio",
-            "sse",
-            "http"
-          ],
-          "title": "Transport Type",
-          "type": "string"
+        "attestation_receipt": {
+          "$ref": "#/$defs/VerifiableCredentialPresentationReceipt"
         }
       },
       "required": [
@@ -9382,6 +9381,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents the definitive collapse of the LMSR market superposition into a crystallized `payout_distribution` using Strictly Proper Scoring Rules (e.g., Brier scores).\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to definitively allocate compute magnitudes to the `winning_hypothesis_id` and flush `falsified_hypothesis_ids` from the active context via a Defeasible Cascade.\n\nEPISTEMIC BOUNDS: Enforces a strictly bounded `payout_distribution` dictionary mapping W3C DIDs to non-negative integers (`ge=0`), with deterministic RFC 8785 array sorting applied to the falsified hypotheses.\n\nMCP ROUTING TRIGGERS: Brier Scoring, Market Settlement, Probability Wave Collapse, Truth Crystallization",
       "properties": {
+        "market_id": {
+          "description": "The ID of the prediction market.",
+          "le": 1000000000,
+          "minLength": 1,
+          "title": "Market Id",
+          "type": "string"
+        },
+        "winning_hypothesis_id": {
+          "description": "The hypothesis ID that was verified.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Winning Hypothesis Id",
+          "type": "string"
+        },
         "falsified_hypothesis_ids": {
           "description": "The hypothesis IDs that were falsified.",
           "items": {
@@ -9392,13 +9406,6 @@
           "maxItems": 1000000000,
           "title": "Falsified Hypothesis Ids",
           "type": "array"
-        },
-        "market_id": {
-          "description": "The ID of the prediction market.",
-          "le": 1000000000,
-          "minLength": 1,
-          "title": "Market Id",
-          "type": "string"
         },
         "payout_distribution": {
           "additionalProperties": {
@@ -9411,14 +9418,6 @@
           },
           "title": "Payout Distribution",
           "type": "object"
-        },
-        "winning_hypothesis_id": {
-          "description": "The hypothesis ID that was verified.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Winning Hypothesis Id",
-          "type": "string"
         }
       },
       "required": [
@@ -9434,29 +9433,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a rigorous Mechanistic Interpretability brain-scan\nprotocol, executing real-time latent state extraction across targeted neural\ncircuits. As a ...Contract suffix, this defines rigid boundaries the orchestrator\nmust enforce globally.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to halt token generation upon\nspecific trigger_conditions Literal [\"on_tool_call\", \"on_belief_mutation\",\n\"on_quarantine\", \"on_falsification\"] to physically slice, quantify, and export\nthe top-k SAE features from the designated target_layers.\n\nEPISTEMIC BOUNDS: GPU VRAM exhaustion is mathematically prevented by capping\nmax_features_per_layer (gt=0, le=1000000000). The @model_validator sort_arrays\ndeterministically sorts both trigger_conditions and target_layers for RFC 8785\ncanonical hashing. System integrity is enforced via require_zk_commitments\n(default=True) to prevent activation spoofing.\n\nMCP ROUTING TRIGGERS: Latent State Extraction, Mechanistic Interpretability, Sparse\nAutoencoder, Zero-Knowledge Commitments, VRAM Optimization",
       "properties": {
-        "max_features_per_layer": {
-          "description": "The top-k features to extract, preventing VRAM exhaustion.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Max Features Per Layer",
-          "type": "integer"
-        },
-        "require_zk_commitments": {
-          "default": true,
-          "description": "If True, the orchestrator MUST generate cryptographic latent state proofs alongside the activation extractions.",
-          "title": "Require Zk Commitments",
-          "type": "boolean"
-        },
-        "target_layers": {
-          "description": "The specific transformer block indices the execution engine must extract from.",
-          "items": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "minItems": 1,
-          "title": "Target Layers",
-          "type": "array"
-        },
         "trigger_conditions": {
           "description": "The specific architectural events that authorize the orchestrator to halt generation and extract internal activations.",
           "items": {
@@ -9471,6 +9447,29 @@
           "minItems": 1,
           "title": "Trigger Conditions",
           "type": "array"
+        },
+        "target_layers": {
+          "description": "The specific transformer block indices the execution engine must extract from.",
+          "items": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "minItems": 1,
+          "title": "Target Layers",
+          "type": "array"
+        },
+        "max_features_per_layer": {
+          "description": "The top-k features to extract, preventing VRAM exhaustion.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Max Features Per Layer",
+          "type": "integer"
+        },
+        "require_zk_commitments": {
+          "default": true,
+          "description": "If True, the orchestrator MUST generate cryptographic latent state proofs alongside the activation extractions.",
+          "title": "Require Zk Commitments",
+          "type": "boolean"
         }
       },
       "required": [
@@ -9485,6 +9484,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Dynamic Programming principles to create a passive,\ncryptographic structural interlock pointing to a historically executed and verified\ngraph branch. As a ...Profile suffix, this is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Bypasses redundant thermodynamic compute expenditure by\ncollapsing an entire sub-DAG execution into a single, O(1) state retrieval\nkeyed by the target_topology_hash (TopologyHashReceipt).\n\nEPISTEMIC BOUNDS: The cache-hit is mathematically locked to the exact\ntarget_topology_hash (TopologyHashReceipt), guaranteeing perfect graph\nisomorphism. The retrieved payload is physically constrained by\nexpected_output_schema (dict, max_length=1000000000). The type discriminator is\nlocked to Literal[\"memoized\"].\n\nMCP ROUTING TRIGGERS: Dynamic Programming, O(1) Retrieval, Cryptographic Cache,\nGraph Isomorphism, Compute Conservation",
       "properties": {
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -9499,11 +9504,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -9522,6 +9543,17 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
           "title": "Domain Extensions"
         },
+        "type": {
+          "const": "memoized",
+          "default": "memoized",
+          "description": "Discriminator for a Memoized node.",
+          "title": "Type",
+          "type": "string"
+        },
+        "target_topology_hash": {
+          "$ref": "#/$defs/TopologyHashReceipt",
+          "description": "The exact SHA-256 fingerprint of the executed topology."
+        },
         "expected_output_schema": {
           "additionalProperties": true,
           "description": "The strictly typed JSON Schema expected from the cached payload.",
@@ -9531,39 +9563,6 @@
           },
           "title": "Expected Output Schema",
           "type": "object"
-        },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
-        },
-        "target_topology_hash": {
-          "$ref": "#/$defs/TopologyHashReceipt",
-          "description": "The exact SHA-256 fingerprint of the executed topology."
-        },
-        "type": {
-          "const": "memoized",
-          "default": "memoized",
-          "description": "Discriminator for a Memoized node.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -9586,14 +9585,17 @@
           "title": "Contract Id",
           "type": "string"
         },
-        "dropped_paths": {
-          "description": "Explicit whitelist of JSON Pointers that are safely deprecated and intentionally dropped during migration.",
-          "items": {
-            "maxLength": 2000,
-            "type": "string"
-          },
-          "title": "Dropped Paths",
-          "type": "array"
+        "source_version": {
+          "description": "The exact semantic version string of the payload before migration.",
+          "maxLength": 2000,
+          "title": "Source Version",
+          "type": "string"
+        },
+        "target_version": {
+          "description": "The exact semantic version string of the payload after migration.",
+          "maxLength": 2000,
+          "title": "Target Version",
+          "type": "string"
         },
         "path_transformations": {
           "additionalProperties": {
@@ -9608,17 +9610,14 @@
           "title": "Path Transformations",
           "type": "object"
         },
-        "source_version": {
-          "description": "The exact semantic version string of the payload before migration.",
-          "maxLength": 2000,
-          "title": "Source Version",
-          "type": "string"
-        },
-        "target_version": {
-          "description": "The exact semantic version string of the payload after migration.",
-          "maxLength": 2000,
-          "title": "Target Version",
-          "type": "string"
+        "dropped_paths": {
+          "description": "Explicit whitelist of JSON Pointers that are safely deprecated and intentionally dropped during migration.",
+          "items": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "title": "Dropped Paths",
+          "type": "array"
         }
       },
       "required": [
@@ -9641,18 +9640,18 @@
           "title": "Artifact Id",
           "type": "string"
         },
+        "mime_type": {
+          "description": "Strict MIME typing of the source artifact (e.g., 'application/pdf').",
+          "maxLength": 2000,
+          "title": "Mime Type",
+          "type": "string"
+        },
         "byte_stream_hash": {
           "description": "The undeniable SHA-256 hash of the pre-transmutation byte stream.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-f0-9]{64}$",
           "title": "Byte Stream Hash",
-          "type": "string"
-        },
-        "mime_type": {
-          "description": "Strict MIME typing of the source artifact (e.g., 'application/pdf').",
-          "maxLength": 2000,
-          "title": "Mime Type",
           "type": "string"
         },
         "temporal_ingest_timestamp": {
@@ -9676,26 +9675,45 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates cross-modal coordinate geometry by mapping 1D\nsequential token spaces (LLMs) to 2D continuous spatial patches\n(Vision-Language Models). As a ...State suffix, this is a declarative, frozen\nsnapshot.\n\nCAUSAL AFFORDANCE: Physically anchors extracted neurosymbolic concepts directly\nto verifiable visual and textual evidence, locking them via block_type\nclassification and visual_patch_hashes arrays.\n\nEPISTEMIC BOUNDS: Token sequences (token_span_start, token_span_end) are\nmathematically bounded 1D limits (ge=0, le=1000000000) constrained by\n@model_validator validate_token_spans to be monotonically increasing. Spatial\ngeometries (bounding_box) enforce normalized Cartesian invariants via\nvalidate_spatial_geometry. Arrays are sorted via sort_arrays.\n\nMCP ROUTING TRIGGERS: Vision-Language Alignment, 1D-2D Projection, VQ-VAE\nSpatial Tracking, Geometric Affine Transforms, Coordinate Bounding",
       "properties": {
-        "block_type": {
+        "token_span_start": {
           "anyOf": [
             {
-              "enum": [
-                "paragraph",
-                "table",
-                "figure",
-                "footnote",
-                "header",
-                "equation"
-              ],
-              "type": "string"
+              "maximum": 1000000000,
+              "minimum": 0,
+              "type": "integer"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The structural classification of the source region.",
-          "title": "Block Type"
+          "description": "The starting index in the discrete VLM context window.",
+          "title": "Token Span Start"
+        },
+        "token_span_end": {
+          "anyOf": [
+            {
+              "maximum": 1000000000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The ending index in the discrete VLM context window.",
+          "title": "Token Span End"
+        },
+        "visual_patch_hashes": {
+          "description": "The explicit array of SHA-256 hashes corresponding to specific VQ-VAE visual patches attended to.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Visual Patch Hashes",
+          "type": "array"
         },
         "bounding_box": {
           "anyOf": [
@@ -9726,45 +9744,26 @@
           "description": "The strictly typed [x_min, y_min, x_max, y_max] normalized coordinate matrix.",
           "title": "Bounding Box"
         },
-        "token_span_end": {
+        "block_type": {
           "anyOf": [
             {
-              "maximum": 1000000000,
-              "minimum": 0,
-              "type": "integer"
+              "enum": [
+                "paragraph",
+                "table",
+                "figure",
+                "footnote",
+                "header",
+                "equation"
+              ],
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The ending index in the discrete VLM context window.",
-          "title": "Token Span End"
-        },
-        "token_span_start": {
-          "anyOf": [
-            {
-              "maximum": 1000000000,
-              "minimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The starting index in the discrete VLM context window.",
-          "title": "Token Span Start"
-        },
-        "visual_patch_hashes": {
-          "description": "The explicit array of SHA-256 hashes corresponding to specific VQ-VAE visual patches attended to.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Visual Patch Hashes",
-          "type": "array"
+          "description": "The structural classification of the source region.",
+          "title": "Block Type"
         }
       },
       "title": "MultimodalTokenAnchorState",
@@ -9811,13 +9810,9 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Tensor Calculus and Differential Geometry representations\nto safely proxy high-dimensional latent structures across zero-trust network boundaries\nwithout transmitting raw, uncompressed bytes. As a ...Manifest suffix, this defines a\nfrozen, declarative coordinate.\n\nCAUSAL AFFORDANCE: Allows the orchestrator to route traffic and reserve exact physical\nGPU memory for massive tensors prior to downloading them via the storage_uri,\npreventing runtime out-of-memory (OOM) execution faults.\n\nEPISTEMIC BOUNDS: The @model_validator _enforce_physics_engine mathematically proves\nthat the topological shape exactly matches the declared vram_footprint_bytes limit\n(le=100000000000) based on the scalar structural_type byte density. Supply-chain\ntampering is physically prevented via the merkle_root SHA-256 requirement.\n\nMCP ROUTING TRIGGERS: Tensor Calculus, Differential Geometry, Merkle Tree Verification, Zero-Trust Computing, Memory Allocation",
       "properties": {
-        "merkle_root": {
-          "description": "SHA-256 Merkle root of the payload chunks.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-fA-F0-9]{64}$",
-          "title": "Merkle Root",
-          "type": "string"
+        "structural_type": {
+          "$ref": "#/$defs/TensorStructuralFormatProfile",
+          "description": "Structural type of the tensor elements."
         },
         "shape": {
           "description": "N-Dimensional shape tuple.",
@@ -9828,22 +9823,26 @@
           "title": "Shape",
           "type": "array"
         },
+        "vram_footprint_bytes": {
+          "description": "Exact byte size of the uncompressed tensor.",
+          "maximum": 100000000000,
+          "title": "Vram Footprint Bytes",
+          "type": "integer"
+        },
+        "merkle_root": {
+          "description": "SHA-256 Merkle root of the payload chunks.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-fA-F0-9]{64}$",
+          "title": "Merkle Root",
+          "type": "string"
+        },
         "storage_uri": {
           "description": "Strict URI pointer to the physical bytes.",
           "maxLength": 128,
           "minLength": 1,
           "title": "Storage Uri",
           "type": "string"
-        },
-        "structural_type": {
-          "$ref": "#/$defs/TensorStructuralFormatProfile",
-          "description": "Structural type of the tensor elements."
-        },
-        "vram_footprint_bytes": {
-          "description": "Exact byte size of the uncompressed tensor.",
-          "maximum": 100000000000,
-          "title": "Vram Footprint Bytes",
-          "type": "integer"
         }
       },
       "required": [
@@ -9868,12 +9867,6 @@
           "title": "Audit Id",
           "type": "string"
         },
-        "causal_scrubbing_applied": {
-          "default": false,
-          "description": "Cryptographic proof that the orchestrator actively resampled or ablated this circuit to verify its causal responsibility for the output.",
-          "title": "Causal Scrubbing Applied",
-          "type": "boolean"
-        },
         "layer_activations": {
           "additionalProperties": {
             "items": {
@@ -9884,6 +9877,12 @@
           "description": "A mapping of specific transformer layer indices to their top-k activated SAE features.",
           "title": "Layer Activations",
           "type": "object"
+        },
+        "causal_scrubbing_applied": {
+          "default": false,
+          "description": "Cryptographic proof that the orchestrator actively resampled or ablated this circuit to verify its causal responsibility for the output.",
+          "title": "Causal Scrubbing Applied",
+          "type": "boolean"
         }
       },
       "required": [
@@ -9897,21 +9896,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Bridges the stochastic-deterministic divide by invoking Satisfiability Modulo Theories (SMT) and formal theorem provers (Z3, Lean4, Coq) to execute mathematically unassailable logic.\n\nCAUSAL AFFORDANCE: Offloads non-monotonic probabilistic reasoning into a rigid, verifiable algebraic solver, returning the mathematically proven result to the swarm via the expected_proof_schema.\n\nEPISTEMIC BOUNDS: The solver target is restricted to the strict solver_protocol Literal automaton. The Halting Problem is explicitly mitigated by clamping timeout_ms (gt=0, le=86400000), preventing infinite computational loops in the solver.\n\nMCP ROUTING TRIGGERS: Satisfiability Modulo Theories, Curry-Howard Correspondence, Theorem Proving, Symbolic Handoff, Halting Problem Mitigation",
       "properties": {
-        "expected_proof_schema": {
-          "additionalProperties": true,
-          "description": "The strict JSON Schema the deterministic solver must use to return the verified answer to the agent.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Expected Proof Schema",
-          "type": "object"
-        },
-        "formal_grammar_payload": {
-          "description": "The raw code or formal proof syntax generated by the LLM to be evaluated.",
-          "maxLength": 100000,
-          "title": "Formal Grammar Payload",
-          "type": "string"
-        },
         "handoff_id": {
           "description": "Unique identifier for this symbolic delegation.",
           "maxLength": 128,
@@ -9931,6 +9915,21 @@
           ],
           "title": "Solver Protocol",
           "type": "string"
+        },
+        "formal_grammar_payload": {
+          "description": "The raw code or formal proof syntax generated by the LLM to be evaluated.",
+          "maxLength": 100000,
+          "title": "Formal Grammar Payload",
+          "type": "string"
+        },
+        "expected_proof_schema": {
+          "additionalProperties": true,
+          "description": "The strict JSON Schema the deterministic solver must use to return the verified answer to the agent.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Expected Proof Schema",
+          "type": "object"
         },
         "timeout_ms": {
           "description": "The maximum compute time allocated to the symbolic solver before aborting.",
@@ -9960,14 +9959,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact tracking the Kullback-Leibler\n(KL) divergence between the swarm's active behavioral manifold and its foundational\nConstitutionalPolicy. As an ...Event suffix, this is an append-only coordinate on the\nMerkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Emits a deterministic topological signal that the causal graph is\nexperiencing logical friction against the tripped_rule_id, unlocking the ability for the\norchestrator to inject a System2RemediationIntent constraint.\n\nEPISTEMIC BOUNDS: Mathematically bounded by the continuous float measured_semantic_drift\n(le=1000000000.0) and cryptographically tied to the exact contradiction_proof_hash\n(SHA-256 pattern ^[a-f0-9]{64}$) proving the anomaly via ThoughtBranch trace.\n\nMCP ROUTING TRIGGERS: Kullback-Leibler Divergence, Normative Drift, Distributional Shift,\nSemantic Friction, Constitutional Alignment",
       "properties": {
-        "contradiction_proof_hash": {
-          "description": "A cryptographic pointer to the internal scratchpad trace (ThoughtBranchState) definitively proving the rule is obsolete or causing a loop.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Contradiction Proof Hash",
-          "type": "string"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -9976,18 +9967,19 @@
           "title": "Event Id",
           "type": "string"
         },
-        "measured_semantic_drift": {
-          "description": "The calculated probabilistic delta showing how far the swarm's observed reality is diverging from the static rule.",
-          "maximum": 1000000000.0,
-          "title": "Measured Semantic Drift",
-          "type": "number"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
           "minimum": 0.0,
           "title": "Timestamp",
           "type": "number"
+        },
+        "type": {
+          "const": "normative_drift",
+          "default": "normative_drift",
+          "description": "Discriminator type for a normative drift event.",
+          "title": "Type",
+          "type": "string"
         },
         "tripped_rule_id": {
           "description": "The Content Identifier (CID) of the specific ConstitutionalPolicy causing logical friction.",
@@ -9997,11 +9989,18 @@
           "title": "Tripped Rule Id",
           "type": "string"
         },
-        "type": {
-          "const": "normative_drift",
-          "default": "normative_drift",
-          "description": "Discriminator type for a normative drift event.",
-          "title": "Type",
+        "measured_semantic_drift": {
+          "description": "The calculated probabilistic delta showing how far the swarm's observed reality is diverging from the static rule.",
+          "maximum": 1000000000.0,
+          "title": "Measured Semantic Drift",
+          "type": "number"
+        },
+        "contradiction_proof_hash": {
+          "description": "A cryptographic pointer to the internal scratchpad trace (ThoughtBranchState) definitively proving the rule is obsolete or causing a loop.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Contradiction Proof Hash",
           "type": "string"
         }
       },
@@ -10019,16 +10018,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the Dapper Distributed Tracing bounds for a given macroscopic\ntopology, formalizing the transparency of the system's Markov Blanket. As a ...Policy suffix,\nthis rigidly bounds the orchestrator's sampling physics.\n\nCAUSAL AFFORDANCE: Modulates the thermodynamic cost of execution tracking by authorizing or\nsevering the emission of high-granularity SpanEvent sequences (detailed_events) to prevent\nlogging backpressure and telemetry starvation.\n\nEPISTEMIC BOUNDS: Operates purely on strictly typed Boolean variables (traces_sampled,\ndetailed_events), mathematically prohibiting adversarial manipulation of telemetry pipelines\nvia unbounded tensor or string injection.\n\nMCP ROUTING TRIGGERS: Distributed Tracing, Dapper Architecture, Telemetry Sampling, Observability Horizon, Thermodynamic Overhead",
       "properties": {
-        "detailed_events": {
-          "default": false,
-          "description": "Whether to include granular intra-tool loop events.",
-          "title": "Detailed Events",
-          "type": "boolean"
-        },
         "traces_sampled": {
           "default": true,
           "description": "Whether the orchestrator must record telemetry for this topology.",
           "title": "Traces Sampled",
+          "type": "boolean"
+        },
+        "detailed_events": {
+          "default": false,
+          "description": "Whether to include granular intra-tool loop events.",
+          "title": "Detailed Events",
           "type": "boolean"
         }
       },
@@ -10047,29 +10046,19 @@
           "title": "Event Id",
           "type": "string"
         },
-        "hardware_attestation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HardwareEnclaveReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The physical hardware root-of-trust proving this observation was appended in a secure enclave."
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
         },
-        "neural_audit": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NeuralAuditAttestationReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical brain-scan proving exactly which neural circuits fired to append this event."
+        "type": {
+          "const": "observation",
+          "default": "observation",
+          "description": "Discriminator type for an observation event.",
+          "title": "Type",
+          "type": "string"
         },
         "payload": {
           "additionalProperties": {
@@ -10081,18 +10070,6 @@
           },
           "title": "Payload",
           "type": "object"
-        },
-        "sensory_trigger": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EmbodiedSensoryVectorProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The continuous multimodal trigger that forced this discrete observation."
         },
         "source_node_id": {
           "anyOf": [
@@ -10106,12 +10083,29 @@
           "default": null,
           "description": "The specific topological node that appended this observation."
         },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
+        "hardware_attestation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HardwareEnclaveReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The physical hardware root-of-trust proving this observation was appended in a secure enclave."
+        },
+        "zk_proof": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ZeroKnowledgeReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical attestation proving this observation was appended securely."
         },
         "toolchain_snapshot": {
           "anyOf": [
@@ -10124,6 +10118,30 @@
           ],
           "default": null,
           "description": "The immutable cryptographic snapshot of the external environment at the moment of observation."
+        },
+        "sensory_trigger": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EmbodiedSensoryVectorProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The continuous multimodal trigger that forced this discrete observation."
+        },
+        "neural_audit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NeuralAuditAttestationReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical brain-scan proving exactly which neural circuits fired to append this event."
         },
         "triggering_invocation_id": {
           "anyOf": [
@@ -10140,25 +10158,6 @@
           "default": null,
           "description": "The Event ID of the specific ToolInvocationEvent that spawned this observation, forming a strict bipartite directed edge.",
           "title": "Triggering Invocation Id"
-        },
-        "type": {
-          "const": "observation",
-          "default": "observation",
-          "description": "Discriminator type for an observation event.",
-          "title": "Type",
-          "type": "string"
-        },
-        "zk_proof": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ZeroKnowledgeReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical attestation proving this observation was appended securely."
         }
       },
       "required": [
@@ -10173,18 +10172,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Vector Space Isometry and Earth Mover's Distance\nbounds to mathematically verify semantic compatibility across disjoint neural\nmodels before allowing multi-agent graph coupling. As a ...Policy suffix, this\ndefines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Mechanically severs federated discovery attempts if the\nparticipating agents' internal embedding distances fall below the required\nthreshold. A fallback_state_contract (StateContract | None, default=None)\nforces agents to use canonical JSON Schemas when geometries are\nincommensurable.\n\nEPISTEMIC BOUNDS: The min_cosine_similarity is strictly clamped\n(ge=-1.0, le=1.0). The require_isometry_proof boolean (no default) enforces\nrigid projection validation prior to semantic mapping.\n\nMCP ROUTING TRIGGERS: Vector Space Isometry, Earth Mover's Distance, Latent\nSemantic Alignment, Zero-Trust Federation, Geometric Projection",
       "properties": {
-        "fallback_state_contract": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StateContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The rigid external JSON schema to force agents to use if their latent vector geometries are hopelessly incommensurable."
-        },
         "min_cosine_similarity": {
           "description": "The absolute minimum latent vector similarity required to allow swarm communication.",
           "maximum": 1.0,
@@ -10196,6 +10183,18 @@
           "description": "If True, the orchestrator must reject dimensional projections that fall below a safe isometry preservation score.",
           "title": "Require Isometry Proof",
           "type": "boolean"
+        },
+        "fallback_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rigid external JSON schema to force agents to use if their latent vector geometries are hopelessly incommensurable."
         }
       },
       "required": [
@@ -10209,6 +10208,33 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the absolute\nmathematical alignment of two swarms' latent vector spaces prior to establishing a shared\nepistemic blackboard. As a ...Receipt suffix, this is an append-only coordinate on the\nMerkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Authorizes the physical bridging of two independent N-dimensional\nsemantic spaces. If native geometries are incommensurable, it structurally demands the\napplication of a DimensionalProjectionContract (applied_projection). The alignment_status\nLiteral [\"aligned\", \"projected\", \"fallback_triggered\", \"incommensurable\"] records the\nfinal verdict.\n\nEPISTEMIC BOUNDS: Semantic isometry is quantified via measured_cosine_similarity, strictly\nclamped between [ge=-1.0, le=1.0]. The participant_node_ids array (min_length=2) is\ndeterministically sorted via @model_validator to prevent Byzantine replay anomalies\nduring cross-swarm Merkle hashing.\n\nMCP ROUTING TRIGGERS: Earth Mover's Distance, Cosine Similarity, Vector Space Isometry,\nLatent Alignment, Holographic Graph Projection",
       "properties": {
+        "handshake_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this protocol handshake to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Handshake Id",
+          "type": "string"
+        },
+        "participant_node_ids": {
+          "description": "The agents establishing semantic alignment.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 1000000000,
+          "minItems": 2,
+          "title": "Participant Node Ids",
+          "type": "array"
+        },
+        "measured_cosine_similarity": {
+          "description": "The calculated geometric alignment of the agents' core definitions.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Measured Cosine Similarity",
+          "type": "number"
+        },
         "alignment_status": {
           "description": "The final verdict of the handshake protocol.",
           "enum": [
@@ -10231,33 +10257,6 @@
           ],
           "default": null,
           "description": "The projection applied if the agents natively used different embedding dimensionalities."
-        },
-        "handshake_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this protocol handshake to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Handshake Id",
-          "type": "string"
-        },
-        "measured_cosine_similarity": {
-          "description": "The calculated geometric alignment of the agents' core definitions.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Measured Cosine Similarity",
-          "type": "number"
-        },
-        "participant_node_ids": {
-          "description": "The agents establishing semantic alignment.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 1000000000,
-          "minItems": 2,
-          "title": "Participant Node Ids",
-          "type": "array"
         }
       },
       "required": [
@@ -10273,22 +10272,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a Bipartite Graph Projection of Gibsonian Affordances, establishing\nthe mathematically bounded subgraph of all capabilities currently valid for the agent.\n\nCAUSAL AFFORDANCE: Injects a dynamic Action Space manifold into the agent's working memory,\nauthorizing the invocation of strictly defined toolsets and procedural manifolds.\n\nEPISTEMIC BOUNDS: The structural integrity is mathematically guaranteed by the verify_unique_action_spaces\n@model_validator, which deterministically sorts action_spaces, supported_personas, and\navailable_procedural_manifolds by their respective CIDs, ensuring invariant RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Gibsonian Affordances, Bipartite Graph Projection, Action Space Manifold, RFC 8785 Canonicalization, Holographic Subgraph",
       "properties": {
-        "action_spaces": {
-          "description": "The full, machine-readable declaration of accessible tools and MCP servers.",
-          "items": {
-            "$ref": "#/$defs/ActionSpaceManifest"
-          },
-          "title": "Action Spaces",
-          "type": "array"
-        },
-        "available_procedural_manifolds": {
-          "description": "The lightweight progressive disclosure tier for procedural skills.",
-          "items": {
-            "$ref": "#/$defs/ProceduralMetadataManifest"
-          },
-          "title": "Available Procedural Manifolds",
-          "type": "array"
-        },
         "projection_id": {
           "description": "A cryptographic Lineage Watermark bounding this specific capability set.",
           "maxLength": 128,
@@ -10297,12 +10280,28 @@
           "title": "Projection Id",
           "type": "string"
         },
+        "action_spaces": {
+          "description": "The full, machine-readable declaration of accessible tools and MCP servers.",
+          "items": {
+            "$ref": "#/$defs/ActionSpaceManifest"
+          },
+          "title": "Action Spaces",
+          "type": "array"
+        },
         "supported_personas": {
           "description": "The strict array of foundational model personas available.",
           "items": {
             "$ref": "#/$defs/ProfileIdentifierState"
           },
           "title": "Supported Personas",
+          "type": "array"
+        },
+        "available_procedural_manifolds": {
+          "description": "The lightweight progressive disclosure tier for procedural skills.",
+          "items": {
+            "$ref": "#/$defs/ProceduralMetadataManifest"
+          },
+          "title": "Available Procedural Manifolds",
           "type": "array"
         }
       },
@@ -10347,15 +10346,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: OverrideIntent is a Dictatorial Byzantine Fault Resolution mechanism. It is an\nabsolute, zero-trust kinetic override that violently preempts autonomous algorithmic consensus or\nprediction market resolution.\n\nCAUSAL AFFORDANCE: Forces an absolute Pearlian do-operator intervention ($do(X=x)$). It physically\nshatters the active causal chain of the target_node_id and forcibly injects the override_action\npayload into the state vector, bypassing all standard decentralized voting protocols.\n\nEPISTEMIC BOUNDS: The blast radius is strictly confined to the target_node_id. The orchestrator\nmust mathematically verify the authorized_node_id against the highest-tier W3C DID enterprise\nclearance before allowing the payload to overwrite the Epistemic Blackboard.\n\nMCP ROUTING TRIGGERS: Dictatorial Override, Byzantine Fault Resolution, Pearlian Intervention, Causal Shattering, Zero-Trust Override",
       "properties": {
+        "type": {
+          "const": "override",
+          "default": "override",
+          "description": "The type of the intervention payload.",
+          "title": "Type",
+          "type": "string"
+        },
         "authorized_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
           "description": "The NodeIdentifierState of the human or agent executing the override."
         },
-        "justification": {
-          "description": "Cryptographic audit justification for bypassing algorithmic consensus.",
-          "maxLength": 2000,
-          "title": "Justification",
-          "type": "string"
+        "target_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The NodeIdentifierState being forcefully overridden."
         },
         "override_action": {
           "additionalProperties": {
@@ -10385,15 +10389,10 @@
           "title": "Override Action",
           "type": "object"
         },
-        "target_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The NodeIdentifierState being forcefully overridden."
-        },
-        "type": {
-          "const": "override",
-          "default": "override",
-          "description": "The type of the intervention payload.",
-          "title": "Type",
+        "justification": {
+          "description": "Cryptographic audit justification for bypassing algorithmic consensus.",
+          "maxLength": 2000,
+          "title": "Justification",
           "type": "string"
         }
       },
@@ -10429,12 +10428,13 @@
           "title": "Adapter Id",
           "type": "string"
         },
-        "adapter_rank": {
-          "description": "The low-rank intrinsic dimension (r) of the update matrices, used by the orchestrator to calculate VRAM cost.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Adapter Rank",
-          "type": "integer"
+        "safetensors_hash": {
+          "description": "The SHA-256 hash of the cold-storage adapter weights file ensuring supply-chain zero-trust.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Safetensors Hash",
+          "type": "string"
         },
         "base_model_hash": {
           "description": "The SHA-256 hash of the exact foundational model this adapter was mathematically trained against.",
@@ -10443,6 +10443,23 @@
           "pattern": "^[a-f0-9]{64}$",
           "title": "Base Model Hash",
           "type": "string"
+        },
+        "adapter_rank": {
+          "description": "The low-rank intrinsic dimension (r) of the update matrices, used by the orchestrator to calculate VRAM cost.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Adapter Rank",
+          "type": "integer"
+        },
+        "target_modules": {
+          "description": "The explicit array of attention head modules to inject (e.g., ['q_proj', 'v_proj']).",
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Target Modules",
+          "type": "array"
         },
         "eviction_ttl_seconds": {
           "anyOf": [
@@ -10458,24 +10475,6 @@
           "default": null,
           "description": "The time-to-live before the inference engine forcefully evicts this adapter from the LRU cache.",
           "title": "Eviction Ttl Seconds"
-        },
-        "safetensors_hash": {
-          "description": "The SHA-256 hash of the cold-storage adapter weights file ensuring supply-chain zero-trust.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Safetensors Hash",
-          "type": "string"
-        },
-        "target_modules": {
-          "description": "The explicit array of attention head modules to inject (e.g., ['q_proj', 'v_proj']).",
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Target Modules",
-          "type": "array"
         }
       },
       "required": [
@@ -10492,6 +10491,11 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: PermissionBoundaryPolicy is the strict Zero-Trust Architecture security perimeter\ndefining exactly what external physical systems or networks an agent node is authorized to touch.\n\nCAUSAL AFFORDANCE: Mechanically limits the subgraph's kinetic reach. It forces the orchestrator to\ndrop network egress packets or block disk I/O unless explicitly whitelisted, and mandates the\nnegotiation of specific cryptographic handshakes (e.g., OAuth2, mTLS) before allocating compute.\n\nEPISTEMIC BOUNDS: Bounded by deterministic string arrays (allowed_domains, auth_requirements)\nthat must be strictly evaluated at runtime. The arrays are alphabetically sorted at instantiation\nto prevent Hash Poisoning attacks on the Merkle trace.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Network Egress Filtering, Capability-Based Security, mTLS Handshake, Hash Poisoning Prevention",
       "properties": {
+        "network_access": {
+          "description": "Whether the tool is permitted to make external network requests.",
+          "title": "Network Access",
+          "type": "boolean"
+        },
         "allowed_domains": {
           "anyOf": [
             {
@@ -10509,6 +10513,11 @@
           "description": "The explicit whitelist of allowed network domains if network access is true.",
           "title": "Allowed Domains"
         },
+        "file_system_mutation_forbidden": {
+          "description": "True if the tool is strictly forbidden from writing to the disk.",
+          "title": "File System Mutation Forbidden",
+          "type": "boolean"
+        },
         "auth_requirements": {
           "anyOf": [
             {
@@ -10525,16 +10534,6 @@
           "default": null,
           "description": "An explicit array of authentication protocol identifiers (e.g., 'oauth2:github', 'mtls:internal') the orchestrator must negotiate before allocating compute.",
           "title": "Auth Requirements"
-        },
-        "file_system_mutation_forbidden": {
-          "description": "True if the tool is strictly forbidden from writing to the disk.",
-          "title": "File System Mutation Forbidden",
-          "type": "boolean"
-        },
-        "network_access": {
-          "description": "Whether the tool is permitted to make external network requests.",
-          "title": "Network Access",
-          "type": "boolean"
         }
       },
       "required": [
@@ -10548,34 +10547,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the absolute\nWrite-Ahead Logging (WAL) serialization of an ephemeral state differential to durable cold-storage.\nAs a ...Receipt suffix, this is an append-only coordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Commits the internal committed_state_diff_id into the macroscopic Apache\nIceberg or Delta Lake backing store, yielding a verifiable lakehouse_snapshot_id to guarantee\ncross-swarm Eventual Consistency.\n\nEPISTEMIC BOUNDS: Inherits strict Merkle-DAG temporal limits from BaseStateEvent. Both the\nlakehouse_snapshot_id and committed_state_diff_id are rigorously clamped by max_length=128\nand a strict CID regex (^[a-zA-Z0-9_.:-]+$), mathematically preventing path traversal injections.\n\nMCP ROUTING TRIGGERS: Event Sourcing, Write-Ahead Logging, Two-Phase Commit, Lakehouse Serialization, State Differential Flush",
       "properties": {
-        "committed_state_diff_id": {
-          "description": "The internal StateDifferentialManifest CID that was flushed.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Committed State Diff Id",
-          "type": "string"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
-          "type": "string"
-        },
-        "lakehouse_snapshot_id": {
-          "description": "The external cryptographic receipt generated by Iceberg/Delta.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Lakehouse Snapshot Id",
-          "type": "string"
-        },
-        "target_table_uri": {
-          "description": "The specific table mutated.",
-          "minLength": 1,
-          "title": "Target Table Uri",
           "type": "string"
         },
         "timestamp": {
@@ -10590,6 +10567,28 @@
           "default": "persistence_commit",
           "description": "Discriminator type for a persistence commit receipt.",
           "title": "Type",
+          "type": "string"
+        },
+        "lakehouse_snapshot_id": {
+          "description": "The external cryptographic receipt generated by Iceberg/Delta.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Lakehouse Snapshot Id",
+          "type": "string"
+        },
+        "committed_state_diff_id": {
+          "description": "The internal StateDifferentialManifest CID that was flushed.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Committed State Diff Id",
+          "type": "string"
+        },
+        "target_table_uri": {
+          "description": "The specific table mutated.",
+          "minLength": 1,
+          "title": "Target Table Uri",
           "type": "string"
         }
       },
@@ -10617,18 +10616,18 @@
           "title": "Pq Algorithm",
           "type": "string"
         },
-        "pq_signature_blob": {
-          "description": "The base64-encoded post-quantum signature. Bounded to 100KB to safely accommodate massive SPHINCS+ hash trees without OOM crashes.",
-          "maxLength": 100000,
-          "title": "Pq Signature Blob",
-          "type": "string"
-        },
         "public_key_id": {
           "description": "The identifier of the post-quantum public evaluation key.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Public Key Id",
+          "type": "string"
+        },
+        "pq_signature_blob": {
+          "description": "The base64-encoded post-quantum signature. Bounded to 100KB to safely accommodate massive SPHINCS+ hash trees without OOM crashes.",
+          "maxLength": 100000,
+          "title": "Pq Signature Blob",
           "type": "string"
         }
       },
@@ -10644,20 +10643,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the mathematical Automated Market Maker (AMM) using Robin Hanson's Logarithmic Market Scoring Rule (LMSR) parameters to guarantee infinite liquidity.\n\nCAUSAL AFFORDANCE: Triggers quadratic staking functions to mathematically prevent Sybil attacks and dictates the exact `convergence_delta_threshold` required to halt trading and collapse the probability wave.\n\nEPISTEMIC BOUNDS: The `min_liquidity_magnitude` is capped at an integer `le=1000000000`, and the `convergence_delta_threshold` is strictly clamped to a probability distribution `[0.0, 1.0]`.\n\nMCP ROUTING TRIGGERS: LMSR, Automated Market Maker, Quadratic Staking, Sybil Resistance, Convergence Delta",
       "properties": {
-        "convergence_delta_threshold": {
-          "description": "The threshold indicating the market price has stabilized enough to trigger the resolution oracle.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Convergence Delta Threshold",
-          "type": "number"
-        },
-        "min_liquidity_magnitude": {
-          "description": "Minimum liquidity required.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Min Liquidity Magnitude",
-          "type": "integer"
-        },
         "staking_function": {
           "description": "The mathematical curve applied to stakes. Quadratic enforces Sybil resistance.",
           "enum": [
@@ -10666,6 +10651,20 @@
           ],
           "title": "Staking Function",
           "type": "string"
+        },
+        "min_liquidity_magnitude": {
+          "description": "Minimum liquidity required.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Min Liquidity Magnitude",
+          "type": "integer"
+        },
+        "convergence_delta_threshold": {
+          "description": "The threshold indicating the market price has stabilized enough to trigger the resolution oracle.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Convergence Delta Threshold",
+          "type": "number"
         }
       },
       "required": [
@@ -10680,6 +10679,36 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of an Automated Market Maker (AMM) utilizing Robin Hanson's Logarithmic Market Scoring Rule (LMSR) to guarantee infinite liquidity. As a ...State suffix, this represents an N-dimensional coordinate of market equilibrium.\n\nCAUSAL AFFORDANCE: Aggregates HypothesisStakeReceipt vectors, allowing the orchestrator to track the shifting probability manifold and trigger market resolution when the AMM reaches the required convergence threshold.\n\nEPISTEMIC BOUNDS: The order_book array is deterministically sorted by agent_id via @model_validator to preserve RFC 8785 canonical hashing. The liquidity parameter lmsr_b_parameter is physically restricted to a stringified decimal regex (^\\d+\\.\\d+$).\n\nMCP ROUTING TRIGGERS: Logarithmic Market Scoring Rule, Automated Market Maker, Prediction Market, Infinite Liquidity, Brier Score",
       "properties": {
+        "market_id": {
+          "description": "The ID of the prediction market.",
+          "le": 1000000000,
+          "minLength": 1,
+          "title": "Market Id",
+          "type": "string"
+        },
+        "resolution_oracle_condition_id": {
+          "description": "The specific FalsificationContract ID whose execution will trigger the market payout.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Resolution Oracle Condition Id",
+          "type": "string"
+        },
+        "lmsr_b_parameter": {
+          "description": "The stringified decimal representing the liquidity parameter defining the market depth and max loss for the AMM.",
+          "maxLength": 255,
+          "pattern": "^\\d+\\.\\d+$",
+          "title": "Lmsr B Parameter",
+          "type": "string"
+        },
+        "order_book": {
+          "description": "The immutable ledger of all stakes placed by the swarm.",
+          "items": {
+            "$ref": "#/$defs/HypothesisStakeReceipt"
+          },
+          "title": "Order Book",
+          "type": "array"
+        },
         "current_market_probabilities": {
           "additionalProperties": {
             "maxLength": 255,
@@ -10692,36 +10721,6 @@
           },
           "title": "Current Market Probabilities",
           "type": "object"
-        },
-        "lmsr_b_parameter": {
-          "description": "The stringified decimal representing the liquidity parameter defining the market depth and max loss for the AMM.",
-          "maxLength": 255,
-          "pattern": "^\\d+\\.\\d+$",
-          "title": "Lmsr B Parameter",
-          "type": "string"
-        },
-        "market_id": {
-          "description": "The ID of the prediction market.",
-          "le": 1000000000,
-          "minLength": 1,
-          "title": "Market Id",
-          "type": "string"
-        },
-        "order_book": {
-          "description": "The immutable ledger of all stakes placed by the swarm.",
-          "items": {
-            "$ref": "#/$defs/HypothesisStakeReceipt"
-          },
-          "title": "Order Book",
-          "type": "array"
-        },
-        "resolution_oracle_condition_id": {
-          "description": "The specific FalsificationContract ID whose execution will trigger the market payout.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Resolution Oracle Condition Id",
-          "type": "string"
         }
       },
       "required": [
@@ -10738,13 +10737,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The macroscopic orchestrator envelope binding a deterministic visual\nmanifold (grid: MacroGridProfile) to a specific Supervisory Control Theory cognitive\nstate (intent: AnyPresentationIntent). As a ...Manifest suffix, this defines a frozen,\nN-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Forces the active orchestration loop to suspend or pivot by projecting\na human-in-the-loop interaction surface (e.g., Drafting, Adjudication) alongside its\nvisual evidentiary warrants.\n\nEPISTEMIC BOUNDS: Mathematically binds exactly one AnyPresentationIntent to one\nMacroGridProfile, preventing asynchronous UI state drift and ensuring the generated grid\nis causally justified by a verified intent.\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, Mixed-Initiative UI, Cognitive State\nBinding, Structural Manifold Envelope, Human-in-the-Loop",
       "properties": {
-        "grid": {
-          "$ref": "#/$defs/MacroGridProfile",
-          "description": "The grid of panels being presented."
-        },
         "intent": {
           "$ref": "#/$defs/AnyPresentationIntent",
           "description": "The reason an agent is presenting this data to a human."
+        },
+        "grid": {
+          "$ref": "#/$defs/MacroGridProfile",
+          "description": "The grid of panels being presented."
         }
       },
       "required": [
@@ -10758,18 +10757,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a Level-1 Epistemic Discovery Surface utilizing Lazy Evaluation\nand Information Bottleneck Theory to act as a progressive disclosure pointer to a massive\nEpistemicSOPManifest.\n\nCAUSAL AFFORDANCE: Prevents context window token exhaustion by keeping the full Standard Operating\nProcedure in cold storage until the agent's generative trajectory actively mathematically intersects\nwith the trigger_description.\n\nEPISTEMIC BOUNDS: The metadata_id and target_sop_id are physically locked to 128-char CIDs.\nThe semantic geometry of the trigger_description is clamped at max_length=2000 to prevent\ndictionary bombing during routing evaluation. The latent_vector_coordinate provides optional\ndense-vector geometry (VectorEmbeddingState).\n\nMCP ROUTING TRIGGERS: Lazy Evaluation, Progressive Disclosure, Information Bottleneck, Discovery Surface, Epistemic Pointer",
       "properties": {
-        "latent_vector_coordinate": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VectorEmbeddingState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional dense-vector geometry for zero-shot semantic routing without LLM forward-pass evaluation."
-        },
         "metadata_id": {
           "description": "A strict cryptographic string identifier for this L1 procedural pointer.",
           "maxLength": 128,
@@ -10791,6 +10778,18 @@
           "maxLength": 2000,
           "title": "Trigger Description",
           "type": "string"
+        },
+        "latent_vector_coordinate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VectorEmbeddingState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional dense-vector geometry for zero-shot semantic routing without LLM forward-pass evaluation."
         }
       },
       "required": [
@@ -10817,6 +10816,20 @@
           "default": null,
           "description": "The dynamic circuit breaker that halts the search when PRM variance converges, preventing VRAM waste."
         },
+        "pruning_threshold": {
+          "description": "If a ThoughtBranchState's prm_score falls below this threshold, the orchestrator MUST halt its generation.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Pruning Threshold",
+          "type": "number"
+        },
+        "max_backtracks_allowed": {
+          "description": "The absolute limit on how many times the agent can start a new branch before throwing a SystemFaultEvent.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Max Backtracks Allowed",
+          "type": "integer"
+        },
         "evaluator_model_name": {
           "anyOf": [
             {
@@ -10830,20 +10843,6 @@
           "default": null,
           "description": "The specific PRM model used to score the logic (e.g., 'math-prm-v2').",
           "title": "Evaluator Model Name"
-        },
-        "max_backtracks_allowed": {
-          "description": "The absolute limit on how many times the agent can start a new branch before throwing a SystemFaultEvent.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Max Backtracks Allowed",
-          "type": "integer"
-        },
-        "pruning_threshold": {
-          "description": "If a ThoughtBranchState's prm_score falls below this threshold, the orchestrator MUST halt its generation.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Pruning Threshold",
-          "type": "number"
         }
       },
       "required": [
@@ -10877,22 +10876,22 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Triggers an Epistemic Quarantine utilizing rigid Spectral Graph Partitioning to mathematically isolate a hallucinating, degraded, or Byzantine node from the active working context. As an ...Intent suffix, the LLM may execute non-monotonic reasoning here.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to sever all outgoing causal edges from the `target_node_id`, reducing its algebraic connectivity to zero. This neutralizes its probability mass in the routing manifold and prevents entropy from contaminating the `EpistemicLedgerState`.\n\nEPISTEMIC BOUNDS: The topological isolation is strictly targeted via a `NodeIdentifierState` (`target_node_id`). The causal justification for the graph cut is physically constrained to `reason` (`max_length=2000`) to mathematically prevent dictionary bombing attacks on the ledger.\n\nMCP ROUTING TRIGGERS: Spectral Graph Partitioning, Byzantine Fault Isolation, Epistemic Contagion, Defeasible Logic, Algebraic Connectivity",
       "properties": {
-        "reason": {
-          "description": "The deterministic causal justification for the structural quarantine.",
-          "maxLength": 2000,
-          "title": "Reason",
-          "type": "string"
-        },
-        "target_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the node to be quarantined."
-        },
         "type": {
           "const": "quarantine_intent",
           "default": "quarantine_intent",
           "description": "The type of the resilience payload.",
           "le": 1000000000,
           "title": "Type",
+          "type": "string"
+        },
+        "target_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The ID of the node to be quarantined."
+        },
+        "reason": {
+          "description": "The deterministic causal justification for the structural quarantine.",
+          "maxLength": 2000,
+          "title": "Reason",
           "type": "string"
         }
       },
@@ -10907,16 +10906,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the Practical Byzantine Fault Tolerance (pBFT)\nmathematical boundaries for a decentralized swarm to survive malicious or hallucinating\nactors. As a ...Policy suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to validate the state_validation_metric\n(Literal [\"ledger_hash\", \"zk_proof\", \"semantic_embedding\"]) across $N$ nodes, physically\nexecuting the byzantine_action (Literal [\"quarantine\", \"slash_escrow\", \"ignore\"])\nagainst nodes that violate the consensus.\n\nEPISTEMIC BOUNDS: Physically bounds max_tolerable_faults (ge=0, le=1000000000) and\nmin_quorum_size (gt=0, le=1000000000). The @model_validator enforce_bft_math enforces\nthe strict invariant $N \\ge 3f + 1$, guaranteeing Byzantine agreement.\n\nMCP ROUTING TRIGGERS: Byzantine Fault Tolerance, pBFT, Quorum Sensing, Sybil\nResistance, Distributed Consensus",
       "properties": {
-        "byzantine_action": {
-          "description": "The deterministic punishment executed by the orchestrator against nodes that violate the consensus quorum.",
-          "enum": [
-            "quarantine",
-            "slash_escrow",
-            "ignore"
-          ],
-          "title": "Byzantine Action",
-          "type": "string"
-        },
         "max_tolerable_faults": {
           "description": "The maximum number of actively malicious, hallucinating, or degraded nodes (f) the swarm must survive.",
           "maximum": 1000000000,
@@ -10940,6 +10929,16 @@
           ],
           "title": "State Validation Metric",
           "type": "string"
+        },
+        "byzantine_action": {
+          "description": "The deterministic punishment executed by the orchestrator against nodes that violate the consensus quorum.",
+          "enum": [
+            "quarantine",
+            "slash_escrow",
+            "ignore"
+          ],
+          "title": "Byzantine Action",
+          "type": "string"
         }
       },
       "required": [
@@ -10955,13 +10954,29 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a deterministic Data Sanitization heuristic mapped to a\nspecific InformationClassificationProfile (e.g., Bell-LaPadula clearance levels). As a\n...Policy suffix, this object defines rigid mathematical boundaries that the orchestrator\nmust enforce globally.\n\nCAUSAL AFFORDANCE: Executes a rigid regex-bounded search-and-replace algorithm via\ntarget_regex_pattern to mutate or mask toxic data payloads, substituting matches with a\nsafe replacement_token. The action (SanitizationActionIntent) dictates the exact\nsanitization method.\n\nEPISTEMIC BOUNDS: The target_regex_pattern is strictly capped at max_length=200 to\nmathematically prevent ReDoS (Regular Expression Denial of Service) CPU exhaustion. A\nsecondary target_pattern (max_length=2000) provides a broader semantic entity match. The\noptional context_exclusion_zones array (max_length=100) is deterministically sorted by\nthe @model_validator.\n\nMCP ROUTING TRIGGERS: Data Sanitization, Regular Expression DoS Prevention,\nBell-LaPadula Model, Masking Heuristic, Algorithmic Redaction",
       "properties": {
-        "action": {
-          "$ref": "#/$defs/SanitizationActionIntent",
-          "description": "The required algorithmic response when this pattern is detected."
+        "rule_id": {
+          "description": "Unique identifier for the sanitization rule.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Rule Id",
+          "type": "string"
         },
         "classification": {
           "$ref": "#/$defs/InformationClassificationProfile",
           "description": "The category of sensitive payload this rule targets."
+        },
+        "target_pattern": {
+          "description": "The semantic entity type or declarative regex pattern to identify.",
+          "maxLength": 2000,
+          "title": "Target Pattern",
+          "type": "string"
+        },
+        "target_regex_pattern": {
+          "description": "The dynamic regex pattern to target.",
+          "maxLength": 200,
+          "title": "Target Regex Pattern",
+          "type": "string"
         },
         "context_exclusion_zones": {
           "anyOf": [
@@ -10981,6 +10996,10 @@
           "description": "Specific JSON paths where this rule should NOT apply.",
           "title": "Context Exclusion Zones"
         },
+        "action": {
+          "$ref": "#/$defs/SanitizationActionIntent",
+          "description": "The required algorithmic response when this pattern is detected."
+        },
         "replacement_token": {
           "anyOf": [
             {
@@ -10994,26 +11013,6 @@
           "default": null,
           "description": "The strictly typed string to insert if the action is 'redact'.",
           "title": "Replacement Token"
-        },
-        "rule_id": {
-          "description": "Unique identifier for the sanitization rule.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Rule Id",
-          "type": "string"
-        },
-        "target_pattern": {
-          "description": "The semantic entity type or declarative regex pattern to identify.",
-          "maxLength": 2000,
-          "title": "Target Pattern",
-          "type": "string"
-        },
-        "target_regex_pattern": {
-          "description": "The dynamic regex pattern to target.",
-          "maxLength": 200,
-          "title": "Target Regex Pattern",
-          "type": "string"
         }
       },
       "required": [
@@ -11040,16 +11039,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A kinetic execution trigger initiating a macroscopic Pearlian\ncounterfactual reversal, mathematically rewinding the state vector to a pristine historical\nMerkle root. As an ...Intent suffix, the LLM may execute non-monotonic reasoning here.\n\nCAUSAL AFFORDANCE: Forces the orchestrator to execute a Pearlian do-operator intervention\n($do(X=x)$), flushing all invalidated_node_ids from the active context and restoring the\ntopology to the target_event_id coordinate.\n\nEPISTEMIC BOUNDS: Deterministic execution is mathematically guaranteed by the\n@model_validator which strictly alphabetizes invalidated_node_ids via sorted() prior to\nRFC 8785 canonical hashing, preventing Byzantine replay divergence.\n\nMCP ROUTING TRIGGERS: Pearlian Counterfactual, Causal Reversal, State Vector Rollback,\nTemporal Negation, Topological Falsification",
       "properties": {
-        "invalidated_node_ids": {
-          "description": "The strict array of nodes whose operational histories are causally tainted and must be flushed.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Invalidated Node Ids",
-          "type": "array"
-        },
         "request_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the causal rollback operation.",
           "maxLength": 128,
@@ -11065,6 +11054,16 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Target Event Id",
           "type": "string"
+        },
+        "invalidated_node_ids": {
+          "description": "The strict array of nodes whose operational histories are causally tainted and must be flushed.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Invalidated Node Ids",
+          "type": "array"
         }
       },
       "required": [
@@ -11078,33 +11077,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: RoutingFrontierPolicy is the Multi-Objective Optimization matrix used to navigate\nthe Spot-Market compute layer, calculating the Pareto Efficiency frontier between speed, cost, and intelligence.\n\nCAUSAL AFFORDANCE: Instructs the Spot-Market router on how to mechanically weigh competing inference\nengines. If a query requires extreme logic, it authorizes high cost; if it requires a UI reflex,\nit enforces strict latency bounds.\n\nEPISTEMIC BOUNDS: Strict physical, economic, and thermodynamic ceilings are mathematically enforced:\nmax_latency_ms (le=86400000), max_cost_magnitude_per_token (le=1000000000), and an absolute ESG bound\nvia max_carbon_intensity_gco2eq_kwh (le=10000.0).\n\nMCP ROUTING TRIGGERS: Pareto Efficiency, Multi-Objective Optimization, Spot-Market Routing, Carbon Budget, Compute Allocation",
       "properties": {
-        "max_carbon_intensity_gco2eq_kwh": {
-          "anyOf": [
-            {
-              "maximum": 10000.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The maximum operational carbon intensity of the physical data center grid allowed for this agent's routing.",
-          "title": "Max Carbon Intensity Gco2Eq Kwh"
+        "max_latency_ms": {
+          "description": "The absolute physical speed limit acceptable for time-to-first-token or total generation.",
+          "exclusiveMinimum": 0,
+          "maximum": 86400000,
+          "title": "Max Latency Ms",
+          "type": "integer"
         },
         "max_cost_magnitude_per_token": {
           "description": "The strict magnitude ceiling. MUST be an integer to maintain cryptographic determinism.",
           "exclusiveMinimum": 0,
           "maximum": 1000000000,
           "title": "Max Cost Magnitude Per Token",
-          "type": "integer"
-        },
-        "max_latency_ms": {
-          "description": "The absolute physical speed limit acceptable for time-to-first-token or total generation.",
-          "exclusiveMinimum": 0,
-          "maximum": 86400000,
-          "title": "Max Latency Ms",
           "type": "integer"
         },
         "min_capability_score": {
@@ -11125,6 +11109,21 @@
           ],
           "title": "Tradeoff Preference",
           "type": "string"
+        },
+        "max_carbon_intensity_gco2eq_kwh": {
+          "anyOf": [
+            {
+              "maximum": 10000.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum operational carbon intensity of the physical data center grid allowed for this agent's routing.",
+          "title": "Max Carbon Intensity Gco2Eq Kwh"
         }
       },
       "required": [
@@ -11140,20 +11139,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot establishing a Secure Multi-Party\nComputation (SMPC) ring, leveraging cryptographic privacy-preserving protocols to\nevaluate a joint function over decentralized inputs. As a ...Manifest suffix, this\ndefines a frozen N-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Authorizes the decentralized orchestrator to route zero-trust\ntraffic via specific mathematical logic (Literal [\"garbled_circuits\",\n\"secret_sharing\", \"oblivious_transfer\"]), allowing mutually distrustful agents to\nsynthesize a shared output. Optional ontological_alignment\n(OntologicalAlignmentPolicy) gates pre-flight semantic alignment.\n\nEPISTEMIC BOUNDS: The topology physically mandates a minimum of two participants\n(participant_node_ids min_length=2) to satisfy the multi-party invariant. The\njoint_function_uri is bounded to max_length=2000.\n\nMCP ROUTING TRIGGERS: Secure Multi-Party Computation, Garbled Circuits, Secret\nSharing, Oblivious Transfer, Zero-Trust Cryptography",
       "properties": {
-        "architectural_intent": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The AI's declarative rationale for selecting this topology.",
-          "title": "Architectural Intent"
-        },
         "epistemic_enforcement": {
           "anyOf": [
             {
@@ -11167,23 +11152,29 @@
           "default": null,
           "description": "Ties the topology to the Truth Maintenance layer."
         },
-        "information_flow": {
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
+        "architectural_intent": {
           "anyOf": [
             {
-              "$ref": "#/$defs/InformationFlowPolicy"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
-        },
-        "joint_function_uri": {
-          "description": "The URI or hash pointing to the exact math circuit or polynomial function the ring will collaboratively compute.",
-          "maxLength": 2000,
-          "title": "Joint Function Uri",
-          "type": "string"
+          "description": "The AI's declarative rationale for selecting this topology.",
+          "title": "Architectural Intent"
         },
         "justification": {
           "anyOf": [
@@ -11199,16 +11190,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -11219,41 +11200,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The distributed tracing rules bound to this specific execution graph."
-        },
-        "ontological_alignment": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/OntologicalAlignmentPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
-        },
-        "participant_node_ids": {
-          "description": "The strict ordered array of NodeIdentifierStates participating in the Secure Multi-Party Computation ring.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "minItems": 2,
-          "title": "Participant Node Ids",
-          "type": "array"
         },
         "shared_state_contract": {
           "anyOf": [
@@ -11267,6 +11213,37 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
+        "type": {
+          "const": "smpc",
+          "default": "smpc",
+          "description": "Discriminator for SMPC Topology.",
+          "title": "Type",
+          "type": "string"
+        },
         "smpc_protocol": {
           "description": "The exact cryptographic P2P protocol the nodes must use to evaluate the function.",
           "enum": [
@@ -11277,12 +11254,34 @@
           "title": "Smpc Protocol",
           "type": "string"
         },
-        "type": {
-          "const": "smpc",
-          "default": "smpc",
-          "description": "Discriminator for SMPC Topology.",
-          "title": "Type",
+        "joint_function_uri": {
+          "description": "The URI or hash pointing to the exact math circuit or polynomial function the ring will collaboratively compute.",
+          "maxLength": 2000,
+          "title": "Joint Function Uri",
           "type": "string"
+        },
+        "participant_node_ids": {
+          "description": "The strict ordered array of NodeIdentifierStates participating in the Secure Multi-Party Computation ring.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 2,
+          "title": "Participant Node Ids",
+          "type": "array"
+        },
+        "ontological_alignment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologicalAlignmentPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
         }
       },
       "required": [
@@ -11298,18 +11297,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements an Asynchronous Event-Driven Architecture leveraging\nServer-Sent Events (SSE) to map a unidirectional, continuous topology of\nServer-to-Client state transitions. As a ...Profile suffix, this is a declarative\nproperty descriptor.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to maintain a persistent, long-lived\nTCP connection (uri: HttpUrl), processing incoming JSON-RPC streams without the\nthermodynamic overhead of continuous polling.\n\nEPISTEMIC BOUNDS: The headers (default_factory=dict) are strictly limited via\nStringConstraints (key max_length=255, value max_length=2000) and mathematically\nsanitized against CRLF injection via @field_validator _prevent_crlf_injection to\npreserve protocol boundary integrity.\n\nMCP ROUTING TRIGGERS: Event-Driven Architecture, Server-Sent Events,\nUnidirectional Stream, Asynchronous Message Passing, TCP Persistence",
       "properties": {
-        "headers": {
-          "additionalProperties": {
-            "maxLength": 2000,
-            "type": "string"
-          },
-          "description": "HTTP headers, e.g., for authentication.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Headers",
-          "type": "object"
-        },
         "type": {
           "const": "sse",
           "default": "sse",
@@ -11324,6 +11311,18 @@
           "minLength": 1,
           "title": "Uri",
           "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "description": "HTTP headers, e.g., for authentication.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Headers",
+          "type": "object"
         }
       },
       "required": [
@@ -11336,18 +11335,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Isolates a discrete, monosemantic feature from the foundational\nmodel's polysemantic residual stream using a Sparse Autoencoder (SAE) projection\nmatrix. As a ...State suffix, this is a frozen N-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Surfaces hidden geometric concept vectors (e.g., 'sycophancy' or\n'truth_retrieval') to the orchestrator, enabling real-time circuit-level inspection,\nfeature clamping, and causal tracing.\n\nEPISTEMIC BOUNDS: The semantic abstraction is rigidly bounded to a specific\nfeature_index (ge=0, le=1000000000). The activation_magnitude physically measures\nthe Euclidean strength (le=1000000000, no ge bound). The optional\ninterpretability_label (str | None, max_length=2000, default=None) restricts\nsemantic descriptions.\n\nMCP ROUTING TRIGGERS: Sparse Autoencoder, Monosemantic Feature, Concept Vector,\nMechanistic Interpretability, Euclidean Magnitude",
       "properties": {
-        "activation_magnitude": {
-          "description": "The mathematical strength of this feature's activation during the forward pass.",
-          "maximum": 1000000000,
-          "title": "Activation Magnitude",
-          "type": "number"
-        },
         "feature_index": {
           "description": "The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
           "maximum": 1000000000,
           "minimum": 0,
           "title": "Feature Index",
           "type": "integer"
+        },
+        "activation_magnitude": {
+          "description": "The mathematical strength of this feature's activation during the forward pass.",
+          "maximum": 1000000000,
+          "title": "Activation Magnitude",
+          "type": "number"
         },
         "interpretability_label": {
           "anyOf": [
@@ -11373,8 +11372,43 @@
     },
     "SaeLatentPolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability\nto actively monitor and steer monosemantic neural circuits during the model's forward\npass. As a ...Policy suffix, this object defines rigid mathematical boundaries that the\norchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Executes real-time tensor remediation \u2014 clamping, halting, quarantining,\nor smoothly decaying residual stream activations via violation_action\n(Literal[\"clamp\", \"halt\", \"quarantine\", \"smooth_decay\"]) \u2014 when specific features\ndiverge toward adversarial or hallucinated geometries. The smooth_decay path requires\nboth a LatentSmoothingProfile and clamp_value target asymptote, enforced by a\n@model_validator.\n\nEPISTEMIC BOUNDS: The max_activation_threshold (ge=0.0, le=1000000000.0) physically\nbounds the continuous Euclidean magnitude of the target_feature_index (ge=0,\nle=1000000000). The policy is topologically locked to the exact SAE projection matrix via\nsae_dictionary_hash (SHA-256 ^[a-f0-9]{64}$). The monitored_layers array (min_length=1)\nis deterministically sorted by @model_validator for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream\nSteering, Tensor Remediation, Monosemantic Features",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability\nto actively monitor and steer monosemantic neural circuits during the model's forward\npass. As a ...Policy suffix, this object defines rigid mathematical boundaries that the\norchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Executes real-time tensor remediation — clamping, halting, quarantining,\nor smoothly decaying residual stream activations via violation_action\n(Literal[\"clamp\", \"halt\", \"quarantine\", \"smooth_decay\"]) — when specific features\ndiverge toward adversarial or hallucinated geometries. The smooth_decay path requires\nboth a LatentSmoothingProfile and clamp_value target asymptote, enforced by a\n@model_validator.\n\nEPISTEMIC BOUNDS: The max_activation_threshold (ge=0.0, le=1000000000.0) physically\nbounds the continuous Euclidean magnitude of the target_feature_index (ge=0,\nle=1000000000). The policy is topologically locked to the exact SAE projection matrix via\nsae_dictionary_hash (SHA-256 ^[a-f0-9]{64}$). The monitored_layers array (min_length=1)\nis deterministically sorted by @model_validator for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream\nSteering, Tensor Remediation, Monosemantic Features",
       "properties": {
+        "target_feature_index": {
+          "description": "The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Target Feature Index",
+          "type": "integer"
+        },
+        "monitored_layers": {
+          "description": "The specific transformer layer indices where this feature activation must be monitored.",
+          "items": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "minItems": 1,
+          "title": "Monitored Layers",
+          "type": "array"
+        },
+        "max_activation_threshold": {
+          "description": "The mathematical magnitude limit. If the feature activates beyond this, the firewall trips.",
+          "maximum": 1000000000.0,
+          "minimum": 0.0,
+          "title": "Max Activation Threshold",
+          "type": "number"
+        },
+        "violation_action": {
+          "description": "The tensor-level remediation applied when the threshold is breached.",
+          "enum": [
+            "clamp",
+            "halt",
+            "quarantine",
+            "smooth_decay"
+          ],
+          "title": "Violation Action",
+          "type": "string"
+        },
         "clamp_value": {
           "anyOf": [
             {
@@ -11388,23 +11422,6 @@
           "default": null,
           "description": "If violation_action is 'clamp', the physical value to which the activation tensor is forced.",
           "title": "Clamp Value"
-        },
-        "max_activation_threshold": {
-          "description": "The mathematical magnitude limit. If the feature activates beyond this, the firewall trips.",
-          "maximum": 1000000000.0,
-          "minimum": 0.0,
-          "title": "Max Activation Threshold",
-          "type": "number"
-        },
-        "monitored_layers": {
-          "description": "The specific transformer layer indices where this feature activation must be monitored.",
-          "items": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "minItems": 1,
-          "title": "Monitored Layers",
-          "type": "array"
         },
         "sae_dictionary_hash": {
           "description": "The SHA-256 hash of the exact SAE projection matrix required to decode this feature.",
@@ -11425,24 +11442,6 @@
           ],
           "default": null,
           "description": "The geometric parameters for continuous attenuation if violation_action is 'smooth_decay'."
-        },
-        "target_feature_index": {
-          "description": "The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Target Feature Index",
-          "type": "integer"
-        },
-        "violation_action": {
-          "description": "The tensor-level remediation applied when the threshold is breached.",
-          "enum": [
-            "clamp",
-            "halt",
-            "quarantine",
-            "smooth_decay"
-          ],
-          "title": "Violation Action",
-          "type": "string"
         }
       },
       "required": [
@@ -11494,19 +11493,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Stevens's levels of measurement and Wilkinson's Grammar\nof Graphics to mathematically project abstract data domains into visual geometric\nranges. As a ...Policy suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Physically distorts or linearly maps the input metric tensor into\nrendering space, dictating how the orchestrator processes logarithmic, temporal, or\nordinal data vectors for UI projection.\n\nEPISTEMIC BOUNDS: The transformation algorithm is strictly constrained to a Literal\nautomaton [\"linear\", \"log\", \"time\", \"ordinal\", \"nominal\"]. Physical data boundaries\n(domain_min, domain_max) are optional (default=None) and upper-bounded by\nle=1000000000.0 to prevent geometric projection overflow (no ge bound enforced).\n\nMCP ROUTING TRIGGERS: Grammar of Graphics, Metric Tensor Distortion, Levels of\nMeasurement, Scale Projection, FSM Literal",
       "properties": {
-        "domain_max": {
-          "anyOf": [
-            {
-              "maximum": 1000000000.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
+        "type": {
+          "description": "The mathematical scale mapping metrics to pixels.",
+          "enum": [
+            "linear",
+            "log",
+            "time",
+            "ordinal",
+            "nominal"
           ],
-          "default": null,
-          "description": "The optional maximum bound of the scale domain.",
-          "title": "Domain Max"
+          "title": "Type",
+          "type": "string"
         },
         "domain_min": {
           "anyOf": [
@@ -11522,17 +11519,19 @@
           "description": "The optional minimum bound of the scale domain.",
           "title": "Domain Min"
         },
-        "type": {
-          "description": "The mathematical scale mapping metrics to pixels.",
-          "enum": [
-            "linear",
-            "log",
-            "time",
-            "ordinal",
-            "nominal"
+        "domain_max": {
+          "anyOf": [
+            {
+              "maximum": 1000000000.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "title": "Type",
-          "type": "string"
+          "default": null,
+          "description": "The optional maximum bound of the scale domain.",
+          "title": "Domain Max"
         }
       },
       "required": [
@@ -11545,6 +11544,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Principle of Least Privilege (PoLP) and Time-Based\nAccess Control (TBAC) for handling high-entropy cryptographic secrets. As a ...State\nsuffix, this is a declarative, frozen N-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Authorizes a temporary, mathematically bounded partition where\nthe agent can access unredacted enterprise vault keys (allowed_vault_keys) without\npermanently leaking them into the global EpistemicLedgerState. The description field\n(max_length=2000) provides audit justification.\n\nEPISTEMIC BOUNDS: The temporal exposure window is physically clamped by\nmax_ttl_seconds (ge=1, le=3600), enforcing an absolute maximum 1-hour session.\nSpatial access is geometrically restricted to allowed_vault_keys (max_length=100),\ndeterministically sorted by @model_validator sort_arrays for RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Principle of Least Privilege, Time-Based Access Control,\nSecret Vaulting, Ephemeral Partition, Cryptographic Isolation",
       "properties": {
+        "session_id": {
+          "description": "Unique identifier for the secure session.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Session Id",
+          "type": "string"
+        },
         "allowed_vault_keys": {
           "description": "The explicit array of enterprise vault keys the agent is temporarily allowed to access.",
           "items": {
@@ -11555,12 +11562,6 @@
           "title": "Allowed Vault Keys",
           "type": "array"
         },
-        "description": {
-          "description": "Audit justification for this temporary secure session.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
-        },
         "max_ttl_seconds": {
           "description": "Maximum time-to-live for the unredacted state partition.",
           "maximum": 3600,
@@ -11568,12 +11569,10 @@
           "title": "Max Ttl Seconds",
           "type": "integer"
         },
-        "session_id": {
-          "description": "Unique identifier for the secure session.",
-          "maxLength": 255,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Session Id",
+        "description": {
+          "description": "Audit justification for this temporary secure session.",
+          "maxLength": 2000,
+          "title": "Description",
           "type": "string"
         }
       },
@@ -11614,16 +11613,23 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates zero-shot latent capability routing by computing the\ngeometric Cosine Distance between the agent's epistemic deficit vector and the available\ntool manifold. As an ...Intent suffix, the LLM may execute non-monotonic reasoning here.\n\nCAUSAL AFFORDANCE: Unlocks the dynamic, runtime mounting of tools and MCP servers whose\ndense vector embeddings (query_vector) align mathematically with the query tensor,\nbypassing hardcoded tool schemas.\n\nEPISTEMIC BOUNDS: Mechanically rejects capabilities that fall below the min_isometry_score\n(ge=-1.0, le=1.0) boundary. The returned toolsets are strictly limited to the\ndeterministically sorted required_structural_types array, enforced by the @model_validator.\n\nMCP ROUTING TRIGGERS: Zero-Shot Tool Discovery, Capability Routing, Dense Vector\nEmbedding, Epistemic Deficit Resolution",
       "properties": {
+        "type": {
+          "const": "semantic_discovery",
+          "default": "semantic_discovery",
+          "description": "Discriminator for geometric boundary of latent tool discovery.",
+          "title": "Type",
+          "type": "string"
+        },
+        "query_vector": {
+          "$ref": "#/$defs/VectorEmbeddingState",
+          "description": "The latent vector representation of the epistemic deficit the agent is trying to solve."
+        },
         "min_isometry_score": {
           "description": "The minimum cosine similarity required to authorize a capability mount.",
           "maximum": 1.0,
           "minimum": -1.0,
           "title": "Min Isometry Score",
           "type": "number"
-        },
-        "query_vector": {
-          "$ref": "#/$defs/VectorEmbeddingState",
-          "description": "The latent vector representation of the epistemic deficit the agent is trying to solve."
         },
         "required_structural_types": {
           "description": "The strict array of strings defining topological limits on the discovered tools.",
@@ -11634,13 +11640,6 @@
           "maxItems": 1000000000,
           "title": "Required Structural Types",
           "type": "array"
-        },
-        "type": {
-          "const": "semantic_discovery",
-          "default": "semantic_discovery",
-          "description": "Discriminator for geometric boundary of latent tool discovery.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -11655,16 +11654,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A mathematical tensor bridging two SemanticNodeStates, executing\nJudea Pearl's Structural Causal Models (SCMs) to explicitly formalize causality,\ncorrelation, or confounding relationships across the Knowledge Graph. As a ...State\nsuffix, this is a frozen N-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Empowers the orchestrator's traversal engine to execute directed\ngraph algorithms (e.g., Random Walk with Restart) via subject_node_id and\nobject_node_id (both 128-char CIDs), utilizing the continuous confidence_score\n(optional, ge=0.0, le=1.0, default=None) to probabilistically prune uncertain paths.\nThe predicate (max_length=2000) carries the semantic relationship label.\n\nEPISTEMIC BOUNDS: Causal directionality is restricted to a strict Literal automaton\n[\"causes\", \"confounds\", \"correlates_with\", \"undirected\"] (default=\"undirected\").\nOptional typed fields (embedding: VectorEmbeddingState, provenance:\nEpistemicProvenanceReceipt, temporal_bounds: TemporalBoundsProfile) extend the edge\ngeometry without mandatory overhead.\n\nMCP ROUTING TRIGGERS: Structural Causal Models, Pearlian Directed Edge, Semantic\nTriplet, Adjacency Matrix, Epistemic Link",
       "properties": {
-        "causal_relationship": {
-          "default": "undirected",
-          "description": "The Pearlian directionality of the semantic relationship.",
-          "enum": [
-            "causes",
-            "confounds",
-            "correlates_with",
-            "undirected"
-          ],
-          "title": "Causal Relationship",
+        "edge_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic edge to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Edge Id",
+          "type": "string"
+        },
+        "subject_node_id": {
+          "description": "The origin SemanticNodeState Content Identifier (CID).",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Subject Node Id",
+          "type": "string"
+        },
+        "object_node_id": {
+          "description": "The destination SemanticNodeState Content Identifier (CID).",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Object Node Id",
           "type": "string"
         },
         "confidence_score": {
@@ -11682,12 +11693,10 @@
           "description": "The probabilistic certainty of this logical connection.",
           "title": "Confidence Score"
         },
-        "edge_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic edge to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Edge Id",
+        "predicate": {
+          "description": "The string representation of the relationship (e.g., 'WORKS_FOR').",
+          "maxLength": 2000,
+          "title": "Predicate",
           "type": "string"
         },
         "embedding": {
@@ -11702,20 +11711,6 @@
           "default": null,
           "description": "Topologically Bounded Latent Spaces used to calculate exact geometric distance and preserve structural Isometry."
         },
-        "object_node_id": {
-          "description": "The destination SemanticNodeState Content Identifier (CID).",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Object Node Id",
-          "type": "string"
-        },
-        "predicate": {
-          "description": "The string representation of the relationship (e.g., 'WORKS_FOR').",
-          "maxLength": 2000,
-          "title": "Predicate",
-          "type": "string"
-        },
         "provenance": {
           "anyOf": [
             {
@@ -11728,14 +11723,6 @@
           "default": null,
           "description": "Optional distinct provenance if the relationship was inferred separately from the nodes."
         },
-        "subject_node_id": {
-          "description": "The origin SemanticNodeState Content Identifier (CID).",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Subject Node Id",
-          "type": "string"
-        },
         "temporal_bounds": {
           "anyOf": [
             {
@@ -11747,6 +11734,18 @@
           ],
           "default": null,
           "description": "The time window during which this relationship holds true."
+        },
+        "causal_relationship": {
+          "default": "undirected",
+          "description": "The Pearlian directionality of the semantic relationship.",
+          "enum": [
+            "causes",
+            "confounds",
+            "correlates_with",
+            "undirected"
+          ],
+          "title": "Causal Relationship",
+          "type": "string"
         }
       },
       "required": [
@@ -11762,15 +11761,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements an execution-layer Semantic Firewall guarding against\nadversarial control-flow overrides and prompt injection attacks. As a ...Policy suffix,\nthis object defines rigid mathematical boundaries that the orchestrator must enforce\nglobally.\n\nCAUSAL AFFORDANCE: Intercepts and physically severs incoming observation topologies if\ntheir classification matches forbidden_intents, executing the deterministic\naction_on_violation (Literal[\"drop\", \"quarantine\", \"redact\"]).\n\nEPISTEMIC BOUNDS: VRAM exhaustion is mathematically prevented by capping max_input_tokens\n(gt=0, le=1000000000). The forbidden_intents array is deterministically sorted by the\n@model_validator to preserve RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Semantic Firewall, Prompt Injection Defense, Adversarial Override,\nZero-Trust Perimeter, Control-Flow Hijacking",
       "properties": {
-        "action_on_violation": {
-          "description": "The deterministic action the orchestrator must take if a firewall rule is violated.",
-          "enum": [
-            "drop",
-            "quarantine",
-            "redact"
-          ],
-          "title": "Action On Violation",
-          "type": "string"
+        "max_input_tokens": {
+          "description": "The absolute physical ceiling of tokens allowed in a single ingress payload.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Max Input Tokens",
+          "type": "integer"
         },
         "forbidden_intents": {
           "description": "A strict array of semantic intents (e.g., 'role_override', 'system_prompt_leak') that trigger immediate quarantine.",
@@ -11781,12 +11777,15 @@
           "title": "Forbidden Intents",
           "type": "array"
         },
-        "max_input_tokens": {
-          "description": "The absolute physical ceiling of tokens allowed in a single ingress payload.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Max Input Tokens",
-          "type": "integer"
+        "action_on_violation": {
+          "description": "The deterministic action the orchestrator must take if a firewall rule is violated.",
+          "enum": [
+            "drop",
+            "quarantine",
+            "redact"
+          ],
+          "title": "Action On Violation",
+          "type": "string"
         }
       },
       "required": [
@@ -11800,6 +11799,37 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen N-dimensional coordinate representing a\ndiscrete entity vertex within a Resource Description Framework (RDF) or continuous\nProperty Graph. As a ...State suffix, this is a mathematically immutable snapshot.\n\nCAUSAL AFFORDANCE: Unlocks privacy-preserving mathematical operations on encrypted\nstate via fhe_profile (HomomorphicEncryptionProfile, optional) and enables zero-shot\nsemantic routing based on dense vector distances (embedding: VectorEmbeddingState,\noptional). Provenance (EpistemicProvenanceReceipt) is required.\n\nEPISTEMIC BOUNDS: The vertex geometry is physically anchored by node_id (128-char CID\nregex). The internal representation (text_chunk) is capped at max_length=50000. The\nscope Literal [\"global\", \"tenant\", \"session\"] (default=\"session\") partitions the\ncryptographic namespace. The tier (CognitiveTierProfile, default=\"semantic\") and\nsalience (SalienceProfile, optional) govern structural pruning.\n\nMCP ROUTING TRIGGERS: Resource Description Framework, Property Graph, Fully\nHomomorphic Encryption, Semantic Coordinate, Vector Embedding",
       "properties": {
+        "node_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic node to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Node Id",
+          "type": "string"
+        },
+        "label": {
+          "description": "The categorical label of the node (e.g., 'Person', 'Concept').",
+          "maxLength": 2000,
+          "title": "Label",
+          "type": "string"
+        },
+        "scope": {
+          "default": "session",
+          "description": "The cryptographic namespace partitioning boundary. Global is public, Tenant is corporate, Session is ephemeral.",
+          "enum": [
+            "global",
+            "tenant",
+            "session"
+          ],
+          "title": "Scope",
+          "type": "string"
+        },
+        "text_chunk": {
+          "description": "The raw natural language representation of the semantic node.",
+          "maxLength": 50000,
+          "title": "Text Chunk",
+          "type": "string"
+        },
         "embedding": {
           "anyOf": [
             {
@@ -11812,58 +11842,14 @@
           "default": null,
           "description": "Topologically Bounded Latent Spaces used to calculate exact geometric distance and preserve structural Isometry."
         },
-        "fhe_profile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HomomorphicEncryptionProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic envelope enabling privacy-preserving computation directly on this node's encrypted state."
-        },
-        "label": {
-          "description": "The categorical label of the node (e.g., 'Person', 'Concept').",
-          "maxLength": 2000,
-          "title": "Label",
-          "type": "string"
-        },
-        "node_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic node to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Node Id",
-          "type": "string"
-        },
         "provenance": {
           "$ref": "#/$defs/EpistemicProvenanceReceipt",
           "description": "The cryptographic chain of custody for this semantic state."
         },
-        "salience": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SalienceProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical importance profile governing structural pruning."
-        },
-        "scope": {
-          "default": "session",
-          "description": "The cryptographic namespace partitioning boundary. Global is public, Tenant is corporate, Session is ephemeral.",
-          "enum": [
-            "global",
-            "tenant",
-            "session"
-          ],
-          "title": "Scope",
-          "type": "string"
+        "tier": {
+          "$ref": "#/$defs/CognitiveTierProfile",
+          "default": "semantic",
+          "description": "The cognitive tier this latent state resides in."
         },
         "temporal_bounds": {
           "anyOf": [
@@ -11877,16 +11863,29 @@
           "default": null,
           "description": "The time window during which this node is considered valid."
         },
-        "text_chunk": {
-          "description": "The raw natural language representation of the semantic node.",
-          "maxLength": 50000,
-          "title": "Text Chunk",
-          "type": "string"
+        "salience": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SalienceProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical importance profile governing structural pruning."
         },
-        "tier": {
-          "$ref": "#/$defs/CognitiveTierProfile",
-          "default": "semantic",
-          "description": "The cognitive tier this latent state resides in."
+        "fhe_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HomomorphicEncryptionProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic envelope enabling privacy-preserving computation directly on this node's encrypted state."
         }
       },
       "required": [
@@ -11902,13 +11901,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Mandatory Access Control (MAC) and Cognitive Load Theory to aggressively cull context window topologies and prevent VRAM exhaustion.\n\nCAUSAL AFFORDANCE: Forces the attention mechanism to physically ignore state representations that lack the whitelisted required_semantic_labels or exceed the permitted_classification_tiers.\n\nEPISTEMIC BOUNDS: VRAM exhaustion is clamped by context_window_token_ceiling (gt=0, le=2000000). The validation pipeline mechanically sorts the tier arrays via @model_validator for invariant RFC 8785 canonical determinism.\n\nMCP ROUTING TRIGGERS: Mandatory Access Control, Zero-Trust Execution, Context Window Partitioning, Cognitive Load Theory, Epistemic Firewall",
       "properties": {
-        "context_window_token_ceiling": {
-          "description": "The mathematical physical limit of the active context partition to prevent VRAM exhaustion.",
-          "exclusiveMinimum": 0,
-          "maximum": 2000000,
-          "title": "Context Window Token Ceiling",
-          "type": "integer"
-        },
         "permitted_classification_tiers": {
           "description": "The explicit whitelist of sensitivity bounds allowed into context.",
           "items": {
@@ -11934,6 +11926,13 @@
           "default": null,
           "description": "The declarative whitelist of strictly typed ontological node labels authorized for context projection.",
           "title": "Required Semantic Labels"
+        },
+        "context_window_token_ceiling": {
+          "description": "The mathematical physical limit of the active context partition to prevent VRAM exhaustion.",
+          "exclusiveMinimum": 0,
+          "maximum": 2000000,
+          "title": "Context Window Token Ceiling",
+          "type": "integer"
         }
       },
       "required": [
@@ -11957,10 +11956,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Cooperative Game Theory to compute the exact Shapley\nvalue ($\\phi_i$) for a specific agent's marginal contribution to a collective outcome.\nAs a ...Receipt suffix, this is an append-only coordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Unlocks deterministic credit assignment and thermodynamic reward\ndistribution, allowing the orchestrator to equitably distribute escrow payouts or\npolicy gradient updates to the participating target_node_id (NodeIdentifierState).\n\nEPISTEMIC BOUNDS: normalized_contribution_percentage is strictly clamped (ge=0.0,\nle=1.0). The causal_attribution_score has only le=1.0 (no ge bound). The Monte Carlo\napproximation confidence bounds (confidence_interval_lower/upper) are capped at\nle=1000000000.0.\n\nMCP ROUTING TRIGGERS: Cooperative Game Theory, Shapley Value, Credit Assignment,\nMarginal Contribution, Monte Carlo Approximation",
       "properties": {
+        "target_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The agent whose causal influence is being measured."
+        },
         "causal_attribution_score": {
           "description": "The exact Shapley value (\\phi_i) satisfying efficiency, symmetry, and additivity axioms.",
           "maximum": 1.0,
           "title": "Causal Attribution Score",
+          "type": "number"
+        },
+        "normalized_contribution_percentage": {
+          "description": "The relative fractional contribution bounded between 0.0 and 1.0.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Normalized Contribution Percentage",
           "type": "number"
         },
         "confidence_interval_lower": {
@@ -11974,17 +11984,6 @@
           "maximum": 1000000000.0,
           "title": "Confidence Interval Upper",
           "type": "number"
-        },
-        "normalized_contribution_percentage": {
-          "description": "The relative fractional contribution bounded between 0.0 and 1.0.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Normalized Contribution Percentage",
-          "type": "number"
-        },
-        "target_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The agent whose causal influence is being measured."
         }
       },
       "required": [
@@ -12067,16 +12066,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a discrete, point-in-time OpenTelemetry annotation within\na broader Dapper-style ExecutionSpanReceipt. As an ...Event suffix, this is a\ncryptographically frozen historical fact that the LLM must never hallucinate a mutation\nto.\n\nCAUSAL AFFORDANCE: Provides fine-grained, localized state-machine logging within an\nactive span, anchoring semantic attributes to a precise nanosecond coordinate without\nspawning a new causal branch.\n\nEPISTEMIC BOUNDS: The timestamp_unix_nano is physically bounded between\n[0, 253402300799000000000]. The attributes payload is strictly constrained by a\ndictionary with string keys (max_length=255, max_length=1000000000 entries) to\nphysically prevent dictionary bombing and VRAM exhaustion during telemetry\nserialization.\n\nMCP ROUTING TRIGGERS: Span Annotation, Point-in-Time Event, Micro-State Logging,\nOpenTelemetry, Telemetry Serialization",
       "properties": {
-        "attributes": {
-          "additionalProperties": true,
-          "description": "Typed metadata bound to the event.",
-          "maxProperties": 1000000000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Attributes",
-          "type": "object"
-        },
         "name": {
           "description": "The semantic name of the event.",
           "maxLength": 2000,
@@ -12089,6 +12078,16 @@
           "minimum": 0,
           "title": "Timestamp Unix Nano",
           "type": "integer"
+        },
+        "attributes": {
+          "additionalProperties": true,
+          "description": "Typed metadata bound to the event.",
+          "maxProperties": 1000000000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Attributes",
+          "type": "object"
         }
       },
       "required": [
@@ -12120,24 +12119,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the Dapper Distributed Tracing model to deterministically map an execution span and its nested causal DAG geometry.\n\nCAUSAL AFFORDANCE: Unlocks systemic observability by connecting parent and child invocations (via parent_span_id), allowing the orchestrator to measure exact latency bottlenecks and topological health.\n\nEPISTEMIC BOUNDS: Temporal geometries are rigidly clamped between start_time and end_time (ge=0.0, le=253402300799.0). Execution health is strictly governed by the status Literal [\"OK\", \"ERROR\", \"PENDING\"].\n\nMCP ROUTING TRIGGERS: Dapper Tracing Model, Distributed Observability, Execution Span, Causal DAG, OpenTelemetry",
       "properties": {
-        "context_profile": {
-          "$ref": "#/$defs/TelemetryContextProfile",
-          "description": "Contextual key-value metadata associated with the span execution."
-        },
-        "end_time": {
-          "anyOf": [
-            {
-              "maximum": 253402300799.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The UNIX timestamp when the span ended.",
-          "title": "End Time"
+        "span_id": {
+          "description": "The unique identifier for this execution span.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Span Id",
+          "type": "string"
         },
         "parent_span_id": {
           "anyOf": [
@@ -12155,20 +12143,27 @@
           "description": "The identifier of the parent span, if any.",
           "title": "Parent Span Id"
         },
-        "span_id": {
-          "description": "The unique identifier for this execution span.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Span Id",
-          "type": "string"
-        },
         "start_time": {
           "description": "The UNIX timestamp when the span started.",
           "maximum": 253402300799.0,
           "minimum": 0.0,
           "title": "Start Time",
           "type": "number"
+        },
+        "end_time": {
+          "anyOf": [
+            {
+              "maximum": 253402300799.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The UNIX timestamp when the span ended.",
+          "title": "End Time"
         },
         "status": {
           "description": "The definitive topological execution state of the span.",
@@ -12179,6 +12174,10 @@
           ],
           "title": "Status",
           "type": "string"
+        },
+        "context_profile": {
+          "$ref": "#/$defs/TelemetryContextProfile",
+          "description": "Contextual key-value metadata associated with the span execution."
         }
       },
       "required": [
@@ -12193,13 +12192,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a 2D Euclidean bounding box within a normalized coordinate\nspace to ensure resolution-independent topological scaling. As a ...Profile suffix,\nthis is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Instructs the frontend rendering matrices to physically constrain\ngraphical overlays, multimodal tokens, and UI projections within a rigid, deterministic\nspatial geometry.\n\nEPISTEMIC BOUNDS: All coordinate tensors (x_min, y_min, x_max, y_max) are\nmathematically clamped to a normalized continuous float space (ge=0.0, le=1.0). The\n@model_validator validate_geometry physically guarantees min bounds cannot exceed max\nbounds, preventing the generation of inverted or non-Euclidean manifolds.\n\nMCP ROUTING TRIGGERS: Euclidean Geometry, Topological Scaling, Normalized Coordinate\nSpace, Bounding Box, Spatial Projection",
       "properties": {
-        "x_max": {
-          "description": "The right boundary.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "X Max",
-          "type": "number"
-        },
         "x_min": {
           "description": "The left boundary.",
           "maximum": 1.0,
@@ -12207,18 +12199,25 @@
           "title": "X Min",
           "type": "number"
         },
-        "y_max": {
-          "description": "The bottom boundary.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Y Max",
-          "type": "number"
-        },
         "y_min": {
           "description": "The top boundary.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Y Min",
+          "type": "number"
+        },
+        "x_max": {
+          "description": "The right boundary.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "X Max",
+          "type": "number"
+        },
+        "y_max": {
+          "description": "The bottom boundary.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Y Max",
           "type": "number"
         }
       },
@@ -12286,28 +12285,6 @@
           "title": "Action Type",
           "type": "string"
         },
-        "bezier_control_points": {
-          "description": "Waypoints for constructing non-linear, bot-evasive movement curves.",
-          "items": {
-            "$ref": "#/$defs/SpatialCoordinateProfile"
-          },
-          "title": "Bezier Control Points",
-          "type": "array"
-        },
-        "expected_visual_concept": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The visual anchor (e.g., 'Submit Button'). The orchestrator must verify this semantic concept exists at the target_coordinate before executing the macro, preventing blind clicks.",
-          "title": "Expected Visual Concept"
-        },
         "target_coordinate": {
           "anyOf": [
             {
@@ -12334,6 +12311,28 @@
           "default": null,
           "description": "The exact temporal duration of the movement, simulating human kinematics.",
           "title": "Trajectory Duration Ms"
+        },
+        "bezier_control_points": {
+          "description": "Waypoints for constructing non-linear, bot-evasive movement curves.",
+          "items": {
+            "$ref": "#/$defs/SpatialCoordinateProfile"
+          },
+          "title": "Bezier Control Points",
+          "type": "array"
+        },
+        "expected_visual_concept": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The visual anchor (e.g., 'Submit Button'). The orchestrator must verify this semantic concept exists at the target_coordinate before executing the macro, preventing blind clicks.",
+          "title": "Expected Visual Concept"
         }
       },
       "required": [
@@ -12346,18 +12345,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a Cryptographic Tuple Space (Blackboard Pattern)\nserving as the strictly typed epistemic synchronization layer for multi-agent\nmanifolds. As a ...Contract suffix, this enforces rigid mathematical boundaries\nglobally.\n\nCAUSAL AFFORDANCE: Physically restricts all state mutations within the topology\nto conform to the explicit schema_definition (JSON Schema dict, key\nmax_length=255), acting as a deterministic Schema-on-Write validation gate.\n\nEPISTEMIC BOUNDS: The strict_validation boolean (default=True) acts as a\nphysical barrier against stochastic drift, forcing the orchestrator to reject\nany state mutation that fails the schema definition. Property names are capped\nat max_length=255 to prevent dictionary bombing.\n\nMCP ROUTING TRIGGERS: Tuple Space, Blackboard Architecture, Schema-on-Write,\nFinite State Automaton, Epistemic Synchronization",
       "properties": {
-        "decoding_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ConstrainedDecodingPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The optional hardware-level execution limits for token masking."
-        },
         "schema_definition": {
           "additionalProperties": true,
           "description": "A strict JSON Schema dictionary defining the required shape of the shared epistemic blackboard.",
@@ -12372,6 +12359,18 @@
           "description": "If True, the orchestrator must reject any state mutation that fails the schema definition.",
           "title": "Strict Validation",
           "type": "boolean"
+        },
+        "decoding_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConstrainedDecodingPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The optional hardware-level execution limits for token masking."
         }
       },
       "required": [
@@ -12384,14 +12383,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Conflict-free Replicated Data Types (CRDTs) using Lamport\nlogical clocks and Vector Clocks to guarantee Eventual Consistency. As a ...Manifest\nsuffix, this defines a frozen, declarative coordinate of a state transition matrix.\n\nCAUSAL AFFORDANCE: Enables lock-free, decentralized state synchronization across the\nswarm. Forces the orchestrator to resolve Last-Writer-Wins (LWW) topological conflicts\nbefore flushing the patches (list[StateMutationIntent]) to the immutable Epistemic\nLedger. The vector_clock dict maps node CIDs to their ge=0 integer mutation counts.\n\nEPISTEMIC BOUNDS: Cryptographically anchored by diff_id and author_node_id (both\nstrict 128-char CID regex). The synchronization math is clamped by lamport_timestamp\n(ge=0, le=1000000000), physically preventing logical clock integer overflow during\nprolonged swarm execution cycles.\n\nMCP ROUTING TRIGGERS: Conflict-Free Replicated Data Types, Lamport Logical Clock,\nVector Clock, Eventual Consistency, Last-Writer-Wins",
       "properties": {
-        "author_node_id": {
-          "description": "The exact Lineage Watermark of the agent or system that authored this state mutation.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Author Node Id",
-          "type": "string"
-        },
         "diff_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for this state differential.",
           "maxLength": 128,
@@ -12400,20 +12391,20 @@
           "title": "Diff Id",
           "type": "string"
         },
+        "author_node_id": {
+          "description": "The exact Lineage Watermark of the agent or system that authored this state mutation.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Author Node Id",
+          "type": "string"
+        },
         "lamport_timestamp": {
           "description": "Strict scalar logical clock governing deterministic LWW (Last-Writer-Wins) conflict resolution.",
           "maximum": 1000000000,
           "minimum": 0,
           "title": "Lamport Timestamp",
           "type": "integer"
-        },
-        "patches": {
-          "description": "The exact, ordered sequence of deterministic state vector mutations.",
-          "items": {
-            "$ref": "#/$defs/StateMutationIntent"
-          },
-          "title": "Patches",
-          "type": "array"
         },
         "vector_clock": {
           "additionalProperties": {
@@ -12426,6 +12417,14 @@
           },
           "title": "Vector Clock",
           "type": "object"
+        },
+        "patches": {
+          "description": "The exact, ordered sequence of deterministic state vector mutations.",
+          "items": {
+            "$ref": "#/$defs/StateMutationIntent"
+          },
+          "title": "Patches",
+          "type": "array"
         }
       },
       "required": [
@@ -12441,6 +12440,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Manages the Epistemic Hydration of an agent's active context\npartition from cold storage, bridging immutable EpistemicLedgerState checkpoints and\nephemeral working memory. As a ...Manifest suffix, this defines a frozen configuration\nstate.\n\nCAUSAL AFFORDANCE: Authorizes the physical injection of serialized semantic data\n(working_context_variables) into the LLM's forward-pass generation window, seeding\nthe context prior to probability wave collapse. The crystallized_ledger_cids (SHA-256\npointers) bind to past immutable ledger blocks.\n\nEPISTEMIC BOUNDS: VRAM exhaustion is prevented by max_retained_tokens (gt=0,\nle=1000000000). The @field_validator enforce_payload_topology calls\n_validate_payload_bounds to prevent Dictionary Bombing on working_context_variables.\nThe @model_validator sort_arrays deterministically sorts crystallized_ledger_cids for\nRFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Epistemic Hydration, Working Memory Injection, Context Window\nPartitioning, VRAM Bounding, Serialization Geometry",
       "properties": {
+        "epistemic_coordinate": {
+          "description": "A string ID representing the session or specific spatial trace binding.",
+          "maxLength": 2000,
+          "title": "Epistemic Coordinate",
+          "type": "string"
+        },
         "crystallized_ledger_cids": {
           "description": "A list of cryptographic pointers to past immutable EpistemicLedgerState blocks.",
           "items": {
@@ -12450,19 +12455,6 @@
           "title": "Crystallized Ledger Cids",
           "type": "array"
         },
-        "epistemic_coordinate": {
-          "description": "A string ID representing the session or specific spatial trace binding.",
-          "maxLength": 2000,
-          "title": "Epistemic Coordinate",
-          "type": "string"
-        },
-        "max_retained_tokens": {
-          "description": "An integer representing the physical limit of the context window.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Max Retained Tokens",
-          "type": "integer"
-        },
         "working_context_variables": {
           "additionalProperties": true,
           "description": "A strictly typed dictionary for ephemeral context variables injected at runtime. AGENT INSTRUCTION: This matrix is deterministically sorted by CoreasonBaseState natively.",
@@ -12471,6 +12463,13 @@
           },
           "title": "Working Context Variables",
           "type": "object"
+        },
+        "max_retained_tokens": {
+          "description": "An integer representing the physical limit of the context window.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Max Retained Tokens",
+          "type": "integer"
         }
       },
       "required": [
@@ -12486,20 +12485,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the formal RFC 6902 JSON Patch standard to execute atomic,\ndeterministic state vector mutations across the swarm's N-dimensional blackboard. As an\n...Intent suffix, this represents an authorized kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's algebraic engine to surgically apply,\ntest, or ablate targeted JSON pointers without requiring full payload transmission. The\nvalue (JsonPrimitiveState, default=None) carries the mutation payload; from_path\n(alias=\"from\") enables RFC 6902 move/copy operations.\n\nEPISTEMIC BOUNDS: The operation geometry is rigidly restricted by the op field to the\nPatchOperationProfile Literal automaton. Target topological coordinates (path and\nfrom_path) are physically bounded to max_length=2000 to prevent path traversal and\nstring exhaustion during pointer resolution.\n\nMCP ROUTING TRIGGERS: RFC 6902, JSON Patch, Atomic Mutation, State Vector Projection,\nDeterministic Operator",
       "properties": {
-        "from": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The JSON pointer from which to copy or move the state vector, if applicable.",
-          "title": "From"
-        },
         "op": {
           "$ref": "#/$defs/PatchOperationProfile",
           "description": "The strict RFC 6902 JSON Patch operation, acting as a deterministic state vector mutation."
@@ -12514,6 +12499,20 @@
           "$ref": "#/$defs/JsonPrimitiveState",
           "default": null,
           "description": "The payload to insert or test, if applicable, for this deterministic state vector mutation."
+        },
+        "from": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The JSON pointer from which to copy or move the state vector, if applicable.",
+          "title": "From"
         }
       },
       "required": [
@@ -12527,6 +12526,19 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Inter-Process Communication (IPC) utilizing POSIX\nstandard streams to execute highly isolated, local binary sandboxing. As a\n...Profile suffix, this is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Physically spawns a child process restricted to the host's\noperating system namespace, mapping remote procedure calls directly into the\nbinary's stdin/stdout descriptors via command (max_length=2000).\n\nEPISTEMIC BOUNDS: To prevent buffer overflow and command injection, args are\nstructurally constrained (max_length=1000000000, string max_length=2000,\ndefault_factory=list) and env_vars keys/values are strictly delimited via\nStringConstraints (key max_length=255, value max_length=2000,\ndefault_factory=dict).\n\nMCP ROUTING TRIGGERS: Inter-Process Communication, POSIX Standard Streams, Local\nSandboxing, Binary Execution, Subprocess Spawn",
       "properties": {
+        "type": {
+          "const": "stdio",
+          "default": "stdio",
+          "description": "Type of transport.",
+          "title": "Type",
+          "type": "string"
+        },
+        "command": {
+          "description": "The command executable to run (e.g., 'node', 'python').",
+          "maxLength": 2000,
+          "title": "Command",
+          "type": "string"
+        },
         "args": {
           "description": "The explicit array of arguments to pass to the command.",
           "items": {
@@ -12536,12 +12548,6 @@
           "maxItems": 1000000000,
           "title": "Args",
           "type": "array"
-        },
-        "command": {
-          "description": "The command executable to run (e.g., 'node', 'python').",
-          "maxLength": 2000,
-          "title": "Command",
-          "type": "string"
         },
         "env_vars": {
           "additionalProperties": {
@@ -12554,13 +12560,6 @@
           },
           "title": "Env Vars",
           "type": "object"
-        },
-        "type": {
-          "const": "stdio",
-          "default": "stdio",
-          "description": "Type of transport.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -12616,12 +12615,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Judea Pearl's Structural Causal Models (SCMs) by mapping the causal topology of observed and latent variables.\n\nCAUSAL AFFORDANCE: Unlocks do-calculus and interventional logic by providing the orchestrator with the explicit DAG required to identify confounders and compute causal effects.\n\nEPISTEMIC BOUNDS: Variables are constrained by strict bounds (max_length=255). The @model_validator deterministically sorts observed_variables, latent_variables, and causal_edges to mathematically guarantee zero-variance RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Structural Causal Models, Pearlian DAG, Latent Confounder, d-separation, Interventional Topology",
       "properties": {
-        "causal_edges": {
-          "description": "The declared topological mapping of causality.",
+        "observed_variables": {
+          "description": "The nodes in the DAG that the agent can passively measure.",
           "items": {
-            "$ref": "#/$defs/CausalDirectedEdgeState"
+            "maxLength": 255,
+            "type": "string"
           },
-          "title": "Causal Edges",
+          "maxItems": 1000000000,
+          "title": "Observed Variables",
           "type": "array"
         },
         "latent_variables": {
@@ -12634,14 +12635,12 @@
           "title": "Latent Variables",
           "type": "array"
         },
-        "observed_variables": {
-          "description": "The nodes in the DAG that the agent can passively measure.",
+        "causal_edges": {
+          "description": "The declared topological mapping of causality.",
           "items": {
-            "maxLength": 255,
-            "type": "string"
+            "$ref": "#/$defs/CausalDirectedEdgeState"
           },
-          "maxItems": 1000000000,
-          "title": "Observed Variables",
+          "title": "Causal Edges",
           "type": "array"
         }
       },
@@ -12657,13 +12656,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot defining a Complex Adaptive System\nrepresenting a fluid, decentralized Swarm topology governed by Algorithmic Mechanism\nDesign and Spot Market dynamics. As a ...Manifest suffix, this defines a frozen\nN-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Unlocks dynamic agent instantiation, allowing the topology to\nspawn concurrent workers up to max_concurrent_agents (le=100, default=10) and resolve\nconsensus probabilistically via active_prediction_markets. Optional auction_policy\n(AuctionPolicy) governs task decentralization.\n\nEPISTEMIC BOUNDS: Horizontal compute explosion is governed by spawning_threshold\n(ge=1, le=100, default=3) and max_concurrent_agents (le=100, default=10). The\n@model_validator enforce_concurrency_ceiling guarantees spawning_threshold cannot\nexceed max_concurrent_agents. A second @model_validator sort_arrays deterministically\nsorts active and resolved prediction markets by market_id for RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Complex Adaptive Systems, Swarm Intelligence, Algorithmic\nMechanism Design, Spot Market Routing, Multi-Agent Reinforcement Learning",
       "properties": {
-        "active_prediction_markets": {
-          "description": "The live algorithmic betting markets resolving swarm consensus.",
-          "items": {
-            "$ref": "#/$defs/PredictionMarketState"
-          },
-          "title": "Active Prediction Markets",
-          "type": "array"
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy",
+              "le": 1000000000
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
         },
         "architectural_intent": {
           "anyOf": [
@@ -12679,43 +12693,6 @@
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
         },
-        "auction_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AuctionPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical policy governing task decentralization via Spot Markets."
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy",
-              "le": 1000000000
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "information_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
-        },
         "justification": {
           "anyOf": [
             {
@@ -12730,23 +12707,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
-        "max_concurrent_agents": {
-          "default": 10,
-          "description": "The absolute ceiling for concurrent agent threads.",
-          "maximum": 100,
-          "title": "Max Concurrent Agents",
-          "type": "integer"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -12757,26 +12717,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The distributed tracing rules bound to this specific execution graph."
-        },
-        "resolved_markets": {
-          "description": "The immutable records of finalized markets and reputation capital distributions.",
-          "items": {
-            "$ref": "#/$defs/MarketResolutionState"
-          },
-          "title": "Resolved Markets",
-          "type": "array"
         },
         "shared_state_contract": {
           "anyOf": [
@@ -12790,6 +12730,37 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The distributed tracing rules bound to this specific execution graph."
+        },
+        "type": {
+          "const": "swarm",
+          "default": "swarm",
+          "description": "Discriminator for a Swarm topology.",
+          "title": "Type",
+          "type": "string"
+        },
         "spawning_threshold": {
           "default": 3,
           "description": "Threshold limit for dynamic spawning of additional nodes.",
@@ -12798,12 +12769,40 @@
           "title": "Spawning Threshold",
           "type": "integer"
         },
-        "type": {
-          "const": "swarm",
-          "default": "swarm",
-          "description": "Discriminator for a Swarm topology.",
-          "title": "Type",
-          "type": "string"
+        "max_concurrent_agents": {
+          "default": 10,
+          "description": "The absolute ceiling for concurrent agent threads.",
+          "maximum": 100,
+          "title": "Max Concurrent Agents",
+          "type": "integer"
+        },
+        "auction_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AuctionPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical policy governing task decentralization via Spot Markets."
+        },
+        "active_prediction_markets": {
+          "description": "The live algorithmic betting markets resolving swarm consensus.",
+          "items": {
+            "$ref": "#/$defs/PredictionMarketState"
+          },
+          "title": "Active Prediction Markets",
+          "type": "array"
+        },
+        "resolved_markets": {
+          "description": "The immutable records of finalized markets and reputation capital distributions.",
+          "items": {
+            "$ref": "#/$defs/MarketResolutionState"
+          },
+          "title": "Resolved Markets",
+          "type": "array"
         }
       },
       "required": [
@@ -12816,10 +12815,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a formal blueprint for Model-Based Fuzzing and\nGenerative Adversarial Testing against the Universal Unified Ontology. As a\n...Profile suffix, this is a declarative, frozen snapshot of an evaluation\ngeometry.\n\nCAUSAL AFFORDANCE: Instructs exogenous fuzzing engines to synthesize\npermutations of the target_schema_ref (min_length=1), actively injecting\nstructural entropy into the system while strictly adhering to the bounding\nmanifold_sla (GenerativeManifoldSLA).\n\nEPISTEMIC BOUNDS: The profile identity is cryptographically anchored to the\nprofile_id (128-char CID regex ^[a-zA-Z0-9_.:-]+$). The simulation scope is\nphysically restricted by the underlying manifold_sla.\n\nMCP ROUTING TRIGGERS: Model-Based Fuzzing, Generative Adversarial Testing,\nStructural Entropy, Fuzzing Blueprint, Synthetic Permutation",
       "properties": {
-        "manifold_sla": {
-          "$ref": "#/$defs/GenerativeManifoldSLA",
-          "description": "The structural topological gas limit."
-        },
         "profile_id": {
           "description": "Unique identifier for this simulation profile.",
           "maxLength": 128,
@@ -12827,6 +12822,10 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Profile Id",
           "type": "string"
+        },
+        "manifold_sla": {
+          "$ref": "#/$defs/GenerativeManifoldSLA",
+          "description": "The structural topological gas limit."
         },
         "target_schema_ref": {
           "description": "The string name of the Pydantic class to synthesize.",
@@ -12847,6 +12846,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Kahneman's Dual-Process Theory (System 1) to execute\nrapid, heuristic-based reflex actions without invoking deep logical search trees. As a\n...Policy suffix, this enforces a rigid computational boundary.\n\nCAUSAL AFFORDANCE: Unlocks zero-shot execution of side-effect-free capabilities when\nthe working context matches established high-probability priors, intentionally bypassing\nexpensive System 2 Monte Carlo Tree Search (MCTS).\n\nEPISTEMIC BOUNDS: Execution is mathematically gated by the confidence_threshold\n(ge=0.0, le=1.0). The allowed_passive_tools array (max_length=1000000000,\nStringConstraints max_length=2000) strictly bounds the agent to non-mutating\ncapabilities, deterministically sorted via @model_validator.\n\nMCP ROUTING TRIGGERS: Dual-Process Theory, System 1 Heuristics, Zero-Shot Reflex,\nMetacognition, Amygdala Hijack Prevention",
       "properties": {
+        "confidence_threshold": {
+          "description": "The confidence threshold required to execute a reflex action.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Threshold",
+          "type": "number"
+        },
         "allowed_passive_tools": {
           "description": "The explicit, bounded array of strictly non-mutating tool capabilities.",
           "items": {
@@ -12856,13 +12862,6 @@
           "maxItems": 1000000000,
           "title": "Allowed Passive Tools",
           "type": "array"
-        },
-        "confidence_threshold": {
-          "description": "The confidence threshold required to execute a reflex action.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Confidence Threshold",
-          "type": "number"
         }
       },
       "required": [
@@ -12876,6 +12875,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Kahneman's Dual-Process Theory by explicitly triggering a System 2 non-monotonic self-correction loop in response to a structural execution collapse. As an ...Intent suffix, this represents an authorized kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Intercepts physical instantiation failures (e.g., Pydantic ValidationErrors) and redirects the generation trajectory, forcing the agent into a recursive backtracking search to rewrite the isolated subgraph via `failing_pointers`.\n\nEPISTEMIC BOUNDS: The `fault_id` is cryptographically tied to a 128-char CID. The `failing_pointers` array (max_length=2000 per string) is deterministically sorted by the `_sort_failing_pointers` hook to preserve RFC 8785 canonical hashing and map exact JSON paths without ambiguity.\n\nMCP ROUTING TRIGGERS: Dual-Process Theory, Non-Monotonic Revision, System 2 Remediation, Backtracking Search, Abstract Syntax Tree",
       "properties": {
+        "fault_id": {
+          "description": "A cryptographic Lineage Watermark (CID) tracking this specific dimensional collapse.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Fault Id",
+          "type": "string"
+        },
+        "target_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The strict W3C DID of the agent that authored the invalid state, ensuring the fault is routed back to the exact state partition."
+        },
         "failing_pointers": {
           "description": "A strictly typed array of RFC 6902 JSON Pointers isolating the exact topological coordinate of the hallucination.",
           "items": {
@@ -12886,23 +12897,11 @@
           "title": "Failing Pointers",
           "type": "array"
         },
-        "fault_id": {
-          "description": "A cryptographic Lineage Watermark (CID) tracking this specific dimensional collapse.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Fault Id",
-          "type": "string"
-        },
         "remediation_prompt": {
           "description": "The deterministic, non-monotonic natural-language constraint the agent must satisfy.",
           "minLength": 1,
           "title": "Remediation Prompt",
           "type": "string"
-        },
-        "target_node_id": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The strict W3C DID of the agent that authored the invalid state, ensuring the fault is routed back to the exact state partition."
         }
       },
       "required": [
@@ -12952,6 +12951,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encapsulates pure functional logic (Lambda Calculus) and Finite\nState Machine (FSM) mechanics to represent a completely deterministic,\nside-effect-free system capability. As a ...Profile suffix, this is a declarative\nproperty descriptor.\n\nCAUSAL AFFORDANCE: Executes rigid, zero-variance procedural logic without invoking\nthe expensive stochastic policy gradients required by foundational LLM models.\n\nEPISTEMIC BOUNDS: This node defines NO additional fields beyond inherited\nBaseNodeProfile constraints, including the rigorous domain_extensions recursive\ndepth limits. The type discriminator is locked to Literal[\"system\"].\n\nMCP ROUTING TRIGGERS: Lambda Calculus, Finite State Machine, Referential\nTransparency, Deterministic Execution, Zero Variance",
       "properties": {
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -12966,11 +12971,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -12988,28 +13009,6 @@
           "default": null,
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks.",
           "title": "Domain Extensions"
-        },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
         },
         "type": {
           "const": "system",
@@ -13029,11 +13028,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Initiates a Request for Proposal (RFP) within a decentralized Spot\nMarket to dynamically allocate thermodynamic compute based on task complexity. As an\n...Intent suffix, this is a kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Triggers an active, non-monotonic bidding phase where eligible Swarm\nnodes evaluate their internal Q-K matrices to formulate competitive execution bids.\n\nEPISTEMIC BOUNDS: The economic payload is physically capped by max_budget_magnitude\n(le=1000000000). The topological routing is strictly constrained if\nrequired_action_space_id is defined (optional, max_length=128, CID regex). Anchored by\na mandatory task_id CID (max_length=128).\n\nMCP ROUTING TRIGGERS: Decentralized Spot Market, Request for Proposal, Thermodynamic\nCompute Allocation, Algorithmic Mechanism Design, Kinetic Execution Trigger",
       "properties": {
-        "max_budget_magnitude": {
-          "description": "The absolute ceiling price the orchestrator is willing to pay.",
-          "maximum": 1000000000,
-          "title": "Max Budget Magnitude",
-          "type": "integer"
+        "task_id": {
+          "description": "Unique identifier for the required task.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Id",
+          "type": "string"
         },
         "required_action_space_id": {
           "anyOf": [
@@ -13051,13 +13052,11 @@
           "description": "Optional restriction forcing bidders to possess a specific toolset.",
           "title": "Required Action Space Id"
         },
-        "task_id": {
-          "description": "Unique identifier for the required task.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Id",
-          "type": "string"
+        "max_budget_magnitude": {
+          "description": "The absolute ceiling price the orchestrator is willing to pay.",
+          "maximum": 1000000000,
+          "title": "Max Budget Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -13069,8 +13068,16 @@
     },
     "TaskAwardReceipt": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the\nsuccessful clearing of an algorithmic auction and the mathematically proven allocation\nof compute capital. As a ...Receipt suffix, this is an append-only coordinate on the\nMerkle-DAG.\n\nCAUSAL AFFORDANCE: Definitively terminates the auction phase and authorizes the\nawarded_syndicate to execute their task trajectory using the locked EscrowPolicy funds.\n\nEPISTEMIC BOUNDS: Two @model_validators execute physical invariant checks: (1)\nConservation of Compute \u2014 the sum of awarded_syndicate values must exactly equal\ncleared_price_magnitude (le=1000000000); (2) Escrow Ceiling \u2014 escrow_locked_magnitude\ncannot exceed cleared_price_magnitude.\n\nMCP ROUTING TRIGGERS: Market Clearing, Escrow Lock, Cryptographic Provenance, Syndicate\nAllocation, Thermodynamic Execution",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the\nsuccessful clearing of an algorithmic auction and the mathematically proven allocation\nof compute capital. As a ...Receipt suffix, this is an append-only coordinate on the\nMerkle-DAG.\n\nCAUSAL AFFORDANCE: Definitively terminates the auction phase and authorizes the\nawarded_syndicate to execute their task trajectory using the locked EscrowPolicy funds.\n\nEPISTEMIC BOUNDS: Two @model_validators execute physical invariant checks: (1)\nConservation of Compute — the sum of awarded_syndicate values must exactly equal\ncleared_price_magnitude (le=1000000000); (2) Escrow Ceiling — escrow_locked_magnitude\ncannot exceed cleared_price_magnitude.\n\nMCP ROUTING TRIGGERS: Market Clearing, Escrow Lock, Cryptographic Provenance, Syndicate\nAllocation, Thermodynamic Execution",
       "properties": {
+        "task_id": {
+          "description": "The identifier of the resolved task.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Id",
+          "type": "string"
+        },
         "awarded_syndicate": {
           "additionalProperties": {
             "minimum": 0,
@@ -13100,14 +13107,6 @@
           ],
           "default": null,
           "description": "The conditional escrow locking the compute budget."
-        },
-        "task_id": {
-          "description": "The identifier of the resolved task.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Id",
-          "type": "string"
         }
       },
       "required": [
@@ -13122,6 +13121,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Hierarchical Agglomerative Clustering to project continuous,\ndense latent vector spaces into a deterministic, discrete N-ary tree structure. As a\n...State suffix, this is a declarative, frozen snapshot of a specific geometric coordinate.\n\nCAUSAL AFFORDANCE: Establishes a strictly bounded, navigable spatial coordinate within\nthe Virtual File System (VFS), allowing agents to traverse high-dimensional semantic\nspaces without consuming excessive context window tokens.\n\nEPISTEMIC BOUNDS: Spatial geometry is locked via node_id (a strictly typed 128-character\nCID). The children_node_ids array is deterministically sorted, and the leaf_provenance\narray is sorted by source_event_id, both via @model_validator to guarantee invariant\nRFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Dimensionality Reduction, Hierarchical Clustering, N-ary Tree,\nVirtual File System, Semantic Coordinate",
       "properties": {
+        "node_id": {
+          "description": "A Content Identifier (CID) bounding this specific taxonomic coordinate.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Node Id",
+          "type": "string"
+        },
+        "semantic_label": {
+          "description": "The human-legible, dynamically synthesized categorical label (e.g., 'High Risk Policies').",
+          "maxLength": 2000,
+          "title": "Semantic Label",
+          "type": "string"
+        },
         "children_node_ids": {
           "description": "Explicit array of child node CIDs to enforce the Directed Acyclic Graph.",
           "items": {
@@ -13139,20 +13152,6 @@
           },
           "title": "Leaf Provenance",
           "type": "array"
-        },
-        "node_id": {
-          "description": "A Content Identifier (CID) bounding this specific taxonomic coordinate.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Node Id",
-          "type": "string"
-        },
-        "semantic_label": {
-          "description": "The human-legible, dynamically synthesized categorical label (e.g., 'High Risk Policies').",
-          "maxLength": 2000,
-          "title": "Semantic Label",
-          "type": "string"
         }
       },
       "required": [
@@ -13166,6 +13165,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Executes a kinetic Graph Isomorphism transformation, dynamically\nmutating the UI's spatial organization via heuristic regrouping without altering the\nunderlying epistemic truth. As an ...Intent suffix, the LLM may execute non-monotonic\nreasoning here.\n\nCAUSAL AFFORDANCE: Forces the Hollow Data Plane to immediately discard the current\nsemantic manifold and re-render the hierarchical projection according to the newly\nsynthesized target_taxonomy (GenerativeTaxonomyManifest) and spatial heuristic.\n\nEPISTEMIC BOUNDS: Execution is rigidly constrained by the restructure_heuristic, strictly\nbounded to a Literal automaton [\"chronological\", \"entity_centric\", \"semantic_cluster\",\n\"confidence_decay\"], mathematically preventing out-of-distribution UI mutations.\n\nMCP ROUTING TRIGGERS: Graph Isomorphism, UI State Mutation, Heuristic Regrouping,\nDynamic Manifold, Spatial Reorganization",
       "properties": {
+        "type": {
+          "const": "taxonomic_restructure",
+          "default": "taxonomic_restructure",
+          "description": "Strict discriminator for dynamic UI regrouping.",
+          "title": "Type",
+          "type": "string"
+        },
         "restructure_heuristic": {
           "description": "The SOTA mathematical heuristic used to project the new manifold.",
           "enum": [
@@ -13180,13 +13186,6 @@
         "target_taxonomy": {
           "$ref": "#/$defs/GenerativeTaxonomyManifest",
           "description": "The newly synthesized topology projected to the frontend."
-        },
-        "type": {
-          "const": "taxonomic_restructure",
-          "default": "taxonomic_restructure",
-          "description": "Strict discriminator for dynamic UI regrouping.",
-          "title": "Type",
-          "type": "string"
         }
       },
       "required": [
@@ -13200,15 +13199,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a deterministic Softmax Router Gate, leveraging Cognitive\nLoad Theory to map high-entropy natural language intents into explicitly bounded spatial\norganizing frameworks. As a ...Policy suffix, this dictates a rigid global boundary.\n\nCAUSAL AFFORDANCE: Pre-emptively routes classified intents to optimized taxonomic\nlayouts, mechanically preventing token exhaustion and attention dilution in downstream\nprocessing nodes before compute is allocated. Unclassified intents default to the\nfallback_heuristic.\n\nEPISTEMIC BOUNDS: The intent_to_heuristic_matrix physically restricts state-space\nexplosion by capping at max_length=1000 dictionary properties. The matrix keys are\nstrictly bounded to 255 characters via StringConstraints to mathematically prevent\nDictionary Bombing during hashing.\n\nMCP ROUTING TRIGGERS: Softmax Gating, Cognitive Load Theory, Pre-Flight Routing,\nDictionary Bombing Prevention, Token Exhaustion Mitigation",
       "properties": {
-        "fallback_heuristic": {
-          "description": "The deterministic default applied if intent classification falls below the safety threshold.",
-          "enum": [
-            "chronological",
-            "entity_centric",
-            "semantic_cluster",
-            "confidence_decay"
-          ],
-          "title": "Fallback Heuristic",
+        "policy_id": {
+          "description": "Unique identifier for this pre-flight routing policy.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Policy Id",
           "type": "string"
         },
         "intent_to_heuristic_matrix": {
@@ -13229,12 +13225,15 @@
           "title": "Intent To Heuristic Matrix",
           "type": "object"
         },
-        "policy_id": {
-          "description": "Unique identifier for this pre-flight routing policy.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Policy Id",
+        "fallback_heuristic": {
+          "description": "The deterministic default applied if intent classification falls below the safety threshold.",
+          "enum": [
+            "chronological",
+            "entity_centric",
+            "semantic_cluster",
+            "confidence_decay"
+          ],
+          "title": "Fallback Heuristic",
           "type": "string"
         }
       },
@@ -13289,18 +13288,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Allen's Interval Algebra to definitively lock a state coordinate within an exact chronological boundary on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to computationally evaluate overlapping or preceding topological events to govern temporal state transitions and eviction.\n\nEPISTEMIC BOUNDS: Both `valid_from` and `valid_to` are physically clamped (`le=1000000000.0`, `ge=0.0`). The `@model_validator` mathematically forbids inverted temporal geometry by guaranteeing `valid_to` is strictly greater than `valid_from`.\n\nMCP ROUTING TRIGGERS: Allen's Interval Algebra, Temporal Geometry, Chronological Bounding, Topological Time, State Transition",
       "properties": {
-        "interval_type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CausalIntervalProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The Allen's interval algebra or causal relationship classification."
-        },
         "valid_from": {
           "anyOf": [
             {
@@ -13329,6 +13316,18 @@
           "default": null,
           "description": "The UNIX timestamp when this coordinate was invalidated.",
           "title": "Valid To"
+        },
+        "interval_type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CausalIntervalProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The Allen's interval algebra or causal relationship classification."
         }
       },
       "title": "TemporalBoundsProfile",
@@ -13386,30 +13385,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents the discrete, deterministic crystallization of an\nephemeral POSIX/TTY execution buffer into a verifiable Merkle-DAG state vector.\nAs a ...State suffix, this is a declarative, frozen snapshot of an external\nconsole.\n\nCAUSAL AFFORDANCE: Acts as the structural sensor array for shell interactions,\ncapturing continuous stdout/stderr streams and environment matrices as\ncryptographically locked exogenous perturbations. The working_directory\n(max_length=2000) anchors the filesystem context.\n\nEPISTEMIC BOUNDS: Physically restricted to SHA-256 canonical fingerprints\n(stdout_hash, stderr_hash, env_variables_hash, all matching ^[a-f0-9]{64}$) to\nmathematically prevent VRAM memory exhaustion from unbounded shell log buffering.\n\nMCP ROUTING TRIGGERS: POSIX Environment, Exogenous Perturbation, TTY Buffer,\nCausal Actuator, Stream Crystallization",
       "properties": {
-        "env_variables_hash": {
-          "description": "The SHA-256 hash of the state-space context matrix.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Env Variables Hash",
-          "type": "string"
-        },
-        "stderr_hash": {
-          "description": "The SHA-256 hash tracking structural deviation anomalies.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Stderr Hash",
-          "type": "string"
-        },
-        "stdout_hash": {
-          "description": "The SHA-256 hash of the Exogenous Perturbations captured.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Stdout Hash",
-          "type": "string"
-        },
         "type": {
           "const": "terminal",
           "default": "terminal",
@@ -13421,6 +13396,30 @@
           "description": "Capability Perimeters defining context bounds.",
           "maxLength": 2000,
           "title": "Working Directory",
+          "type": "string"
+        },
+        "stdout_hash": {
+          "description": "The SHA-256 hash of the Exogenous Perturbations captured.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Stdout Hash",
+          "type": "string"
+        },
+        "stderr_hash": {
+          "description": "The SHA-256 hash tracking structural deviation anomalies.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Stderr Hash",
+          "type": "string"
+        },
+        "env_variables_hash": {
+          "description": "The SHA-256 hash of the state-space context matrix.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Env Variables Hash",
           "type": "string"
         }
       },
@@ -13437,6 +13436,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Bayesian Theory of Mind (BToM) and Multi-Agent Epistemic Logic to model the hidden cognitive state and knowledge gaps of foreign agents.\n\nCAUSAL AFFORDANCE: Empowers the orchestrator to dynamically compress and target interpersonal communication by referencing assumed_shared_beliefs to avoid redundant information transfer across the swarm.\n\nEPISTEMIC BOUNDS: The predictive certainty is physically bounded by empathy_confidence_score (ge=0.0, le=1.0). The target_agent_id is anchored to a 128-char CID. Arrays are deterministically sorted by the @model_validator to preserve cryptographic canonicalization.\n\nMCP ROUTING TRIGGERS: Bayesian Theory of Mind, Epistemic Logic, Cognitive Modeling, Common Knowledge, Multi-Agent Inference",
       "properties": {
+        "target_agent_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the agent whose mind is being modeled.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Agent Id",
+          "type": "string"
+        },
         "assumed_shared_beliefs": {
           "description": "The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses.",
           "items": {
@@ -13446,13 +13453,6 @@
           },
           "title": "Assumed Shared Beliefs",
           "type": "array"
-        },
-        "empathy_confidence_score": {
-          "description": "The mathematical confidence (0.0 to 1.0) the agent has in its model of the target's mind.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Empathy Confidence Score",
-          "type": "number"
         },
         "identified_knowledge_gaps": {
           "description": "Specific topics or logical premises the target agent is assumed to be missing.",
@@ -13464,13 +13464,12 @@
           "title": "Identified Knowledge Gaps",
           "type": "array"
         },
-        "target_agent_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the agent whose mind is being modeled.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Agent Id",
-          "type": "string"
+        "empathy_confidence_score": {
+          "description": "The mathematical confidence (0.0 to 1.0) the agent has in its model of the target's mind.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Empathy Confidence Score",
+          "type": "number"
         }
       },
       "required": [
@@ -13494,14 +13493,6 @@
           "title": "Branch Id",
           "type": "string"
         },
-        "latent_content_hash": {
-          "description": "The SHA-256 hash of the raw latent dimensions explored in this branch.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Latent Content Hash",
-          "type": "string"
-        },
         "parent_branch_id": {
           "anyOf": [
             {
@@ -13517,6 +13508,14 @@
           "default": null,
           "description": "The branch this thought diverged from, enabling tree reconstruction.",
           "title": "Parent Branch Id"
+        },
+        "latent_content_hash": {
+          "description": "The SHA-256 hash of the raw latent dimensions explored in this branch.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Latent Content Hash",
+          "type": "string"
         },
         "prm_score": {
           "anyOf": [
@@ -13554,19 +13553,34 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Landauer's Principle of thermodynamic computing within the\nneurosymbolic network, serving as a lock-free, cryptographically frozen record of\nirreversible token and energy expenditure. As a ...Receipt suffix, this is an append-only\ncoordinate on the Merkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Deducts exact computational magnitude from the agent's localized\nProof-of-Stake (PoS) execution escrow, progressively narrowing its available search\ndepth. Cryptographically bound to its causal origin via tool_invocation_id CID.\n\nEPISTEMIC BOUNDS: Integer bounds (ge=0, le=1000000000) on input_tokens, output_tokens,\nand burn_magnitude mathematically prevent integer overflow and fractional bypasses during\ndecentralized ledger tallying.\n\nMCP ROUTING TRIGGERS: Landauer's Principle, Thermodynamic Compute, Token Burn, Resource\nExhaustion, Lock-Free Tallying",
       "properties": {
-        "burn_magnitude": {
-          "description": "The normalized economic cost magnitude representing thermodynamic burn.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Burn Magnitude",
-          "type": "integer"
-        },
         "event_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "token_burn",
+          "default": "token_burn",
+          "description": "Discriminator type for a token burn receipt.",
+          "title": "Type",
+          "type": "string"
+        },
+        "tool_invocation_id": {
+          "description": "A string linking this burn back to the specific ToolInvocationEvent CID.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Tool Invocation Id",
           "type": "string"
         },
         "input_tokens": {
@@ -13583,27 +13597,12 @@
           "title": "Output Tokens",
           "type": "integer"
         },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "tool_invocation_id": {
-          "description": "A string linking this burn back to the specific ToolInvocationEvent CID.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Tool Invocation Id",
-          "type": "string"
-        },
-        "type": {
-          "const": "token_burn",
-          "default": "token_burn",
-          "description": "Discriminator type for a token burn receipt.",
-          "title": "Type",
-          "type": "string"
+        "burn_magnitude": {
+          "description": "The normalized economic cost magnitude representing thermodynamic burn.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Burn Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -13632,8 +13631,43 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Judea Pearl's Do-Operator ($do(X=x)$) on an\nexternal or internal toolset, acting as an A Priori Kinetic Commitment. As an\n...Event suffix, this is an append-only, cryptographically frozen coordinate on\nthe Merkle-DAG.\n\nCAUSAL AFFORDANCE: Transitions the swarm from internal epistemic deliberation to\nkinetic execution. It targets tool_name (max_length=2000) with parameters (dict,\nmax_length=1000000000) and requires a mandatory agent_attestation\n(AgentAttestationReceipt) proving identity.\n\nEPISTEMIC BOUNDS: The execution's thermodynamic cost is economically bounded by\nauthorized_budget_magnitude (int | None, le=1000000000, ge=0, default=None).\nZero-Trust execution is rigidly enforced by the mandatory zk_proof\n(ZeroKnowledgeReceipt), physically prohibiting forged network executions.\n\nMCP ROUTING TRIGGERS: Pearlian Do-Operator, Kinetic Commitment, Active Inference,\nThermodynamic Escrow, Zero-Trust Actuation",
       "properties": {
-        "agent_attestation": {
-          "$ref": "#/$defs/AgentAttestationReceipt"
+        "event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Event Id",
+          "type": "string"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "tool_invocation",
+          "default": "tool_invocation",
+          "description": "Discriminator type for a tool invocation event.",
+          "title": "Type",
+          "type": "string"
+        },
+        "tool_name": {
+          "description": "The exact tool targeted in the ActionSpaceManifest.",
+          "maxLength": 2000,
+          "title": "Tool Name",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": true,
+          "description": "The intended JSON-RPC payload.",
+          "maxProperties": 1000000000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Parameters",
+          "type": "object"
         },
         "authorized_budget_magnitude": {
           "anyOf": [
@@ -13650,43 +13684,8 @@
           "description": "The maximum escrow unlocked for this specific run.",
           "title": "Authorized Budget Magnitude"
         },
-        "event_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Event Id",
-          "type": "string"
-        },
-        "parameters": {
-          "additionalProperties": true,
-          "description": "The intended JSON-RPC payload.",
-          "maxProperties": 1000000000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Parameters",
-          "type": "object"
-        },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "tool_name": {
-          "description": "The exact tool targeted in the ActionSpaceManifest.",
-          "maxLength": 2000,
-          "title": "Tool Name",
-          "type": "string"
-        },
-        "type": {
-          "const": "tool_invocation",
-          "default": "tool_invocation",
-          "description": "Discriminator type for a tool invocation event.",
-          "title": "Type",
-          "type": "string"
+        "agent_attestation": {
+          "$ref": "#/$defs/AgentAttestationReceipt"
         },
         "zk_proof": {
           "$ref": "#/$defs/ZeroKnowledgeReceipt",
@@ -13708,6 +13707,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the discrete formalization of a Gibsonian Affordance within\nthe agent's Reinforcement Learning Action Space ($A$). As a ...Manifest suffix, this is\na declarative, frozen N-dimensional coordinate of a capability.\n\nCAUSAL AFFORDANCE: Unlocks a specific, localized Pearlian Do-Operator intervention\n($do(X=x)$) mapped to an external kinetic capability. Governed by side_effects\n(SideEffectProfile), permissions (PermissionBoundaryPolicy), and an optional sla\n(ExecutionSLA).\n\nEPISTEMIC BOUNDS: The tool's operational perimeter is rigidly confined by input_schema\n(a dictionary bounded to max_length=1000000000 properties). The is_preemptible boolean\n(default=False) establishes a physical Halting Problem limit by authorizing the\norchestrator to abort execution mid-flight.\n\nMCP ROUTING TRIGGERS: Gibsonian Affordance, MDP Action Space, Pearlian Do-Operator,\nCapability-Based Security, Halting Problem",
       "properties": {
+        "tool_name": {
+          "description": "The exact identifier of the tool.",
+          "maxLength": 2000,
+          "title": "Tool Name",
+          "type": "string"
+        },
         "description": {
           "description": "The mathematically bounded semantic projection defining the tool's causal affordances.",
           "maxLength": 2000,
@@ -13724,19 +13729,13 @@
           "title": "Input Schema",
           "type": "object"
         },
-        "is_preemptible": {
-          "default": false,
-          "description": "If True, the orchestrator is authorized to send a SIGINT to abort this tool's execution mid-flight if a BargeInInterruptEvent occurs.",
-          "title": "Is Preemptible",
-          "type": "boolean"
+        "side_effects": {
+          "$ref": "#/$defs/SideEffectProfile",
+          "description": "The declarative side-effect and idempotency profile of the tool."
         },
         "permissions": {
           "$ref": "#/$defs/PermissionBoundaryPolicy",
           "description": "The zero-trust security boundaries for the tool's execution."
-        },
-        "side_effects": {
-          "$ref": "#/$defs/SideEffectProfile",
-          "description": "The declarative side-effect and idempotency profile of the tool."
         },
         "sla": {
           "anyOf": [
@@ -13750,11 +13749,11 @@
           "default": null,
           "description": "Execution limits for the tool."
         },
-        "tool_name": {
-          "description": "The exact identifier of the tool.",
-          "maxLength": 2000,
-          "title": "Tool Name",
-          "type": "string"
+        "is_preemptible": {
+          "default": false,
+          "description": "If True, the orchestrator is authorized to send a SIGINT to abort this tool's execution mid-flight if a BargeInInterruptEvent occurs.",
+          "title": "Is Preemptible",
+          "type": "boolean"
         }
       },
       "required": [
@@ -13771,6 +13770,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the rigid traversal perimeters for Graph Convolutional Network\n(GCN) or Random Walk with Restart (RWR) operations across the Causal DAG. As a ...Contract\nsuffix, this object defines rigid mathematical boundaries that the orchestrator must\nenforce globally.\n\nCAUSAL AFFORDANCE: Restricts graph hopping algorithms to explicit Pearlian edge types\n(Literal[\"causes\", \"confounds\", \"correlates_with\", \"undirected\"]), mathematically\npreventing epistemic drift and hallucination during deep multi-hop retrieval.\n\nEPISTEMIC BOUNDS: Bounded recursively by max_hop_depth (ge=1, le=1000000000). The\n@model_validator physically enforces deterministic sorting of\nallowed_causal_relationships (min_length=1) to guarantee RFC 8785 canonical hashing.\nGeometric distance preservation is toggled via enforce_isometry (default=True).\n\nMCP ROUTING TRIGGERS: Directed Acyclic Graph, Pearlian Traversal, Isometry Preservation,\nRandom Walk with Restart",
       "properties": {
+        "max_hop_depth": {
+          "description": "The strictly typed search depth bound for the cDAG.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Max Hop Depth",
+          "type": "integer"
+        },
         "allowed_causal_relationships": {
           "description": "The explicit whitelist of permissible causal edges to traverse.",
           "items": {
@@ -13791,13 +13797,6 @@
           "description": "Enforces preservation of geometric distances.",
           "title": "Enforce Isometry",
           "type": "boolean"
-        },
-        "max_hop_depth": {
-          "description": "The strictly typed search depth bound for the cDAG.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Max Hop Depth",
-          "type": "integer"
         }
       },
       "required": [
@@ -13811,16 +13810,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces Graph Representation Learning (GCN/GAT) constraints to\nshape the epistemic reward based purely on the topological centrality and spectral\nconnectivity of the extracted axioms. As a ...Contract suffix, this object defines\nrigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Commands the orchestrator to execute deterministic graph traversal\nalgorithms (Random Walk with Restart, Spatial GCN) to compute node reachability and\nvector similarity before allocating policy gradients to the actor model.\n\nEPISTEMIC BOUNDS: Clamps structural relevance geometrically using\nmin_link_criticality_score and min_semantic_relevance_score, both strictly between\n(ge=0.0, le=1.0). The aggregation_method restricts the orchestrator to a strict\nLiteral automaton [\"gcn_spatial\", \"attention_gat\", \"rwr_topological\"].\n\nMCP ROUTING TRIGGERS: Graph Convolutional Networks, Spectral Graph Theory, Random Walk\nwith Restart, Topological Reward Shaping, PageRank",
       "properties": {
-        "aggregation_method": {
-          "description": "The deterministic protocol the orchestrator must use to compute these scores.",
-          "enum": [
-            "gcn_spatial",
-            "attention_gat",
-            "rwr_topological"
-          ],
-          "title": "Aggregation Method",
-          "type": "string"
-        },
         "min_link_criticality_score": {
           "description": "The lower bound for Random Walk with Restart (RWR) reachability.",
           "maximum": 1.0,
@@ -13834,6 +13823,16 @@
           "minimum": 0.0,
           "title": "Min Semantic Relevance Score",
           "type": "number"
+        },
+        "aggregation_method": {
+          "description": "The deterministic protocol the orchestrator must use to compute these scores.",
+          "enum": [
+            "gcn_spatial",
+            "attention_gat",
+            "rwr_topological"
+          ],
+          "title": "Aggregation Method",
+          "type": "string"
         }
       },
       "required": [
@@ -13887,18 +13886,18 @@
           "title": "Decay Propagation Rate",
           "type": "number"
         },
-        "enforce_cross_agent_quarantine": {
-          "default": false,
-          "description": "If True, the orchestrator must automatically emit global QuarantineIntents to sever infected SemanticEdges across the swarm to prevent epistemic contagion.",
-          "title": "Enforce Cross Agent Quarantine",
-          "type": "boolean"
-        },
         "epistemic_quarantine_threshold": {
           "description": "The minimum certainty boundary. If an event's propagated confidence drops below this threshold, it is structurally quarantined.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Epistemic Quarantine Threshold",
           "type": "number"
+        },
+        "enforce_cross_agent_quarantine": {
+          "default": false,
+          "description": "If True, the orchestrator must automatically emit global QuarantineIntents to sever infected SemanticEdges across the swarm to prevent epistemic contagion.",
+          "title": "Enforce Cross Agent Quarantine",
+          "type": "boolean"
         },
         "max_cascade_depth": {
           "description": "The absolute recursion depth limit for state retractions.",
@@ -13928,32 +13927,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Multi-Attribute Utility Theory (MAUT) to capture the exact multi-dimensional trade-offs (Pareto vectors) of a given routing decision.\n\nCAUSAL AFFORDANCE: Provides explicit mathematical justification for an agent's trajectory. If the variance of the utility distribution exceeds the threshold, it physically forces the orchestrator to deploy the embedded ensemble specification for deterministic resolution.\n\nEPISTEMIC BOUNDS: The superposition variance threshold is physically clamped (ge=0.0, le=1000000000.0). The @model_validator mathematically forbids a 0.0 variance threshold from co-existing with an active ensemble specification, as absolute certainty physically precludes superposition.\n\nMCP ROUTING TRIGGERS: Multi-Attribute Utility Theory, Pareto Efficiency, Variance Reduction, Fallback Superposition, Utility Routing",
       "properties": {
-        "degrading_vectors": {
-          "additionalProperties": {
-            "maximum": 1000.0,
-            "minimum": -1000.0,
-            "type": "number"
-          },
-          "description": "Multi-dimensional continuous values representing degradations.",
-          "le": 1000000000.0,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Degrading Vectors",
-          "type": "object"
-        },
-        "ensemble_spec": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EnsembleTopologyProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The deterministic ensemble specification to fall back on when threshold falls below delta."
-        },
         "optimizing_vectors": {
           "additionalProperties": {
             "maximum": 1000.0,
@@ -13968,12 +13941,38 @@
           "title": "Optimizing Vectors",
           "type": "object"
         },
+        "degrading_vectors": {
+          "additionalProperties": {
+            "maximum": 1000.0,
+            "minimum": -1000.0,
+            "type": "number"
+          },
+          "description": "Multi-dimensional continuous values representing degradations.",
+          "le": 1000000000.0,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Degrading Vectors",
+          "type": "object"
+        },
         "superposition_variance_threshold": {
           "description": "The statistical variance threshold below which deterministic fallback is enforced.",
           "maximum": 1000000000.0,
           "minimum": 0.0,
           "title": "Superposition Variance Threshold",
           "type": "number"
+        },
+        "ensemble_spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EnsembleTopologyProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The deterministic ensemble specification to fall back on when threshold falls below delta."
         }
       },
       "required": [
@@ -13986,6 +13985,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a declarative, frozen geometric coordinate\nwithin a high-dimensional latent manifold, acting as a dense vector anchor\nfor zero-shot semantic routing. As a ...State suffix, this is a frozen\nN-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Unlocks Maximum Inner Product Search (MIPS) and k-Nearest\nNeighbors (k-NN) retrieval without invoking stochastic token generation. The\nmodel_name (max_length=2000) traces embedding provenance. The dimensionality\n(int, unbounded) specifies the vector array size.\n\nEPISTEMIC BOUNDS: The vector_base64 enforces a strict Base64 regex\n(^[A-Za-z0-9+/]*={0,2}$) and is physically capped at max_length=5000000 to\nprevent VRAM exhaustion during deserialization.\n\nMCP ROUTING TRIGGERS: Topological Data Analysis, Dense Vector Embedding,\nLatent Manifold, Maximum Inner Product Search, k-Nearest Neighbors",
       "properties": {
+        "vector_base64": {
+          "description": "The base64-encoded dense vector array.",
+          "maxLength": 5000000,
+          "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+          "title": "Vector Base64",
+          "type": "string"
+        },
         "dimensionality": {
           "description": "The size of the vector array.",
           "title": "Dimensionality",
@@ -13995,13 +14001,6 @@
           "description": "The provenance of the embedding model used (e.g., 'text-embedding-3-large').",
           "maxLength": 2000,
           "title": "Model Name",
-          "type": "string"
-        },
-        "vector_base64": {
-          "description": "The base64-encoded dense vector array.",
-          "maxLength": 5000000,
-          "pattern": "^[A-Za-z0-9+/]*={0,2}$",
-          "title": "Vector Base64",
           "type": "string"
         }
       },
@@ -14017,26 +14016,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the W3C Verifiable Credentials Data Model\n(VCDM v2.0) to establish a decentralized, Zero-Trust identity perimeter. As a\n...Receipt suffix, this is an append-only coordinate on the Merkle-DAG that the\nLLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Unlocks isolated execution bounds by projecting\ncryptographically verified geometric predicates (authorization_claims) into the\norchestrator via issuer_did (NodeIdentifierState), allowing an agent to prove\nauthorization clearance without centralized identity brokers.\n\nEPISTEMIC BOUNDS: The cryptographic_proof_blob is physically capped at\nmax_length=100000 to prevent VRAM buffer overflow. The presentation_format is\nrigidly clamped to a Literal automaton [\"jwt_vc\", \"ldp_vc\", \"sd_jwt\",\n\"zkp_vc\"] enforcing Selective Disclosure and ZKP boundaries. The\nauthorization_claims dict is bounded (max_length=86400000, key max_length=255).\n\nMCP ROUTING TRIGGERS: W3C VCDM, Zero-Knowledge Proofs, Selective Disclosure,\nDecentralized Identifiers, Object Capability Model",
       "properties": {
-        "authorization_claims": {
-          "additionalProperties": true,
-          "description": "The strict, domain-agnostic JSON dictionary of strictly bounded geometric predicates that define the operational perimeter of the agent (e.g., {'clearance': 'RESTRICTED'}).",
-          "maxProperties": 86400000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Authorization Claims",
-          "type": "object"
-        },
-        "cryptographic_proof_blob": {
-          "description": "The base64-encoded cryptographic proof (e.g., ZK-SNARKs, zkVM receipts, or programmable trust attestations) proving the claims without revealing the private key.",
-          "maxLength": 100000,
-          "title": "Cryptographic Proof Blob",
-          "type": "string"
-        },
-        "issuer_did": {
-          "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The W3C DID of the trusted authority that cryptographically signed the credential, explicitly representing the delegation of authority from a human or parent principal."
-        },
         "presentation_format": {
           "description": "The exact cryptographic standard used to encode this credential presentation.",
           "enum": [
@@ -14047,6 +14026,26 @@
           ],
           "title": "Presentation Format",
           "type": "string"
+        },
+        "issuer_did": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The W3C DID of the trusted authority that cryptographically signed the credential, explicitly representing the delegation of authority from a human or parent principal."
+        },
+        "cryptographic_proof_blob": {
+          "description": "The base64-encoded cryptographic proof (e.g., ZK-SNARKs, zkVM receipts, or programmable trust attestations) proving the claims without revealing the private key.",
+          "maxLength": 100000,
+          "title": "Cryptographic Proof Blob",
+          "type": "string"
+        },
+        "authorization_claims": {
+          "additionalProperties": true,
+          "description": "The strict, domain-agnostic JSON dictionary of strictly bounded geometric predicates that define the operational perimeter of the agent (e.g., {'clearance': 'RESTRICTED'}).",
+          "maxProperties": 86400000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Authorization Claims",
+          "type": "object"
         }
       },
       "required": [
@@ -14062,6 +14061,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen receipt representing a Verifiable Random\nFunction (VRF) output via elliptic curve cryptography. As a ...Receipt suffix, this is an\nappend-only coordinate on the Merkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Unlocks stochastic graph mutations (such as EvolutionaryTopology\ncrossovers or prediction market resolutions) by providing mathematical proof via vrf_proof\nthat the randomness was uniformly distributed and not manipulated by a Byzantine node.\n\nEPISTEMIC BOUNDS: The validity of the VRF is physically bound to the seed_hash (a strict\nSHA-256 pattern ^[a-f0-9]{64}$) and the public_key (min_length=10). This prevents\nadversarial Hash Poisoning, ensuring the entropy remains deterministically reproducible\nby the orchestrator.\n\nMCP ROUTING TRIGGERS: Verifiable Random Function, VRF, Stochastic Fairness, Elliptic\nCurve Cryptography, Zero-Knowledge Entropy",
       "properties": {
+        "vrf_proof": {
+          "description": "The zero-knowledge cryptographic proof of fair random generation.",
+          "minLength": 10,
+          "title": "Vrf Proof",
+          "type": "string"
+        },
         "public_key": {
           "description": "The public key of the oracle or node used to verify the VRF proof.",
           "minLength": 10,
@@ -14074,12 +14079,6 @@
           "minLength": 10,
           "pattern": "^[a-f0-9]{64}$",
           "title": "Seed Hash",
-          "type": "string"
-        },
-        "vrf_proof": {
-          "description": "The zero-knowledge cryptographic proof of fair random generation.",
-          "minLength": 10,
-          "title": "Vrf Proof",
           "type": "string"
         }
       },
@@ -14139,6 +14138,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Hardware-Backed Human-in-the-Loop (HITL)\nauthentication, utilizing FIDO2/WebAuthn or Post-Quantum physical security\nkeys to verify human intent. As a ...Contract suffix, this enforces rigid\nmathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Translates physical human entropy (e.g., a biometric tap or\nhardware key touch) into a definitive mathematical signature via mechanism\n(AttestationMechanismProfile), authorizing the orchestrator to break a\nMixed-Initiative execution halt. The did_subject (DID pattern\n^did:[a-z0-9]+:.*$) anchors the human identity.\n\nEPISTEMIC BOUNDS: Physically binds the signature to a specific Merkle-DAG\ncoordinate via dag_node_nonce (UUID), strictly preventing cryptographic Replay\nAttacks. The cryptographic_payload is restricted by regex\n(^[A-Za-z0-9+/=_-]+$) to prevent injection anomalies.\n\nMCP ROUTING TRIGGERS: WebAuthn, FIDO2, Cryptographic Nonce, Replay Attack\nPrevention, Wetware Entropy",
       "properties": {
+        "mechanism": {
+          "$ref": "#/$defs/AttestationMechanismProfile",
+          "description": "The SOTA cryptographic mechanism used to generate the proof."
+        },
+        "did_subject": {
+          "description": "The Decentralized Identifier (DID) of the human operator.",
+          "pattern": "^did:[a-z0-9]+:.*$",
+          "title": "Did Subject",
+          "type": "string"
+        },
         "cryptographic_payload": {
           "description": "The strictly formatted (Base64url/Hex/Multibase) signature or proof.",
           "pattern": "^[A-Za-z0-9+/=_-]+$",
@@ -14150,16 +14159,6 @@
           "format": "uuid",
           "title": "Dag Node Nonce",
           "type": "string"
-        },
-        "did_subject": {
-          "description": "The Decentralized Identifier (DID) of the human operator.",
-          "pattern": "^did:[a-z0-9]+:.*$",
-          "title": "Did Subject",
-          "type": "string"
-        },
-        "mechanism": {
-          "$ref": "#/$defs/AttestationMechanismProfile",
-          "description": "The SOTA cryptographic mechanism used to generate the proof."
         }
       },
       "required": [
@@ -14175,6 +14174,74 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Topos Theory representation of a fully\nencapsulated swarm environment, serving as the macroscopic topological\nenvelope for the entire execution payload. As a ...Manifest suffix, this is\na frozen N-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Physically initializes the execution DAG via topology\n(AnyTopologyManifest), bounding thermodynamic capacity through governance\n(GlobalGovernancePolicy | None). Cryptographically anchored to\ngenesis_provenance (EpistemicProvenanceReceipt). Federation is controlled\nvia federated_discovery, federated_sla, and pq_signature. Enterprise\nisolation via tenant_id/session_id (max_length=255).\n\nEPISTEMIC BOUNDS: The @model_validator sort_arrays deterministically sorts\nallowed_information_classifications (list | None) for RFC 8785 canonical\nhashing. manifest_version (SemanticVersionState) pins the schema.\n\nMCP ROUTING TRIGGERS: Topos Theory, Cybernetics, Execution Envelope,\nMacroscopic Topology, Viable System Model",
       "properties": {
+        "genesis_provenance": {
+          "$ref": "#/$defs/EpistemicProvenanceReceipt",
+          "description": "\"\"\"AGENT INSTRUCTION: This structural lock guarantees that any graph execution is mathematically anchored to a CoReason Genesis Block. Stripping this field violates the Topological Consistency of the Shared Kernel.\"\"\""
+        },
+        "manifest_version": {
+          "$ref": "#/$defs/SemanticVersionState",
+          "description": "The semantic version of this workflow manifestation schema."
+        },
+        "topology": {
+          "$ref": "#/$defs/AnyTopologyManifest",
+          "description": "The underlying topology governing execution routing. [SITD-Beta: Defeasible Merkle-DAG Causal Bounding]"
+        },
+        "governance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GlobalGovernancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Macro-economic circuit breakers and TTL limits for the swarm."
+        },
+        "tenant_id": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The enterprise tenant boundary for this execution.",
+          "title": "Tenant Id"
+        },
+        "session_id": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The ephemeral session boundary for this execution.",
+          "title": "Session Id"
+        },
+        "max_risk_tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RiskLevelPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The absolute maximum enterprise risk threshold permitted for this topology."
+        },
         "allowed_information_classifications": {
           "anyOf": [
             {
@@ -14215,38 +14282,6 @@
           "default": null,
           "description": "The B2B Service Level Agreement contract that must be mathematically satisfied before multi-tenant graph coupling."
         },
-        "genesis_provenance": {
-          "$ref": "#/$defs/EpistemicProvenanceReceipt",
-          "description": "\"\"\"AGENT INSTRUCTION: This structural lock guarantees that any graph execution is mathematically anchored to a CoReason Genesis Block. Stripping this field violates the Topological Consistency of the Shared Kernel.\"\"\""
-        },
-        "governance": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/GlobalGovernancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Macro-economic circuit breakers and TTL limits for the swarm."
-        },
-        "manifest_version": {
-          "$ref": "#/$defs/SemanticVersionState",
-          "description": "The semantic version of this workflow manifestation schema."
-        },
-        "max_risk_tolerance": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RiskLevelPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The absolute maximum enterprise risk threshold permitted for this topology."
-        },
         "pq_signature": {
           "anyOf": [
             {
@@ -14258,42 +14293,6 @@
           ],
           "default": null,
           "description": "The quantum-resistant signature securing the root execution graph."
-        },
-        "session_id": {
-          "anyOf": [
-            {
-              "maxLength": 255,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The ephemeral session boundary for this execution.",
-          "title": "Session Id"
-        },
-        "tenant_id": {
-          "anyOf": [
-            {
-              "maxLength": 255,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The enterprise tenant boundary for this execution.",
-          "title": "Tenant Id"
-        },
-        "topology": {
-          "$ref": "#/$defs/AnyTopologyManifest",
-          "description": "The underlying topology governing execution routing. [SITD-Beta: Defeasible Merkle-DAG Causal Bounding]"
         }
       },
       "required": [
@@ -14308,25 +14307,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces Computational Integrity via Verifiable Computing,\nutilizing succinct non-interactive arguments of knowledge (zk-SNARKs/STARKs)\nto prove execution correctness without revealing private state. As a ...Receipt\nsuffix, this is a cryptographically frozen historical fact.\n\nCAUSAL AFFORDANCE: Authorizes the zero-trust orchestrator to accept and merge\noff-chain state mutations by verifying the cryptographic_blob\n(max_length=5000000) against the public_inputs_hash and verifier_key_id\n(128-char CID). The latent_state_commitments (dict, key max_length=255,\nvalue max_length=100, le=1000000000, default_factory=dict) bind intermediate\nresidual stream states.\n\nEPISTEMIC BOUNDS: The proof_protocol is strictly clamped to a Literal\nautomaton [\"zk-SNARK\", \"zk-STARK\", \"plonk\", \"bulletproofs\"]. The\npublic_inputs_hash guarantees linkage via SHA-256 regex (^[a-f0-9]{64}$).\n\nMCP ROUTING TRIGGERS: Computational Integrity, Verifiable Computing,\nZero-Knowledge Proofs, zk-SNARK, State Attestation",
       "properties": {
-        "cryptographic_blob": {
-          "description": "The base64-encoded succinct cryptographic proof payload.",
-          "maxLength": 5000000,
-          "title": "Cryptographic Blob",
-          "type": "string"
-        },
-        "latent_state_commitments": {
-          "additionalProperties": {
-            "maxLength": 100,
-            "type": "string"
-          },
-          "description": "Cryptographic bindings (hashes) of intermediate residual stream states to prevent activation spoofing.",
-          "le": 1000000000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Latent State Commitments",
-          "type": "object"
-        },
         "proof_protocol": {
           "description": "The mathematical dialect of the cryptographic proof.",
           "enum": [
@@ -14353,6 +14333,25 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Verifier Key Id",
           "type": "string"
+        },
+        "cryptographic_blob": {
+          "description": "The base64-encoded succinct cryptographic proof payload.",
+          "maxLength": 5000000,
+          "title": "Cryptographic Blob",
+          "type": "string"
+        },
+        "latent_state_commitments": {
+          "additionalProperties": {
+            "maxLength": 100,
+            "type": "string"
+          },
+          "description": "Cryptographic bindings (hashes) of intermediate residual stream states to prevent activation spoofing.",
+          "le": 1000000000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Latent State Commitments",
+          "type": "object"
         }
       },
       "required": [
@@ -14365,6 +14364,6 @@
       "type": "object"
     }
   },
-  "description": "CoReason Shared Kernel Ontology\n\nUnified JSON Schema for the Coreason Manifest",
-  "title": "CoReason Shared Kernel Ontology"
+  "title": "CoReason Shared Kernel Ontology",
+  "description": "CoReason Shared Kernel Ontology\n\nUnified JSON Schema for the Coreason Manifest"
 }

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -7422,6 +7422,63 @@ class ExecutionSpanReceipt(CoreasonBaseState):
         return self
 
 
+class KinematicNoiseProfile(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Implements non-linear stochastic perturbations to physical trajectories.
+
+    CAUSAL AFFORDANCE: Mutates continuous polynomial control points.
+
+    EPISTEMIC BOUNDS: Clamped by pink_noise_amplitude (le=1.0).
+
+    MCP ROUTING TRIGGERS: Mathematical Kinematics, Noise, Perturbation, Stochastic Vector
+    """
+
+    pink_noise_amplitude: float = Field(
+        le=1.0, ge=0.0, description="The mathematical limit of non-linear noise injected."
+    )
+    frequency_hz: float = Field(le=1000.0, ge=0.0, description="The frequency of the injected noise.")
+
+
+class EnvironmentalSpoofingProfile(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Mathematically spoofs hardware and environmental markers.
+
+    CAUSAL AFFORDANCE: Bypasses static fingerprinting heuristics by mutating DOM properties.
+
+    EPISTEMIC BOUNDS: Bounded by rigid string constraints to prevent payload bloat.
+
+    MCP ROUTING TRIGGERS: DOM Spoofing, Fingerprint Mutation, Environmental Marker
+    """
+
+    webgl_entropy_seed_hash: str = Field(
+        pattern="^[a-f0-9]{64}$",
+        description="The SHA-256 hash used to deterministically alter WebGL rendering arrays.",
+    )
+    canvas_noise_seed: str = Field(
+        max_length=128,
+        description="The deterministic seed used to slightly mutate Canvas 2D render pixels.",
+    )
+
+
+class AdversarialEmulationProfile(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Orchestrates the simulation of complex adversarial actor heuristics.
+
+    CAUSAL AFFORDANCE: Emulates advanced evasion tactics including non-linear spatial vectors.
+
+    EPISTEMIC BOUNDS: Contains rigid constraints governing kinetic and environmental spoofing.
+
+    MCP ROUTING TRIGGERS: Threat Emulation, Adversarial Actor, Evasion Tactics
+    """
+
+    kinematic_noise: KinematicNoiseProfile | None = Field(
+        default=None, description="The physical perturbation constraints."
+    )
+    environmental_spoofing: EnvironmentalSpoofingProfile | None = Field(
+        default=None, description="The hardware and DOM spoofing constraints."
+    )
+
+
 class SpatialKinematicActionIntent(CoreasonBaseState):
     """
     AGENT INSTRUCTION: Employs Mathematical Kinematics and Fitts's Law to project precise, non-linear physical interactions across an exogenous UI manifold.
@@ -7433,6 +7490,9 @@ class SpatialKinematicActionIntent(CoreasonBaseState):
     MCP ROUTING TRIGGERS: Mathematical Kinematics, Bezier Geometry, Fitts's Law, OS-Level Actuation, Non-Linear Trajectory
     """
 
+    noise_profile: KinematicNoiseProfile | None = Field(
+        default=None, description="The mathematical constraints for applying stochastic perturbations."
+    )
     action_type: Literal["click", "double_click", "drag_and_drop", "scroll", "hover", "keystroke"] = Field(
         description="The specific kinematic interaction paradigm."
     )
@@ -8724,6 +8784,10 @@ class AgentNodeProfile(BaseNodeProfile):
         description="The semantic boundary defining the objective function of the execution node. [SITD-Gamma: Neurosymbolic Substrate Alignment]",
     )
     type: Literal["agent"] = Field(default="agent", description="Discriminator for an Agent node.")
+    adversarial_emulation: AdversarialEmulationProfile | None = Field(
+        default=None, description="The deterministic emulation rules for simulating evasive behaviors."
+    )
+
     logit_steganography: LogitSteganographyContract | None = Field(
         default=None,
         description="The cryptographic contract forcing this agent to embed an undeniable provenance signature into its generative token stream.",
@@ -10560,3 +10624,7 @@ DifferentiableLogicConstraint.model_rebuild()
 CausalExplanationEvent.model_rebuild()
 LatentSchemaInferenceIntent.model_rebuild()
 IntentClassificationReceipt.model_rebuild()
+KinematicNoiseProfile.model_rebuild()
+EnvironmentalSpoofingProfile.model_rebuild()
+AdversarialEmulationProfile.model_rebuild()
+SpatialKinematicActionIntent.model_rebuild()

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -33,6 +33,8 @@ from coreason_manifest.spec.ontology import (
     EpistemicCompressionSLA,
     EpistemicTransmutationTask,
     ExecutionNodeReceipt,
+    IntentClassificationReceipt,
+    LatentSchemaInferenceIntent,
     OntologicalAlignmentPolicy,
     StateMutationIntent,
     System2RemediationIntent,
@@ -46,6 +48,8 @@ SCHEMA_REGISTRY: dict[str, type[BaseModel]] = {
     "state_differential": StateMutationIntent,
     "cognitive_sync": CognitiveStateProfile,
     "system2_remediation": System2RemediationIntent,
+    "schema_inference": LatentSchemaInferenceIntent,
+    "intent_classification": IntentClassificationReceipt,
 }
 
 
@@ -521,3 +525,14 @@ def apply_state_differential(
                 raise ValueError("Patch test operation failed.") from e
 
     return new_state
+
+
+def extract_webgl_entropy_seed_hash(profile: ontology.AgentNodeProfile) -> str | None:
+    """
+    A pure mathematical functor to passively extract the webgl_entropy_seed_hash
+    from an AgentNodeProfile to ensure the orchestrator can natively access spoofing profiles.
+    """
+    if profile.adversarial_emulation is not None:
+        if profile.adversarial_emulation.environmental_spoofing is not None:
+            return profile.adversarial_emulation.environmental_spoofing.webgl_entropy_seed_hash
+    return None

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -532,7 +532,6 @@ def extract_webgl_entropy_seed_hash(profile: ontology.AgentNodeProfile) -> str |
     A pure mathematical functor to passively extract the webgl_entropy_seed_hash
     from an AgentNodeProfile to ensure the orchestrator can natively access spoofing profiles.
     """
-    if profile.adversarial_emulation is not None:
-        if profile.adversarial_emulation.environmental_spoofing is not None:
-            return profile.adversarial_emulation.environmental_spoofing.webgl_entropy_seed_hash
+    if profile.adversarial_emulation is not None and profile.adversarial_emulation.environmental_spoofing is not None:
+        return profile.adversarial_emulation.environmental_spoofing.webgl_entropy_seed_hash
     return None

--- a/tests/contracts/test_algebra_emulation.py
+++ b/tests/contracts/test_algebra_emulation.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import coreason_manifest.utils.algebra as algebra
+
+
+def test_algebra_placeholder() -> None:
+    assert True
+
+
+def test_extract_webgl_entropy_seed_hash() -> None:
+    from coreason_manifest.spec.ontology import (
+        AdversarialEmulationProfile,
+        AgentNodeProfile,
+        EnvironmentalSpoofingProfile,
+    )
+
+    hash_str = "b" * 64
+    spoofing = EnvironmentalSpoofingProfile(webgl_entropy_seed_hash=hash_str, canvas_noise_seed="seed")
+    adv = AdversarialEmulationProfile(environmental_spoofing=spoofing)
+    profile = AgentNodeProfile(description="test", adversarial_emulation=adv)
+
+    res = algebra.extract_webgl_entropy_seed_hash(profile)
+    assert res == hash_str
+
+    empty_profile = AgentNodeProfile(description="test")
+    assert algebra.extract_webgl_entropy_seed_hash(empty_profile) is None
+
+
+def test_algebra_validate_payload() -> None:
+    import json
+
+    from coreason_manifest.spec.ontology import IntentClassificationReceipt, LatentSchemaInferenceIntent
+
+    # Test valid schema inference
+    payload = json.dumps({"target_buffer_id": "abc", "max_schema_depth": 5, "max_properties": 100})
+    res = algebra.validate_payload("schema_inference", payload.encode())
+    assert isinstance(res, LatentSchemaInferenceIntent)
+    assert res.target_buffer_id == "abc"
+
+    # Test valid intent classification
+    payload2 = json.dumps(
+        {
+            "event_id": "chain-xyz",
+            "timestamp": 123.4,
+            "raw_input_string": "do something",
+            "classified_intent": "task_intent",
+            "confidence_score": 0.9,
+        }
+    )
+    res2 = algebra.validate_payload("intent_classification", payload2.encode())
+    assert isinstance(res2, IntentClassificationReceipt)
+    assert res2.classified_intent == "task_intent"

--- a/tests/contracts/test_emulation_inference.py
+++ b/tests/contracts/test_emulation_inference.py
@@ -1,0 +1,115 @@
+# Copyright (c) 2026 CoReason, Inc.
+#
+# This software is proprietary and dual-licensed.
+# Licensed under the Prosperity Public License 3.0 (the "License").
+# A copy of the license is available at https://prosperitylicense.com/versions/3.0.0
+# For details, see the LICENSE file.
+# Commercial use beyond a 30-day trial requires a separate license.
+#
+# Source Code: https://github.com/CoReason-AI/coreason-manifest
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import (
+    AdversarialEmulationProfile,
+    AgentNodeProfile,
+    EnvironmentalSpoofingProfile,
+    IntentClassificationReceipt,
+    KinematicNoiseProfile,
+    LatentSchemaInferenceIntent,
+    RoutingFrontierPolicy,
+    SpatialCoordinateProfile,
+    SpatialKinematicActionIntent,
+)
+
+
+def test_latent_schema_inference_intent() -> None:
+    intent = LatentSchemaInferenceIntent(target_buffer_id="abc-123", max_schema_depth=5, max_properties=100)
+    assert intent.target_buffer_id == "abc-123"
+    assert intent.max_schema_depth == 5
+    assert intent.max_properties == 100
+
+    with pytest.raises(ValidationError):
+        LatentSchemaInferenceIntent(
+            target_buffer_id="abc-123",
+            max_schema_depth=11,  # out of bounds (> 10)
+            max_properties=100,
+        )
+
+
+def test_intent_classification_receipt() -> None:
+    receipt = IntentClassificationReceipt(
+        event_id="chain-xyz",
+        timestamp=123.4,
+        raw_input_string="do something",
+        classified_intent="task_intent",
+        confidence_score=0.9,
+    )
+    assert receipt.classified_intent == "task_intent"
+
+    with pytest.raises(ValidationError):
+        IntentClassificationReceipt(
+            event_id="chain-xyz",
+            timestamp=123.4,
+            raw_input_string="do something",
+            classified_intent="task_intent",
+            confidence_score=1.5,  # out of bounds (> 1.0)
+        )
+
+
+def test_kinematic_noise_profile() -> None:
+    profile = KinematicNoiseProfile(pink_noise_amplitude=0.5, frequency_hz=60.0)
+    assert profile.pink_noise_amplitude == 0.5
+
+    with pytest.raises(ValidationError):
+        KinematicNoiseProfile(pink_noise_amplitude=1.5, frequency_hz=60.0)
+
+
+def test_environmental_spoofing_profile() -> None:
+    hash_str = "a" * 64
+    profile = EnvironmentalSpoofingProfile(webgl_entropy_seed_hash=hash_str, canvas_noise_seed="seed1")
+    assert profile.webgl_entropy_seed_hash == hash_str
+
+    with pytest.raises(ValidationError):
+        EnvironmentalSpoofingProfile(webgl_entropy_seed_hash="invalid-hash", canvas_noise_seed="seed1")
+
+
+def test_adversarial_emulation_profile() -> None:
+    noise = KinematicNoiseProfile(pink_noise_amplitude=0.5, frequency_hz=60.0)
+    spoofing = EnvironmentalSpoofingProfile(webgl_entropy_seed_hash="a" * 64, canvas_noise_seed="seed1")
+    profile = AdversarialEmulationProfile(kinematic_noise=noise, environmental_spoofing=spoofing)
+    assert profile.kinematic_noise is not None
+    assert profile.environmental_spoofing is not None
+
+
+def test_spatial_kinematic_action_intent() -> None:
+    coord = SpatialCoordinateProfile(x=0.5, y=0.5)
+    noise = KinematicNoiseProfile(pink_noise_amplitude=0.5, frequency_hz=60.0)
+    intent = SpatialKinematicActionIntent(
+        action_type="click",
+        target_coordinate=coord,
+        trajectory_duration_ms=1000,
+        bezier_control_points=[coord, coord],
+        expected_visual_concept="button",
+        noise_profile=noise,
+    )
+    assert intent.action_type == "click"
+    assert intent.noise_profile is not None
+
+
+def test_agent_node_profile() -> None:
+    compute_frontier = RoutingFrontierPolicy(
+        max_latency_ms=1000,
+        max_cost_magnitude_per_token=10,
+        min_capability_score=0.8,
+        tradeoff_preference="latency_optimized",
+    )
+    noise = KinematicNoiseProfile(pink_noise_amplitude=0.5, frequency_hz=60.0)
+    spoofing = EnvironmentalSpoofingProfile(webgl_entropy_seed_hash="a" * 64, canvas_noise_seed="seed1")
+    adversarial = AdversarialEmulationProfile(kinematic_noise=noise, environmental_spoofing=spoofing)
+    profile = AgentNodeProfile(
+        description="A test agent profile", compute_frontier=compute_frontier, adversarial_emulation=adversarial
+    )
+    assert profile.type == "agent"
+    assert profile.adversarial_emulation is not None


### PR DESCRIPTION
This commit finalizes the Epic 8.3 ecosystem alignment by addressing previous feedback from the code review. The scratchpad scripts used during initial exploration have been removed. Additionally, `extract_webgl_entropy_seed_hash` and the validation test cases were refactored to use safe type narrowing instead of `getattr` to properly satisfy strict `mypy` typing without masking structural boundaries.

---
*PR created automatically by Jules for task [15376890317080728532](https://jules.google.com/task/15376890317080728532) started by @gowthamrao*