### PR TITLE
Implement SOTA Grammar & LMQL Constrained Decoding in Ontology

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2519,11 +2519,18 @@
           "type": "boolean"
         },
         "final_answer_regex": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
           "default": "^Final Answer: .*$",
           "description": "The strict regular expression the model must satisfy to yield a valid discrete classification.",
-          "maxLength": 2000,
-          "title": "Final Answer Regex",
-          "type": "string"
+          "title": "Final Answer Regex"
         },
         "decoding_policy": {
           "$ref": "#/$defs/ConstrainedDecodingPolicy",
@@ -3346,9 +3353,14 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: ConstrainedDecodingPolicy is a rigid mathematical boundary enforcing systemic constraints\nglobally. Dictates the hardware-level execution limits for the token sampling phase by converting structural\nformatting from a probabilistic neural suggestion into a deterministic physics problem.\n\nCAUSAL AFFORDANCE: Enforces rigid isolation perimeters and limits subgraph generation by physically\nsuffocating invalid token probabilities. It instructs the inference engine (e.g., Outlines, XGrammar)\nto compile a Deterministic Finite Automaton (DFA) or Pushdown Automaton (PDA) and mechanically overwrite\nillegal token logits to negative infinity.\n\nEPISTEMIC BOUNDS: The absolute mathematical and physical limits are strictly bounded categorical literals\non fields: enforcement_strategy, compiler_backend. All field limits must be strictly validated at\ninstantiation to prevent epistemic contagion and prompt-injection payload sabotage.\n\nMCP ROUTING TRIGGERS: FSM Logit Masking, Constrained Decoding, Tokenizer Interception, Hardware Execution Boundary",
       "properties": {
         "enforcement_strategy": {
-          "const": "fsm_logit_mask",
           "default": "fsm_logit_mask",
           "description": "The mechanistic strategy for intercepting the LLM forward pass.",
+          "enum": [
+            "fsm_logit_mask",
+            "lmql_query",
+            "guidance_program",
+            "ebnf_grammar"
+          ],
           "title": "Enforcement Strategy",
           "type": "string"
         },
@@ -3357,11 +3369,27 @@
           "enum": [
             "outlines",
             "xgrammar",
+            "sglang",
+            "lmql",
+            "guidance",
             "llama_cpp",
             "agnostic"
           ],
           "title": "Compiler Backend",
           "type": "string"
+        },
+        "formal_grammar_string": {
+          "anyOf": [
+            {
+              "maxLength": 50000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Formal Grammar String"
         },
         "terminate_on_eos_leak": {
           "default": true,

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -10324,16 +10324,28 @@ class ConstrainedDecodingPolicy(CoreasonBaseState):
     MCP ROUTING TRIGGERS: FSM Logit Masking, Constrained Decoding, Tokenizer Interception, Hardware Execution Boundary
     """
 
-    enforcement_strategy: Literal["fsm_logit_mask"] = Field(
+    enforcement_strategy: Literal["fsm_logit_mask", "lmql_query", "guidance_program", "ebnf_grammar"] = Field(
         default="fsm_logit_mask", description="The mechanistic strategy for intercepting the LLM forward pass."
     )
-    compiler_backend: Literal["outlines", "xgrammar", "llama_cpp", "agnostic"] = Field(
+    compiler_backend: Literal["outlines", "xgrammar", "sglang", "lmql", "guidance", "llama_cpp", "agnostic"] = Field(
         description="The C++/CUDA backend used to compile the CFG or Regex into a DFA/PDA."
     )
+    formal_grammar_string: str | None = Field(default=None, max_length=50000)
     terminate_on_eos_leak: bool = Field(
         default=True,
         description="If True, mathematically forces the engine to halt if the LLM attempts to generate an EOS token before the FSM reaches an accepting state.",
     )
+
+    @model_validator(mode="after")
+    def validate_grammar_requirements(self) -> Self:
+        if (
+            self.enforcement_strategy in {"lmql_query", "guidance_program", "ebnf_grammar"}
+            and not self.formal_grammar_string
+        ):
+            raise ValueError(
+                f"formal_grammar_string must be provided when enforcement_strategy is '{self.enforcement_strategy}'"
+            )
+        return self
 
 
 class CognitiveFormatContract(CoreasonBaseState):
@@ -10359,7 +10371,7 @@ class CognitiveFormatContract(CoreasonBaseState):
     require_think_tags: bool = Field(
         default=True, description="Forces the inclusion of structural XML tags to isolate the reasoning trace."
     )
-    final_answer_regex: str = Field(
+    final_answer_regex: str | None = Field(
         max_length=2000,
         default="^Final Answer: .*$",
         description="The strict regular expression the model must satisfy to yield a valid discrete classification.",
@@ -10367,6 +10379,14 @@ class CognitiveFormatContract(CoreasonBaseState):
     decoding_policy: ConstrainedDecodingPolicy = Field(
         description="The mandatory hardware-level execution limits for token masking."
     )
+
+    @model_validator(mode="after")
+    def resolve_contract_conflicts(self) -> Self:
+        if self.decoding_policy.enforcement_strategy == "lmql_query" and self.final_answer_regex is not None:
+            raise ValueError(
+                "Regex constraints must be embedded directly inside the LMQL grammar string when using 'lmql_query'."
+            )
+        return self
 
 
 class EpistemicRewardModelPolicy(CoreasonBaseState):


### PR DESCRIPTION
- Updated `enforcement_strategy` and `compiler_backend` literals in `ConstrainedDecodingPolicy` to support frameworks like LMQL, Guidance, and EBNF Grammar.
- Added optional `formal_grammar_string` to `ConstrainedDecodingPolicy`.
- Created `@model_validator` in `ConstrainedDecodingPolicy` to enforce that `formal_grammar_string` is present when required by specific execution strategies.
- Refactored `final_answer_regex` in `CognitiveFormatContract` to be optional, accommodating non-regex based LMQL/Guidance requirements.
- Introduced `@model_validator` in `CognitiveFormatContract` to raise an error if regex constraints conflict with the `lmql_query` strategy.
- Verified all Pydantic validations, strict typing, and system stability according to internal guidelines using `pytest`, `mypy`, and `ruff`.

---
*PR created automatically by Jules for task [2281967522402001469](https://jules.google.com/task/2281967522402001469) started by @gowthamrao*