### PR TITLE
fix(ontology): inject missing emulation profile fields

### DIFF
--- a/patch_descriptions.py
+++ b/patch_descriptions.py
@@ -1,0 +1,31 @@
+import re
+
+file_path = "src/coreason_manifest/spec/ontology.py"
+with open(file_path) as f:
+    content = f.read()
+
+replacements = {
+    r'generative_persona: Literal\["hesitant_novice", "fast_expert", "distracted_browser"\] = Field\(\n        default="fast_expert", description="The imitation learning persona governing the emulation."\n    \)': r'generative_persona: Literal["hesitant_novice", "fast_expert", "distracted_browser"] = Field(\n        default="fast_expert",\n        description="The imitation learning persona governing the behavioral emulation profile.",\n    )',
+    r'kinematic_noise: "KinematicNoiseProfile \| None" = Field\(default=None\)': r'kinematic_noise: "KinematicNoiseProfile | None" = Field(\n        default=None,\n        description="The stochastic pointer trajectory perturbation profile for human-like motor control emulation.",\n    )',
+    r'environmental_spoofing: "EnvironmentalSpoofingProfile \| None" = Field\(default=None\)': r'environmental_spoofing: "EnvironmentalSpoofingProfile | None" = Field(\n        default=None,\n        description="The browser fingerprint and environmental telemetry spoofing geometry.",\n    )',
+    r"emulation_fidelity_target: float = Field\(..., ge=0.0, le=1.0\)": r'emulation_fidelity_target: float = Field(\n        ge=0.0,\n        le=1.0,\n        description="The target normalized score for human-likeness against anti-bot heuristic classifiers.",\n    )',
+    r'tls_cipher_permutation: Literal\["chrome_windows", "safari_macos", "firefox_macos", "android_webview"\] = Field\(\n        default="chrome_windows", description="The JA3/JA4 TLS Client Hello fingerprint to project."\n    \)': r'tls_cipher_permutation: Literal["chrome_windows", "safari_macos", "firefox_macos", "android_webview"] = Field(\n        default="chrome_windows",\n        description="The JA3/JA4 TLS Client Hello fingerprint to project during handshake emulation.",\n    )',
+    r'webgl_entropy_seed_hash: str = Field\(..., min_length=1, max_length=128, pattern="\^\[a-zA-Z0-9_.:-\]\+\$"\)': r'webgl_entropy_seed_hash: str = Field(\n        min_length=1,\n        max_length=128,\n        pattern="^[a-zA-Z0-9_.:-]+$",\n        description="The Content Identifier (CID) of the WebGL canvas entropy seed used to generate a deterministic spoofed fingerprint.",\n    )',
+    r"user_agent_template: str = Field\(..., max_length=2000\)": r'user_agent_template: str = Field(\n        max_length=2000,\n        description="The User-Agent string template projected to exogenous web servers to mask the true computational substrate.",\n    )',
+    r'hardware_concurrency_mask: int = Field\(\n        default=8, gt=0, le=256, description="Spoofed CPU core count projected to the DOM."\n    \)': r'hardware_concurrency_mask: int = Field(\n        gt=0,\n        le=256,\n        default=8,\n        description="The spoofed CPU core count projected to the DOM via navigator.hardwareConcurrency.",\n    )',
+    r"timezone_offset_minutes: int = Field\(..., ge=-720, le=840\)": r'timezone_offset_minutes: int = Field(\n        ge=-720,\n        le=840,\n        description="The spoofed UTC timezone offset in minutes, bounded to the valid terrestrial range.",\n    )',
+    r"screen_resolution_width: int = Field\(..., ge=1, le=15360\)": r'screen_resolution_width: int = Field(\n        ge=1,\n        le=15360,\n        description="The spoofed horizontal display resolution in pixels.",\n    )',
+    r"screen_resolution_height: int = Field\(..., ge=1, le=15360\)": r'screen_resolution_height: int = Field(\n        ge=1,\n        le=15360,\n        description="The spoofed vertical display resolution in pixels.",\n    )',
+    r'velocity_profile: Literal\["minimum_jerk", "constant", "fractional_brownian"\] = Field\(\n        default="minimum_jerk", description="The mathematical model governing movement acceleration."\n    \)': r'velocity_profile: Literal["minimum_jerk", "constant", "fractional_brownian"] = Field(\n        default="minimum_jerk",\n        description="The mathematical model governing movement acceleration and velocity smoothing.",\n    )',
+    r"pink_noise_amplitude: float = Field\(..., ge=0.0, le=1.0\)": r'pink_noise_amplitude: float = Field(\n        ge=0.0,\n        le=1.0,\n        description="The normalized amplitude of the 1/f noise injected into the pointer trajectory. Bounded [0.0, 1.0].",\n    )',
+    r"frequency_exponent: float = Field\(..., ge=0.0, le=5.0\)": r'frequency_exponent: float = Field(\n        ge=0.0,\n        le=5.0,\n        description="The spectral exponent β in the 1/f^β power spectral density function governing noise color.",\n    )',
+    r'target_overshoot_radius_pixels: int = Field\(\n        default=0, ge=0, le=5000, description="The Euclidean radius for corrective submovements."\n    \)': r'target_overshoot_radius_pixels: int = Field(\n        ge=0,\n        le=5000,\n        default=0,\n        description="The Euclidean radius in pixels for corrective submovements overshooting the target coordinate.",\n    )',
+    r'hick_hyman_dwell_time_ms: int = Field\(\n        default=0, ge=0, le=86400000, description="Cognitive choice reaction delay in milliseconds."\n    \)': r'hick_hyman_dwell_time_ms: int = Field(\n        ge=0,\n        le=86400000,\n        default=0,\n        description="Cognitive choice reaction delay in milliseconds, modeled via Hick-Hyman Law.",\n    )',
+    r'noise_type: Literal\["pink", "brownian", "gaussian"\] = Field\(...\)': r'noise_type: Literal["pink", "brownian", "gaussian"] = Field(\n        description="The stochastic process governing the noise generation for pointer trajectory perturbation.",\n    )',
+}
+
+for old, new in replacements.items():
+    content = re.sub(old, new, content)
+
+with open(file_path, "w") as f:
+    f.write(content)

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2218,22 +2218,11 @@ class AdversarialEmulationProfile(CoreasonBaseState):
     """
 
     generative_persona: Literal["hesitant_novice", "fast_expert", "distracted_browser"] = Field(
-        default="fast_expert",
-        description="The imitation learning persona governing the behavioral emulation profile.",
+        default="fast_expert", description="The imitation learning persona governing the emulation."
     )
-    kinematic_noise: "KinematicNoiseProfile | None" = Field(
-        default=None,
-        description="The stochastic pointer trajectory perturbation profile for human-like motor control emulation.",
-    )
-    environmental_spoofing: "EnvironmentalSpoofingProfile | None" = Field(
-        default=None,
-        description="The browser fingerprint and environmental telemetry spoofing geometry.",
-    )
-    emulation_fidelity_target: float = Field(
-        ge=0.0,
-        le=1.0,
-        description="The target normalized score for human-likeness against anti-bot heuristic classifiers.",
-    )
+    kinematic_noise: "KinematicNoiseProfile | None" = Field(default=None)
+    environmental_spoofing: "EnvironmentalSpoofingProfile | None" = Field(default=None)
+    emulation_fidelity_target: float = Field(..., ge=0.0, le=1.0)
 
 
 class AgentBidIntent(CoreasonBaseState):
@@ -3836,40 +3825,16 @@ class EnvironmentalSpoofingProfile(CoreasonBaseState):
     """
 
     tls_cipher_permutation: Literal["chrome_windows", "safari_macos", "firefox_macos", "android_webview"] = Field(
-        default="chrome_windows",
-        description="The JA3/JA4 TLS Client Hello fingerprint to project during handshake emulation.",
+        default="chrome_windows", description="The JA3/JA4 TLS Client Hello fingerprint to project."
     )
-    webgl_entropy_seed_hash: str = Field(
-        min_length=1,
-        max_length=128,
-        pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The Content Identifier (CID) of the WebGL canvas entropy seed used to generate a deterministic spoofed fingerprint.",
-    )
-    user_agent_template: str = Field(
-        max_length=2000,
-        description="The User-Agent string template projected to exogenous web servers to mask the true computational substrate.",
-    )
+    webgl_entropy_seed_hash: str = Field(..., min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")
+    user_agent_template: str = Field(..., max_length=2000)
     hardware_concurrency_mask: int = Field(
-        gt=0,
-        le=256,
-        default=8,
-        description="The spoofed CPU core count projected to the DOM via navigator.hardwareConcurrency.",
+        default=8, gt=0, le=256, description="Spoofed CPU core count projected to the DOM."
     )
-    timezone_offset_minutes: int = Field(
-        ge=-720,
-        le=840,
-        description="The spoofed UTC timezone offset in minutes, bounded to the valid terrestrial range.",
-    )
-    screen_resolution_width: int = Field(
-        ge=1,
-        le=15360,
-        description="The spoofed horizontal display resolution in pixels.",
-    )
-    screen_resolution_height: int = Field(
-        ge=1,
-        le=15360,
-        description="The spoofed vertical display resolution in pixels.",
-    )
+    timezone_offset_minutes: int = Field(..., ge=-720, le=840)
+    screen_resolution_width: int = Field(..., ge=1, le=15360)
+    screen_resolution_height: int = Field(..., ge=1, le=15360)
 
 
 class EpistemicCompressionSLA(CoreasonBaseState):
@@ -5933,34 +5898,17 @@ class KinematicNoiseProfile(CoreasonBaseState):
     Motor Control Perturbation, Hick-Hyman Law, Fitts's Law
     """
 
-    noise_type: Literal["pink", "brownian", "gaussian"] = Field(
-        description="The stochastic process governing the noise generation for pointer trajectory perturbation.",
-    )
+    noise_type: Literal["pink", "brownian", "gaussian"] = Field(...)
     velocity_profile: Literal["minimum_jerk", "constant", "fractional_brownian"] = Field(
-        default="minimum_jerk",
-        description="The mathematical model governing movement acceleration and velocity smoothing.",
+        default="minimum_jerk", description="The mathematical model governing movement acceleration."
     )
-    pink_noise_amplitude: float = Field(
-        ge=0.0,
-        le=1.0,
-        description="The normalized amplitude of the 1/f noise injected into the pointer trajectory. Bounded [0.0, 1.0].",
-    )
-    frequency_exponent: float = Field(
-        ge=0.0,
-        le=5.0,
-        description="The spectral exponent β in the 1/f^β power spectral density function governing noise color.",
-    )
+    pink_noise_amplitude: float = Field(..., ge=0.0, le=1.0)
+    frequency_exponent: float = Field(..., ge=0.0, le=5.0)
     target_overshoot_radius_pixels: int = Field(
-        ge=0,
-        le=5000,
-        default=0,
-        description="The Euclidean radius in pixels for corrective submovements overshooting the target coordinate.",
+        default=0, ge=0, le=5000, description="The Euclidean radius for corrective submovements."
     )
     hick_hyman_dwell_time_ms: int = Field(
-        ge=0,
-        le=86400000,
-        default=0,
-        description="Cognitive choice reaction delay in milliseconds, modeled via Hick-Hyman Law.",
+        default=0, ge=0, le=86400000, description="Cognitive choice reaction delay in milliseconds."
     )
 
 

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2218,11 +2218,22 @@ class AdversarialEmulationProfile(CoreasonBaseState):
     """
 
     generative_persona: Literal["hesitant_novice", "fast_expert", "distracted_browser"] = Field(
-        default="fast_expert", description="The imitation learning persona governing the emulation."
+        default="fast_expert",
+        description="The imitation learning persona governing the behavioral emulation profile.",
     )
-    kinematic_noise: "KinematicNoiseProfile | None" = Field(default=None)
-    environmental_spoofing: "EnvironmentalSpoofingProfile | None" = Field(default=None)
-    emulation_fidelity_target: float = Field(..., ge=0.0, le=1.0)
+    kinematic_noise: "KinematicNoiseProfile | None" = Field(
+        default=None,
+        description="The stochastic pointer trajectory perturbation profile for human-like motor control emulation.",
+    )
+    environmental_spoofing: "EnvironmentalSpoofingProfile | None" = Field(
+        default=None,
+        description="The browser fingerprint and environmental telemetry spoofing geometry.",
+    )
+    emulation_fidelity_target: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The target normalized score for human-likeness against anti-bot heuristic classifiers.",
+    )
 
 
 class AgentBidIntent(CoreasonBaseState):
@@ -3825,16 +3836,40 @@ class EnvironmentalSpoofingProfile(CoreasonBaseState):
     """
 
     tls_cipher_permutation: Literal["chrome_windows", "safari_macos", "firefox_macos", "android_webview"] = Field(
-        default="chrome_windows", description="The JA3/JA4 TLS Client Hello fingerprint to project."
+        default="chrome_windows",
+        description="The JA3/JA4 TLS Client Hello fingerprint to project during handshake emulation.",
     )
-    webgl_entropy_seed_hash: str = Field(..., min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")
-    user_agent_template: str = Field(..., max_length=2000)
+    webgl_entropy_seed_hash: str = Field(
+        min_length=1,
+        max_length=128,
+        pattern="^[a-zA-Z0-9_.:-]+$",
+        description="The Content Identifier (CID) of the WebGL canvas entropy seed used to generate a deterministic spoofed fingerprint.",
+    )
+    user_agent_template: str = Field(
+        max_length=2000,
+        description="The User-Agent string template projected to exogenous web servers to mask the true computational substrate.",
+    )
     hardware_concurrency_mask: int = Field(
-        default=8, gt=0, le=256, description="Spoofed CPU core count projected to the DOM."
+        gt=0,
+        le=256,
+        default=8,
+        description="The spoofed CPU core count projected to the DOM via navigator.hardwareConcurrency.",
     )
-    timezone_offset_minutes: int = Field(..., ge=-720, le=840)
-    screen_resolution_width: int = Field(..., ge=1, le=15360)
-    screen_resolution_height: int = Field(..., ge=1, le=15360)
+    timezone_offset_minutes: int = Field(
+        ge=-720,
+        le=840,
+        description="The spoofed UTC timezone offset in minutes, bounded to the valid terrestrial range.",
+    )
+    screen_resolution_width: int = Field(
+        ge=1,
+        le=15360,
+        description="The spoofed horizontal display resolution in pixels.",
+    )
+    screen_resolution_height: int = Field(
+        ge=1,
+        le=15360,
+        description="The spoofed vertical display resolution in pixels.",
+    )
 
 
 class EpistemicCompressionSLA(CoreasonBaseState):
@@ -5898,17 +5933,34 @@ class KinematicNoiseProfile(CoreasonBaseState):
     Motor Control Perturbation, Hick-Hyman Law, Fitts's Law
     """
 
-    noise_type: Literal["pink", "brownian", "gaussian"] = Field(...)
-    velocity_profile: Literal["minimum_jerk", "constant", "fractional_brownian"] = Field(
-        default="minimum_jerk", description="The mathematical model governing movement acceleration."
+    noise_type: Literal["pink", "brownian", "gaussian"] = Field(
+        description="The stochastic process governing the noise generation for pointer trajectory perturbation.",
     )
-    pink_noise_amplitude: float = Field(..., ge=0.0, le=1.0)
-    frequency_exponent: float = Field(..., ge=0.0, le=5.0)
+    velocity_profile: Literal["minimum_jerk", "constant", "fractional_brownian"] = Field(
+        default="minimum_jerk",
+        description="The mathematical model governing movement acceleration and velocity smoothing.",
+    )
+    pink_noise_amplitude: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The normalized amplitude of the 1/f noise injected into the pointer trajectory. Bounded [0.0, 1.0].",
+    )
+    frequency_exponent: float = Field(
+        ge=0.0,
+        le=5.0,
+        description="The spectral exponent β in the 1/f^β power spectral density function governing noise color.",
+    )
     target_overshoot_radius_pixels: int = Field(
-        default=0, ge=0, le=5000, description="The Euclidean radius for corrective submovements."
+        ge=0,
+        le=5000,
+        default=0,
+        description="The Euclidean radius in pixels for corrective submovements overshooting the target coordinate.",
     )
     hick_hyman_dwell_time_ms: int = Field(
-        default=0, ge=0, le=86400000, description="Cognitive choice reaction delay in milliseconds."
+        ge=0,
+        le=86400000,
+        default=0,
+        description="Cognitive choice reaction delay in milliseconds, modeled via Hick-Hyman Law.",
     )
 
 


### PR DESCRIPTION
Closes Epic 8.4 issue by properly defining kinematic and environmental bounds to emulation profiles.

---
*PR created automatically by Jules for task [16772072326384464656](https://jules.google.com/task/16772072326384464656) started by @gowthamrao*