### PR TITLE
chore: Opt-in to Node 24 for GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   lint-and-audit:
     name: Lint and Audit (Zero-Pollution Tooling Injection)

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,9 @@ permissions:
   id-token: write # Required for PyPI OIDC Trusted Publishing and Sigstore
   pages: write    # Required for GitHub Pages deployment
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -8,6 +8,9 @@ on:
       - 'uv.lock'
       - 'pyproject.toml'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   audit:
     name: Dependency Audit


### PR DESCRIPTION
This resolves the warning seen in GitHub Actions runs about Node.js 20 being deprecated by opting in to Node 24 ahead of time.

---
*PR created automatically by Jules for task [8955327680947001168](https://jules.google.com/task/8955327680947001168) started by @gowthamrao*