### PR TITLE
ci: update GitHub Actions to support Node.js 24 and resolve deprecation warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   lint-and-audit:
@@ -118,7 +118,7 @@ jobs:
         run: uv run pytest
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -157,7 +157,7 @@ jobs:
         run: uv run pytest
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ permissions:
   pages: write    # Required for GitHub Pages deployment
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   release:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,7 +9,7 @@ on:
       - 'pyproject.toml'
 
 env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
 
 jobs:
   audit:


### PR DESCRIPTION
Fixes the Node.js 20 deprecation warnings in GitHub actions by updating `codecov/codecov-action` to `v5` and correctly formatting `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"` as a string in all workflows.

---
*PR created automatically by Jules for task [8283831352767402314](https://jules.google.com/task/8283831352767402314) started by @gowthamrao*