### PR TITLE
feat(ontology): Support Non-Monotonic Logic, Continuous State Space, and Speculative Execution

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -3500,6 +3500,55 @@
       "title": "ContinuousMutationPolicy",
       "type": "object"
     },
+    "ContinuousObservationStream": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the geometric snapshot of a continuous stream and its \"forget gate\" disfluency rules. As a ...Stream suffix, this acts as a declarative snapshot of continuous token flows.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to continuously process and retain token buffers governed by a temporal decay matrix.\n\nEPISTEMIC BOUNDS: The token_buffer is mathematically capped at max_length=1000000. Each token is restricted to max_length=10000. The temporal_decay_matrix forces bounded temporal scaling (ge=0.0, le=1.0) applied to continuous sequence identifiers (ge=0).\n\nMCP ROUTING TRIGGERS: Continuous Observation, State Space Models, Temporal Decay, Forget Gate, Streaming Disfluency",
+      "properties": {
+        "stream_id": {
+          "description": "A Content Identifier (CID) for the continuous observation stream.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Stream Id",
+          "type": "string"
+        },
+        "token_buffer": {
+          "description": "The array of ingested tokens representing the continuous stream.",
+          "items": {
+            "maxLength": 10000,
+            "type": "string"
+          },
+          "maxItems": 1000000,
+          "title": "Token Buffer",
+          "type": "array"
+        },
+        "temporal_decay_matrix": {
+          "additionalProperties": {
+            "maximum": 1.0,
+            "minimum": 0.0,
+            "type": "number"
+          },
+          "description": "The mathematical decay map applied to historical token indices.",
+          "title": "Temporal Decay Matrix",
+          "type": "object"
+        },
+        "latest_confidence_score": {
+          "description": "The certainty score of the latest token prediction.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Latest Confidence Score",
+          "type": "number"
+        }
+      },
+      "required": [
+        "stream_id",
+        "token_buffer",
+        "temporal_decay_matrix",
+        "latest_confidence_score"
+      ],
+      "title": "ContinuousObservationStream",
+      "type": "object"
+    },
     "CouncilTopologyManifest": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Social Choice Theory, Condorcet's Jury Theorem, and\nPractical Byzantine Fault Tolerance (pBFT) to synthesize an authoritative truth\nfrom a multi-agent network. As a ...Manifest suffix, this defines a frozen,\nN-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Unlocks decentralized truth-synthesis by routing conflicting\nproposals through a strict consensus_policy (ConsensusPolicy), ultimately collapsing\nthe epistemic probability wave via the designated adjudicator_id\n(NodeIdentifierState). Cognitive heterogeneity is enforced by\ndiversity_policy (DiversityPolicy).\n\nEPISTEMIC BOUNDS: The @model_validator enforce_funded_byzantine_slashing enforces a\nstrict economic interlock: if the consensus_policy demands slash_escrow via pBFT,\nit halts instantiation unless a funded council_escrow (EscrowPolicy, magnitude > 0)\nis present. A second @model_validator check_adjudicator_id verifies the\nadjudicator_id exists in the nodes registry.\n\nMCP ROUTING TRIGGERS: Social Choice Theory, PBFT Consensus, Multi-Agent Debate,\nByzantine Fault Tolerance, Slashing Condition",
@@ -4114,6 +4163,14 @@
           "minimum": 1,
           "title": "Max Fan Out",
           "type": "integer"
+        },
+        "speculative_boundaries": {
+          "description": "The deterministic speculative boundaries executing within the DAG.",
+          "items": {
+            "$ref": "#/$defs/SpeculativeExecutionBoundary"
+          },
+          "title": "Speculative Boundaries",
+          "type": "array"
         }
       },
       "required": [
@@ -5282,6 +5339,42 @@
       "title": "EpistemicCompressionSLA",
       "type": "object"
     },
+    "EpistemicContractionPolicy": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the mathematical rules for surgically retracting a belief within a Defeasible Logic framework. As a ...Policy suffix, this defines rigid algorithmic boundaries.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's Truth Maintenance System to physically severe edges in the Knowledge Graph by excising the target CID and cascading the falsification recursively.\n\nEPISTEMIC BOUNDS: The contraction operation is physically bounded by the cascade_depth (ge=0, le=1000000) integer constraint, preventing runaway causal unravelling. The triggers are restricted to strict 128-char CID regex strings.\n\nMCP ROUTING TRIGGERS: Defeasible Logic, Belief Retraction, Causal Excising, Non-Monotonic Inference, Topological Amputation",
+      "properties": {
+        "contradiction_trigger": {
+          "description": "The CID of the observation or event that triggered the logical contradiction.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Contradiction Trigger",
+          "type": "string"
+        },
+        "excision_target": {
+          "description": "The target CID of the specific axiom or node slated for epistemic amputation.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Excision Target",
+          "type": "string"
+        },
+        "cascade_depth": {
+          "description": "The mathematical limit determining how deep the falsification signal propagates through connected edges.",
+          "maximum": 1000000,
+          "minimum": 0,
+          "title": "Cascade Depth",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "contradiction_trigger",
+        "excision_target",
+        "cascade_depth"
+      ],
+      "title": "EpistemicContractionPolicy",
+      "type": "object"
+    },
     "EpistemicCurriculumManifest": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Curriculum Learning and Experience Replay manifolds,\nserving as the definitive batch transport layer for continuous swarm optimization. As a\n...Manifest suffix, this defines a frozen, N-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Injects a validated cluster of EpistemicGroundedTaskManifest\nprimitives into the decentralized training pipeline, forcing deterministic policy\ngradient updates across all subscribing nodes.\n\nEPISTEMIC BOUNDS: The tasks array requires min_length=1 to prevent empty compute\ncycles. To guarantee zero-trust distribution and prevent Byzantine hash fractures, the\n@model_validator sort_tasks mechanically sorts the array by task_id, ensuring perfect\nRFC 8785 canonical hashing. Anchored by a 128-char curriculum_id CID.\n\nMCP ROUTING TRIGGERS: Curriculum Learning, Experience Replay, Policy Gradient,\nCanonical Hashing, Knowledge Distillation",
@@ -5480,6 +5573,30 @@
           },
           "maxItems": 10000,
           "title": "History",
+          "type": "array"
+        },
+        "defeasible_claims": {
+          "description": "The set of non-monotonic claims residing in the epistemic ledger that are structurally liable to falsification.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_.:-]+$": {
+              "$ref": "#/$defs/SemanticNodeState"
+            }
+          },
+          "propertyNames": {
+            "maxLength": 128
+          },
+          "title": "Defeasible Claims",
+          "type": "object"
+        },
+        "retracted_nodes": {
+          "description": "A strict sequence of CIDs representing historical nodes that have been severed from the causal graph via defeasible logic.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_.:-]+$",
+            "type": "string"
+          },
+          "title": "Retracted Nodes",
           "type": "array"
         },
         "checkpoints": {
@@ -12463,6 +12580,63 @@
       "title": "SpatialKinematicActionIntent",
       "type": "object"
     },
+    "SpeculativeExecutionBoundary": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the structural boundary for executing graph nodes probabilistically, enabling speculative execution branches and time-rewinding geometry. As a ...Boundary suffix, this object acts as a declarative state checkpoint for probabilistic divergence.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's traversal engine to fork the execution context, probabilistically committing or reversing the subgraph based on downstream verification results.\n\nEPISTEMIC BOUNDS: The commit_probability is strictly clamped (ge=0.0, le=1.0). The graph is physically bounded by the boundary_id (128-char CID). The rollback_pointers and competing_hypotheses arrays are deterministically sorted via @model_validator to preserve invariant RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Speculative Topology, Time-Rewinding Geometry, Probabilistic Divergence, Subgraph Fork, Execution Boundary",
+      "properties": {
+        "boundary_id": {
+          "description": "The unique CID anchoring the start of the speculative execution branch.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Boundary Id",
+          "type": "string"
+        },
+        "is_speculative": {
+          "default": true,
+          "description": "Strict boolean indicating whether the boundary forces probabilistic execution paths.",
+          "title": "Is Speculative",
+          "type": "boolean"
+        },
+        "commit_probability": {
+          "description": "The assigned mathematical likelihood that the speculative branch will merge successfully.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Commit Probability",
+          "type": "number"
+        },
+        "rollback_pointers": {
+          "description": "CIDs referencing the deterministic states the orchestrator must rewind to upon branch falsification.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_.:-]+$",
+            "type": "string"
+          },
+          "maxItems": 10000,
+          "title": "Rollback Pointers",
+          "type": "array"
+        },
+        "competing_hypotheses": {
+          "description": "CIDs for concurrent alternative paths generated during speculation.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_.:-]+$",
+            "type": "string"
+          },
+          "maxItems": 10000,
+          "title": "Competing Hypotheses",
+          "type": "array"
+        }
+      },
+      "required": [
+        "boundary_id",
+        "commit_probability"
+      ],
+      "title": "SpeculativeExecutionBoundary",
+      "type": "object"
+    },
     "StateContract": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a Cryptographic Tuple Space (Blackboard Pattern)\nserving as the strictly typed epistemic synchronization layer for multi-agent\nmanifolds. As a ...Contract suffix, this enforces rigid mathematical boundaries\nglobally.\n\nCAUSAL AFFORDANCE: Physically restricts all state mutations within the topology\nto conform to the explicit schema_definition (JSON Schema dict, key\nmax_length=255), acting as a deterministic Schema-on-Write validation gate.\n\nEPISTEMIC BOUNDS: The strict_validation boolean (default=True) acts as a\nphysical barrier against stochastic drift, forcing the orchestrator to reject\nany state mutation that fails the schema definition. Property names are capped\nat max_length=255 to prevent dictionary bombing.\n\nMCP ROUTING TRIGGERS: Tuple Space, Blackboard Architecture, Schema-on-Write,\nFinite State Automaton, Epistemic Synchronization",
@@ -12731,6 +12905,39 @@
         "max_loops_allowed"
       ],
       "title": "SteadyStateHypothesisState",
+      "type": "object"
+    },
+    "StreamingDisfluencyContract": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements non-monotonic disfluency and \"forget gate\" triggers to repair continuous ingestion streams. As a ...Contract suffix, this object defines rigid mathematical boundaries that the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Triggers the orchestrator to excise or repair segments of the token stream when the repair_marker_regex matches, probabilistically governed by the decay_threshold.\n\nEPISTEMIC BOUNDS: The repair_marker_regex is strictly capped at max_length=2000 to prevent ReDoS CPU exhaustion. The decay_threshold is geometrically bounded (ge=0.0, le=1.0). The maximum temporal lookback window is clamped (ge=0, le=1000000000).\n\nMCP ROUTING TRIGGERS: Streaming Disfluency, Forget Gate, Token Excise, Sequence Repair, Temporal Lookback",
+      "properties": {
+        "repair_marker_regex": {
+          "description": "The regular expression pattern identifying a structural disfluency marker in the stream.",
+          "maxLength": 2000,
+          "title": "Repair Marker Regex",
+          "type": "string"
+        },
+        "decay_threshold": {
+          "description": "The probability boundary below which historical stream data is aggressively decayed.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Decay Threshold",
+          "type": "number"
+        },
+        "max_lookback_window": {
+          "description": "The maximum number of sequence steps the orchestrator is permitted to rewind and repair.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Max Lookback Window",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "repair_marker_regex",
+        "decay_threshold",
+        "max_lookback_window"
+      ],
+      "title": "StreamingDisfluencyContract",
       "type": "object"
     },
     "StructuralCausalGraphProfile": {

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -3513,7 +3513,7 @@
           "type": "string"
         },
         "token_buffer": {
-          "description": "The array of ingested tokens representing the continuous stream.",
+          "description": "The array of ingested tokens representing the continuous stream. AGENT INSTRUCTION: Topological Exemption applied. Do NOT sort this array, as its chronological sequence is its mathematical state.",
           "items": {
             "maxLength": 10000,
             "type": "string"

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -10674,7 +10674,8 @@ class ContinuousObservationStream(CoreasonBaseState):
         description="A Content Identifier (CID) for the continuous observation stream."
     )
     token_buffer: list[Annotated[str, StringConstraints(max_length=10000)]] = Field(
-        max_length=1000000, description="The array of ingested tokens representing the continuous stream."
+        max_length=1000000,
+        description="The array of ingested tokens representing the continuous stream. AGENT INSTRUCTION: Topological Exemption applied. Do NOT sort this array, as its chronological sequence is its mathematical state.",
     )
     temporal_decay_matrix: dict[Annotated[int, Field(ge=0)], Annotated[float, Field(ge=0.0, le=1.0)]] = Field(
         description="The mathematical decay map applied to historical token indices."
@@ -10682,11 +10683,6 @@ class ContinuousObservationStream(CoreasonBaseState):
     latest_confidence_score: float = Field(
         ge=0.0, le=1.0, description="The certainty score of the latest token prediction."
     )
-
-    @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
-        object.__setattr__(self, "token_buffer", sorted(self.token_buffer))
-        return self
 
 
 class StreamingDisfluencyContract(CoreasonBaseState):

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -9119,9 +9119,16 @@ class DAGTopologyManifest(BaseTopologyManifest):
     max_fan_out: int = Field(ge=1, le=1024, description="The maximum number of parallel child nodes.")
     "\n    TOPOLOGICAL BOUNDARY: Must be >= 1 and <= 1024. Limits horizontal compute explosion.\n    "
 
+    speculative_boundaries: list[SpeculativeExecutionBoundary] = Field(
+        default_factory=list, description="The deterministic speculative boundaries executing within the DAG."
+    )
+
     @model_validator(mode="after")
     def sort_dag_topology_arrays(self) -> Self:
         object.__setattr__(self, "edges", sorted(self.edges))
+        object.__setattr__(
+            self, "speculative_boundaries", sorted(self.speculative_boundaries, key=lambda x: x.boundary_id)
+        )
         return self
 
     @model_validator(mode="after")
@@ -10652,6 +10659,131 @@ type AnyStateEvent = Annotated[
 ]
 
 
+class ContinuousObservationStream(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Defines the geometric snapshot of a continuous stream and its "forget gate" disfluency rules. As a ...Stream suffix, this acts as a declarative snapshot of continuous token flows.
+
+    CAUSAL AFFORDANCE: Instructs the orchestrator to continuously process and retain token buffers governed by a temporal decay matrix.
+
+    EPISTEMIC BOUNDS: The token_buffer is mathematically capped at max_length=1000000. Each token is restricted to max_length=10000. The temporal_decay_matrix forces bounded temporal scaling (ge=0.0, le=1.0) applied to continuous sequence identifiers (ge=0).
+
+    MCP ROUTING TRIGGERS: Continuous Observation, State Space Models, Temporal Decay, Forget Gate, Streaming Disfluency
+    """
+
+    stream_id: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        description="A Content Identifier (CID) for the continuous observation stream."
+    )
+    token_buffer: list[Annotated[str, StringConstraints(max_length=10000)]] = Field(
+        max_length=1000000, description="The array of ingested tokens representing the continuous stream."
+    )
+    temporal_decay_matrix: dict[Annotated[int, Field(ge=0)], Annotated[float, Field(ge=0.0, le=1.0)]] = Field(
+        description="The mathematical decay map applied to historical token indices."
+    )
+    latest_confidence_score: float = Field(
+        ge=0.0, le=1.0, description="The certainty score of the latest token prediction."
+    )
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "token_buffer", sorted(self.token_buffer))
+        return self
+
+
+class StreamingDisfluencyContract(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Implements non-monotonic disfluency and "forget gate" triggers to repair continuous ingestion streams. As a ...Contract suffix, this object defines rigid mathematical boundaries that the orchestrator must enforce globally.
+
+    CAUSAL AFFORDANCE: Triggers the orchestrator to excise or repair segments of the token stream when the repair_marker_regex matches, probabilistically governed by the decay_threshold.
+
+    EPISTEMIC BOUNDS: The repair_marker_regex is strictly capped at max_length=2000 to prevent ReDoS CPU exhaustion. The decay_threshold is geometrically bounded (ge=0.0, le=1.0). The maximum temporal lookback window is clamped (ge=0, le=1000000000).
+
+    MCP ROUTING TRIGGERS: Streaming Disfluency, Forget Gate, Token Excise, Sequence Repair, Temporal Lookback
+    """
+
+    repair_marker_regex: str = Field(
+        max_length=2000,
+        description="The regular expression pattern identifying a structural disfluency marker in the stream.",
+    )
+    decay_threshold: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The probability boundary below which historical stream data is aggressively decayed.",
+    )
+    max_lookback_window: int = Field(
+        ge=0,
+        le=1000000000,
+        description="The maximum number of sequence steps the orchestrator is permitted to rewind and repair.",
+    )
+
+
+class SpeculativeExecutionBoundary(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Defines the structural boundary for executing graph nodes probabilistically, enabling speculative execution branches and time-rewinding geometry. As a ...Boundary suffix, this object acts as a declarative state checkpoint for probabilistic divergence.
+
+    CAUSAL AFFORDANCE: Instructs the orchestrator's traversal engine to fork the execution context, probabilistically committing or reversing the subgraph based on downstream verification results.
+
+    EPISTEMIC BOUNDS: The commit_probability is strictly clamped (ge=0.0, le=1.0). The graph is physically bounded by the boundary_id (128-char CID). The rollback_pointers and competing_hypotheses arrays are deterministically sorted via @model_validator to preserve invariant RFC 8785 hashing.
+
+    MCP ROUTING TRIGGERS: Speculative Topology, Time-Rewinding Geometry, Probabilistic Divergence, Subgraph Fork, Execution Boundary
+    """
+
+    boundary_id: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        description="The unique CID anchoring the start of the speculative execution branch."
+    )
+    is_speculative: bool = Field(
+        default=True, description="Strict boolean indicating whether the boundary forces probabilistic execution paths."
+    )
+    commit_probability: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The assigned mathematical likelihood that the speculative branch will merge successfully.",
+    )
+    rollback_pointers: list[
+        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    ] = Field(
+        max_length=10000,
+        default_factory=list,
+        description="CIDs referencing the deterministic states the orchestrator must rewind to upon branch falsification.",
+    )
+    competing_hypotheses: list[
+        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    ] = Field(
+        max_length=10000,
+        default_factory=list,
+        description="CIDs for concurrent alternative paths generated during speculation.",
+    )
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        object.__setattr__(self, "rollback_pointers", sorted(self.rollback_pointers))
+        object.__setattr__(self, "competing_hypotheses", sorted(self.competing_hypotheses))
+        return self
+
+
+class EpistemicContractionPolicy(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Defines the mathematical rules for surgically retracting a belief within a Defeasible Logic framework. As a ...Policy suffix, this defines rigid algorithmic boundaries.
+
+    CAUSAL AFFORDANCE: Instructs the orchestrator's Truth Maintenance System to physically severe edges in the Knowledge Graph by excising the target CID and cascading the falsification recursively.
+
+    EPISTEMIC BOUNDS: The contraction operation is physically bounded by the cascade_depth (ge=0, le=1000000) integer constraint, preventing runaway causal unravelling. The triggers are restricted to strict 128-char CID regex strings.
+
+    MCP ROUTING TRIGGERS: Defeasible Logic, Belief Retraction, Causal Excising, Non-Monotonic Inference, Topological Amputation
+    """
+
+    contradiction_trigger: Annotated[
+        str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")
+    ] = Field(description="The CID of the observation or event that triggered the logical contradiction.")
+    excision_target: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = (
+        Field(description="The target CID of the specific axiom or node slated for epistemic amputation.")
+    )
+    cascade_depth: int = Field(
+        ge=0,
+        le=1000000,
+        description="The mathematical limit determining how deep the falsification signal propagates through connected edges.",
+    )
+
+
 class EpistemicLedgerState(CoreasonBaseState):
     """
     AGENT INSTRUCTION: Formalizes Event Sourcing and the Merkle-DAG structure as
@@ -10678,6 +10810,18 @@ class EpistemicLedgerState(CoreasonBaseState):
     history: list[AnyStateEvent] = Field(
         max_length=10000,
         description="An append-only, cryptographic ledger of state events. [SITD-Alpha: Non-Monotonic Epistemic Quarantine Isometry]",
+    )
+    defeasible_claims: dict[
+        Annotated[str, StringConstraints(max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")], SemanticNodeState
+    ] = Field(
+        default_factory=dict,
+        description="The set of non-monotonic claims residing in the epistemic ledger that are structurally liable to falsification.",
+    )
+    retracted_nodes: list[
+        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    ] = Field(
+        default_factory=list,
+        description="A strict sequence of CIDs representing historical nodes that have been severed from the causal graph via defeasible logic.",
     )
     checkpoints: list[TemporalCheckpointState] = Field(
         max_length=1000000000, default_factory=list, description="Hard temporal anchors allowing state restoration."
@@ -10709,6 +10853,7 @@ class EpistemicLedgerState(CoreasonBaseState):
     @model_validator(mode="after")
     def sort_history(self) -> Self:
         object.__setattr__(self, "history", sorted(self.history, key=lambda event: event.timestamp))
+        object.__setattr__(self, "retracted_nodes", sorted(self.retracted_nodes))
         object.__setattr__(self, "checkpoints", sorted(self.checkpoints, key=lambda x: x.checkpoint_id))
         object.__setattr__(self, "active_rollbacks", sorted(self.active_rollbacks, key=lambda x: x.request_id))
         object.__setattr__(self, "migration_contracts", sorted(self.migration_contracts, key=lambda x: x.contract_id))
@@ -10762,3 +10907,8 @@ IntentClassificationReceipt.model_rebuild()
 KinematicNoiseProfile.model_rebuild()
 EnvironmentalSpoofingProfile.model_rebuild()
 AdversarialEmulationProfile.model_rebuild()
+ContinuousObservationStream.model_rebuild()
+StreamingDisfluencyContract.model_rebuild()
+SpeculativeExecutionBoundary.model_rebuild()
+EpistemicContractionPolicy.model_rebuild()
+EpistemicLedgerState.model_rebuild()

--- a/test_ontology.py
+++ b/test_ontology.py
@@ -1,0 +1,10 @@
+from src.coreason_manifest.spec.ontology import ContinuousObservationStream
+
+stream = ContinuousObservationStream(
+    stream_id="stream-123",
+    token_buffer=["hello", "world", "this", "is", "a", "test"],
+    temporal_decay_matrix={0: 1.0, 1: 0.9, 2: 0.8},
+    latest_confidence_score=0.95,
+)
+
+print(stream.token_buffer)

--- a/tests/test_new_ontology_models.py
+++ b/tests/test_new_ontology_models.py
@@ -1,0 +1,74 @@
+from coreason_manifest.spec.ontology import (
+    ContinuousObservationStream,
+    DAGTopologyManifest,
+    EpistemicContractionPolicy,
+    EpistemicLedgerState,
+    ObservationEvent,
+    SpeculativeExecutionBoundary,
+    StreamingDisfluencyContract,
+    SystemNodeProfile,
+)
+
+
+def test_continuous_observation_stream() -> None:
+    stream = ContinuousObservationStream(
+        stream_id="stream-123",
+        token_buffer=["c", "b", "a"],
+        temporal_decay_matrix={1: 0.5},
+        latest_confidence_score=0.9,
+    )
+    assert stream.stream_id == "stream-123"
+    # Token buffer should NOT be sorted because of topological exemption!
+    assert stream.token_buffer == ["c", "b", "a"]
+
+
+def test_streaming_disfluency_contract() -> None:
+    contract = StreamingDisfluencyContract(repair_marker_regex=".*", decay_threshold=0.5, max_lookback_window=10)
+    assert contract.repair_marker_regex == ".*"
+    assert contract.decay_threshold == 0.5
+    assert contract.max_lookback_window == 10
+
+
+def test_speculative_execution_boundary() -> None:
+    boundary = SpeculativeExecutionBoundary(
+        boundary_id="bound-123",
+        commit_probability=0.5,
+        rollback_pointers=["pointer-b", "pointer-a"],
+        competing_hypotheses=["hyp-b", "hyp-a"],
+    )
+    assert boundary.boundary_id == "bound-123"
+    assert boundary.commit_probability == 0.5
+    # Should be sorted
+    assert boundary.rollback_pointers == ["pointer-a", "pointer-b"]
+    assert boundary.competing_hypotheses == ["hyp-a", "hyp-b"]
+
+
+def test_epistemic_contraction_policy() -> None:
+    policy = EpistemicContractionPolicy(
+        contradiction_trigger="trigger-123", excision_target="target-123", cascade_depth=5
+    )
+    assert policy.contradiction_trigger == "trigger-123"
+
+
+def test_dag_topology_manifest_speculative_boundaries() -> None:
+    boundary_b = SpeculativeExecutionBoundary(boundary_id="b-bound", commit_probability=0.5)
+    boundary_a = SpeculativeExecutionBoundary(boundary_id="a-bound", commit_probability=0.5)
+
+    node_a = SystemNodeProfile(description="node a for test")
+    node_b = SystemNodeProfile(description="node b for test")
+
+    manifest = DAGTopologyManifest(
+        nodes={"did:test:node-id-a": node_a, "did:test:node-id-b": node_b},
+        speculative_boundaries=[boundary_b, boundary_a],
+        max_depth=10,
+        max_fan_out=10,
+    )
+    # Should be sorted
+    assert manifest.speculative_boundaries[0].boundary_id == "a-bound"
+    assert manifest.speculative_boundaries[1].boundary_id == "b-bound"
+
+
+def test_epistemic_ledger_state() -> None:
+    event = ObservationEvent(event_id="obs-1", timestamp=100.0, payload={"data": "test"})
+    ledger = EpistemicLedgerState(history=[event], retracted_nodes=["node-b", "node-a"])
+    assert ledger.retracted_nodes == ["node-a", "node-b"]


### PR DESCRIPTION
This PR adds required models and fields to `src/coreason_manifest/spec/ontology.py` to enable **Non-Monotonic Logic, Continuous State Space Processing, and Speculative Execution**.

Key changes:
- `ContinuousObservationStream` and `StreamingDisfluencyContract`
- `SpeculativeExecutionBoundary` and modifications to `DAGTopologyManifest`
- `EpistemicContractionPolicy`
- Enhancements to `EpistemicLedgerState`

Strict compliance to repository architectural mandates (No UUIDs, Anti-CRUD, Single Source of Truth, RFC 8785 canonical hashing) was observed. All required schemas also have a 4-part docstring definition.

---
*PR created automatically by Jules for task [2731380503269882756](https://jules.google.com/task/2731380503269882756) started by @gowthamrao*