### PR TITLE
Task 1.2: Latent Space Typing in `ontology.py` (#1316)

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -228,7 +228,7 @@
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the node that was evaluated."
+          "description": "The deterministic capability pointer representing the node that was evaluated."
         },
         "score": {
           "description": "The final score assigned based on the rubric.",
@@ -280,7 +280,7 @@
           "type": "array"
         },
         "passing_threshold": {
-          "description": "The minimum score required to pass.",
+          "description": "The absolute mathematical lower-bound scalar required to authorize execution.",
           "maximum": 100.0,
           "minimum": 0.0,
           "title": "Passing Threshold",
@@ -487,6 +487,7 @@
         },
         "capability_merkle_root": {
           "description": "The SHA-256 Merkle root of the agent's verified semantic capabilities.",
+          "maxLength": 128,
           "pattern": "^[a-f0-9]{64}$",
           "title": "Capability Merkle Root",
           "type": "string"
@@ -685,7 +686,7 @@
             }
           ],
           "default": null,
-          "description": "The ID of the specific ActionSpaceManifest (curated tool environment) bound to this agent.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the specific ActionSpaceManifest (curated tool environment) bound to this agent.",
           "title": "Action Space Id"
         },
         "secure_sub_session": {
@@ -2164,7 +2165,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a Cryptographic Null-Operator within Kahn's\nTopological Sort, preserving the topological chain of custody when an\nextraction node is intentionally skipped. As a ...Receipt suffix, this is an\nappend-only coordinate that the LLM must never mutate.\n\nCAUSAL AFFORDANCE: Safely starves a subgraph of compute without fracturing\nthe continuous Merkle-DAG hash chain. The bypassed_node_id\n(NodeIdentifierState) identifies the exact starved vertex. The\nartifact_event_id (128-char CID) ensures continuity with the genesis artifact.\n\nEPISTEMIC BOUNDS: The cryptographic_null_hash strictly requires a 64-char\nSHA-256 fingerprint (^[a-f0-9]{64}$). The execution skip rationale is\nmathematically locked to the justification Literal automaton\n[\"modality_mismatch\", \"budget_exhaustion\", \"sla_timeout\"], preventing\nhallucinated bypass reasons.\n\nMCP ROUTING TRIGGERS: Topological Sort, Cryptographic Null-Operator, Compute\nStarvation, DAG Integrity, Lazy Evaluation",
       "properties": {
         "artifact_event_id": {
-          "description": "The exact genesis CID of the document, ensuring continuity.",
+          "description": "The exact genesis globally unique decentralized identifier (DID) anchoring the document, ensuring continuity.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -2236,12 +2237,14 @@
       "properties": {
         "source_variable": {
           "description": "The independent variable $X$.",
+          "maxLength": 255,
           "minLength": 1,
           "title": "Source Variable",
           "type": "string"
         },
         "target_variable": {
           "description": "The dependent variable $Y$.",
+          "maxLength": 255,
           "minLength": 1,
           "title": "Target Variable",
           "type": "string"
@@ -2293,7 +2296,7 @@
           "type": "string"
         },
         "target_outcome_event_id": {
-          "description": "The CID of the collective outcome being explained.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the collective outcome being explained.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -2387,7 +2390,7 @@
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the node for which the circuit breaker was tripped."
+          "description": "The deterministic capability pointer representing the node for which the circuit breaker was tripped."
         },
         "error_signature": {
           "description": "Signature or summary of the error causing the trip.",
@@ -2481,11 +2484,11 @@
       "properties": {
         "primary_verifier_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The DID of the primary evaluating agent."
+          "description": "The globally unique decentralized identifier (DID) anchoring the primary evaluating agent."
         },
         "secondary_verifier_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The DID of the independent secondary evaluating agent."
+          "description": "The globally unique decentralized identifier (DID) anchoring the independent secondary evaluating agent."
         },
         "trace_factual_alignment": {
           "description": "Strict Boolean indicating if BOTH agents mathematically agree on factual alignment.",
@@ -2598,7 +2601,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of a continuous proof trace resulting\nfrom a successfully resolved non-monotonic search, projecting internal System 2 thinking\ninto the observable graph. As a ...State suffix, this is a frozen N-dimensional\ncoordinate.\n\nCAUSAL AFFORDANCE: Binds the raw, unstructured Chain-of-Thought (trace_payload) to a\nformal EpistemicTopologicalProofManifest (source_proof_id), injecting the internal\nmonologue into the verifiable DAG for downstream reward shaping (GRPO).\n\nEPISTEMIC BOUNDS: The token_length is restricted (ge=0, le=1000000000). The textual\nreasoning is physically bounded to max_length=100000 to prevent context window\nexplosion. The trace_id is locked to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Chain of Thought, Non-Monotonic Trace, Proof Crystallization,\nLatent Monologue, Verifiable Reasoning",
       "properties": {
         "trace_id": {
-          "description": "CID of this specific non-monotonic reasoning trace.",
+          "description": "The globally unique decentralized identifier (DID) anchoring this specific non-monotonic reasoning trace.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -2662,7 +2665,7 @@
           "type": "string"
         },
         "source_generation_id": {
-          "description": "The CID of the LLM's raw generated text trajectory.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the LLM's raw generated text trajectory.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -3261,7 +3264,7 @@
           "type": "string"
         },
         "drift_event_id": {
-          "description": "The CID of the NormativeDriftEvent that justified triggering this proposal.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the NormativeDriftEvent that justified triggering this proposal.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -3311,7 +3314,7 @@
           "type": "string"
         },
         "severity": {
-          "description": "Severity level if the rule is violated.",
+          "description": "The categorical magnitude of the systemic breach enacted upon rule violation.",
           "enum": [
             "low",
             "medium",
@@ -3949,7 +3952,7 @@
           "type": "string"
         },
         "applied_policy_id": {
-          "description": "The ID of the InformationFlowPolicy successfully applied.",
+          "description": "The deterministic capability pointer representing the InformationFlowPolicy successfully applied.",
           "maxLength": 255,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -5178,7 +5181,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements First-Order Logic and Resource Description Framework (RDF)\ntriples to mathematically formalize knowledge. As a ...State suffix, this is a\ndeclarative, frozen snapshot of a specific causal connection at a point in time.\n\nCAUSAL AFFORDANCE: Distills high-entropy natural language token streams into rigid,\nhashable causal edges (Subject, Predicate, Object), unlocking deterministic querying\nand Truth Maintenance System (TMS) traversals.\n\nEPISTEMIC BOUNDS: Source and target concept physical boundaries are strictly locked to\n128-char CIDs matching the regex ^[a-zA-Z0-9_.:-]+$. The directed_edge_type is clamped\nto a max_length of 2000 to prevent dictionary bombing during semantic evaluation.\n\nMCP ROUTING TRIGGERS: First-Order Logic, RDF Triple, Semantic Distillation, Causal\nEdge, Directed Graph",
       "properties": {
         "source_concept_id": {
-          "description": "CID of the origin node.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the origin node.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -5192,7 +5195,7 @@
           "type": "string"
         },
         "target_concept_id": {
-          "description": "CID of destination node.",
+          "description": "The globally unique decentralized identifier (DID) anchoring destination node.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -5448,7 +5451,7 @@
           "type": "string"
         },
         "source_trajectory_id": {
-          "description": "The CID of the partial CognitiveReasoningTraceState.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the partial CognitiveReasoningTraceState.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -5483,7 +5486,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Trajectory Distillation and Direct Preference Optimization\n(DPO) by encapsulating a mathematically verified ground-truth training datum. As a\n...Manifest suffix, this defines a frozen, N-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Unlocks verifiable Reinforcement Learning across the swarm by\nsecurely binding an unstructured vignette_payload to a formal topological_proof\n(EpistemicTopologicalProofManifest) and its resulting non-monotonic thinking_trace\n(CognitiveReasoningTraceState).\n\nEPISTEMIC BOUNDS: The task_id is cryptographically constrained to a 128-char CID\n(^[a-zA-Z0-9_.:-]+$). The vignette_payload is bounded to 100000 characters to prevent\ncontext exhaustion. A verification_lock (CognitiveDualVerificationReceipt) is\nstructurally mandated to physically prevent reward hacking via isolated consensus.\n\nMCP ROUTING TRIGGERS: Trajectory Distillation, Direct Preference Optimization,\nReinforcement Learning, Dual Verification, Curry-Howard Correspondence",
       "properties": {
         "task_id": {
-          "description": "The cryptographic CID of the task.",
+          "description": "The cryptographic globally unique decentralized identifier (DID) anchoring the task.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -5670,7 +5673,7 @@
           "type": "array"
         },
         "crystallized_semantic_node_id": {
-          "description": "The resulting permanent W3C DID / CID of the newly minted knowledge node.",
+          "description": "The resulting permanent W3C DID / The globally unique decentralized identifier (DID) anchoring the newly minted knowledge node.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -5723,7 +5726,7 @@
             }
           ],
           "default": null,
-          "description": "The CID of the Genesis MultimodalArtifactReceipt this semantic state was transmutated from.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the Genesis MultimodalArtifactReceipt this semantic state was transmutated from.",
           "title": "Source Artifact Id"
         },
         "multimodal_anchor": {
@@ -5842,7 +5845,7 @@
           "type": "string"
         },
         "reference_graph_id": {
-          "description": "The CID of the EpistemicDomainGraphManifest acting as the deterministic ground truth.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the EpistemicDomainGraphManifest acting as the deterministic ground truth.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -6142,7 +6145,7 @@
           "type": "string"
         },
         "artifact_event_id": {
-          "description": "The CID of the MultimodalArtifactReceipt being processed.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the MultimodalArtifactReceipt being processed.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -6240,7 +6243,7 @@
           "type": "string"
         },
         "tripped_rule_id": {
-          "description": "The ID of the Payload Loss Prevention (PLP) or Governance rule that blocked execution.",
+          "description": "The deterministic capability pointer representing the Payload Loss Prevention (PLP) or Governance rule that blocked execution.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -6420,11 +6423,11 @@
         },
         "generator_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the actor generating the payload."
+          "description": "The deterministic capability pointer representing the actor generating the payload."
         },
         "evaluator_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the critic scoring the payload."
+          "description": "The deterministic capability pointer representing the critic scoring the payload."
         },
         "max_revision_loops": {
           "description": "The absolute limit on Actor-Critic cycles to prevent infinite compute burn.",
@@ -6711,7 +6714,7 @@
             }
           ],
           "default": null,
-          "description": "The ID of the parent request.",
+          "description": "The deterministic capability pointer anchoring the parent request manifold.",
           "title": "Parent Request Id"
         },
         "root_request_id": {
@@ -6727,7 +6730,7 @@
             }
           ],
           "default": null,
-          "description": "The ID of the trace root.",
+          "description": "The deterministic capability pointer anchoring the trace root manifold.",
           "title": "Root Request Id"
         },
         "inputs": {
@@ -7016,11 +7019,11 @@
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the failing node."
+          "description": "The deterministic capability pointer representing the failing node."
         },
         "fallback_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the node to use as a fallback."
+          "description": "The deterministic capability pointer representing the node to use as a fallback."
         }
       },
       "required": [
@@ -7183,7 +7186,7 @@
         },
         "target_topology_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The DID of the discovered external state matrix/VPC."
+          "description": "The globally unique decentralized identifier (DID) anchoring the discovered external state matrix/VPC."
         },
         "authorized_session": {
           "$ref": "#/$defs/SecureSubSessionState",
@@ -7242,6 +7245,7 @@
       "properties": {
         "adapter_merkle_root": {
           "description": "CoReason Shared Kernel Ontology: The tamper-evident SHA-256 hash of the exact safetensors weight matrix.",
+          "maxLength": 128,
           "pattern": "^[a-f0-9]{64}$",
           "title": "Adapter Merkle Root",
           "type": "string"
@@ -7415,7 +7419,7 @@
           "type": "string"
         },
         "root_node_id": {
-          "description": "The CID of the top-level TaxonomicNodeState initiating the tree.",
+          "description": "The globally unique decentralized identifier (DID) anchoring the top-level TaxonomicNodeState initiating the tree.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -7511,7 +7515,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a structural invariant profile mapping the macroscopic dimensional properties of an artifact prior to deep inference.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator's routing engine to allocate specific functional experts and reserve physical VRAM budgets without needing to parse the full artifact into the active context window.\n\nEPISTEMIC BOUNDS: Memory allocation limits are mathematically bounded by token_density (ge=0, le=1000000000). The @model_validator deterministically sorts the detected_modalities enum array, guaranteeing zero-variance RFC 8785 canonical hashing across distributed nodes.\n\nMCP ROUTING TRIGGERS: Structural Indexing, VRAM Budgeting, Representation Engineering, Modality Detection, RFC 8785 Canonicalization",
       "properties": {
         "artifact_event_id": {
-          "description": "The exact genesis CID of the MultimodalArtifactReceipt entering the routing tier.",
+          "description": "The exact genesis globally unique decentralized identifier (DID) anchoring the MultimodalArtifactReceipt entering the routing tier.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -8028,7 +8032,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Cryptographically freezes an agent's probabilistic belief in a `HypothesisGenerationEvent` as an immutable economic stake on the Epistemic Ledger.\n\nCAUSAL AFFORDANCE: Projects the agent's internal `implied_probability` into the shared LMSR order book, injecting liquidity and actively shifting the global consensus gradient.\n\nEPISTEMIC BOUNDS: The `staked_magnitude` is constrained to a strictly positive integer `le=1000000000`, and the `implied_probability` is bounded mathematically to `[0.0, 1.0]`.\n\nMCP ROUTING TRIGGERS: Epistemic Staking, Brier Score Input, Belief Freezing, Market Order",
       "properties": {
         "agent_id": {
-          "description": "The ID of the agent placing the stake.",
+          "description": "The deterministic capability pointer representing the agent placing the stake.",
           "le": 1000000000,
           "minLength": 1,
           "title": "Agent Id",
@@ -8136,7 +8140,7 @@
         "type": {
           "const": "informational",
           "default": "informational",
-          "description": "Discriminator for read-only informational handoffs.",
+          "description": "The discriminative topological boundary for read-only informational handoffs.",
           "title": "Type",
           "type": "string"
         },
@@ -8337,7 +8341,7 @@
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the target node."
+          "description": "The deterministic capability pointer representing the target node."
         },
         "context_summary": {
           "description": "A summary of the context requiring intervention.",
@@ -8444,7 +8448,7 @@
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the target node."
+          "description": "The deterministic capability pointer representing the target node."
         },
         "approved": {
           "description": "Indicates whether the proposed action was approved.",
@@ -8595,7 +8599,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A mathematically constrained error vector reflecting execution\ncollapse within the JSON-RPC 2.0 specification. As a ...State suffix, this is a\nfrozen N-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Projects execution faults back across the network boundary\nwithout risking secondary buffer overflow attacks during serialization. The\nerror_payload (alias=\"data\", External Protocol Exemption) carries optional\nstructured diagnostic data.\n\nEPISTEMIC BOUNDS: The code integer is rigidly capped (le=1000000000, no ge bound)\nand the semantic message is restricted to max_length=2000 to prevent log-poisoning\nduring telemetry serialization.\n\nMCP ROUTING TRIGGERS: Fault Projection, Buffer Overflow Prevention, Error Vector,\nLog Poisoning, Stateful Rollback",
       "properties": {
         "code": {
-          "description": "A Number that indicates the error type that occurred.",
+          "description": "The strict integer identifier classifying the specific topological or execution collapse.",
           "maximum": 1000000000,
           "title": "Code",
           "type": "integer"
@@ -9280,7 +9284,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a Higher-Order Function within the Model Context Protocol, mapping\na dynamic Latent Prompt Manifold into the agent's execution context.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to fetch and interpolate an exogenous prompt\ntemplate from a remote server, using the arguments dictionary to inject localized state into the template.\n\nEPISTEMIC BOUNDS: Supply-chain execution attacks are mathematically mitigated by the optional\nprompt_hash (strictly matching SHA-256 pattern ^[a-f0-9]{64}$). The arguments matrix is physically\ncapped at max_length=1000000000 (with keys at max_length=255) to prevent OOM faults during interpolation.\nThe optional fallback_persona is bounded to max_length=2000.\n\nMCP ROUTING TRIGGERS: Higher-Order Function, Latent Prompt Manifold, Template Interpolation, Supply-Chain Verification, Stateless RPC",
       "properties": {
         "server_id": {
-          "description": "The ID of the MCP server providing this prompt.",
+          "description": "The deterministic capability pointer representing the MCP server providing this prompt.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -9346,7 +9350,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Exposes a zero-trust Resource Description Framework (RDF) URI mapping,\npassively projecting external data geometries into the swarm's accessible environment.\n\nCAUSAL AFFORDANCE: Unlocks the agent's ability to perceive specific remote or local files,\ndatabases, or API endpoints without granting them kinetic execution privileges over those endpoints.\n\nEPISTEMIC BOUNDS: The URI namespace is physically bounded by the uris array, where each string\nis clamped to max_length=2000. The server_id is restricted to a 128-character CID. The sort_arrays\n@model_validator deterministically alphabetizes the URIs to preserve Merkle-DAG integrity across the distributed system.\n\nMCP ROUTING TRIGGERS: Resource Description Framework, Zero-Trust Perception, Epistemic Projection, Passive URI Mapping, Data Topography",
       "properties": {
         "server_id": {
-          "description": "The ID of the MCP server providing these resources.",
+          "description": "The deterministic capability pointer representing the MCP server providing these resources.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -9508,7 +9512,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents the definitive collapse of the LMSR market superposition into a crystallized `payout_distribution` using Strictly Proper Scoring Rules (e.g., Brier scores).\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to definitively allocate compute magnitudes to the `winning_hypothesis_id` and flush `falsified_hypothesis_ids` from the active context via a Defeasible Cascade.\n\nEPISTEMIC BOUNDS: Enforces a strictly bounded `payout_distribution` dictionary mapping W3C DIDs to non-negative integers (`ge=0`), with deterministic RFC 8785 array sorting applied to the falsified hypotheses.\n\nMCP ROUTING TRIGGERS: Brier Scoring, Market Settlement, Probability Wave Collapse, Truth Crystallization",
       "properties": {
         "market_id": {
-          "description": "The ID of the prediction market.",
+          "description": "The deterministic capability pointer representing the prediction market.",
           "le": 1000000000,
           "minLength": 1,
           "title": "Market Id",
@@ -10282,7 +10286,7 @@
             }
           ],
           "default": null,
-          "description": "The Event ID of the specific ToolInvocationEvent that spawned this observation, forming a strict bipartite directed edge.",
+          "description": "The deterministic capability pointer representing the specific ToolInvocationEvent that spawned this observation, forming a strict bipartite directed edge.",
           "title": "Triggering Invocation Id"
         },
         "continuous_stream": {
@@ -10654,7 +10658,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: PermissionBoundaryPolicy is the strict Zero-Trust Architecture security perimeter\ndefining exactly what external physical systems or networks an agent node is authorized to touch.\n\nCAUSAL AFFORDANCE: Mechanically limits the subgraph's kinetic reach. It forces the orchestrator to\ndrop network egress packets or block disk I/O unless explicitly whitelisted, and mandates the\nnegotiation of specific cryptographic handshakes (e.g., OAuth2, mTLS) before allocating compute.\n\nEPISTEMIC BOUNDS: Bounded by deterministic string arrays (allowed_domains, auth_requirements)\nthat must be strictly evaluated at runtime. The arrays are alphabetically sorted at instantiation\nto prevent Hash Poisoning attacks on the Merkle trace.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Network Egress Filtering, Capability-Based Security, mTLS Handshake, Hash Poisoning Prevention",
       "properties": {
         "network_access": {
-          "description": "Whether the tool is permitted to make external network requests.",
+          "description": "The absolute Boolean gate authorizing or severing exogenous network egress.",
           "title": "Network Access",
           "type": "boolean"
         },
@@ -10676,7 +10680,7 @@
           "title": "Allowed Domains"
         },
         "file_system_mutation_forbidden": {
-          "description": "True if the tool is strictly forbidden from writing to the disk.",
+          "description": "The strict Boolean constraint severing local disk I/O capabilities.",
           "title": "File System Mutation Forbidden",
           "type": "boolean"
         },
@@ -10749,6 +10753,7 @@
         },
         "target_table_uri": {
           "description": "The specific table mutated.",
+          "maxLength": 2048,
           "minLength": 1,
           "title": "Target Table Uri",
           "type": "string"
@@ -10842,7 +10847,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of an Automated Market Maker (AMM) utilizing Robin Hanson's Logarithmic Market Scoring Rule (LMSR) to guarantee infinite liquidity. As a ...State suffix, this represents an N-dimensional coordinate of market equilibrium.\n\nCAUSAL AFFORDANCE: Aggregates HypothesisStakeReceipt vectors, allowing the orchestrator to track the shifting probability manifold and trigger market resolution when the AMM reaches the required convergence threshold.\n\nEPISTEMIC BOUNDS: The order_book array is deterministically sorted by agent_id via @model_validator to preserve RFC 8785 canonical hashing. The liquidity parameter lmsr_b_parameter is physically restricted to a stringified decimal regex (^\\d+\\.\\d+$).\n\nMCP ROUTING TRIGGERS: Logarithmic Market Scoring Rule, Automated Market Maker, Prediction Market, Infinite Liquidity, Brier Score",
       "properties": {
         "market_id": {
-          "description": "The ID of the prediction market.",
+          "description": "The deterministic capability pointer representing the prediction market.",
           "le": 1000000000,
           "minLength": 1,
           "title": "Market Id",
@@ -11060,7 +11065,7 @@
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The ID of the node to be quarantined."
+          "description": "The deterministic capability pointer representing the node to be quarantined."
         },
         "reason": {
           "description": "The deterministic causal justification for the structural quarantine.",
@@ -11668,7 +11673,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Stevens's levels of measurement and Wilkinson's Grammar\nof Graphics to mathematically project abstract data domains into visual geometric\nranges. As a ...Policy suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Physically distorts or linearly maps the input metric tensor into\nrendering space, dictating how the orchestrator processes logarithmic, temporal, or\nordinal data vectors for UI projection.\n\nEPISTEMIC BOUNDS: The transformation algorithm is strictly constrained to a Literal\nautomaton [\"linear\", \"log\", \"time\", \"ordinal\", \"nominal\"]. Physical data boundaries\n(domain_min, domain_max) are optional (default=None) and upper-bounded by\nle=1000000000.0 to prevent geometric projection overflow (no ge bound enforced).\n\nMCP ROUTING TRIGGERS: Grammar of Graphics, Metric Tensor Distortion, Levels of\nMeasurement, Scale Projection, FSM Literal",
       "properties": {
         "type": {
-          "description": "The mathematical scale mapping metrics to pixels.",
+          "description": "The strictly typed mathematical mapping function distorting metrics into Euclidean pixel space.",
           "enum": [
             "linear",
             "log",
@@ -12593,7 +12598,7 @@
           "type": "string"
         },
         "crystallized_ledger_cids": {
-          "description": "A list of cryptographic pointers to past immutable EpistemicLedgerState blocks.",
+          "description": "The explicit array of cryptographic pointers to past immutable EpistemicLedgerState blocks.",
           "items": {
             "pattern": "^[a-f0-9]{64}$",
             "type": "string"
@@ -12950,7 +12955,7 @@
         },
         "max_concurrent_agents": {
           "default": 10,
-          "description": "The absolute ceiling for concurrent agent threads.",
+          "description": "The mathematically bounded limit for concurrent agent threads.",
           "maximum": 100,
           "title": "Max Concurrent Agents",
           "type": "integer"
@@ -13008,6 +13013,7 @@
         },
         "target_schema_ref": {
           "description": "The string name of the Pydantic class to synthesize.",
+          "maxLength": 2048,
           "minLength": 1,
           "title": "Target Schema Ref",
           "type": "string"
@@ -13064,7 +13070,7 @@
         },
         "target_node_id": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The strict W3C DID of the agent that authored the invalid state, ensuring the fault is routed back to the exact state partition."
+          "description": "The globally unique decentralized identifier (DID) anchoring the agent that authored the invalid state, ensuring the fault is routed back to the exact state partition."
         },
         "failing_pointers": {
           "description": "A strictly typed array of RFC 6902 JSON Pointers isolating the exact topological coordinate of the hallucination.",
@@ -13078,6 +13084,7 @@
         },
         "remediation_prompt": {
           "description": "The deterministic, non-monotonic natural-language constraint the agent must satisfy.",
+          "maxLength": 100000,
           "minLength": 1,
           "title": "Remediation Prompt",
           "type": "string"
@@ -14208,7 +14215,7 @@
         },
         "issuer_did": {
           "$ref": "#/$defs/NodeIdentifierState",
-          "description": "The W3C DID of the trusted authority that cryptographically signed the credential, explicitly representing the delegation of authority from a human or parent principal."
+          "description": "The globally unique decentralized identifier (DID) anchoring the trusted authority that cryptographically signed the credential, explicitly representing the delegation of authority from a human or parent principal."
         },
         "cryptographic_proof_blob": {
           "description": "The base64-encoded cryptographic proof (e.g., ZK-SNARKs, zkVM receipts, or programmable trust attestations) proving the claims without revealing the private key.",
@@ -14242,12 +14249,14 @@
       "properties": {
         "vrf_proof": {
           "description": "The zero-knowledge cryptographic proof of fair random generation.",
+          "maxLength": 5000000,
           "minLength": 10,
           "title": "Vrf Proof",
           "type": "string"
         },
         "public_key": {
           "description": "The public key of the oracle or node used to verify the VRF proof.",
+          "maxLength": 8192,
           "minLength": 10,
           "title": "Public Key",
           "type": "string"
@@ -14323,12 +14332,14 @@
         },
         "did_subject": {
           "description": "The Decentralized Identifier (DID) of the human operator.",
+          "maxLength": 1024,
           "pattern": "^did:[a-z0-9]+:.*$",
           "title": "Did Subject",
           "type": "string"
         },
         "cryptographic_payload": {
           "description": "The strictly formatted (Base64url/Hex/Multibase) signature or proof.",
+          "maxLength": 100000,
           "pattern": "^[A-Za-z0-9+/=_-]+$",
           "title": "Cryptographic Payload",
           "type": "string"

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -135,6 +135,7 @@ type NodeIdentifierState = Annotated[
 ]
 type OptimizationDirectionProfile = Literal["maximize", "minimize"]
 type PatchOperationProfile = Literal["add", "remove", "replace", "copy", "move", "test"]
+# Note: External Protocol Exemption. (RFC 6902)
 type ProfileIdentifierState = Annotated[
     str,
     Field(
@@ -504,7 +505,7 @@ class ScalePolicy(CoreasonBaseState):
     """
 
     type: Literal["linear", "log", "time", "ordinal", "nominal"] = Field(
-        description="The mathematical scale mapping metrics to pixels."
+        description="The strictly typed mathematical mapping function distorting metrics into Euclidean pixel space."
     )
     domain_min: float | None = Field(
         le=1000000000.0, default=None, description="The optional minimum bound of the scale domain."
@@ -582,10 +583,10 @@ class VerifiableEntropyReceipt(CoreasonBaseState):
     Curve Cryptography, Zero-Knowledge Entropy
     """
 
-    vrf_proof: str = Field(
+    vrf_proof: Annotated[str, StringConstraints(max_length=5000000)] = Field(
         min_length=10, description="The zero-knowledge cryptographic proof of fair random generation."
     )
-    public_key: str = Field(
+    public_key: Annotated[str, StringConstraints(max_length=8192)] = Field(
         min_length=10, description="The public key of the oracle or node used to verify the VRF proof."
     )
     seed_hash: str = Field(
@@ -769,13 +770,14 @@ class PermissionBoundaryPolicy(CoreasonBaseState):
     MCP ROUTING TRIGGERS: Zero-Trust Architecture, Network Egress Filtering, Capability-Based Security, mTLS Handshake, Hash Poisoning Prevention
     """
 
-    network_access: bool = Field(description="Whether the tool is permitted to make external network requests.")
+    network_access: bool = Field(
+        description="The absolute Boolean gate authorizing or severing exogenous network egress."
+    )
     allowed_domains: list[Annotated[str, StringConstraints(max_length=2000)]] | None = Field(
-        default=None,
-        description="The explicit whitelist of allowed network domains if network access is true.",
+        default=None, description="The explicit whitelist of allowed network domains if network access is true."
     )
     file_system_mutation_forbidden: bool = Field(
-        description="True if the tool is strictly forbidden from writing to the disk."
+        description="The strict Boolean constraint severing local disk I/O capabilities."
     )
     auth_requirements: list[Annotated[str, StringConstraints(max_length=2000)]] | None = Field(
         default=None,
@@ -928,8 +930,7 @@ class ActivationSteeringContract(CoreasonBaseState):
         description="The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
     )
     injection_layers: list[Annotated[int, Field(ge=0)]] = Field(
-        min_length=1,
-        description="The specific transformer layer indices where this vector must be applied.",
+        min_length=1, description="The specific transformer layer indices where this vector must be applied."
     )
     scaling_factor: float = Field(
         le=100.0, description="The mathematical magnitude/strength of the injection (can be negative for ablation)."
@@ -978,6 +979,12 @@ class SemanticSlicingPolicy(CoreasonBaseState):
         )
         if self.required_semantic_labels is not None:
             object.__setattr__(self, "required_semantic_labels", sorted(self.required_semantic_labels))
+        if getattr(self, "permitted_classification_tiers", None) is not None:
+            object.__setattr__(
+                self,
+                "permitted_classification_tiers",
+                sorted(self.permitted_classification_tiers, key=lambda x: str(x.value)),
+            )
         return self
 
 
@@ -1122,7 +1129,7 @@ class ConstitutionalPolicy(CoreasonBaseState):
         max_length=2000, description="The definitive causal constraint or heuristic boundary enforced by this rule."
     )
     severity: Literal["low", "medium", "high", "critical"] = Field(
-        description="Severity level if the rule is violated."
+        description="The categorical magnitude of the systemic breach enacted upon rule violation."
     )
     forbidden_intents: list[Annotated[str, StringConstraints(min_length=1)]] = Field(
         max_length=1000000000, description="The explicit, structurally bounded set of forbidden semantic intents."
@@ -1191,7 +1198,9 @@ class AdjudicationRubricProfile(CoreasonBaseState):
     criteria: list[GradingCriterionProfile] = Field(
         description="The explicit array of strict evaluation criteria defining the rubric."
     )
-    passing_threshold: float = Field(ge=0.0, le=100.0, description="The minimum score required to pass.")
+    passing_threshold: float = Field(
+        ge=0.0, le=100.0, description="The absolute mathematical lower-bound scalar required to authorize execution."
+    )
 
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
@@ -1590,6 +1599,8 @@ class MultimodalTokenAnchorState(CoreasonBaseState):
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
         object.__setattr__(self, "visual_patch_hashes", sorted(self.visual_patch_hashes))
+        if getattr(self, "visual_patch_hashes", None) is not None:
+            object.__setattr__(self, "visual_patch_hashes", sorted(self.visual_patch_hashes))
         return self
 
 
@@ -1710,10 +1721,12 @@ class StateDifferentialManifest(CoreasonBaseState):
         description="Strict scalar logical clock governing deterministic LWW (Last-Writer-Wins) conflict resolution.",
     )
     vector_clock: dict[Annotated[str, StringConstraints(max_length=255)], Annotated[int, Field(ge=0)]] = Field(
-        description="Causal history mapping of all known Lineage Watermarks to their latest logical mutation count at the time of authoring.",
+        description="Causal history mapping of all known Lineage Watermarks to their latest logical mutation count at the time of authoring."
     )
     patches: list[StateMutationIntent] = Field(
-        default_factory=list, description="The exact, ordered sequence of deterministic state vector mutations."
+        default_factory=list,
+        description="The exact, ordered sequence of deterministic state vector mutations.",
+        # Note: patches is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
     )
 
 
@@ -1743,10 +1756,10 @@ class StateHydrationManifest(CoreasonBaseState):
         max_length=2000, description="A string ID representing the session or specific spatial trace binding."
     )
     crystallized_ledger_cids: list[Annotated[str, StringConstraints(pattern="^[a-f0-9]{64}$")]] = Field(
-        description="A list of cryptographic pointers to past immutable EpistemicLedgerState blocks."
+        description="The explicit array of cryptographic pointers to past immutable EpistemicLedgerState blocks."
     )
     working_context_variables: dict[Annotated[str, StringConstraints(max_length=255)], Any] = Field(
-        description="A strictly typed dictionary for ephemeral context variables injected at runtime. AGENT INSTRUCTION: This matrix is deterministically sorted by CoreasonBaseState natively.",
+        description="A strictly typed dictionary for ephemeral context variables injected at runtime. AGENT INSTRUCTION: This matrix is deterministically sorted by CoreasonBaseState natively."
     )
 
     @field_validator("working_context_variables", mode="before")
@@ -1762,6 +1775,8 @@ class StateHydrationManifest(CoreasonBaseState):
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
         object.__setattr__(self, "crystallized_ledger_cids", sorted(self.crystallized_ledger_cids))
+        if getattr(self, "crystallized_ledger_cids", None) is not None:
+            object.__setattr__(self, "crystallized_ledger_cids", sorted(self.crystallized_ledger_cids))
         return self
 
 
@@ -1880,7 +1895,7 @@ class LatentScratchpadReceipt(CoreasonBaseState):
         description="All logical paths the agent attempted within this Ephemeral Epistemic Quarantine—a volatile workspace where probability waves collapse before being committed to the immutable ledger."
     )
     discarded_branches: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
-        description="The strict array of Content Identifiers (CIDs) that were explicitly pruned due to logical dead-ends.",
+        description="The strict array of Content Identifiers (CIDs) that were explicitly pruned due to logical dead-ends."
     )
     resolution_branch_id: str | None = Field(
         min_length=1,
@@ -1942,8 +1957,7 @@ class EphemeralNamespacePartitionState(CoreasonBaseState):
         description="The strict virtual machine target mandated for dynamic execution."
     )
     authorized_bytecode_hashes: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
-        min_length=1,
-        description="The explicit whitelist of SHA-256 hashes allowed to execute within this partition.",
+        min_length=1, description="The explicit whitelist of SHA-256 hashes allowed to execute within this partition."
     )
     max_ttl_seconds: int = Field(
         le=86400, gt=0, description="The absolute temporal guillotine before the orchestrator drops the context."
@@ -2096,6 +2110,8 @@ class FederatedDiscoveryManifest(CoreasonBaseState):
     def sort_arrays(self) -> Self:
         object.__setattr__(self, "broadcast_endpoints", sorted(self.broadcast_endpoints, key=str))
         object.__setattr__(self, "supported_ontologies", sorted(self.supported_ontologies))
+        if getattr(self, "supported_ontologies", None) is not None:
+            object.__setattr__(self, "supported_ontologies", sorted(self.supported_ontologies))
         return self
 
 
@@ -2174,7 +2190,7 @@ class AdjudicationIntent(CoreasonBaseState):
         description="The conflicting claim IDs or proposals the human must choose between.",
     )
     resolution_schema: dict[Annotated[str, StringConstraints(max_length=255)], Any] = Field(
-        description="The strict JSON Schema for the tie-breaking response (usually an enum of the deadlocked_claims).",
+        description="The strict JSON Schema for the tie-breaking response (usually an enum of the deadlocked_claims)."
     )
     timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
         description="The action to take if the oracle is unresponsive."
@@ -2212,7 +2228,9 @@ class AdjudicationReceipt(CoreasonBaseState):
         pattern="^[a-zA-Z0-9_.:-]+$",
         description="The cryptographic pointer to the rubric dictating adjudication.",
     )
-    target_node_id: NodeIdentifierState = Field(description="The ID of the node that was evaluated.")
+    target_node_id: NodeIdentifierState = Field(
+        description="The deterministic capability pointer representing the node that was evaluated."
+    )
     score: int = Field(ge=0, le=100, description="The final score assigned based on the rubric.")
     passed: bool = Field(description="Indicates whether the evaluation passed the threshold.")
     reasoning: str = Field(
@@ -2282,16 +2300,14 @@ class AdversarialEmulationProfile(CoreasonBaseState):
     """
 
     generative_persona: Literal["hesitant_novice", "fast_expert", "distracted_browser"] = Field(
-        default="fast_expert",
-        description="The imitation learning persona governing the behavioral emulation profile.",
+        default="fast_expert", description="The imitation learning persona governing the behavioral emulation profile."
     )
     kinematic_noise: "KinematicNoiseProfile | None" = Field(
         default=None,
         description="The stochastic pointer trajectory perturbation profile for human-like motor control emulation.",
     )
     environmental_spoofing: "EnvironmentalSpoofingProfile | None" = Field(
-        default=None,
-        description="The browser fingerprint and environmental telemetry spoofing geometry.",
+        default=None, description="The browser fingerprint and environmental telemetry spoofing geometry."
     )
     emulation_fidelity_target: float = Field(
         ge=0.0,
@@ -2830,7 +2846,7 @@ class BypassReceipt(CoreasonBaseState):
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
         min_length=1,
-        description="The exact genesis CID of the document, ensuring continuity.",
+        description="The exact genesis globally unique decentralized identifier (DID) anchoring the document, ensuring continuity.",
     )
     bypassed_node_id: NodeIdentifierState = Field(
         description="The exact extraction step in the DAG that was mathematically starved of compute."
@@ -2970,7 +2986,7 @@ class CausalExplanationEvent(BaseStateEvent):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The CID of the collective outcome being explained.",
+        description="The globally unique decentralized identifier (DID) anchoring the collective outcome being explained.",
     )
     collective_intelligence: CollectiveIntelligenceProfile = Field(description="The system-level emergence metrics.")
     agent_attributions: list[ShapleyAttributionReceipt] = Field(
@@ -3004,8 +3020,12 @@ class CausalDirectedEdgeState(CoreasonBaseState):
     d-separation, Do-Calculus, Directed Edge
     """
 
-    source_variable: str = Field(min_length=1, description="The independent variable $X$.")
-    target_variable: str = Field(min_length=1, description="The dependent variable $Y$.")
+    source_variable: Annotated[str, StringConstraints(max_length=255)] = Field(
+        min_length=1, description="The independent variable $X$."
+    )
+    target_variable: Annotated[str, StringConstraints(max_length=255)] = Field(
+        min_length=1, description="The dependent variable $Y$."
+    )
     edge_type: Literal["direct_cause", "confounder", "collider", "mediator"] = Field(
         description="The specific Pearlian topological relationship between the two variables."
     )
@@ -3026,7 +3046,7 @@ class CircuitBreakerEvent(CoreasonBaseState):
         default="circuit_breaker_event", description="The type of the resilience payload."
     )
     target_node_id: NodeIdentifierState = Field(
-        description="The ID of the node for which the circuit breaker was tripped."
+        description="The deterministic capability pointer representing the node for which the circuit breaker was tripped."
     )
     error_signature: str = Field(max_length=2000, description="Signature or summary of the error causing the trip.")
 
@@ -3058,10 +3078,10 @@ class ConstitutionalAmendmentIntent(CoreasonBaseState):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The CID of the NormativeDriftEvent that justified triggering this proposal.",
+        description="The globally unique decentralized identifier (DID) anchoring the NormativeDriftEvent that justified triggering this proposal.",
     )
     proposed_patch: dict[Annotated[str, StringConstraints(max_length=255)], Any] = Field(
-        description="A strict, structurally bounded JSON Patch (RFC 6902) proposed by the AI to mutate the GovernancePolicy.",
+        description="A strict, structurally bounded JSON Patch (RFC 6902) proposed by the AI to mutate the GovernancePolicy."
     )
     justification: str = Field(
         max_length=2000,
@@ -3292,7 +3312,7 @@ class CustodyReceipt(CoreasonBaseState):
         min_length=1,
         pattern="^[a-zA-Z0-9_.:-]+$",
         max_length=255,
-        description="The ID of the InformationFlowPolicy successfully applied.",
+        description="The deterministic capability pointer representing the InformationFlowPolicy successfully applied.",
     )
     pre_redaction_hash: str | None = Field(
         min_length=1,
@@ -3520,6 +3540,7 @@ class DocumentLayoutManifest(CoreasonBaseState):
     )
     chronological_flow_edges: list[tuple[str, str]] = Field(
         default_factory=list,
+        # Note: chronological_flow_edges is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
         description="Directed edges defining the topological sort (chronological flow) of the document.",
     )
 
@@ -3906,14 +3927,10 @@ class EnvironmentalSpoofingProfile(CoreasonBaseState):
         description="The spoofed UTC timezone offset in minutes, bounded to the valid terrestrial range.",
     )
     screen_resolution_width: int = Field(
-        ge=1,
-        le=15360,
-        description="The spoofed horizontal display resolution in pixels.",
+        ge=1, le=15360, description="The spoofed horizontal display resolution in pixels."
     )
     screen_resolution_height: int = Field(
-        ge=1,
-        le=15360,
-        description="The spoofed vertical display resolution in pixels.",
+        ge=1, le=15360, description="The spoofed vertical display resolution in pixels."
     )
 
 
@@ -3971,13 +3988,13 @@ class EpistemicPromotionEvent(BaseStateEvent):
         default="epistemic_promotion", description="Discriminator type for an epistemic promotion event."
     )
     source_episodic_event_ids: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
-        description="The strict array of CIDs (Content Identifiers) representing the raw logs being compressed and archived.",
+        description="The strict array of CIDs (Content Identifiers) representing the raw logs being compressed and archived."
     )
     crystallized_semantic_node_id: str = Field(
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The resulting permanent W3C DID / CID of the newly minted knowledge node.",
+        description="The resulting permanent W3C DID / The globally unique decentralized identifier (DID) anchoring the newly minted knowledge node.",
     )
     compression_ratio: float = Field(
         le=1.0,
@@ -4042,7 +4059,7 @@ class EpistemicTransmutationTask(CoreasonBaseState):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The CID of the MultimodalArtifactReceipt being processed.",
+        description="The globally unique decentralized identifier (DID) anchoring the MultimodalArtifactReceipt being processed.",
     )
     target_modalities: list[
         Literal["text", "raster_image", "vector_graphics", "tabular_grid", "n_dimensional_tensor"]
@@ -4136,10 +4153,10 @@ class EscalationIntent(CoreasonBaseState):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The ID of the Payload Loss Prevention (PLP) or Governance rule that blocked execution.",
+        description="The deterministic capability pointer representing the Payload Loss Prevention (PLP) or Governance rule that blocked execution.",
     )
     resolution_schema: dict[Annotated[str, StringConstraints(max_length=255)], Any] = Field(
-        description="The strict JSON Schema requiring an explicit cryptographic sign-off or justification string to bypass the breaker.",
+        description="The strict JSON Schema requiring an explicit cryptographic sign-off or justification string to bypass the breaker."
     )
     timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
         description="The default action is usually terminate or rollback for security escalations."
@@ -4322,9 +4339,7 @@ class EpistemicArgumentGraphState(CoreasonBaseState):
         max_length=10000, description="Components of an Abstract Argumentation Framework."
     )
     attacks: dict[Annotated[str, StringConstraints(max_length=255)], DefeasibleAttackEvent] = Field(
-        default_factory=dict,
-        max_length=10000,
-        description="Geometric matrices of undercutting defeaters.",
+        default_factory=dict, max_length=10000, description="Geometric matrices of undercutting defeaters."
     )
 
 
@@ -4351,14 +4366,14 @@ class ExecutionNodeReceipt(CoreasonBaseState):
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
         default=None,
-        description="The ID of the parent request.",
+        description="The deterministic capability pointer anchoring the parent request manifold.",
     )
     root_request_id: str | None = Field(
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
         default=None,
-        description="The ID of the trace root.",
+        description="The deterministic capability pointer anchoring the trace root manifold.",
     )
     inputs: JsonPrimitiveState = Field(description="The inputs provided to the execution node.")
     outputs: JsonPrimitiveState = Field(description="The outputs generated by the execution node.")
@@ -4370,6 +4385,7 @@ class ExecutionNodeReceipt(CoreasonBaseState):
         return _validate_payload_bounds(v)
 
     parent_hashes: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
+        # Note: parent_hashes is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
         default_factory=list,
         description="The strict array of cryptographic hashes of parent execution nodes.",
     )
@@ -4486,8 +4502,12 @@ class FallbackIntent(CoreasonBaseState):
     type: Literal["fallback_intent"] = Field(
         le=1000000000, default="fallback_intent", description="The type of the resilience payload."
     )
-    target_node_id: NodeIdentifierState = Field(description="The ID of the failing node.")
-    fallback_node_id: NodeIdentifierState = Field(description="The ID of the node to use as a fallback.")
+    target_node_id: NodeIdentifierState = Field(
+        description="The deterministic capability pointer representing the failing node."
+    )
+    fallback_node_id: NodeIdentifierState = Field(
+        description="The deterministic capability pointer representing the node to use as a fallback."
+    )
 
 
 class FalsificationContract(CoreasonBaseState):
@@ -4580,7 +4600,9 @@ class FederatedCapabilityAttestationReceipt(CoreasonBaseState):
         min_length=1,
         description="Cryptographic Lineage Watermark for the attestation.",
     )
-    target_topology_id: NodeIdentifierState = Field(description="The DID of the discovered external state matrix/VPC.")
+    target_topology_id: NodeIdentifierState = Field(
+        description="The globally unique decentralized identifier (DID) anchoring the discovered external state matrix/VPC."
+    )
     authorized_session: SecureSubSessionState = Field(
         description="The isolated state partition granted to the agent for this connection."
     )
@@ -4926,7 +4948,7 @@ class GlobalSemanticProfile(CoreasonBaseState):
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
         min_length=1,
-        description="The exact genesis CID of the MultimodalArtifactReceipt entering the routing tier.",
+        description="The exact genesis globally unique decentralized identifier (DID) anchoring the MultimodalArtifactReceipt entering the routing tier.",
     )
     detected_modalities: list[
         Literal["text", "raster_image", "vector_graphics", "tabular_grid", "n_dimensional_tensor"]
@@ -4962,7 +4984,7 @@ class DynamicRoutingManifest(CoreasonBaseState):
     )
     artifact_profile: GlobalSemanticProfile = Field(description="The semantic profile governing this route.")
     active_subgraphs: dict[Annotated[str, StringConstraints(max_length=255)], list[NodeIdentifierState]] = Field(
-        description="Mapping of specific modalities (e.g., 'tabular_grid') to the explicit lists of worker NodeIdentifierStates authorized to execute.",
+        description="Mapping of specific modalities (e.g., 'tabular_grid') to the explicit lists of worker NodeIdentifierStates authorized to execute."
     )
     bypassed_steps: list[BypassReceipt] = Field(
         default_factory=list, description="The declarative array of steps the orchestrator is mandated to skip."
@@ -4974,6 +4996,7 @@ class DynamicRoutingManifest(CoreasonBaseState):
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
         object.__setattr__(self, "active_subgraphs", {k: sorted(v) for k, v in self.active_subgraphs.items()})
+
         return self
 
     @model_validator(mode="after")
@@ -5182,7 +5205,7 @@ class HypothesisStakeReceipt(CoreasonBaseState):
     """
 
     agent_id: Annotated[str, StringConstraints(min_length=1)] = Field(
-        le=1000000000, description="The ID of the agent placing the stake."
+        le=1000000000, description="The deterministic capability pointer representing the agent placing the stake."
     )
     target_hypothesis_id: Annotated[str, StringConstraints(min_length=1)] = Field(
         le=1000000000, description="The exact HypothesisGenerationEvent the agent is betting on."
@@ -5214,7 +5237,8 @@ class InformationalIntent(CoreasonBaseState):
     """
 
     type: Literal["informational"] = Field(
-        default="informational", description="Discriminator for read-only informational handoffs."
+        default="informational",
+        description="The discriminative topological boundary for read-only informational handoffs.",
     )
     message: str = Field(max_length=2000, description="The context or summary to display to the human operator.")
     timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
@@ -5252,8 +5276,7 @@ class TaxonomicNodeState(CoreasonBaseState):
         description="The human-legible, dynamically synthesized categorical label (e.g., 'High Risk Policies').",
     )
     children_node_ids: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
-        default_factory=list,
-        description="Explicit array of child node CIDs to enforce the Directed Acyclic Graph.",
+        default_factory=list, description="Explicit array of child node CIDs to enforce the Directed Acyclic Graph."
     )
     leaf_provenance: list["EpistemicProvenanceReceipt"] = Field(
         default_factory=list,
@@ -5298,7 +5321,7 @@ class GenerativeTaxonomyManifest(CoreasonBaseState):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The CID of the top-level TaxonomicNodeState initiating the tree.",
+        description="The globally unique decentralized identifier (DID) anchoring the top-level TaxonomicNodeState initiating the tree.",
     )
     nodes: dict[Annotated[str, StringConstraints(max_length=255)], TaxonomicNodeState] = Field(
         max_length=1000000000, description="Flat dictionary matrix containing all nodes within the manifold."
@@ -5537,7 +5560,9 @@ class InterventionIntent(CoreasonBaseState):
         default=None, description="The scope constraints bounding the intervention."
     )
     fallback_sla: FallbackSLA | None = Field(default=None, description="The SLA constraints on the intervention delay.")
-    target_node_id: NodeIdentifierState = Field(description="The ID of the target node.")
+    target_node_id: NodeIdentifierState = Field(
+        description="The deterministic capability pointer representing the target node."
+    )
     context_summary: str = Field(max_length=2000, description="A summary of the context requiring intervention.")
     proposed_action: dict[Annotated[str, StringConstraints(max_length=255)], str | int | float | bool | None] = Field(
         max_length=1000000000, description="The action proposed by the agent that requires approval."
@@ -5608,7 +5633,11 @@ class JSONRPCErrorState(CoreasonBaseState):
     Log Poisoning, Stateful Rollback
     """
 
-    code: int = Field(..., le=1000000000, description="A Number that indicates the error type that occurred.")
+    code: int = Field(
+        ...,
+        le=1000000000,
+        description="The strict integer identifier classifying the specific topological or execution collapse.",
+    )
     message: str = Field(
         ...,
         max_length=2000,
@@ -5877,16 +5906,14 @@ class MCPCapabilityWhitelistPolicy(CoreasonBaseState):
     """
 
     allowed_tools: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        default_factory=list,
-        description="The explicit whitelist of function names the node is allowed to call.",
+        default_factory=list, description="The explicit whitelist of function names the node is allowed to call."
     )
     allowed_resources: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
         default_factory=list,
         description="The explicit whitelist of resource URIs the node is allowed to passively perceive.",
     )
     allowed_prompts: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        default_factory=list,
-        description="The explicit whitelist of workflow templates the node is allowed to trigger.",
+        default_factory=list, description="The explicit whitelist of workflow templates the node is allowed to trigger."
     )
     required_licenses: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
         default_factory=list,
@@ -5955,10 +5982,9 @@ class MCPServerManifest(CoreasonBaseState):
         If a local POSIX stream (stdio) is requested, an explicit cryptographic hash of the
         binary MUST be provided to prevent Arbitrary Code Execution (ACE) via file-swapping.
         """
-        if getattr(self.transport, "type", None) == "stdio" and not self.binary_hash:
+        if getattr(self.transport, "type", None) == "stdio" and (not self.binary_hash):
             raise ValueError(
-                "SUPPLY CHAIN VULNERABILITY: An MCPServerManifest utilizing a StdioTransportProfile "
-                "MUST provide a cryptographic 'binary_hash' to prevent arbitrary code execution attacks on the host OS."
+                "SUPPLY CHAIN VULNERABILITY: An MCPServerManifest utilizing a StdioTransportProfile MUST provide a cryptographic 'binary_hash' to prevent arbitrary code execution attacks on the host OS."
             )
         return self
 
@@ -5990,7 +6016,7 @@ class KinematicNoiseProfile(CoreasonBaseState):
     """
 
     noise_type: Literal["pink", "brownian", "gaussian"] = Field(
-        description="The stochastic process governing the noise generation for pointer trajectory perturbation.",
+        description="The stochastic process governing the noise generation for pointer trajectory perturbation."
     )
     velocity_profile: Literal["minimum_jerk", "constant", "fractional_brownian"] = Field(
         default="minimum_jerk",
@@ -6048,7 +6074,7 @@ class KineticSeparationPolicy(CoreasonBaseState):
         description="Unique identifier for this specific separation boundary.",
     )
     mutually_exclusive_clusters: list[list[Annotated[str, StringConstraints(max_length=2000)]]] = Field(
-        description="A topological matrix of tool names or MCP URIs. If an agent mounts one capability in a cluster, all other capabilities in that cluster are mathematically quarantined.",
+        description="A topological matrix of tool names or MCP URIs. If an agent mounts one capability in a cluster, all other capabilities in that cluster are mathematically quarantined."
     )
     enforcement_action: Literal["halt_and_quarantine", "sever_causal_chain"] = Field(
         description="The deterministic action the orchestrator must take if a bipartite cycle is detected."
@@ -6118,6 +6144,14 @@ class ActionSpaceManifest(CoreasonBaseState):
         object.__setattr__(
             self, "ephemeral_partitions", sorted(self.ephemeral_partitions, key=lambda x: x.partition_id)
         )
+        return self
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "ephemeral_partitions", None) is not None:
+            object.__setattr__(
+                self, "ephemeral_partitions", sorted(self.ephemeral_partitions, key=lambda x: x.partition_id)
+            )
         return self
 
 
@@ -6206,6 +6240,16 @@ class OntologicalSurfaceProjectionManifest(CoreasonBaseState):
         )
         return self
 
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "available_procedural_manifolds", None) is not None:
+            object.__setattr__(
+                self,
+                "available_procedural_manifolds",
+                sorted(self.available_procedural_manifolds, key=lambda x: x.metadata_id),
+            )
+        return self
+
 
 class MCPClientIntent(BoundedJSONRPCIntent):
     """
@@ -6249,7 +6293,7 @@ class MCPPromptReferenceState(CoreasonBaseState):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The ID of the MCP server providing this prompt.",
+        description="The deterministic capability pointer representing the MCP server providing this prompt.",
     )
     prompt_name: str = Field(..., max_length=2000, description="The name of the prompt template.")
     arguments: dict[Annotated[str, StringConstraints(max_length=255)], Any] = Field(
@@ -6287,11 +6331,10 @@ class MCPResourceManifest(CoreasonBaseState):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The ID of the MCP server providing these resources.",
+        description="The deterministic capability pointer representing the MCP server providing these resources.",
     )
     uris: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        default_factory=list,
-        description="The explicit array of resource URIs mathematically bound to the agent.",
+        default_factory=list, description="The explicit array of resource URIs mathematically bound to the agent."
     )
 
     @model_validator(mode="after")
@@ -6315,10 +6358,13 @@ class MacroGridProfile(CoreasonBaseState):
     """
 
     layout_matrix: list[list[Annotated[str, StringConstraints(max_length=255)]]] = Field(
-        max_length=1000000000, description="A matrix defining the layout structure, using panel IDs."
+        # Note: layout_matrix is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
+        max_length=1000000000,
+        description="A matrix defining the layout structure, using panel IDs.",
     )
     panels: list[AnyPanelProfile] = Field(
         description="The ordered array of topological UI panels physically rendered in the grid."
+        # Note: panels is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
     )
 
     @model_validator(mode="after")
@@ -6368,7 +6414,7 @@ class MarketResolutionState(CoreasonBaseState):
     """
 
     market_id: Annotated[str, StringConstraints(min_length=1)] = Field(
-        le=1000000000, description="The ID of the prediction market."
+        le=1000000000, description="The deterministic capability pointer representing the prediction market."
     )
     winning_hypothesis_id: str = Field(
         min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$", description="The hypothesis ID that was verified."
@@ -6377,7 +6423,7 @@ class MarketResolutionState(CoreasonBaseState):
         max_length=1000000000, description="The hypothesis IDs that were falsified."
     )
     payout_distribution: dict[Annotated[str, StringConstraints(max_length=255)], Annotated[int, Field(ge=0)]] = Field(
-        description="The deterministic mapping of agent IDs to their earned compute budget/magnitude based on Brier scoring.",
+        description="The deterministic mapping of agent IDs to their earned compute budget/magnitude based on Brier scoring."
     )
 
     @model_validator(mode="after")
@@ -6415,8 +6461,7 @@ class MechanisticAuditContract(CoreasonBaseState):
         )
     )
     target_layers: list[Annotated[int, Field(ge=0)]] = Field(
-        min_length=1,
-        description="The specific transformer block indices the execution engine must extract from.",
+        min_length=1, description="The specific transformer block indices the execution engine must extract from."
     )
     max_features_per_layer: int = Field(
         le=1000000000, gt=0, description="The top-k features to extract, preventing VRAM exhaustion."
@@ -6458,7 +6503,7 @@ class EpistemicProvenanceReceipt(CoreasonBaseState):
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
         default=None,
-        description="The CID of the Genesis MultimodalArtifactReceipt this semantic state was transmutated from.",
+        description="The globally unique decentralized identifier (DID) anchoring the Genesis MultimodalArtifactReceipt this semantic state was transmutated from.",
     )
     multimodal_anchor: MultimodalTokenAnchorState | None = Field(
         default=None, description="The unified VLM spatial and temporal token matrix where this data was extracted."
@@ -6514,6 +6559,8 @@ class MigrationContract(CoreasonBaseState):
     @model_validator(mode="after")
     def sort_arrays(self) -> Self:
         object.__setattr__(self, "dropped_paths", sorted(self.dropped_paths))
+        if getattr(self, "dropped_paths", None) is not None:
+            object.__setattr__(self, "dropped_paths", sorted(self.dropped_paths))
         return self
 
 
@@ -6656,7 +6703,7 @@ class NeuralAuditAttestationReceipt(CoreasonBaseState):
         description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
     )
     layer_activations: dict[int, list[SaeFeatureActivationState]] = Field(
-        description="A mapping of specific transformer layer indices to their top-k activated SAE features.",
+        description="A mapping of specific transformer layer indices to their top-k activated SAE features."
     )
     causal_scrubbing_applied: bool = Field(
         default=False,
@@ -6670,6 +6717,8 @@ class NeuralAuditAttestationReceipt(CoreasonBaseState):
             "layer_activations",
             {k: sorted(v, key=lambda x: x.feature_index) for k, v in self.layer_activations.items()},
         )
+        if getattr(self, "layer_activations", None) is not None:
+            object.__setattr__(self, "layer_activations", sorted(self.layer_activations, key=lambda x: x.layer_index))
         return self
 
 
@@ -6697,7 +6746,7 @@ class NeuroSymbolicHandoffContract(CoreasonBaseState):
         max_length=100000, description="The raw code or formal proof syntax generated by the LLM to be evaluated."
     )
     expected_proof_schema: dict[Annotated[str, StringConstraints(max_length=255)], Any] = Field(
-        description="The strict JSON Schema the deterministic solver must use to return the verified answer to the agent.",
+        description="The strict JSON Schema the deterministic solver must use to return the verified answer to the agent."
     )
     timeout_ms: int = Field(
         le=86400000, gt=0, description="The maximum compute time allocated to the symbolic solver before aborting."
@@ -6809,8 +6858,7 @@ class OntologicalHandshakeReceipt(CoreasonBaseState):
         description="The projection applied if the agents natively used different embedding dimensionalities.",
     )
     remote_state_snapshot: FederatedStateSnapshot | None = Field(
-        default=None,
-        description="Isolated holographic clone of remote swarm state for safe cross-boundary evaluation.",
+        default=None, description="Isolated holographic clone of remote swarm state for safe cross-boundary evaluation."
     )
 
     @model_validator(mode="after")
@@ -6951,8 +6999,7 @@ class PeftAdapterContract(CoreasonBaseState):
         description="The low-rank intrinsic dimension (r) of the update matrices, used by the orchestrator to calculate VRAM cost.",
     )
     target_modules: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
-        min_length=1,
-        description="The explicit array of attention head modules to inject (e.g., ['q_proj', 'v_proj']).",
+        min_length=1, description="The explicit array of attention head modules to inject (e.g., ['q_proj', 'v_proj'])."
     )
     eviction_ttl_seconds: int | None = Field(
         le=86400,
@@ -6999,7 +7046,9 @@ class PersistenceCommitReceipt(BaseStateEvent):
         min_length=1,
         description="The internal StateDifferentialManifest CID that was flushed.",
     )
-    target_table_uri: str = Field(min_length=1, description="The specific table mutated.")
+    target_table_uri: Annotated[str, StringConstraints(max_length=2048)] = Field(
+        min_length=1, description="The specific table mutated."
+    )
 
 
 class PredictionMarketState(CoreasonBaseState):
@@ -7014,7 +7063,7 @@ class PredictionMarketState(CoreasonBaseState):
     """
 
     market_id: Annotated[str, StringConstraints(min_length=1)] = Field(
-        le=1000000000, description="The ID of the prediction market."
+        le=1000000000, description="The deterministic capability pointer representing the prediction market."
     )
     resolution_oracle_condition_id: str = Field(
         min_length=1,
@@ -7103,11 +7152,13 @@ class EpistemicSOPManifest(CoreasonBaseState):
         max_length=1000000000, description="Dictionary mapping step_ids to strict causal DAG constraints."
     )
     structural_grammar_hashes: dict[Annotated[str, StringConstraints(max_length=255)], str] = Field(
-        description="Dictionary mapping step_ids to SHA-256 hashes of strict Context-Free Grammars or JSON Schemas.",
+        description="Dictionary mapping step_ids to SHA-256 hashes of strict Context-Free Grammars or JSON Schemas."
     )
     chronological_flow_edges: list[tuple[str, str]] = Field(description="The exact topological flow between step_ids.")
+    # Note: chronological_flow_edges is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
     prm_evaluations: list["ProcessRewardContract"] = Field(
         description="The strict array of Process Reward Contracts evaluating the logic."
+        # Note: prm_evaluations is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
     )
 
     @model_validator(mode="after")
@@ -7219,7 +7270,9 @@ class QuarantineIntent(CoreasonBaseState):
     type: Literal["quarantine_intent"] = Field(
         le=1000000000, default="quarantine_intent", description="The type of the resilience payload."
     )
-    target_node_id: NodeIdentifierState = Field(description="The ID of the node to be quarantined.")
+    target_node_id: NodeIdentifierState = Field(
+        description="The deterministic capability pointer representing the node to be quarantined."
+    )
     reason: str = Field(
         max_length=2000, description="The deterministic causal justification for the structural quarantine."
     )
@@ -7398,6 +7451,12 @@ class InformationFlowPolicy(CoreasonBaseState):
         object.__setattr__(
             self, "latent_firewalls", sorted(self.latent_firewalls, key=lambda x: x.target_feature_index)
         )
+        return self
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "latent_firewalls", None) is not None:
+            object.__setattr__(self, "latent_firewalls", sorted(self.latent_firewalls, key=lambda x: x.rule_id))
         return self
 
 
@@ -7626,7 +7685,9 @@ class SpatialKinematicActionIntent(CoreasonBaseState):
         description="The exact temporal duration of the movement, simulating human kinematics.",
     )
     bezier_control_points: list[SpatialCoordinateProfile] = Field(
-        default_factory=list, description="Waypoints for constructing non-linear, bot-evasive movement curves."
+        default_factory=list,
+        description="Waypoints for constructing non-linear, bot-evasive movement curves.",
+        # Note: bezier_control_points is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
     )
     expected_visual_concept: str | None = Field(
         max_length=2000,
@@ -7656,7 +7717,7 @@ class StateContract(CoreasonBaseState):
     """
 
     schema_definition: dict[Annotated[str, StringConstraints(max_length=255)], Any] = Field(
-        description="A strict JSON Schema dictionary defining the required shape of the shared epistemic blackboard.",
+        description="A strict JSON Schema dictionary defining the required shape of the shared epistemic blackboard."
     )
     strict_validation: bool = Field(
         default=True,
@@ -7725,6 +7786,7 @@ class StdioTransportProfile(CoreasonBaseState):
     type: Literal["stdio"] = Field(default="stdio", description="Type of transport.")
     command: str = Field(..., max_length=2000, description="The command executable to run (e.g., 'node', 'python').")
     args: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
+        # Note: args is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
         max_length=1000000000,
         default_factory=list,
         description="The explicit array of arguments to pass to the command.",
@@ -7842,6 +7904,10 @@ class StructuralCausalGraphProfile(CoreasonBaseState):
         object.__setattr__(
             self, "causal_edges", sorted(self.causal_edges, key=lambda x: (x.source_variable, x.target_variable))
         )
+        if getattr(self, "causal_edges", None) is not None:
+            object.__setattr__(
+                self, "causal_edges", sorted(self.causal_edges, key=lambda x: (x.source_node_id, x.target_node_id))
+            )
         return self
 
 
@@ -7886,6 +7952,10 @@ class HypothesisGenerationEvent(BaseStateEvent):
         object.__setattr__(
             self, "falsification_conditions", sorted(self.falsification_conditions, key=lambda x: x.condition_id)
         )
+        if getattr(self, "falsification_conditions", None) is not None:
+            object.__setattr__(
+                self, "falsification_conditions", sorted(self.falsification_conditions, key=lambda x: x.condition_id)
+            )
         return self
 
 
@@ -7916,7 +7986,9 @@ class SyntheticGenerationProfile(CoreasonBaseState):
         description="Unique identifier for this simulation profile.",
     )
     manifold_sla: GenerativeManifoldSLA = Field(description="The structural topological gas limit.")
-    target_schema_ref: str = Field(min_length=1, description="The string name of the Pydantic class to synthesize.")
+    target_schema_ref: Annotated[str, StringConstraints(max_length=2048)] = Field(
+        min_length=1, description="The string name of the Pydantic class to synthesize."
+    )
 
 
 class System1ReflexPolicy(CoreasonBaseState):
@@ -7969,13 +8041,13 @@ class System2RemediationIntent(CoreasonBaseState):
         description="A cryptographic Lineage Watermark (CID) tracking this specific dimensional collapse.",
     )
     target_node_id: NodeIdentifierState = Field(
-        description="The strict W3C DID of the agent that authored the invalid state, ensuring the fault is routed back to the exact state partition."
+        description="The globally unique decentralized identifier (DID) anchoring the agent that authored the invalid state, ensuring the fault is routed back to the exact state partition."
     )
     failing_pointers: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
         min_length=1,
         description="A strictly typed array of RFC 6902 JSON Pointers isolating the exact topological coordinate of the hallucination.",
     )
-    remediation_prompt: str = Field(
+    remediation_prompt: Annotated[str, StringConstraints(max_length=100000)] = Field(
         min_length=1, description="The deterministic, non-monotonic natural-language constraint the agent must satisfy."
     )
 
@@ -8049,7 +8121,7 @@ class TaskAwardReceipt(CoreasonBaseState):
         min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$", description="The identifier of the resolved task."
     )
     awarded_syndicate: dict[Annotated[str, StringConstraints(max_length=255)], Annotated[int, Field(ge=0)]] = Field(
-        description="Strict mapping of agent NodeIdentifierStates to their exact fractional payout in magnitude.",
+        description="Strict mapping of agent NodeIdentifierStates to their exact fractional payout in magnitude."
     )
     cleared_price_magnitude: int = Field(le=1000000000, description="The final cryptographic clearing price.")
     escrow: EscrowPolicy | None = Field(default=None, description="The conditional escrow locking the compute budget.")
@@ -8093,6 +8165,12 @@ class AuctionState(CoreasonBaseState):
         object.__setattr__(
             self, "bids", sorted(self.bids, key=lambda bid: (bid.estimated_cost_magnitude, bid.agent_id))
         )
+        return self
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "bids", None) is not None:
+            object.__setattr__(self, "bids", sorted(self.bids, key=lambda x: x.agent_id))
         return self
 
 
@@ -8229,7 +8307,7 @@ class TheoryOfMindSnapshot(CoreasonBaseState):
         description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the agent whose mind is being modeled.",
     )
     assumed_shared_beliefs: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
-        description="The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses.",
+        description="The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses."
     )
     identified_knowledge_gaps: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
         max_length=1000000000,
@@ -8240,6 +8318,8 @@ class TheoryOfMindSnapshot(CoreasonBaseState):
     def sort_arrays(self) -> Self:
         object.__setattr__(self, "assumed_shared_beliefs", sorted(self.assumed_shared_beliefs))
         object.__setattr__(self, "identified_knowledge_gaps", sorted(self.identified_knowledge_gaps))
+        if getattr(self, "identified_knowledge_gaps", None) is not None:
+            object.__setattr__(self, "identified_knowledge_gaps", sorted(self.identified_knowledge_gaps))
         return self
 
     empathy_confidence_score: float = Field(
@@ -8562,7 +8642,7 @@ class FederatedPeftContract(CoreasonBaseState):
     Hot-Swapping, GPU VRAM Management
     """
 
-    adapter_merkle_root: str = Field(
+    adapter_merkle_root: Annotated[str, StringConstraints(max_length=128)] = Field(
         pattern="^[a-f0-9]{64}$",
         description="CoReason Shared Kernel Ontology: The tamper-evident SHA-256 hash of the exact safetensors weight matrix.",
     )
@@ -8729,7 +8809,7 @@ class VerifiableCredentialPresentationReceipt(CoreasonBaseState):
         description="The exact cryptographic standard used to encode this credential presentation."
     )
     issuer_did: NodeIdentifierState = Field(
-        description="The W3C DID of the trusted authority that cryptographically signed the credential, explicitly representing the delegation of authority from a human or parent principal."
+        description="The globally unique decentralized identifier (DID) anchoring the trusted authority that cryptographically signed the credential, explicitly representing the delegation of authority from a human or parent principal."
     )
     cryptographic_proof_blob: str = Field(
         max_length=100000,
@@ -8773,7 +8853,7 @@ class AgentAttestationReceipt(CoreasonBaseState):
     developer_signature: str = Field(
         max_length=2000, description="The cryptographic signature of the developer/vendor."
     )
-    capability_merkle_root: str = Field(
+    capability_merkle_root: Annotated[str, StringConstraints(max_length=128)] = Field(
         pattern="^[a-f0-9]{64}$", description="The SHA-256 Merkle root of the agent's verified semantic capabilities."
     )
     credential_presentations: list[VerifiableCredentialPresentationReceipt] = Field(
@@ -8786,6 +8866,10 @@ class AgentAttestationReceipt(CoreasonBaseState):
         object.__setattr__(
             self, "credential_presentations", sorted(self.credential_presentations, key=lambda x: x.issuer_did)
         )
+        if getattr(self, "credential_presentations", None) is not None:
+            object.__setattr__(
+                self, "credential_presentations", sorted(self.credential_presentations, key=lambda x: x.issuer_did)
+            )
         return self
 
 
@@ -8837,7 +8921,7 @@ class AgentNodeProfile(BaseNodeProfile):
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
         default=None,
-        description="The ID of the specific ActionSpaceManifest (curated tool environment) bound to this agent.",
+        description="The globally unique decentralized identifier (DID) anchoring the specific ActionSpaceManifest (curated tool environment) bound to this agent.",
     )
     secure_sub_session: SecureSubSessionState | None = Field(
         default=None,
@@ -8894,8 +8978,7 @@ class AgentNodeProfile(BaseNodeProfile):
         description="The adversarial emulation geometry composing kinematic noise and environmental spoofing for anti-bot trajectory evasion.",
     )
     gflownet_balance_policy: CognitiveDetailedBalanceContract | None = Field(
-        default=None,
-        description="Authorizes trajectory balance optimization during non-monotonic reasoning.",
+        default=None, description="Authorizes trajectory balance optimization during non-monotonic reasoning."
     )
 
     @model_validator(mode="after")
@@ -9058,10 +9141,8 @@ class DAGTopologyManifest(BaseTopologyManifest):
     def verify_edges_exist_and_compute_bounds(self) -> Self:
         if self.lifecycle_phase == "draft":
             return self
-
         adj: dict[NodeIdentifierState, list[NodeIdentifierState]] = {node_id: [] for node_id in self.nodes}
         in_degree: dict[NodeIdentifierState, int] = dict.fromkeys(self.nodes, 0)
-
         for source, target in self.edges:
             if source not in self.nodes:
                 raise ValueError(f"Edge source '{source}' does not exist in nodes registry.")
@@ -9069,12 +9150,9 @@ class DAGTopologyManifest(BaseTopologyManifest):
                 raise ValueError(f"Edge target '{target}' does not exist in nodes registry.")
             adj[source].append(target)
             in_degree[target] += 1
-
-        # Validate max_fan_out
         for node, neighbors in adj.items():
             if len(neighbors) > self.max_fan_out:
                 raise ValueError(f"Topological Violation: Node '{node}' exceeds max_fan_out of {self.max_fan_out}.")
-
         if not self.allow_cycles:
             visited: set[NodeIdentifierState] = set()
             recursion_stack: set[NodeIdentifierState] = set()
@@ -9085,14 +9163,11 @@ class DAGTopologyManifest(BaseTopologyManifest):
                     raise ValueError("Graph contains cycles but allow_cycles is False.")
                 if curr in visited:
                     return depth_memo.get(curr, 1)
-
                 visited.add(curr)
                 recursion_stack.add(curr)
-
                 max_child_depth = 0
                 for neighbor in adj[curr]:
                     max_child_depth = max(max_child_depth, dfs(neighbor))
-
                 recursion_stack.remove(curr)
                 current_depth = 1 + max_child_depth
                 depth_memo[curr] = current_depth
@@ -9100,19 +9175,25 @@ class DAGTopologyManifest(BaseTopologyManifest):
 
             max_calculated_depth = 0
             for start_node in self.nodes:
-                if in_degree[start_node] == 0:  # Start from roots
+                if in_degree[start_node] == 0:
                     max_calculated_depth = max(max_calculated_depth, dfs(start_node))
-
-            # Handle isolated cyclic components if no roots exist
             for start_node in self.nodes:
                 if start_node not in visited:
                     max_calculated_depth = max(max_calculated_depth, dfs(start_node))
-
             if max_calculated_depth > self.max_depth:
                 raise ValueError(
                     f"Topological Violation: Graph depth {max_calculated_depth} exceeds max_depth of {self.max_depth}."
                 )
+        return self
 
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "speculative_boundaries", None) is not None:
+            object.__setattr__(
+                self, "speculative_boundaries", sorted(self.speculative_boundaries, key=lambda x: x.boundary_id)
+            )
+        if getattr(self, "edges", None) is not None:
+            object.__setattr__(self, "edges", sorted(self.edges))
         return self
 
 
@@ -9178,8 +9259,12 @@ class EvaluatorOptimizerTopologyManifest(BaseTopologyManifest):
     type: Literal["evaluator_optimizer"] = Field(
         default="evaluator_optimizer", description="Discriminator for an Evaluator-Optimizer loop."
     )
-    generator_node_id: NodeIdentifierState = Field(description="The ID of the actor generating the payload.")
-    evaluator_node_id: NodeIdentifierState = Field(description="The ID of the critic scoring the payload.")
+    generator_node_id: NodeIdentifierState = Field(
+        description="The deterministic capability pointer representing the actor generating the payload."
+    )
+    evaluator_node_id: NodeIdentifierState = Field(
+        description="The deterministic capability pointer representing the critic scoring the payload."
+    )
     max_revision_loops: int = Field(
         le=1000000000, ge=1, description="The absolute limit on Actor-Critic cycles to prevent infinite compute burn."
     )
@@ -9240,6 +9325,14 @@ class EvolutionaryTopologyManifest(BaseTopologyManifest):
         )
         return self
 
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "fitness_objectives", None) is not None:
+            object.__setattr__(
+                self, "fitness_objectives", sorted(self.fitness_objectives, key=lambda x: x.target_metric)
+            )
+        return self
+
 
 class SMPCTopologyManifest(BaseTopologyManifest):
     """
@@ -9279,6 +9372,12 @@ class SMPCTopologyManifest(BaseTopologyManifest):
         description="The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology.",
     )
 
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "participant_node_ids", None) is not None:
+            object.__setattr__(self, "participant_node_ids", sorted(self.participant_node_ids))
+        return self
+
 
 class SwarmTopologyManifest(BaseTopologyManifest):
     """
@@ -9307,7 +9406,7 @@ class SwarmTopologyManifest(BaseTopologyManifest):
         ge=1, le=100, default=3, description="Threshold limit for dynamic spawning of additional nodes."
     )
     max_concurrent_agents: int = Field(
-        default=10, le=100, description="The absolute ceiling for concurrent agent threads."
+        default=10, le=100, description="The mathematically bounded limit for concurrent agent threads."
     )
     auction_policy: AuctionPolicy | None = Field(
         default=None, description="The mathematical policy governing task decentralization via Spot Markets."
@@ -9332,6 +9431,10 @@ class SwarmTopologyManifest(BaseTopologyManifest):
             self, "active_prediction_markets", sorted(self.active_prediction_markets, key=lambda x: x.market_id)
         )
         object.__setattr__(self, "resolved_markets", sorted(self.resolved_markets, key=lambda x: x.market_id))
+        if getattr(self, "active_prediction_markets", None) is not None:
+            object.__setattr__(
+                self, "active_prediction_markets", sorted(self.active_prediction_markets, key=lambda x: x.market_id)
+            )
         return self
 
 
@@ -9500,6 +9603,14 @@ class WorkflowManifest(CoreasonBaseState):
             object.__setattr__(
                 self, "allowed_information_classifications", sorted(self.allowed_information_classifications)
             )
+        if getattr(self, "allowed_information_classifications", None) is not None:
+            object.__setattr__(
+                self,
+                "allowed_information_classifications",
+                sorted(self.allowed_information_classifications, key=lambda x: str(x.value))
+                if self.allowed_information_classifications
+                else [],
+            )
         return self
 
     @model_validator(mode="after")
@@ -9539,10 +9650,10 @@ class WetwareAttestationContract(CoreasonBaseState):
     mechanism: AttestationMechanismProfile = Field(
         ..., description="The SOTA cryptographic mechanism used to generate the proof."
     )
-    did_subject: str = Field(
+    did_subject: Annotated[str, StringConstraints(max_length=1024)] = Field(
         ..., pattern="^did:[a-z0-9]+:.*$", description="The Decentralized Identifier (DID) of the human operator."
     )
-    cryptographic_payload: str = Field(
+    cryptographic_payload: Annotated[str, StringConstraints(max_length=100000)] = Field(
         ...,
         pattern="^[A-Za-z0-9+/=_-]+$",
         description="The strictly formatted (Base64url/Hex/Multibase) signature or proof.",
@@ -9575,7 +9686,9 @@ class InterventionReceipt(CoreasonBaseState):
     intervention_request_id: Annotated[
         str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")
     ] = Field(description="The cryptographic nonce uniquely identifying the intervention request.")
-    target_node_id: NodeIdentifierState = Field(description="The ID of the target node.")
+    target_node_id: NodeIdentifierState = Field(
+        description="The deterministic capability pointer representing the target node."
+    )
     approved: bool = Field(description="Indicates whether the proposed action was approved.")
     feedback: str | None = Field(max_length=2000, description="Optional feedback provided along with the verdict.")
     attestation: WetwareAttestationContract | None = Field(
@@ -9657,6 +9770,14 @@ class EpistemicQuarantineSnapshot(CoreasonBaseState):
         object.__setattr__(
             self, "capability_attestations", sorted(self.capability_attestations, key=lambda x: x.attestation_id)
         )
+        if getattr(self, "theory_of_mind_models", None) is not None:
+            object.__setattr__(
+                self, "theory_of_mind_models", sorted(self.theory_of_mind_models, key=lambda x: x.target_agent_id)
+            )
+        if getattr(self, "capability_attestations", None) is not None:
+            object.__setattr__(
+                self, "capability_attestations", sorted(self.capability_attestations, key=lambda x: x.attestation_id)
+            )
         return self
 
 
@@ -9736,7 +9857,7 @@ class BeliefMutationEvent(BaseStateEvent):
         default="belief_mutation", description="Discriminator type for a Belief Assertion event."
     )
     payload: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        description="Topologically Bounded Latent Spaces capturing the semantic representation of the agent's internal cognitive shift or synthesis that anchor statistical probability to a definitive causal event hash.",
+        description="Topologically Bounded Latent Spaces capturing the semantic representation of the agent's internal cognitive shift or synthesis that anchor statistical probability to a definitive causal event hash."
     )
     source_node_id: NodeIdentifierState | None = Field(
         default=None, description="The specific topological node that synthesized this belief assertion."
@@ -9772,6 +9893,10 @@ class BeliefMutationEvent(BaseStateEvent):
         object.__setattr__(
             self, "causal_attributions", sorted(self.causal_attributions, key=lambda x: x.source_event_id)
         )
+        if getattr(self, "causal_attributions", None) is not None:
+            object.__setattr__(
+                self, "causal_attributions", sorted(self.causal_attributions, key=lambda x: x.source_event_id)
+            )
         return self
 
     @field_validator("payload", mode="before")
@@ -9807,7 +9932,7 @@ class ObservationEvent(BaseStateEvent):
         default="observation", description="Discriminator type for an observation event."
     )
     payload: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        description="Neurosymbolic Bindings of the raw, lossless semantic output appended from the environment or tool execution that anchor statistical probability to a definitive causal event hash.",
+        description="Neurosymbolic Bindings of the raw, lossless semantic output appended from the environment or tool execution that anchor statistical probability to a definitive causal event hash."
     )
     source_node_id: NodeIdentifierState | None = Field(
         default=None, description="The specific topological node that appended this observation."
@@ -9835,15 +9960,13 @@ class ObservationEvent(BaseStateEvent):
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
         default=None,
-        description="The Event ID of the specific ToolInvocationEvent that spawned this observation, forming a strict bipartite directed edge.",
+        description="The deterministic capability pointer representing the specific ToolInvocationEvent that spawned this observation, forming a strict bipartite directed edge.",
     )
     continuous_stream: ContinuousObservationStream | None = Field(
-        default=None,
-        description="Buffers real-time audio/video or continuous token streams.",
+        default=None, description="Buffers real-time audio/video or continuous token streams."
     )
     disfluency_rules: StreamingDisfluencyContract | None = Field(
-        default=None,
-        description="Rules for the forget gate to slice out stutters or ambient noise.",
+        default=None, description="Rules for the forget gate to slice out stutters or ambient noise."
     )
 
     @field_validator("payload", mode="before")
@@ -9905,11 +10028,17 @@ class EpistemicAxiomState(CoreasonBaseState):
     """
 
     source_concept_id: str = Field(
-        min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$", description="CID of the origin node."
+        min_length=1,
+        max_length=128,
+        pattern="^[a-zA-Z0-9_.:-]+$",
+        description="The globally unique decentralized identifier (DID) anchoring the origin node.",
     )
     directed_edge_type: str = Field(max_length=2000, description="The topological relationship.")
     target_concept_id: str = Field(
-        min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$", description="CID of destination node."
+        min_length=1,
+        max_length=128,
+        pattern="^[a-zA-Z0-9_.:-]+$",
+        description="The globally unique decentralized identifier (DID) anchoring destination node.",
     )
 
 
@@ -9968,6 +10097,7 @@ class EpistemicChainGraphState(CoreasonBaseState):
                 self.semantic_leaves, key=lambda x: (x.source_concept_id, x.directed_edge_type, x.target_concept_id)
             ),
         )
+
         return self
 
 
@@ -9986,6 +10116,12 @@ class CognitivePredictionReceipt(BaseStateEvent):
     source_chain_id: str = Field(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")
     target_source_concept: str = Field(max_length=2000)
     predicted_top_k_tokens: list[Annotated[str, StringConstraints(max_length=255)]] = Field(min_length=1)
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "predicted_top_k_tokens", None) is not None:
+            object.__setattr__(self, "predicted_top_k_tokens", sorted(self.predicted_top_k_tokens))
+        return self
 
 
 class IntentClassificationReceipt(BaseStateEvent):
@@ -10080,6 +10216,7 @@ class EpistemicDomainGraphManifest(CoreasonBaseState):
                 self.verified_axioms, key=lambda x: (x.source_concept_id, x.directed_edge_type, x.target_concept_id)
             ),
         )
+
         return self
 
 
@@ -10109,7 +10246,9 @@ class EpistemicTopologicalProofManifest(CoreasonBaseState):
         description="A Content Identifier (CID) for this specific topological proof.",
     )
     axiomatic_chain: list[EpistemicAxiomState] = Field(
-        min_length=1, description="The strictly ordered sequence of axioms forming the reasoning path."
+        min_length=1,
+        description="The strictly ordered sequence of axioms forming the reasoning path.",
+        # Note: axiomatic_chain is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
     )
 
 
@@ -10153,7 +10292,7 @@ class CognitiveReasoningTraceState(CoreasonBaseState):
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
         min_length=1,
-        description="CID of this specific non-monotonic reasoning trace.",
+        description="The globally unique decentralized identifier (DID) anchoring this specific non-monotonic reasoning trace.",
     )
     source_proof_id: str = Field(
         min_length=1,
@@ -10186,9 +10325,11 @@ class CognitiveDualVerificationReceipt(CoreasonBaseState):
     Cryptography, Symmetric Consensus, Zero-Trust Evaluation
     """
 
-    primary_verifier_id: NodeIdentifierState = Field(description="The DID of the primary evaluating agent.")
+    primary_verifier_id: NodeIdentifierState = Field(
+        description="The globally unique decentralized identifier (DID) anchoring the primary evaluating agent."
+    )
     secondary_verifier_id: NodeIdentifierState = Field(
-        description="The DID of the independent secondary evaluating agent."
+        description="The globally unique decentralized identifier (DID) anchoring the independent secondary evaluating agent."
     )
     trace_factual_alignment: bool = Field(
         description="Strict Boolean indicating if BOTH agents mathematically agree on factual alignment."
@@ -10224,7 +10365,10 @@ class EpistemicGroundedTaskManifest(CoreasonBaseState):
     """
 
     task_id: str = Field(
-        max_length=128, pattern="^[a-zA-Z0-9_.:-]+$", min_length=1, description="The cryptographic CID of the task."
+        max_length=128,
+        pattern="^[a-zA-Z0-9_.:-]+$",
+        min_length=1,
+        description="The cryptographic globally unique decentralized identifier (DID) anchoring the task.",
     )
     topological_proof: EpistemicTopologicalProofManifest = Field(description="The underlying latent path.")
     vignette_payload: str = Field(max_length=100000, description="The generated natural language scenario.")
@@ -10396,7 +10540,7 @@ class EpistemicRewardModelPolicy(CoreasonBaseState):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The CID of the EpistemicDomainGraphManifest acting as the deterministic ground truth.",
+        description="The globally unique decentralized identifier (DID) anchoring the EpistemicDomainGraphManifest acting as the deterministic ground truth.",
     )
     format_contract: CognitiveFormatContract = Field(
         description="The syntactic constraints the agent must follow to prevent reward zeroing."
@@ -10436,7 +10580,7 @@ class CognitiveRewardEvaluationReceipt(BaseStateEvent):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The CID of the LLM's raw generated text trajectory.",
+        description="The globally unique decentralized identifier (DID) anchoring the LLM's raw generated text trajectory.",
     )
     extracted_axioms: list[EpistemicAxiomState] = Field(
         default_factory=list,
@@ -10458,6 +10602,7 @@ class CognitiveRewardEvaluationReceipt(BaseStateEvent):
                 self.extracted_axioms, key=lambda x: (x.source_concept_id, x.directed_edge_type, x.target_concept_id)
             ),
         )
+
         return self
 
 
@@ -10517,7 +10662,7 @@ class EpistemicFlowStateReceipt(BaseStateEvent):
         min_length=1,
         max_length=128,
         pattern="^[a-zA-Z0-9_.:-]+$",
-        description="The CID of the partial CognitiveReasoningTraceState.",
+        description="The globally unique decentralized identifier (DID) anchoring the partial CognitiveReasoningTraceState.",
     )
     estimated_flow_value: float = Field(
         le=1000000000.0,
@@ -10630,6 +10775,7 @@ class ContinuousObservationStream(CoreasonBaseState):
         description="A Content Identifier (CID) for the continuous observation stream."
     )
     token_buffer: list[Annotated[str, StringConstraints(max_length=10000)]] = Field(
+        # Note: token_buffer is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
         max_length=1000000,
         description="The array of ingested tokens representing the continuous stream. AGENT INSTRUCTION: Topological Exemption applied. Do NOT sort this array, as its chronological sequence is its mathematical state.",
     )
@@ -10786,6 +10932,12 @@ class EpistemicLedgerState(CoreasonBaseState):
         object.__setattr__(self, "active_rollbacks", sorted(self.active_rollbacks, key=lambda x: x.request_id))
         object.__setattr__(self, "migration_contracts", sorted(self.migration_contracts, key=lambda x: x.contract_id))
         object.__setattr__(self, "active_cascades", sorted(self.active_cascades, key=lambda x: x.cascade_id))
+        return self
+
+    @model_validator(mode="after")
+    def sort_arrays(self) -> Self:
+        if getattr(self, "history", None) is not None:
+            object.__setattr__(self, "history", sorted(self.history, key=lambda x: x.timestamp))
         return self
 
 


### PR DESCRIPTION
* refactor(ontology): rewrite conversational Field descriptions to RepE vectors

- Scanned `ontology.py` to identify Pydantic `Field` descriptions with legacy, human-centric filler or CRUD terminology.
- Transmuted phrases like "The ID of", "A list of", and "Extra info" into mathematically-dense vectors adhering to RepE bounds (e.g., "The explicit array of", "The globally unique decentralized identifier (DID) anchoring").
- Maintained absolute strictness against modifying class-level `"""docstrings"""`.
- Used AST parsing and unparsing to apply replacements cleanly and prevent matching drift.
- Ensured resulting `ontology.py` passes `ruff format` and `ruff check --fix`.

* refactor(ontology): rewrite conversational Field descriptions to RepE vectors

- Scanned `ontology.py` to identify Pydantic `Field` descriptions with legacy, human-centric filler or CRUD terminology.
- Transmuted phrases like "The ID of", "A list of", and "Extra info" into mathematically-dense vectors adhering to RepE bounds.
- Generated updated `coreason_ontology.schema.json` to ensure CI Semantic Backward-Compatibility checks pass.

* refactor(ontology): add RFC 8785 deterministic bounds and Anti-Contagion typing

- Restored the required CoReason `Copyright` header to `ontology.py` in compliance with legal directives.
- Mathematically classified `list` and `Sequence` fields across the ontology into Paradigm 1 (Unordered Sets) and Paradigm 2 (Structural Sequences).
- Implemented `object.__setattr__(self, field_name, sorted(...))` inside `@model_validator`s to sort unordered sets, preventing Merkle-DAG hash fractures across the swarm.
- Added topological exemption `# Note: <field_name> is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.` to structural sequence fields.
- Defended against Dictionary Bombing and OOM attacks by strictly replacing unbounded `str` fields and key strings with `Annotated[str, StringConstraints(max_length=X)]` typing.
- Kept the `ontology.py` monolith explicitly intact and avoided generic inheritance.
- Fixed `test_epistemic_chain_graph_state_sorting` error and regenerated JSON schemas to pass rigorous testing and coverage limits.

* Update ontology.py

* Update ontology.py

* Update ontology.py

* Update coreason_ontology.schema.json