### PR TITLE
Epic 2: The AST Alignment Mandate (Lexical Standardization)

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -745,7 +745,7 @@ class ComputeEngineProfile(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "capabilities", sorted(self.capabilities))
         object.__setattr__(self, "supported_functional_experts", sorted(self.supported_functional_experts))
         return self
@@ -782,7 +782,7 @@ class PermissionBoundaryPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         if self.allowed_domains is not None:
             object.__setattr__(self, "allowed_domains", sorted(self.allowed_domains))
         if self.auth_requirements is not None:
@@ -937,7 +937,7 @@ class ActivationSteeringContract(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "injection_layers", sorted(self.injection_layers))
         return self
 
@@ -967,7 +967,7 @@ class SemanticSlicingPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         """Mathematically sort arrays to guarantee deterministic canonical hashing."""
         object.__setattr__(
             self,
@@ -1124,7 +1124,7 @@ class ConstitutionalPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "forbidden_intents", sorted(self.forbidden_intents))
         return self
 
@@ -1191,7 +1191,7 @@ class AdjudicationRubricProfile(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "criteria", sorted(self.criteria, key=lambda x: x.criterion_id))
         return self
 
@@ -1353,7 +1353,7 @@ class RedactionPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         if self.context_exclusion_zones is not None:
             object.__setattr__(self, "context_exclusion_zones", sorted(self.context_exclusion_zones))
         return self
@@ -1417,7 +1417,7 @@ class SaeLatentPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "monitored_layers", sorted(self.monitored_layers))
         return self
 
@@ -1467,7 +1467,7 @@ class SecureSubSessionState(CoreasonBaseState):
     description: str = Field(max_length=2000, description="Audit justification for this temporary secure session.")
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "allowed_vault_keys", sorted(self.allowed_vault_keys))
         return self
 
@@ -1516,7 +1516,7 @@ class DefeasibleCascadeEvent(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "quarantined_event_ids", sorted(self.quarantined_event_ids))
         return self
 
@@ -1585,7 +1585,7 @@ class MultimodalTokenAnchorState(CoreasonBaseState):
         return self
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "visual_patch_hashes", sorted(self.visual_patch_hashes))
         if getattr(self, "visual_patch_hashes", None) is not None:
             object.__setattr__(self, "visual_patch_hashes", sorted(self.visual_patch_hashes))
@@ -1628,7 +1628,7 @@ class RollbackIntent(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_invalidated_nodes(self) -> Self:
+    def _enforce_canonical_sort_invalidated_nodes(self) -> Self:
         object.__setattr__(self, "invalidated_node_ids", sorted(self.invalidated_node_ids))
         return self
 
@@ -1766,7 +1766,7 @@ class StateHydrationManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "crystallized_ledger_cids", sorted(self.crystallized_ledger_cids))
         if getattr(self, "crystallized_ledger_cids", None) is not None:
             object.__setattr__(self, "crystallized_ledger_cids", sorted(self.crystallized_ledger_cids))
@@ -1912,7 +1912,7 @@ class LatentScratchpadReceipt(CoreasonBaseState):
         return self
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "explored_branches", sorted(self.explored_branches, key=lambda x: x.branch_id))
         object.__setattr__(self, "discarded_branches", sorted(self.discarded_branches))
         return self
@@ -1973,7 +1973,7 @@ class EphemeralNamespacePartitionState(CoreasonBaseState):
         return self
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "authorized_bytecode_hashes", sorted(self.authorized_bytecode_hashes))
         return self
 
@@ -2066,7 +2066,7 @@ class BilateralSLA(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "permitted_geographic_regions", sorted(self.permitted_geographic_regions))
         return self
 
@@ -2100,7 +2100,7 @@ class FederatedDiscoveryManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "broadcast_endpoints", sorted(self.broadcast_endpoints, key=str))
         object.__setattr__(self, "supported_ontologies", sorted(self.supported_ontologies))
         if getattr(self, "supported_ontologies", None) is not None:
@@ -2196,7 +2196,7 @@ class AdjudicationIntent(CoreasonBaseState):
         return _validate_payload_bounds(v)
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "deadlocked_claims", sorted(self.deadlocked_claims))
         return self
 
@@ -2635,7 +2635,7 @@ class BoundedInterventionScopePolicy(CoreasonBaseState):
         return _validate_payload_bounds(v)
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "allowed_fields", sorted(self.allowed_fields))
         return self
 
@@ -2972,7 +2972,7 @@ class CausalExplanationEvent(BaseStateEvent):
     )
 
     @model_validator(mode="after")
-    def sort_agent_attributions(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "agent_attributions", sorted(self.agent_attributions, key=lambda x: x.target_node_id))
         return self
 
@@ -3621,7 +3621,7 @@ class TopologicalRetrievalContract(CoreasonBaseState):
     enforce_isometry: bool = Field(default=True, description="Enforces preservation of geometric distances.")
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "allowed_causal_relationships", sorted(self.allowed_causal_relationships))
         return self
 
@@ -3696,7 +3696,7 @@ class SemanticDiscoveryIntent(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_required_structural_types(self) -> Self:
+    def _enforce_canonical_sort_types(self) -> Self:
         object.__setattr__(self, "required_structural_types", sorted(self.required_structural_types))
         return self
 
@@ -3862,7 +3862,7 @@ class EnsembleTopologyProfile(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "concurrent_branch_ids", sorted(self.concurrent_branch_ids))
         return self
 
@@ -3991,7 +3991,7 @@ class EpistemicPromotionEvent(BaseStateEvent):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "source_episodic_event_ids", sorted(self.source_episodic_event_ids))
         return self
 
@@ -4074,7 +4074,7 @@ class EpistemicTransmutationTask(CoreasonBaseState):
         return self
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "target_modalities", sorted(self.target_modalities))
         return self
 
@@ -4224,7 +4224,7 @@ class EvictionPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "protected_event_ids", sorted(self.protected_event_ids))
         return self
 
@@ -4305,7 +4305,7 @@ class EpistemicArgumentClaimState(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_argument_claim_arrays(self) -> Self:
+    def _enforce_canonical_sort_warrants(self) -> Self:
         object.__setattr__(self, "warrants", sorted(self.warrants, key=lambda x: x.justification))
         return self
 
@@ -4754,7 +4754,7 @@ class DelegatedCapabilityManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "allowed_tool_ids", sorted(self.allowed_tool_ids))
         return self
 
@@ -4954,7 +4954,7 @@ class GlobalSemanticProfile(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "detected_modalities", sorted(self.detected_modalities))
         return self
 
@@ -4988,13 +4988,8 @@ class DynamicRoutingManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "active_subgraphs", {k: sorted(v) for k, v in self.active_subgraphs.items()})
-
-        return self
-
-    @model_validator(mode="after")
-    def sort_bypassed_steps(self) -> Self:
         object.__setattr__(self, "bypassed_steps", sorted(self.bypassed_steps, key=lambda x: x.bypassed_node_id))
         return self
 
@@ -5044,7 +5039,7 @@ class GovernancePolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_rules(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "rules", sorted(self.rules, key=lambda r: r.rule_id))
         return self
 
@@ -5083,7 +5078,7 @@ class GrammarPanelProfile(CoreasonBaseState):
     facet: FacetMatrixProfile | None = Field(default=None, description="Optional faceting matrix for small multiples.")
 
     @model_validator(mode="after")
-    def sort_encodings(self) -> Self:
+    def _enforce_canonical_sort_encodings(self) -> Self:
         """Mathematically sorts self.encodings by the string value of channel for deterministic hashing."""
         object.__setattr__(self, "encodings", sorted(self.encodings, key=lambda e: e.channel))
         return self
@@ -5292,7 +5287,7 @@ class TaxonomicNodeState(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_taxonomic_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         """Mathematically sort arrays to guarantee deterministic canonical hashing."""
         object.__setattr__(self, "children_node_ids", sorted(self.children_node_ids))
         object.__setattr__(self, "leaf_provenance", sorted(self.leaf_provenance, key=lambda x: x.source_event_id))
@@ -5766,7 +5761,7 @@ class BaseNodeProfile(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_agent_attestation_arrays(self) -> Self:
+    def _enforce_canonical_sort_intervention_policies(self) -> Self:
         object.__setattr__(self, "intervention_policies", sorted(self.intervention_policies, key=lambda x: x.trigger))
         return self
 
@@ -5906,7 +5901,7 @@ class MCPCapabilityWhitelistPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "allowed_tools", sorted(self.allowed_tools))
         object.__setattr__(self, "allowed_resources", sorted(self.allowed_resources))
         object.__setattr__(self, "allowed_prompts", sorted(self.allowed_prompts))
@@ -6070,7 +6065,7 @@ class KineticSeparationPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_clusters(self) -> Self:
+    def _enforce_canonical_sort_clusters(self) -> Self:
         """
         AGENT INSTRUCTION: Mathematically stabilize the 2D array to guarantee
         deterministic RFC 8785 canonical hashing across distributed nodes.
@@ -6124,23 +6119,19 @@ class ActionSpaceManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def verify_unique_tool_namespaces_and_sort(self) -> Self:
+    def _enforce_structural_uniqueness(self) -> Self:
         tool_names = {t.tool_name for t in self.native_tools}
         if len(tool_names) < len(self.native_tools):
             raise ValueError("Tool names within an ActionSpaceManifest must be strictly unique.")
+        return self
+
+    @model_validator(mode="after")
+    def _enforce_canonical_sort_action_spaces(self) -> Self:
         object.__setattr__(self, "native_tools", sorted(self.native_tools, key=lambda x: x.tool_name))
         object.__setattr__(self, "mcp_servers", sorted(self.mcp_servers, key=lambda x: x.server_uri))
         object.__setattr__(
             self, "ephemeral_partitions", sorted(self.ephemeral_partitions, key=lambda x: x.partition_id)
         )
-        return self
-
-    @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
-        if getattr(self, "ephemeral_partitions", None) is not None:
-            object.__setattr__(
-                self, "ephemeral_partitions", sorted(self.ephemeral_partitions, key=lambda x: x.partition_id)
-            )
         return self
 
 
@@ -6216,10 +6207,14 @@ class OntologicalSurfaceProjectionManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def verify_unique_action_spaces(self) -> Self:
+    def _enforce_structural_uniqueness(self) -> Self:
         space_ids = {space.action_space_id for space in self.action_spaces}
         if len(space_ids) < len(self.action_spaces):
             raise ValueError("Action spaces within a projection must have strictly unique action_space_ids.")
+        return self
+
+    @model_validator(mode="after")
+    def _enforce_canonical_sort_projections(self) -> Self:
         object.__setattr__(self, "action_spaces", sorted(self.action_spaces, key=lambda x: x.action_space_id))
         object.__setattr__(self, "supported_personas", sorted(self.supported_personas))
         object.__setattr__(
@@ -6227,16 +6222,6 @@ class OntologicalSurfaceProjectionManifest(CoreasonBaseState):
             "available_procedural_manifolds",
             sorted(self.available_procedural_manifolds, key=lambda x: x.metadata_id),
         )
-        return self
-
-    @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
-        if getattr(self, "available_procedural_manifolds", None) is not None:
-            object.__setattr__(
-                self,
-                "available_procedural_manifolds",
-                sorted(self.available_procedural_manifolds, key=lambda x: x.metadata_id),
-            )
         return self
 
 
@@ -6332,7 +6317,7 @@ class MCPResourceManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "uris", sorted(self.uris))
         return self
 
@@ -6421,7 +6406,7 @@ class MarketResolutionState(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "falsified_hypothesis_ids", sorted(self.falsified_hypothesis_ids))
         return self
 
@@ -6466,7 +6451,7 @@ class MechanisticAuditContract(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "trigger_conditions", sorted(self.trigger_conditions))
         object.__setattr__(self, "target_layers", sorted(self.target_layers))
         return self
@@ -6551,7 +6536,7 @@ class MigrationContract(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "dropped_paths", sorted(self.dropped_paths))
         if getattr(self, "dropped_paths", None) is not None:
             object.__setattr__(self, "dropped_paths", sorted(self.dropped_paths))
@@ -6705,7 +6690,7 @@ class NeuralAuditAttestationReceipt(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self,
             "layer_activations",
@@ -6856,7 +6841,7 @@ class OntologicalHandshakeReceipt(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "participant_node_ids", sorted(self.participant_node_ids))
         return self
 
@@ -6914,7 +6899,7 @@ class CompositeNodeProfile(BaseNodeProfile):
     )
 
     @model_validator(mode="after")
-    def sort_composite_arrays(self) -> Self:
+    def _enforce_canonical_sort_mappings(self) -> Self:
         object.__setattr__(self, "input_mappings", sorted(self.input_mappings, key=lambda x: x.parent_key))
         object.__setattr__(self, "output_mappings", sorted(self.output_mappings, key=lambda x: x.child_key))
         return self
@@ -6995,7 +6980,7 @@ class PeftAdapterContract(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "target_modules", sorted(self.target_modules))
         return self
 
@@ -7076,7 +7061,7 @@ class PredictionMarketState(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_prediction_market_state_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "order_book", sorted(self.order_book, key=lambda x: x.agent_id))
         return self
 
@@ -7230,7 +7215,7 @@ class ComputeProvisioningIntent(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "required_capabilities", sorted(self.required_capabilities))
         return self
 
@@ -7386,7 +7371,7 @@ class SemanticFirewallPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "forbidden_intents", sorted(self.forbidden_intents))
         return self
 
@@ -7430,7 +7415,7 @@ class InformationFlowPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_rules(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         """
         Mathematically sorts rules by rule_id to guarantee deterministic hashing.
         """
@@ -7438,12 +7423,6 @@ class InformationFlowPolicy(CoreasonBaseState):
         object.__setattr__(
             self, "latent_firewalls", sorted(self.latent_firewalls, key=lambda x: x.target_feature_index)
         )
-        return self
-
-    @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
-        if getattr(self, "latent_firewalls", None) is not None:
-            object.__setattr__(self, "latent_firewalls", sorted(self.latent_firewalls, key=lambda x: x.rule_id))
         return self
 
 
@@ -7643,7 +7622,7 @@ class ExecutionSpanReceipt(CoreasonBaseState):
         return self
 
     @model_validator(mode="after")
-    def sort_events(self) -> Any:
+    def _enforce_canonical_sort_events(self) -> Any:
         object.__setattr__(self, "events", sorted(self.events, key=lambda e: e.timestamp_unix_nano))
         return self
 
@@ -7819,7 +7798,7 @@ class SteadyStateHypothesisState(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         if self.required_tool_usage is not None:
             object.__setattr__(self, "required_tool_usage", sorted(self.required_tool_usage))
         return self
@@ -7859,7 +7838,7 @@ class ChaosExperimentTask(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "faults", sorted(self.faults, key=lambda x: (x.fault_type, x.target_node_id)))
         object.__setattr__(self, "shocks", sorted(self.shocks, key=lambda x: x.shock_id))
         return self
@@ -7885,7 +7864,7 @@ class StructuralCausalGraphProfile(CoreasonBaseState):
     causal_edges: list[CausalDirectedEdgeState] = Field(description="The declared topological mapping of causality.")
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "observed_variables", sorted(self.observed_variables))
         object.__setattr__(self, "latent_variables", sorted(self.latent_variables))
         object.__setattr__(
@@ -7935,7 +7914,7 @@ class HypothesisGenerationEvent(BaseStateEvent):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self, "falsification_conditions", sorted(self.falsification_conditions, key=lambda x: x.condition_id)
         )
@@ -8005,7 +7984,7 @@ class System1ReflexPolicy(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "allowed_passive_tools", sorted(self.allowed_passive_tools))
         return self
 
@@ -8039,7 +8018,7 @@ class System2RemediationIntent(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def _sort_failing_pointers(self) -> Self:
+    def _enforce_canonical_sort_failing_pointers(self) -> Self:
         """Mathematically sort pointers to guarantee deterministic canonical hashing."""
         object.__setattr__(self, "failing_pointers", sorted(self.failing_pointers))
         return self
@@ -8147,17 +8126,11 @@ class AuctionState(CoreasonBaseState):
     minimum_tick_size: int = Field(le=1000000000, gt=0, description="The smallest allowable discrete bid increment.")
 
     @model_validator(mode="after")
-    def sort_bids(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         """Mathematically sort bids by price then agent_id for deterministic hashing and correct supply curve geometry."""
         object.__setattr__(
             self, "bids", sorted(self.bids, key=lambda bid: (bid.estimated_cost_magnitude, bid.agent_id))
         )
-        return self
-
-    @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
-        if getattr(self, "bids", None) is not None:
-            object.__setattr__(self, "bids", sorted(self.bids, key=lambda x: x.agent_id))
         return self
 
 
@@ -8302,7 +8275,7 @@ class TheoryOfMindSnapshot(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "assumed_shared_beliefs", sorted(self.assumed_shared_beliefs))
         object.__setattr__(self, "identified_knowledge_gaps", sorted(self.identified_knowledge_gaps))
         if getattr(self, "identified_knowledge_gaps", None) is not None:
@@ -8381,7 +8354,7 @@ class TraceExportManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_spans(self) -> Any:
+    def _enforce_canonical_sort(self) -> Any:
         object.__setattr__(self, "spans", sorted(self.spans, key=lambda s: s.span_id))
         return self
 
@@ -8823,7 +8796,7 @@ class AgentAttestationReceipt(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self, "credential_presentations", sorted(self.credential_presentations, key=lambda x: x.issuer_did)
         )
@@ -8943,7 +8916,7 @@ class AgentNodeProfile(BaseNodeProfile):
     )
 
     @model_validator(mode="after")
-    def sort_agent_node_arrays(self) -> Self:
+    def _enforce_canonical_sort_peft_adapters(self) -> Self:
         object.__setattr__(self, "peft_adapters", sorted(self.peft_adapters, key=lambda x: x.adapter_id))
         return self
 
@@ -9080,7 +9053,7 @@ class DAGTopologyManifest(BaseTopologyManifest):
     )
 
     @model_validator(mode="after")
-    def sort_dag_topology_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "edges", sorted(self.edges))
         object.__setattr__(
             self, "speculative_boundaries", sorted(self.speculative_boundaries, key=lambda x: x.boundary_id)
@@ -9134,16 +9107,6 @@ class DAGTopologyManifest(BaseTopologyManifest):
                 raise ValueError(
                     f"Topological Violation: Graph depth {max_calculated_depth} exceeds max_depth of {self.max_depth}."
                 )
-        return self
-
-    @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
-        if getattr(self, "speculative_boundaries", None) is not None:
-            object.__setattr__(
-                self, "speculative_boundaries", sorted(self.speculative_boundaries, key=lambda x: x.boundary_id)
-            )
-        if getattr(self, "edges", None) is not None:
-            object.__setattr__(self, "edges", sorted(self.edges))
         return self
 
 
@@ -9269,14 +9232,14 @@ class EvolutionaryTopologyManifest(BaseTopologyManifest):
     )
 
     @model_validator(mode="after")
-    def sort_objectives(self) -> Self:
+    def _enforce_canonical_sort_objectives(self) -> Self:
         object.__setattr__(
             self, "fitness_objectives", sorted(self.fitness_objectives, key=lambda obj: obj.target_metric)
         )
         return self
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         if getattr(self, "fitness_objectives", None) is not None:
             object.__setattr__(
                 self, "fitness_objectives", sorted(self.fitness_objectives, key=lambda x: x.target_metric)
@@ -9323,7 +9286,7 @@ class SMPCTopologyManifest(BaseTopologyManifest):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         if getattr(self, "participant_node_ids", None) is not None:
             object.__setattr__(self, "participant_node_ids", sorted(self.participant_node_ids))
         return self
@@ -9376,15 +9339,11 @@ class SwarmTopologyManifest(BaseTopologyManifest):
         return self
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self, "active_prediction_markets", sorted(self.active_prediction_markets, key=lambda x: x.market_id)
         )
         object.__setattr__(self, "resolved_markets", sorted(self.resolved_markets, key=lambda x: x.market_id))
-        if getattr(self, "active_prediction_markets", None) is not None:
-            object.__setattr__(
-                self, "active_prediction_markets", sorted(self.active_prediction_markets, key=lambda x: x.market_id)
-            )
         return self
 
 
@@ -9420,7 +9379,7 @@ class AdversarialMarketTopologyManifest(CoreasonBaseState):
         return self
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "blue_team_ids", sorted(self.blue_team_ids))
         object.__setattr__(self, "red_team_ids", sorted(self.red_team_ids))
         return self
@@ -9463,7 +9422,7 @@ class ConsensusFederationTopologyManifest(CoreasonBaseState):
         return self
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "participant_ids", sorted(self.participant_ids))
         return self
 
@@ -9548,7 +9507,7 @@ class WorkflowManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         if self.allowed_information_classifications is not None:
             object.__setattr__(
                 self, "allowed_information_classifications", sorted(self.allowed_information_classifications)
@@ -9713,7 +9672,7 @@ class EpistemicQuarantineSnapshot(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self, "theory_of_mind_models", sorted(self.theory_of_mind_models, key=lambda x: x.target_agent_id)
         )
@@ -9826,7 +9785,7 @@ class BeliefMutationEvent(BaseStateEvent):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self, "causal_attributions", sorted(self.causal_attributions, key=lambda x: x.source_event_id)
         )
@@ -10026,7 +9985,7 @@ class EpistemicChainGraphState(CoreasonBaseState):
     semantic_leaves: list[EpistemicAxiomState]
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self,
             "semantic_leaves",
@@ -10055,7 +10014,7 @@ class CognitivePredictionReceipt(BaseStateEvent):
     predicted_top_k_tokens: list[Annotated[str, StringConstraints(max_length=255)]] = Field(min_length=1)
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         if getattr(self, "predicted_top_k_tokens", None) is not None:
             object.__setattr__(self, "predicted_top_k_tokens", sorted(self.predicted_top_k_tokens))
         return self
@@ -10145,7 +10104,7 @@ class EpistemicDomainGraphManifest(CoreasonBaseState):
     verified_axioms: list[EpistemicAxiomState] = Field(min_length=1)
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self,
             "verified_axioms",
@@ -10345,7 +10304,7 @@ class EpistemicCurriculumManifest(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_tasks(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "tasks", sorted(self.tasks, key=lambda task: task.task_id))
         return self
 
@@ -10535,7 +10494,7 @@ class CognitiveRewardEvaluationReceipt(BaseStateEvent):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self,
             "extracted_axioms",
@@ -10793,7 +10752,7 @@ class SpeculativeExecutionBoundary(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "rollback_pointers", sorted(self.rollback_pointers))
         object.__setattr__(self, "competing_hypotheses", sorted(self.competing_hypotheses))
         return self
@@ -10866,19 +10825,13 @@ class EpistemicLedgerState(CoreasonBaseState):
     )
 
     @model_validator(mode="after")
-    def sort_history(self) -> Self:
+    def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "history", sorted(self.history, key=lambda event: event.timestamp))
         object.__setattr__(self, "retracted_nodes", sorted(self.retracted_nodes))
         object.__setattr__(self, "checkpoints", sorted(self.checkpoints, key=lambda x: x.checkpoint_id))
         object.__setattr__(self, "active_rollbacks", sorted(self.active_rollbacks, key=lambda x: x.request_id))
         object.__setattr__(self, "migration_contracts", sorted(self.migration_contracts, key=lambda x: x.contract_id))
         object.__setattr__(self, "active_cascades", sorted(self.active_cascades, key=lambda x: x.cascade_id))
-        return self
-
-    @model_validator(mode="after")
-    def sort_arrays(self) -> Self:
-        if getattr(self, "history", None) is not None:
-            object.__setattr__(self, "history", sorted(self.history, key=lambda x: x.timestamp))
         return self
 
 

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -9238,14 +9238,6 @@ class EvolutionaryTopologyManifest(BaseTopologyManifest):
         )
         return self
 
-    @model_validator(mode="after")
-    def _enforce_canonical_sort(self) -> Self:
-        if getattr(self, "fitness_objectives", None) is not None:
-            object.__setattr__(
-                self, "fitness_objectives", sorted(self.fitness_objectives, key=lambda x: x.target_metric)
-            )
-        return self
-
 
 class SMPCTopologyManifest(BaseTopologyManifest):
     """

--- a/tests/contracts/test_ontology_validators.py
+++ b/tests/contracts/test_ontology_validators.py
@@ -523,7 +523,7 @@ def test_composite_node_profile_sorts_mappings() -> None:
     assert node.output_mappings[1].child_key == "y"
 
 
-def test_action_space_manifest_sort_arrays() -> None:
+def test_action_space_manifest_enforce_canonical_sort() -> None:
     from pydantic import ValidationError
 
     from coreason_manifest.spec.ontology import (
@@ -654,7 +654,7 @@ def test_epistemic_sop_manifest_ghost_nodes() -> None:
         )
 
 
-def test_executionspanreceipt_sort_events() -> None:
+def test_executionspanreceipt_enforce_canonical_sort_events() -> None:
     from coreason_manifest.spec.ontology import ExecutionSpanReceipt, SpanEvent
 
     event1 = SpanEvent(name="event_a", timestamp_unix_nano=1000)


### PR DESCRIPTION
Executed Epic 2: The AST Alignment Mandate (Lexical Standardization) to standardize all sorting mechanisms to a strict, mathematically predictable lexical automaton.

**Tasks Completed:**
1. **Broad Lexical Sweep:** Renamed all generic `def sort_arrays(self) -> Self:` methods to `def _enforce_canonical_sort(self) -> Self:`.
2. **Custom Sorter Normalization:** Renamed specific noun-verb sorting methods to adhere to the `^_enforce_canonical_sort(_[a-z0-9_]+)?$` pattern based on the target execution mapping.
3. **Single-Responsibility Isolation:** Split validators in `ActionSpaceManifest` and `OntologicalSurfaceProjectionManifest` that mixed structural uniqueness checks with canonical sorting into discrete `_enforce_structural_uniqueness` and `_enforce_canonical_sort_*` methods.
4. **AST Compaction:** Merged redundant sorting methods in `AuctionState`, `EpistemicLedgerState`, `DAGTopologyManifest`, `InformationFlowPolicy`, and `SwarmTopologyManifest` to prevent execution ordering bugs and duplicate array sortings.
5. **Test Updates:** Verified the changes and updated the references in `tests/contracts/test_ontology_validators.py` to point to the new, standardized method names. Tested with `uv run pytest`.

---
*PR created automatically by Jules for task [16838148242627432631](https://jules.google.com/task/16838148242627432631) started by @gowthamrao*