### PR TITLE
feat: autonomous recovery substrate with structured fault receipts (#…

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -9495,6 +9495,37 @@
       "title": "MacroGridProfile",
       "type": "object"
     },
+    "ManifestViolationReceipt": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A machine-readable, deterministic JSON receipt of an exact topological failure, replacing unstructured stack traces.\n\nCAUSAL AFFORDANCE: Enables the agent to execute $O(1)$ surgical patches via StateMutationIntent rather than hallucinating fixes.\n\nEPISTEMIC BOUNDS: failing_pointer maps exactly to RFC 6902 JSON Pointers.\n\nMCP ROUTING TRIGGERS: Fault Receipt, RFC 6902, Epistemic Loss Prevention",
+      "properties": {
+        "failing_pointer": {
+          "description": "The exact RFC 6902 JSON pointer isolating the topological failure.",
+          "maxLength": 2000,
+          "title": "Failing Pointer",
+          "type": "string"
+        },
+        "violation_type": {
+          "description": "Categorical descriptor of the failure, e.g., missing, type_error.",
+          "maxLength": 255,
+          "title": "Violation Type",
+          "type": "string"
+        },
+        "diagnostic_message": {
+          "description": "The specific constraint breached.",
+          "maxLength": 2000,
+          "title": "Diagnostic Message",
+          "type": "string"
+        }
+      },
+      "required": [
+        "failing_pointer",
+        "violation_type",
+        "diagnostic_message"
+      ],
+      "title": "ManifestViolationReceipt",
+      "type": "object"
+    },
     "MarketContract": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces Algorithmic Mechanism Design and Proof-of-Stake (PoS) economic collateralization required for an agent to participate in the epistemic market.\n\nCAUSAL AFFORDANCE: Unlocks the ability for the orchestrator to computationally slash Byzantine or hallucinating nodes, ensuring a strict thermodynamic cost to semantic drift.\n\nEPISTEMIC BOUNDS: Physically restricts the mathematical invariant where `slashing_penalty` <= `minimum_collateral` via an `@model_validator`. Downstream agents must secure this collateral before execution. To prevent floating-point consensus vulnerabilities across the distributed ledger, both bounds are strictly enforced as atomic integer magnitudes (`ge=0`).\n\nMCP ROUTING TRIGGERS: Proof-of-Stake, Slashing Condition, Byzantine Fault Tolerance, Economic Escrow",
@@ -13100,29 +13131,20 @@
           "$ref": "#/$defs/NodeIdentifierState",
           "description": "The globally unique decentralized identifier (DID) anchoring the agent that authored the invalid state, ensuring the fault is routed back to the exact state partition."
         },
-        "failing_pointers": {
-          "description": "A strictly typed array of RFC 6902 JSON Pointers isolating the exact topological coordinate of the hallucination.",
+        "violation_receipts": {
+          "description": "The deterministic array of exact structural faults the agent must correct.",
           "items": {
-            "maxLength": 2000,
-            "type": "string"
+            "$ref": "#/$defs/ManifestViolationReceipt"
           },
           "minItems": 1,
-          "title": "Failing Pointers",
+          "title": "Violation Receipts",
           "type": "array"
-        },
-        "remediation_prompt": {
-          "description": "The deterministic, non-monotonic natural-language constraint the agent must satisfy.",
-          "maxLength": 100000,
-          "minLength": 1,
-          "title": "Remediation Prompt",
-          "type": "string"
         }
       },
       "required": [
         "fault_id",
         "target_node_id",
-        "failing_pointers",
-        "remediation_prompt"
+        "violation_receipts"
       ],
       "title": "System2RemediationIntent",
       "type": "object"

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -8079,6 +8079,26 @@ class System1ReflexPolicy(CoreasonBaseState):
         return self
 
 
+class ManifestViolationReceipt(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A machine-readable, deterministic JSON receipt of an exact topological failure, replacing unstructured stack traces.
+
+    CAUSAL AFFORDANCE: Enables the agent to execute $O(1)$ surgical patches via StateMutationIntent rather than hallucinating fixes.
+
+    EPISTEMIC BOUNDS: failing_pointer maps exactly to RFC 6902 JSON Pointers.
+
+    MCP ROUTING TRIGGERS: Fault Receipt, RFC 6902, Epistemic Loss Prevention
+    """
+
+    failing_pointer: str = Field(
+        max_length=2000, description="The exact RFC 6902 JSON pointer isolating the topological failure."
+    )
+    violation_type: str = Field(
+        max_length=255, description="Categorical descriptor of the failure, e.g., missing, type_error."
+    )
+    diagnostic_message: str = Field(max_length=2000, description="The specific constraint breached.")
+
+
 class System2RemediationIntent(CoreasonBaseState):
     """
     AGENT INSTRUCTION: Implements Kahneman's Dual-Process Theory by explicitly triggering a System 2 non-monotonic self-correction loop in response to a structural execution collapse. As an ...Intent suffix, this represents an authorized kinetic execution trigger.
@@ -8099,18 +8119,14 @@ class System2RemediationIntent(CoreasonBaseState):
     target_node_id: NodeIdentifierState = Field(
         description="The globally unique decentralized identifier (DID) anchoring the agent that authored the invalid state, ensuring the fault is routed back to the exact state partition."
     )
-    failing_pointers: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        min_length=1,
-        description="A strictly typed array of RFC 6902 JSON Pointers isolating the exact topological coordinate of the hallucination.",
-    )
-    remediation_prompt: Annotated[str, StringConstraints(max_length=100000)] = Field(
-        min_length=1, description="The deterministic, non-monotonic natural-language constraint the agent must satisfy."
+    violation_receipts: list[ManifestViolationReceipt] = Field(
+        min_length=1, description="The deterministic array of exact structural faults the agent must correct."
     )
 
     @model_validator(mode="after")
-    def _enforce_canonical_sort_failing_pointers(self) -> Self:
-        """Mathematically sort pointers to guarantee deterministic canonical hashing."""
-        object.__setattr__(self, "failing_pointers", sorted(self.failing_pointers))
+    def _enforce_canonical_sort_receipts(self) -> Self:
+        """Mathematically sort receipts to guarantee deterministic canonical hashing."""
+        object.__setattr__(self, "violation_receipts", sorted(self.violation_receipts, key=lambda x: x.failing_pointer))
         return self
 
 
@@ -10974,3 +10990,6 @@ EpistemicLedgerState.model_rebuild()
 PresentationManifest.model_rebuild()
 ObservationEvent.model_rebuild()
 OntologicalHandshakeReceipt.model_rebuild()
+
+ManifestViolationReceipt.model_rebuild()
+System2RemediationIntent.model_rebuild()

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -33,6 +33,7 @@ from coreason_manifest.spec.ontology import (
     EpistemicCompressionSLA,
     EpistemicTransmutationTask,
     ExecutionNodeReceipt,
+    ManifestViolationReceipt,
     OntologicalAlignmentPolicy,
     StateMutationIntent,
     System2RemediationIntent,
@@ -169,30 +170,19 @@ def generate_correction_prompt(error: ValidationError, target_node_id: str, faul
     Pure functional adapter. Maps a raw Pythonic pydantic.ValidationError into a
     language-model-legible System2RemediationIntent without triggering runtime side effects.
     """
-    failing_pointers: list[str] = []
-    error_messages: list[str] = []
+    receipts: list[ManifestViolationReceipt] = []
     for err in error.errors():
         loc_path = "".join(f"/{item!s}" for item in err["loc"]) if err["loc"] else "/"
-        failing_pointers.append(loc_path)
         err_type = err["type"]
+        msg = err.get("msg", "Invalid structural payload.")
         if err_type == "missing":
-            error_messages.append(
-                f"The required semantic boundary at '{loc_path}' is completely missing. You must project this missing dimension to satisfy the StateContract."
-            )
-        else:
-            msg = err.get("msg", "Invalid structural payload.")
-            error_messages.append(f"A structural boundary violation occurred at '{loc_path}': {msg}")
-    failing_pointers = list(set(failing_pointers))
-    remediation_prompt = (
-        "CRITICAL CONTRACT BREACH: Your generated state representation violates the formal ontological boundaries of the Shared Kernel. Review the following strict topological failures and correct your JSON projection:\n"
-        + "\n".join(f"- {msg}" for msg in error_messages)
-    )
-    return System2RemediationIntent(
-        fault_id=fault_id,
-        target_node_id=target_node_id,
-        failing_pointers=failing_pointers,
-        remediation_prompt=remediation_prompt,
-    )
+            msg = f"The required semantic boundary at '{loc_path}' is completely missing. You must project this missing dimension to satisfy the StateContract."
+
+        receipts.append(
+            ManifestViolationReceipt(failing_pointer=loc_path, violation_type=err_type, diagnostic_message=msg)
+        )
+
+    return System2RemediationIntent(fault_id=fault_id, target_node_id=target_node_id, violation_receipts=receipts)
 
 
 def align_semantic_manifolds(
@@ -257,7 +247,7 @@ def calculate_latent_alignment(
     similarity = 0.0 if mag1 == 0 or mag2 == 0 else dot_product / (mag1 * mag2)
 
     if similarity < policy.min_cosine_similarity:
-        raise ValueError("TamperFaultEvent: Latent alignment failed.")
+        raise TamperFaultEvent("Latent alignment failed.")
 
     return similarity
 
@@ -332,6 +322,163 @@ def verify_ast_safety(payload: str) -> bool:
     return True
 
 
+def _resolve_from_path(new_state: Any, from_path: str) -> tuple[Any, Any]:
+    if not isinstance(from_path, str) or not from_path.startswith("/"):
+        raise ValueError(f"Invalid from_path: {from_path}")
+
+    from_parts = [p.replace("~1", "/").replace("~0", "~") for p in from_path.split("/")[1:]]
+    from_target: Any = new_state
+    for part in from_parts[:-1]:
+        if isinstance(from_target, dict):
+            if part not in from_target:
+                raise ValueError(f"Invalid from_path: {from_path}")
+            from_target = from_target[part]
+        elif isinstance(from_target, list):
+            try:
+                idx = int(part)
+                from_target = from_target[idx]
+            except (ValueError, IndexError) as e:
+                raise ValueError(f"Invalid from_path: {from_path}") from e
+        else:
+            raise ValueError(f"Invalid from_path: {from_path}")
+
+    from_last = from_parts[-1]
+    return from_target, from_last
+
+
+def _extract_from_target(t: Any, key: str) -> Any:
+    if isinstance(t, dict):
+        if key not in t:
+            raise ValueError("Key not found")
+        return t[key]
+    if isinstance(t, list):
+        if key == "-":
+            raise ValueError("Cannot extract from end of array")
+        try:
+            idx = int(key)
+            if idx < 0 or idx >= len(t):
+                raise ValueError("Index out of bounds")
+            return t[idx]
+        except ValueError as e:
+            raise ValueError("Invalid index") from e
+    raise ValueError("Target is not dict or list")
+
+
+def _ablate_from_target(t: Any, key: str) -> None:
+    if isinstance(t, dict):
+        if key not in t:
+            raise ValueError("Key not found")
+        del t[key]
+    elif isinstance(t, list):
+        if key == "-":
+            raise ValueError("Cannot remove from end of array")
+        try:
+            idx = int(key)
+            if idx < 0 or idx >= len(t):
+                raise ValueError("Index out of bounds")
+            t.pop(idx)
+        except ValueError as e:
+            raise ValueError("Invalid index") from e
+
+
+def _apply_patch_add(target: Any, last_part: str, value: Any) -> None:
+    if isinstance(target, dict):
+        target[last_part] = value
+    elif isinstance(target, list):
+        if last_part == "-":
+            target.append(value)
+        else:
+            try:
+                idx = int(last_part)
+                if idx < 0 or idx > len(target):
+                    raise ValueError(f"Index out of bounds: {last_part}")
+                target.insert(idx, value)
+            except ValueError as e:
+                raise ValueError(f"Invalid index: {last_part}") from e
+    else:
+        raise ValueError(f"Cannot add to path: {last_part}")
+
+
+def _apply_patch_remove(target: Any, last_part: str) -> None:
+    try:
+        _ablate_from_target(target, last_part)
+    except ValueError as e:
+        raise ValueError(f"Cannot remove from path: {e}") from e
+
+
+def _apply_patch_replace(target: Any, last_part: str, value: Any) -> None:
+    try:
+        _extract_from_target(target, last_part)
+        if isinstance(target, dict):
+            target[last_part] = value
+        elif isinstance(target, list):
+            if last_part == "-":
+                raise ValueError("Cannot replace at end of array")
+            idx = int(last_part)
+            target[idx] = value
+    except ValueError as e:
+        raise ValueError(f"{e}") from e
+
+
+def _apply_patch_copy_move(new_state: Any, target: Any, last_part: str, patch: Any) -> None:
+    from_path = patch.from_path
+    if from_path is None:
+        raise ValueError("from_path is mathematically required for copy/move operations.")
+
+    if patch.path.startswith(from_path + "/"):
+        raise ValueError(f"The 'from' location MUST NOT be a proper prefix of the 'path' location: {patch.path}")
+
+    try:
+        from_target, from_last = _resolve_from_path(new_state, from_path)
+        val = _extract_from_target(from_target, from_last)
+        if patch.op == "move":
+            _ablate_from_target(from_target, from_last)
+        if patch.op == "copy":
+            val = copy.deepcopy(val)
+    except ValueError as e:
+        raise ValueError(f"Invalid from_path operation: {e}") from e
+
+    if isinstance(target, dict):
+        target[last_part] = val
+    elif isinstance(target, list):
+        if last_part == "-":
+            target.append(val)
+        else:
+            try:
+                idx = int(last_part)
+
+                if patch.op == "move" and from_target is target:
+                    try:
+                        from_idx = int(from_last)
+                        if from_idx < int(last_part):
+                            idx -= 1
+                    except ValueError:
+                        pass
+
+                if idx < 0 or idx > len(target):
+                    raise ValueError("Index out of bounds")
+                target.insert(idx, val)
+            except ValueError as e:
+                raise ValueError(f"Invalid index: {last_part}") from e
+    else:
+        raise ValueError("Cannot copy/move to path")
+
+
+def _apply_patch_test(target: Any, last_part: str, value: Any) -> None:
+    try:
+        current_val = _extract_from_target(target, last_part)
+        if current_val != value:
+            raise ValueError("Patch test operation failed.")
+    except ValueError as e:
+        if (
+            "Patch test operation failed" in str(e)
+            or "Index out of bounds" in str(e)
+            or "Cannot extract from end of array" in str(e)
+        ):
+            raise
+        raise ValueError("Patch test operation failed.") from e
+
+
 def apply_state_differential(
     current_state: dict[str, Any], manifest: ontology.StateDifferentialManifest
 ) -> dict[str, Any]:
@@ -374,150 +521,52 @@ def apply_state_differential(
 
         last_part = parts[-1]
 
-        def resolve_from_path(from_path: str) -> tuple[Any, Any]:
-            if not isinstance(from_path, str) or not from_path.startswith("/"):
-                raise ValueError(f"Invalid from_path: {from_path}")
+        patch_value = patch.value
 
-            from_parts = [p.replace("~1", "/").replace("~0", "~") for p in from_path.split("/")[1:]]
-            from_target: Any = new_state
-            for part in from_parts[:-1]:
-                if isinstance(from_target, dict):
-                    if part not in from_target:
-                        raise ValueError(f"Invalid from_path: {from_path}")
-                    from_target = from_target[part]
-                elif isinstance(from_target, list):
-                    try:
-                        idx = int(part)
-                        from_target = from_target[idx]
-                    except (ValueError, IndexError) as e:
-                        raise ValueError(f"Invalid from_path: {from_path}") from e
-                else:
-                    raise ValueError(f"Invalid from_path: {from_path}")
-
-            from_last = from_parts[-1]
-            return from_target, from_last
-
-        def extract_from_target(t: Any, key: str) -> Any:
-            if isinstance(t, dict):
-                if key not in t:
-                    raise ValueError("Key not found")
-                return t[key]
-            if isinstance(t, list):
-                if key == "-":
-                    raise ValueError("Cannot extract from end of array")
-                try:
-                    idx = int(key)
-                    if idx < 0 or idx >= len(t):
-                        raise ValueError("Index out of bounds")
-                    return t[idx]
-                except ValueError as e:
-                    raise ValueError("Invalid index") from e
-            raise ValueError("Target is not dict or list")
-
-        def ablate_from_target(t: Any, key: str) -> None:
-            if isinstance(t, dict):
-                if key not in t:
-                    raise ValueError("Key not found")
-                del t[key]
-            elif isinstance(t, list):
-                if key == "-":
-                    raise ValueError("Cannot remove from end of array")
-                try:
-                    idx = int(key)
-                    if idx < 0 or idx >= len(t):
-                        raise ValueError("Index out of bounds")
-                    t.pop(idx)
-                except ValueError as e:
-                    raise ValueError("Invalid index") from e
-
-        if patch.op == "add":
-            if isinstance(target, dict):
-                target[last_part] = patch.value
-            elif isinstance(target, list):
-                if last_part == "-":
-                    target.append(patch.value)
-                else:
-                    try:
-                        idx = int(last_part)
-                        if idx < 0 or idx > len(target):
-                            raise ValueError(f"Index out of bounds: {path}")
-                        target.insert(idx, patch.value)
-                    except ValueError as e:
-                        raise ValueError(f"Invalid index: {last_part}") from e
+        try:
+            if patch.op == "add":
+                _apply_patch_add(target, last_part, patch_value)
+            elif patch.op == "remove":
+                _apply_patch_remove(target, last_part)
+            elif patch.op == "replace":
+                _apply_patch_replace(target, last_part, patch_value)
+            elif patch.op in ("copy", "move"):
+                _apply_patch_copy_move(new_state, target, last_part, patch)
+            elif patch.op == "test":
+                _apply_patch_test(target, last_part, patch_value)
             else:
-                raise ValueError(f"Cannot add to path: {path}")
-
-        elif patch.op == "remove":
-            try:
-                ablate_from_target(target, last_part)
-            except ValueError as e:
+                raise ValueError(f"Unknown patch op: {patch.op}")
+        except ValueError as e:
+            # We preserve the original exception messaging strategy to not break any possible external test suite reliance on the exact strings in apply_state_differential.
+            if (
+                patch.op in ("remove", "replace")
+                and "Patch test operation failed" not in str(e)
+                and "Index out of bounds" not in str(e)
+                and "Cannot extract from end of array" not in str(e)
+            ):
+                raise ValueError(f"Cannot {patch.op} at path {path}: {e}") from e
+            if patch.op == "remove":
+                # Special case, old code used from path: {e} and from path {path}: {e} for remove/replace.
                 raise ValueError(f"Cannot remove from path {path}: {e}") from e
-
-        elif patch.op == "replace":
-            try:
-                extract_from_target(target, last_part)
-
-                if isinstance(target, dict):
-                    target[last_part] = patch.value
-                elif isinstance(target, list):
-                    if last_part == "-":
-                        raise ValueError("Cannot replace at end of array")
-                    idx = int(last_part)
-                    target[idx] = patch.value
-            except ValueError as e:
+            if patch.op == "replace":
                 raise ValueError(f"Cannot replace at path {path}: {e}") from e
-
-        elif patch.op in ("copy", "move"):
-            from_path = patch.from_path
-            if from_path is None:
-                raise ValueError("from_path is mathematically required for copy/move operations.")
-
-            if path.startswith(from_path + "/"):
-                raise ValueError(f"The 'from' location MUST NOT be a proper prefix of the 'path' location: {path}")
-
-            try:
-                from_target, from_last = resolve_from_path(from_path)
-                val = extract_from_target(from_target, from_last)
-                if patch.op == "move":
-                    ablate_from_target(from_target, from_last)
-                if patch.op == "copy":
-                    val = copy.deepcopy(val)
-            except ValueError as e:
-                raise ValueError(f"Invalid from_path operation: {e}") from e
-
-            if isinstance(target, dict):
-                target[last_part] = val
-            elif isinstance(target, list):
-                if last_part == "-":
-                    target.append(val)
-                else:
-                    try:
-                        idx = int(last_part)
-
-                        if patch.op == "move" and from_target is target:
-                            try:
-                                from_idx = int(from_last)
-                                if from_idx < int(last_part):
-                                    idx -= 1
-                            except ValueError:
-                                pass
-
-                        if idx < 0 or idx > len(target):
-                            raise ValueError(f"Index out of bounds: {path}")
-                        target.insert(idx, val)
-                    except ValueError as e:
-                        raise ValueError(f"Invalid index: {last_part}") from e
-            else:
-                raise ValueError(f"Cannot copy/move to path: {path}")
-
-        elif patch.op == "test":
-            try:
-                current_val = extract_from_target(target, last_part)
-                if current_val != patch.value:
-                    raise ValueError("Patch test operation failed.")
-            except ValueError as e:
-                if "Patch test operation failed" in str(e):
-                    raise
-                raise ValueError("Patch test operation failed.") from e
+            if patch.op in ("copy", "move"):
+                # Exception was: raise ValueError(f"Cannot copy/move to path: {path}") from e or f"Index out of bounds: {path}"
+                msg = str(e)
+                if msg.startswith("Cannot copy/move to path"):
+                    raise ValueError(f"Cannot copy/move to path: {path}") from e
+                    raise ValueError(f"Cannot copy/move to path: {path}") from e
+                if msg.startswith("Index out of bounds"):
+                    raise ValueError(f"Index out of bounds: {path}") from e
+                    raise ValueError(f"Index out of bounds: {path}") from e
+                raise
+            if patch.op == "add":
+                msg = str(e)
+                if msg.startswith("Cannot add to path"):
+                    raise ValueError(f"Cannot add to path: {path}") from e
+                if msg.startswith("Index out of bounds"):
+                    raise ValueError(f"Index out of bounds: {path}") from e
+                raise
+            raise
 
     return new_state

--- a/tests/contracts/test_algebra_coverage.py
+++ b/tests/contracts/test_algebra_coverage.py
@@ -104,7 +104,7 @@ def test_generate_correction_prompt_missing_and_invalid() -> None:
         WorkflowManifest(manifest_version="1.0.0")  # type: ignore[call-arg]
     except ValidationError as e:
         prompt = generate_correction_prompt(e, "did:node:faulty1", "fault1")
-        assert "completely missing" in prompt.remediation_prompt
+        assert any("completely missing" in r.diagnostic_message for r in prompt.violation_receipts)
 
     # Trigger an invalid error
     try:
@@ -117,7 +117,7 @@ def test_generate_correction_prompt_missing_and_invalid() -> None:
         )
     except ValidationError as e:
         prompt = generate_correction_prompt(e, "did:node:faulty1", "fault1")
-        assert "structural boundary violation" in prompt.remediation_prompt
+        assert any("String should match pattern" in r.diagnostic_message for r in prompt.violation_receipts)
 
 
 @given(source=st.lists(st.sampled_from(["text", "raster_image", "vector_graphics"]), min_size=2, unique=True))

--- a/tests/contracts/test_algebra_hypothesis.py
+++ b/tests/contracts/test_algebra_hypothesis.py
@@ -12,6 +12,7 @@ from coreason_manifest.spec.ontology import (
     OntologicalAlignmentPolicy,
     StateDifferentialManifest,
     StateMutationIntent,
+    TamperFaultEvent,
     TokenBurnReceipt,
     VectorEmbeddingState,
 )
@@ -92,8 +93,8 @@ def test_calculate_latent_alignment(vec1_list: list[float], vec2_list: list[floa
             )  # Edge case due to floating point underflow with identical subnormals
             or (math.isclose(actual_similarity, 0.0, abs_tol=1e-5) and abs(expected_similarity) > 0.0)
         )
-    except ValueError as e:
-        if "TamperFaultEvent: Latent alignment failed" in str(e):
+    except (ValueError, TamperFaultEvent) as e:
+        if "TamperFaultEvent: Latent alignment failed" in str(e) or "Latent alignment failed" in str(e):
             pass
         else:
             raise


### PR DESCRIPTION
…1341)

* feat: implement autonomous recovery substrate with structured JSON fault receipts

- Added ManifestViolationReceipt to ontology
- Rewrote System2RemediationIntent to use structured fault receipts
- Hoisted JSON patch operations out of apply_state_differential loop
- Refactored apply_state_differential to use dictionary dispatch
- Mapped pydantic validation errors directly to fault receipts

* fix: correct unused variables, B904 exception raising rules, lambda capturing in patching loop

- Handled loop variables safely in lambdas.
- Removed unused imports and unassigned variables in `PATCH_DISPATCH`.
- Passed tests with 93% coverage and passed `ruff check --fix`.

* fix: sort imports in tests/contracts/test_algebra_hypothesis.py

* format

* Update algebra.py