### PR TITLE
test: Add hypothesis property based testing of state boundary schemas

### DIFF
--- a/tests/fuzzing/test_json_rpc.py
+++ b/tests/fuzzing/test_json_rpc.py
@@ -1,0 +1,138 @@
+import hypothesis.strategies as st
+from hypothesis import given
+from pydantic import ValidationError
+import pytest
+from coreason_manifest.spec.ontology import (
+    BoundedJSONRPCIntent,
+    LatentSchemaInferenceIntent,
+    MarketContract,
+    LatentScratchpadReceipt,
+    ThoughtBranchState,
+    ActionSpaceManifest,
+    ToolManifest,
+    ContinuousMutationPolicy,
+    EpistemicLedgerState,
+    SideEffectProfile,
+    PermissionBoundaryPolicy
+)
+
+# Define a recursive strategy to simulate valid JSON payload topologies
+valid_json_st = st.recursive(
+    st.none() | st.booleans() | st.floats(allow_nan=False, allow_infinity=False) | st.integers() | st.text(max_size=50),
+    lambda children: st.lists(children, max_size=5) | st.dictionaries(st.text(max_size=50), children, max_size=5),
+    max_leaves=10,
+)
+
+@given(params=st.one_of(st.none(), st.dictionaries(st.text(max_size=50), valid_json_st, max_size=5)))
+def test_valid_json_rpc_intent(params):
+    # Prove that payloads under the depth limits are instantiated without error
+    intent = BoundedJSONRPCIntent(jsonrpc="2.0", method="fuzzed_method", params=params, id=1)
+    assert intent.params == params
+
+@given(
+    target_buffer_id=st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128),
+    max_schema_depth=st.integers(min_value=1, max_value=10),
+    max_properties=st.integers(min_value=1, max_value=1000),
+    require_strict_validation=st.booleans()
+)
+def test_latent_schema_inference_intent_valid(target_buffer_id, max_schema_depth, max_properties, require_strict_validation):
+    intent = LatentSchemaInferenceIntent(
+        target_buffer_id=target_buffer_id,
+        max_schema_depth=max_schema_depth,
+        max_properties=max_properties,
+        require_strict_validation=require_strict_validation
+    )
+    assert intent.target_buffer_id == target_buffer_id
+
+@given(
+    minimum_collateral=st.integers(min_value=0, max_value=1000000000),
+    slashing_penalty=st.integers(min_value=0)
+)
+def test_market_contract_bounds(minimum_collateral, slashing_penalty):
+    if slashing_penalty > minimum_collateral:
+        with pytest.raises(ValidationError):
+            MarketContract(minimum_collateral=minimum_collateral, slashing_penalty=slashing_penalty)
+    else:
+        contract = MarketContract(minimum_collateral=minimum_collateral, slashing_penalty=slashing_penalty)
+        assert contract.minimum_collateral == minimum_collateral
+
+
+@given(
+    trace_id=st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128),
+    explored_branch_ids=st.lists(st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128), min_size=1, unique=True),
+    total_latent_tokens=st.integers(min_value=0, max_value=1000000000)
+)
+def test_latent_scratchpad_receipt_referential_integrity(trace_id, explored_branch_ids, total_latent_tokens):
+    explored_branches = [
+        ThoughtBranchState(
+            branch_id=b_id,
+            latent_content_hash="a" * 64,
+            prm_score=0.5
+        ) for b_id in explored_branch_ids
+    ]
+
+    resolution_id = explored_branch_ids[0]
+    discarded_id = explored_branch_ids[-1] if len(explored_branch_ids) > 1 else resolution_id
+
+    receipt = LatentScratchpadReceipt(
+        trace_id=trace_id,
+        explored_branches=explored_branches,
+        resolution_branch_id=resolution_id,
+        discarded_branches=[discarded_id],
+        total_latent_tokens=total_latent_tokens
+    )
+    assert receipt.resolution_branch_id == resolution_id
+
+@given(
+    action_space_id=st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128),
+    tool_names=st.lists(st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128), unique=True, min_size=1, max_size=5)
+)
+def test_action_space_manifest_uniqueness(action_space_id, tool_names):
+    native_tools = [
+        ToolManifest(
+            tool_name=name,
+            input_schema={"type": "object"},
+            description="desc",
+            side_effects=SideEffectProfile(is_idempotent=True, mutates_state=False),
+            permissions=PermissionBoundaryPolicy(network_access=False, file_system_mutation_forbidden=True)
+        ) for name in tool_names
+    ]
+    manifest = ActionSpaceManifest(action_space_id=action_space_id, native_tools=native_tools)
+    assert [t.tool_name for t in manifest.native_tools] == sorted(tool_names)
+
+
+@given(
+    retracted_nodes=st.lists(st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128))
+)
+def test_epistemic_ledger_state_bounds(retracted_nodes):
+    ledger = EpistemicLedgerState(
+        history=[],
+        defeasible_claims={},
+        retracted_nodes=retracted_nodes,
+        checkpoints=[],
+        active_cascades=[],
+        active_rollbacks=[],
+        migration_contracts=[]
+    )
+    assert ledger.retracted_nodes == sorted(retracted_nodes)
+
+@given(
+    mutation_paradigm=st.sampled_from(["append_only", "merge_on_resolve"]),
+    max_uncommitted_edges=st.integers(min_value=1, max_value=1000000000),
+    micro_batch_interval_ms=st.integers(min_value=1, max_value=86400000)
+)
+def test_continuous_mutation_policy_vram_bounds(mutation_paradigm, max_uncommitted_edges, micro_batch_interval_ms):
+    if mutation_paradigm == "append_only" and max_uncommitted_edges > 10000:
+        with pytest.raises(ValidationError):
+            ContinuousMutationPolicy(
+                mutation_paradigm=mutation_paradigm,
+                max_uncommitted_edges=max_uncommitted_edges,
+                micro_batch_interval_ms=micro_batch_interval_ms
+            )
+    else:
+        policy = ContinuousMutationPolicy(
+            mutation_paradigm=mutation_paradigm,
+            max_uncommitted_edges=max_uncommitted_edges,
+            micro_batch_interval_ms=micro_batch_interval_ms
+        )
+        assert policy.mutation_paradigm == mutation_paradigm

--- a/tests/fuzzing/test_json_rpc.py
+++ b/tests/fuzzing/test_json_rpc.py
@@ -24,31 +24,33 @@ valid_json_st = st.recursive(
     max_leaves=10,
 )
 
+
 @given(params=st.one_of(st.none(), st.dictionaries(st.text(max_size=50), valid_json_st, max_size=5)))
 def test_valid_json_rpc_intent(params):
     # Prove that payloads under the depth limits are instantiated without error
     intent = BoundedJSONRPCIntent(jsonrpc="2.0", method="fuzzed_method", params=params, id=1)
     assert intent.params == params
 
+
 @given(
     target_buffer_id=st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128),
     max_schema_depth=st.integers(min_value=1, max_value=10),
     max_properties=st.integers(min_value=1, max_value=1000),
-    require_strict_validation=st.booleans()
+    require_strict_validation=st.booleans(),
 )
-def test_latent_schema_inference_intent_valid(target_buffer_id, max_schema_depth, max_properties, require_strict_validation):
+def test_latent_schema_inference_intent_valid(
+    target_buffer_id, max_schema_depth, max_properties, require_strict_validation
+):
     intent = LatentSchemaInferenceIntent(
         target_buffer_id=target_buffer_id,
         max_schema_depth=max_schema_depth,
         max_properties=max_properties,
-        require_strict_validation=require_strict_validation
+        require_strict_validation=require_strict_validation,
     )
     assert intent.target_buffer_id == target_buffer_id
 
-@given(
-    minimum_collateral=st.integers(min_value=0, max_value=1000000000),
-    slashing_penalty=st.integers(min_value=0)
-)
+
+@given(minimum_collateral=st.integers(min_value=0, max_value=1000000000), slashing_penalty=st.integers(min_value=0))
 def test_market_contract_bounds(minimum_collateral, slashing_penalty):
     if slashing_penalty > minimum_collateral:
         with pytest.raises(ValidationError):
@@ -60,16 +62,16 @@ def test_market_contract_bounds(minimum_collateral, slashing_penalty):
 
 @given(
     trace_id=st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128),
-    explored_branch_ids=st.lists(st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128), min_size=1, unique=True),
-    total_latent_tokens=st.integers(min_value=0, max_value=1000000000)
+    explored_branch_ids=st.lists(
+        st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128),
+        min_size=1,
+        unique=True,
+    ),
+    total_latent_tokens=st.integers(min_value=0, max_value=1000000000),
 )
 def test_latent_scratchpad_receipt_referential_integrity(trace_id, explored_branch_ids, total_latent_tokens):
     explored_branches = [
-        ThoughtBranchState(
-            branch_id=b_id,
-            latent_content_hash="a" * 64,
-            prm_score=0.5
-        ) for b_id in explored_branch_ids
+        ThoughtBranchState(branch_id=b_id, latent_content_hash="a" * 64, prm_score=0.5) for b_id in explored_branch_ids
     ]
 
     resolution_id = explored_branch_ids[0]
@@ -80,13 +82,19 @@ def test_latent_scratchpad_receipt_referential_integrity(trace_id, explored_bran
         explored_branches=explored_branches,
         resolution_branch_id=resolution_id,
         discarded_branches=[discarded_id],
-        total_latent_tokens=total_latent_tokens
+        total_latent_tokens=total_latent_tokens,
     )
     assert receipt.resolution_branch_id == resolution_id
 
+
 @given(
     action_space_id=st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128),
-    tool_names=st.lists(st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128), unique=True, min_size=1, max_size=5)
+    tool_names=st.lists(
+        st.from_regex("^[a-zA-Z0-9_.:-]+$", fullmatch=True).filter(lambda x: 1 <= len(x) <= 128),
+        unique=True,
+        min_size=1,
+        max_size=5,
+    ),
 )
 def test_action_space_manifest_uniqueness(action_space_id, tool_names):
     native_tools = [
@@ -95,8 +103,9 @@ def test_action_space_manifest_uniqueness(action_space_id, tool_names):
             input_schema={"type": "object"},
             description="desc",
             side_effects=SideEffectProfile(is_idempotent=True, mutates_state=False),
-            permissions=PermissionBoundaryPolicy(network_access=False, file_system_mutation_forbidden=True)
-        ) for name in tool_names
+            permissions=PermissionBoundaryPolicy(network_access=False, file_system_mutation_forbidden=True),
+        )
+        for name in tool_names
     ]
     manifest = ActionSpaceManifest(action_space_id=action_space_id, native_tools=native_tools)
     assert [t.tool_name for t in manifest.native_tools] == sorted(tool_names)
@@ -113,14 +122,15 @@ def test_epistemic_ledger_state_bounds(retracted_nodes):
         checkpoints=[],
         active_cascades=[],
         active_rollbacks=[],
-        migration_contracts=[]
+        migration_contracts=[],
     )
     assert ledger.retracted_nodes == sorted(retracted_nodes)
+
 
 @given(
     mutation_paradigm=st.sampled_from(["append_only", "merge_on_resolve"]),
     max_uncommitted_edges=st.integers(min_value=1, max_value=1000000000),
-    micro_batch_interval_ms=st.integers(min_value=1, max_value=86400000)
+    micro_batch_interval_ms=st.integers(min_value=1, max_value=86400000),
 )
 def test_continuous_mutation_policy_vram_bounds(mutation_paradigm, max_uncommitted_edges, micro_batch_interval_ms):
     if mutation_paradigm == "append_only" and max_uncommitted_edges > 10000:
@@ -128,12 +138,12 @@ def test_continuous_mutation_policy_vram_bounds(mutation_paradigm, max_uncommitt
             ContinuousMutationPolicy(
                 mutation_paradigm=mutation_paradigm,
                 max_uncommitted_edges=max_uncommitted_edges,
-                micro_batch_interval_ms=micro_batch_interval_ms
+                micro_batch_interval_ms=micro_batch_interval_ms,
             )
     else:
         policy = ContinuousMutationPolicy(
             mutation_paradigm=mutation_paradigm,
             max_uncommitted_edges=max_uncommitted_edges,
-            micro_batch_interval_ms=micro_batch_interval_ms
+            micro_batch_interval_ms=micro_batch_interval_ms,
         )
         assert policy.mutation_paradigm == mutation_paradigm

--- a/tests/fuzzing/test_json_rpc.py
+++ b/tests/fuzzing/test_json_rpc.py
@@ -1,19 +1,20 @@
 import hypothesis.strategies as st
+import pytest
 from hypothesis import given
 from pydantic import ValidationError
-import pytest
+
 from coreason_manifest.spec.ontology import (
-    BoundedJSONRPCIntent,
-    LatentSchemaInferenceIntent,
-    MarketContract,
-    LatentScratchpadReceipt,
-    ThoughtBranchState,
     ActionSpaceManifest,
-    ToolManifest,
+    BoundedJSONRPCIntent,
     ContinuousMutationPolicy,
     EpistemicLedgerState,
+    LatentSchemaInferenceIntent,
+    LatentScratchpadReceipt,
+    MarketContract,
+    PermissionBoundaryPolicy,
     SideEffectProfile,
-    PermissionBoundaryPolicy
+    ThoughtBranchState,
+    ToolManifest,
 )
 
 # Define a recursive strategy to simulate valid JSON payload topologies


### PR DESCRIPTION
This commit adds property based testing of state boundary schemas `BoundedJSONRPCIntent`, `LatentSchemaInferenceIntent`, `MarketContract`, `LatentScratchpadReceipt`, `ActionSpaceManifest`, `EpistemicLedgerState`, and `ContinuousMutationPolicy` using Hypothesis testing strategies. This helps improve the robustness of code structure constraint checking tests without hardcoding edge case bounds.

---
*PR created automatically by Jules for task [13098704978753394367](https://jules.google.com/task/13098704978753394367) started by @gowthamrao*