### PR TITLE
feat: Intent Elicitation Airlock Macro-Topology (#1387)

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1327,6 +1327,7 @@
           "evaluator_optimizer": "#/$defs/EvaluatorOptimizerTopologyManifest",
           "evolutionary": "#/$defs/EvolutionaryTopologyManifest",
           "macro_adversarial": "#/$defs/AdversarialMarketTopologyManifest",
+          "macro_elicitation": "#/$defs/IntentElicitationTopologyManifest",
           "macro_federation": "#/$defs/ConsensusFederationTopologyManifest",
           "macro_forge": "#/$defs/CapabilityForgeTopologyManifest",
           "smpc": "#/$defs/SMPCTopologyManifest",
@@ -1364,6 +1365,9 @@
         },
         {
           "$ref": "#/$defs/CapabilityForgeTopologyManifest"
+        },
+        {
+          "$ref": "#/$defs/IntentElicitationTopologyManifest"
         }
       ]
     },
@@ -9421,6 +9425,153 @@
         "confidence_score"
       ],
       "title": "IntentClassificationReceipt",
+      "type": "object"
+    },
+    "IntentElicitationTopologyManifest": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Zero-Cost Macro-Topology that translates unstructured, high-entropy human multimodal input into a mathematically verified, zero-entropy HumanDirectiveIntent.\n\nCAUSAL AFFORDANCE: Unrolls a cyclic Directed Graph that orchestrates Multimodal Transmutation, Metacognitive Scanning (Shannon Entropy measurement), and Schema-on-Write Drafting (Human Interrogation) before yielding to the Agentic Forge.\n\nEPISTEMIC BOUNDS: The max_clarification_loops physical Halting Problem guillotine is mathematically clamped between 1 and 50 to prevent infinite clarification loops.\n\nMCP ROUTING TRIGGERS: Intent Elicitation, Zero-Entropy Distillation, Cyclical Routing, Human Interrogation, Multimodal Transmutation",
+      "properties": {
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
+        "architectural_intent": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The AI's declarative rationale for selecting this topology.",
+          "title": "Architectural Intent"
+        },
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this topology's configuration.",
+          "title": "Justification"
+        },
+        "nodes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AnyNodeProfile"
+          },
+          "description": "Flat registry of all nodes in this topology.",
+          "propertyNames": {
+            "$ref": "#/$defs/NodeIdentifierState"
+          },
+          "title": "Nodes",
+          "type": "object"
+        },
+        "shared_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The schema-on-write contract governing the internal state of this topology."
+        },
+        "information_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
+        "type": {
+          "const": "macro_elicitation",
+          "default": "macro_elicitation",
+          "description": "Discriminator for the elicitation macro.",
+          "title": "Type",
+          "type": "string"
+        },
+        "raw_human_artifact_id": {
+          "description": "The anchor to the initial, unstructured MultimodalArtifactReceipt uploaded by the human.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Raw Human Artifact Id",
+          "type": "string"
+        },
+        "transmuter_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The system node responsible for executing the EpistemicTransmutationTask."
+        },
+        "scanner_node_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The agent node actively running the EpistemicScanningPolicy."
+        },
+        "human_oracle_id": {
+          "$ref": "#/$defs/NodeIdentifierState",
+          "description": "The human UI node receiving the DraftingIntent."
+        },
+        "max_clarification_loops": {
+          "default": 5,
+          "description": "A physical Halting Problem guillotine preventing infinite clarification loops.",
+          "maximum": 50,
+          "minimum": 1,
+          "title": "Max Clarification Loops",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "nodes",
+        "raw_human_artifact_id",
+        "transmuter_node_id",
+        "scanner_node_id",
+        "human_oracle_id"
+      ],
+      "title": "IntentElicitationTopologyManifest",
       "type": "object"
     },
     "InterventionIntent": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -10713,6 +10713,66 @@ class CapabilityForgeTopologyManifest(BaseTopologyManifest):
         )
 
 
+class IntentElicitationTopologyManifest(BaseTopologyManifest):
+    """
+    AGENT INSTRUCTION: Zero-Cost Macro-Topology that translates unstructured, high-entropy human multimodal input into a mathematically verified, zero-entropy HumanDirectiveIntent.
+
+    CAUSAL AFFORDANCE: Unrolls a cyclic Directed Graph that orchestrates Multimodal Transmutation, Metacognitive Scanning (Shannon Entropy measurement), and Schema-on-Write Drafting (Human Interrogation) before yielding to the Agentic Forge.
+
+    EPISTEMIC BOUNDS: The max_clarification_loops physical Halting Problem guillotine is mathematically clamped between 1 and 50 to prevent infinite clarification loops.
+
+    MCP ROUTING TRIGGERS: Intent Elicitation, Zero-Entropy Distillation, Cyclical Routing, Human Interrogation, Multimodal Transmutation
+    """
+
+    type: Literal["macro_elicitation"] = Field(
+        default="macro_elicitation", description="Discriminator for the elicitation macro."
+    )
+    raw_human_artifact_id: Annotated[
+        str, StringConstraints(pattern="^[a-zA-Z0-9_.:-]+$", min_length=1, max_length=128)
+    ] = Field(description="The anchor to the initial, unstructured MultimodalArtifactReceipt uploaded by the human.")
+    transmuter_node_id: NodeIdentifierState = Field(
+        description="The system node responsible for executing the EpistemicTransmutationTask."
+    )
+    scanner_node_id: NodeIdentifierState = Field(
+        description="The agent node actively running the EpistemicScanningPolicy."
+    )
+    human_oracle_id: NodeIdentifierState = Field(description="The human UI node receiving the DraftingIntent.")
+    max_clarification_loops: int = Field(
+        default=5,
+        ge=1,
+        le=50,
+        description="A physical Halting Problem guillotine preventing infinite clarification loops.",
+    )
+
+    def compile_to_base_topology(self) -> DAGTopologyManifest:
+        """Deterministically unwraps the macro into a cyclic DAGTopologyManifest."""
+        nodes: dict[NodeIdentifierState, AnyNodeProfile] = {
+            self.transmuter_node_id: SystemNodeProfile(description="Multimodal Transmuter"),
+            self.scanner_node_id: AgentNodeProfile(
+                description="Metacognitive Entropy Scanner",
+                epistemic_policy=EpistemicScanningPolicy(
+                    active=True, dissonance_threshold=0.1, action_on_gap="clarify"
+                ),
+            ),
+            self.human_oracle_id: HumanNodeProfile(
+                description="Elicitation Oracle", required_attestation="fido2_webauthn"
+            ),
+        }
+        edges = [
+            (self.transmuter_node_id, self.scanner_node_id),
+            (self.scanner_node_id, self.human_oracle_id),
+            (self.human_oracle_id, self.scanner_node_id),
+        ]
+
+        return DAGTopologyManifest(
+            nodes=nodes,
+            edges=edges,
+            allow_cycles=True,
+            max_depth=50,
+            max_fan_out=10,
+        )
+
+
 type AnyTopologyManifest = Annotated[
     DAGTopologyManifest
     | CouncilTopologyManifest
@@ -10723,7 +10783,8 @@ type AnyTopologyManifest = Annotated[
     | DigitalTwinTopologyManifest
     | AdversarialMarketTopologyManifest
     | ConsensusFederationTopologyManifest
-    | CapabilityForgeTopologyManifest,
+    | CapabilityForgeTopologyManifest
+    | IntentElicitationTopologyManifest,
     Field(discriminator="type", description="A discriminated union of workflow topologies."),
 ]
 
@@ -12190,6 +12251,7 @@ DigitalTwinTopologyManifest.model_rebuild()
 AdversarialMarketTopologyManifest.model_rebuild()
 ConsensusFederationTopologyManifest.model_rebuild()
 CapabilityForgeTopologyManifest.model_rebuild()
+IntentElicitationTopologyManifest.model_rebuild()
 EpistemicSOPManifest.model_rebuild()
 DelegatedCapabilityManifest.model_rebuild()
 TokenBurnReceipt.model_rebuild()

--- a/tests/test_oracle_interfaces.py
+++ b/tests/test_oracle_interfaces.py
@@ -2,9 +2,11 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import (
+    AgentNodeProfile,
     CapabilityForgeTopologyManifest,
     HumanDirectiveIntent,
     HumanNodeProfile,
+    IntentElicitationTopologyManifest,
     SemanticDiscoveryIntent,
     VectorEmbeddingState,
 )
@@ -70,3 +72,27 @@ def test_capability_forge_topology_manifest_with_human_supervisor() -> None:
     assert isinstance(human_node, HumanNodeProfile)
     assert human_node.description == "Forge HITL Supervisor"
     assert human_node.required_attestation == "fido2_webauthn"
+
+
+def test_intent_elicitation_macro_compilation() -> None:
+    manifest = IntentElicitationTopologyManifest(
+        raw_human_artifact_id="test_artifact_1",
+        transmuter_node_id="did:coreason:sys-transmuter",
+        scanner_node_id="did:coreason:agent-scanner",
+        human_oracle_id="did:coreason:human-oracle",
+        nodes={},
+    )
+    dag = manifest.compile_to_base_topology()
+
+    assert len(dag.nodes) == 3
+    assert len(dag.edges) == 3
+    assert ("did:coreason:sys-transmuter", "did:coreason:agent-scanner") in dag.edges
+    assert ("did:coreason:agent-scanner", "did:coreason:human-oracle") in dag.edges
+    assert ("did:coreason:human-oracle", "did:coreason:agent-scanner") in dag.edges
+
+    assert dag.allow_cycles is True
+
+    scanner_node = dag.nodes["did:coreason:agent-scanner"]
+    assert isinstance(scanner_node, AgentNodeProfile)
+    assert scanner_node.epistemic_policy is not None
+    assert scanner_node.epistemic_policy.action_on_gap == "clarify"


### PR DESCRIPTION
* feat: Implement Intent Elicitation Airlock macro-topology

- Added `IntentElicitationTopologyManifest` to model the cyclic clarification loop
- Handled deterministic macro unrolling to `DAGTopologyManifest` with `allow_cycles=True`
- Updated global registry `AnyTopologyManifest` and added model rebuild
- Included test suite validation in `tests/test_oracle_interfaces.py` for cyclic edge and policy constraints
- Removed temporary scratch files from testing