### PR TITLE
Bug 12 - Fix XSS filter bypass in InsightCardProfile

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import ast
 import hashlib
+import html
 import ipaddress
 import json
 import math
@@ -5826,7 +5827,8 @@ class InsightCardProfile(CoreasonBaseState):
     @classmethod
     def _prevent_malicious_uri_schemes(cls, v: str) -> str:
         """AGENT INSTRUCTION: Statically sever XSS vectors embedded in markdown links."""
-        if re.search("\\]\\(\\s*(javascript|vbscript|data):", v, flags=re.IGNORECASE):
+        v_unescaped = html.unescape(v)
+        if re.search("\\]\\(\\s*(javascript|vbscript|data):", v_unescaped, flags=re.IGNORECASE):
             raise ValueError("Malicious executable link scheme detected in markdown content")
         return v
 

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -62,7 +62,13 @@ def test_browser_dom_ssrf_quarantine(url: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "payload", ["<script>alert(1)</script>", "<img src='x' onerror='alert(1)'>", "[click me](javascript:alert(1))"]
+    "payload",
+    [
+        "<script>alert(1)</script>",
+        "<img src='x' onerror='alert(1)'>",
+        "[click me](javascript:alert(1))",
+        "[Click Here](javascript&#58;alert('XSS'))",
+    ],
 )
 def test_polymorphic_xss_proof(payload: str) -> None:
     """Prove InsightCardProfile definitively rejects malicious Markdown tags and schemas."""


### PR DESCRIPTION
Fixes an XSS filter bypass vulnerability in `InsightCardProfile` by unescaping HTML entities before performing the security check on `markdown_content`. Also adds a test case to ensure the payload is correctly rejected.

---
*PR created automatically by Jules for task [5812062276833559422](https://jules.google.com/task/5812062276833559422) started by @gowthamrao*