### PR TITLE
Bug 6: Fix fail-open AST sandbox vulnerability

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -859,8 +859,8 @@ class DynamicLayoutManifest(CoreasonBaseState):
         """
         try:
             tree = ast.parse(v, mode="exec")
-        except SyntaxError:
-            pass
+        except SyntaxError as e:
+            raise ValueError(f"Security Validation Failed: Invalid syntax in dynamic string: {e}")
         else:
             allowed_nodes = (ast.Module, ast.Expr, ast.Constant, ast.Name, ast.Load, ast.FormattedValue, ast.JoinedStr)
             for node in ast.walk(tree):

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -860,7 +860,7 @@ class DynamicLayoutManifest(CoreasonBaseState):
         try:
             tree = ast.parse(v, mode="exec")
         except SyntaxError as e:
-            raise ValueError(f"Security Validation Failed: Invalid syntax in dynamic string: {e}")
+            raise ValueError(f"Security Validation Failed: Invalid syntax in dynamic string: {e}") from e
         else:
             allowed_nodes = (ast.Module, ast.Expr, ast.Constant, ast.Name, ast.Load, ast.FormattedValue, ast.JoinedStr)
             for node in ast.walk(tree):

--- a/tests/contracts/test_ontology_validators.py
+++ b/tests/contracts/test_ontology_validators.py
@@ -214,9 +214,9 @@ def test_dynamic_layout_manifest_valid_ast(tstring: str) -> None:
 
 
 def test_dynamic_layout_manifest_syntax_error() -> None:
-    # A SyntaxError in parsing is silently ignored because it poses no execution bleed risk.
-    manifest = DynamicLayoutManifest(layout_tstring="f'{a")
-    assert manifest.layout_tstring == "f'{a"
+    # A SyntaxError in parsing must not be ignored to prevent fail-open security bypass.
+    with pytest.raises(ValidationError, match="Invalid syntax in dynamic string"):
+        DynamicLayoutManifest(layout_tstring="f'{a")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fixes a fail-open security vulnerability where `SyntaxError`s during AST parsing of dynamic layout strings allowed malicious code to bypass the validation pipeline. Replaced the `pass` statement with an explicit `ValueError` mapping to fail-closed architecture.

---
*PR created automatically by Jules for task [415427106875180477](https://jules.google.com/task/415427106875180477) started by @gowthamrao*