### PR TITLE
Bug 13: Fix Pre-Validation TypeError Crash in RoutingFrontierPolicy

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1282,15 +1282,31 @@ class RoutingFrontierPolicy(CoreasonBaseState):
     def _clamp_frontier_bounds_before(cls, values: Any) -> Any:
         if isinstance(values, dict):
             if "max_latency_ms" in values:
-                values["max_latency_ms"] = max(1, min(values["max_latency_ms"], 86400000))
+                try:
+                    val = int(values["max_latency_ms"])
+                    values["max_latency_ms"] = max(1, min(val, 86400000))
+                except (ValueError, TypeError):
+                    pass
             if "max_cost_magnitude_per_token" in values:
-                values["max_cost_magnitude_per_token"] = max(1, min(values["max_cost_magnitude_per_token"], 1000000000))
+                try:
+                    val = int(values["max_cost_magnitude_per_token"])
+                    values["max_cost_magnitude_per_token"] = max(1, min(val, 1000000000))
+                except (ValueError, TypeError):
+                    pass
             if "min_capability_score" in values:
-                values["min_capability_score"] = max(0.0, min(values["min_capability_score"], 1.0))
+                try:
+                    val = float(values["min_capability_score"])
+                    values["min_capability_score"] = max(0.0, min(val, 1.0))
+                except (ValueError, TypeError):
+                    pass
             if values.get("max_carbon_intensity_gco2eq_kwh") is not None:
-                values["max_carbon_intensity_gco2eq_kwh"] = max(
-                    0.0, min(values["max_carbon_intensity_gco2eq_kwh"], 10000.0)
-                )
+                try:
+                    val = float(values["max_carbon_intensity_gco2eq_kwh"])
+                    values["max_carbon_intensity_gco2eq_kwh"] = max(
+                        0.0, min(val, 10000.0)
+                    )
+                except (ValueError, TypeError):
+                    pass
         return values
 
 
@@ -6873,7 +6889,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1285,27 +1285,25 @@ class RoutingFrontierPolicy(CoreasonBaseState):
                 try:
                     val = int(values["max_latency_ms"])
                     values["max_latency_ms"] = max(1, min(val, 86400000))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if "max_cost_magnitude_per_token" in values:
                 try:
                     val = int(values["max_cost_magnitude_per_token"])
                     values["max_cost_magnitude_per_token"] = max(1, min(val, 1000000000))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if "min_capability_score" in values:
                 try:
                     val = float(values["min_capability_score"])
                     values["min_capability_score"] = max(0.0, min(val, 1.0))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if values.get("max_carbon_intensity_gco2eq_kwh") is not None:
                 try:
                     val = float(values["max_carbon_intensity_gco2eq_kwh"])
-                    values["max_carbon_intensity_gco2eq_kwh"] = max(
-                        0.0, min(val, 10000.0)
-                    )
-                except (ValueError, TypeError):
+                    values["max_carbon_intensity_gco2eq_kwh"] = max(0.0, min(val, 10000.0))
+                except ValueError, TypeError:
                     pass
         return values
 
@@ -6889,7 +6887,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1284,26 +1284,26 @@ class RoutingFrontierPolicy(CoreasonBaseState):
             if "max_latency_ms" in values:
                 try:
                     val = int(values["max_latency_ms"])
-                    values["max_latency_ms"] = max(1, min(val, 86400000))
-                except ValueError, TypeError:
+                    values["max_latency_ms"] = int(max(1, min(val, 86400000)))
+                except (ValueError, TypeError):
                     pass
             if "max_cost_magnitude_per_token" in values:
                 try:
                     val = int(values["max_cost_magnitude_per_token"])
-                    values["max_cost_magnitude_per_token"] = max(1, min(val, 1000000000))
-                except ValueError, TypeError:
+                    values["max_cost_magnitude_per_token"] = int(max(1, min(val, 1000000000)))
+                except (ValueError, TypeError):
                     pass
             if "min_capability_score" in values:
                 try:
-                    val = float(values["min_capability_score"])
-                    values["min_capability_score"] = max(0.0, min(val, 1.0))
-                except ValueError, TypeError:
+                    val_float = float(values["min_capability_score"])
+                    values["min_capability_score"] = float(max(0.0, min(val_float, 1.0)))
+                except (ValueError, TypeError):
                     pass
             if values.get("max_carbon_intensity_gco2eq_kwh") is not None:
                 try:
-                    val = float(values["max_carbon_intensity_gco2eq_kwh"])
-                    values["max_carbon_intensity_gco2eq_kwh"] = max(0.0, min(val, 10000.0))
-                except ValueError, TypeError:
+                    val_float = float(values["max_carbon_intensity_gco2eq_kwh"])
+                    values["max_carbon_intensity_gco2eq_kwh"] = float(max(0.0, min(val_float, 10000.0)))
+                except (ValueError, TypeError):
                     pass
         return values
 
@@ -6887,7 +6887,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1285,25 +1285,25 @@ class RoutingFrontierPolicy(CoreasonBaseState):
                 try:
                     val = int(values["max_latency_ms"])
                     values["max_latency_ms"] = int(max(1, min(val, 86400000)))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             if "max_cost_magnitude_per_token" in values:
                 try:
                     val = int(values["max_cost_magnitude_per_token"])
                     values["max_cost_magnitude_per_token"] = int(max(1, min(val, 1000000000)))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             if "min_capability_score" in values:
                 try:
                     val_float = float(values["min_capability_score"])
                     values["min_capability_score"] = float(max(0.0, min(val_float, 1.0)))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             if values.get("max_carbon_intensity_gco2eq_kwh") is not None:
                 try:
                     val_float = float(values["max_carbon_intensity_gco2eq_kwh"])
                     values["max_carbon_intensity_gco2eq_kwh"] = float(max(0.0, min(val_float, 10000.0)))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
         return values
 
@@ -6887,7 +6887,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1285,25 +1285,25 @@ class RoutingFrontierPolicy(CoreasonBaseState):
                 try:
                     val = int(values["max_latency_ms"])
                     values["max_latency_ms"] = int(max(1, min(val, 86400000)))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if "max_cost_magnitude_per_token" in values:
                 try:
                     val = int(values["max_cost_magnitude_per_token"])
                     values["max_cost_magnitude_per_token"] = int(max(1, min(val, 1000000000)))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if "min_capability_score" in values:
                 try:
                     val_float = float(values["min_capability_score"])
                     values["min_capability_score"] = float(max(0.0, min(val_float, 1.0)))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if values.get("max_carbon_intensity_gco2eq_kwh") is not None:
                 try:
                     val_float = float(values["max_carbon_intensity_gco2eq_kwh"])
                     values["max_carbon_intensity_gco2eq_kwh"] = float(max(0.0, min(val_float, 10000.0)))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
         return values
 
@@ -6887,7 +6887,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:

--- a/tests/fuzzing/test_economics.py
+++ b/tests/fuzzing/test_economics.py
@@ -108,16 +108,16 @@ def test_escrow_policy(escrow: int) -> None:
 
 
 def test_routing_frontier_policy_invalid_types() -> None:
+    import pytest
+    from pydantic import ValidationError
+
     # Test that invalid types pass through pre-validation without a crash,
     # and fail Pydantic's core validation safely instead of a 500 error.
-    try:
+    with pytest.raises(ValidationError, match=r"(?i)validation error"):
         RoutingFrontierPolicy(
             max_latency_ms="invalid",
-            max_cost_magnitude_per_token="invalid",
+            max_cost_magnitude_per_token="invalid",  # noqa: S106
             min_capability_score="invalid",
             tradeoff_preference="balanced",
             max_carbon_intensity_gco2eq_kwh="invalid",
         )
-    except Exception as e:
-        # Pydantic's core validation error will be raised
-        assert "validation error" in str(e).lower()

--- a/tests/fuzzing/test_economics.py
+++ b/tests/fuzzing/test_economics.py
@@ -115,9 +115,9 @@ def test_routing_frontier_policy_invalid_types() -> None:
     # and fail Pydantic's core validation safely instead of a 500 error.
     with pytest.raises(ValidationError, match=r"(?i)validation error"):
         RoutingFrontierPolicy(
-            max_latency_ms="invalid",
-            max_cost_magnitude_per_token="invalid",  # noqa: S106
-            min_capability_score="invalid",
+            max_latency_ms="invalid",  # type: ignore[arg-type]
+            max_cost_magnitude_per_token="invalid",  # type: ignore[arg-type]  # noqa: S106
+            min_capability_score="invalid",  # type: ignore[arg-type]
             tradeoff_preference="balanced",
-            max_carbon_intensity_gco2eq_kwh="invalid",
+            max_carbon_intensity_gco2eq_kwh="invalid",  # type: ignore[arg-type]
         )

--- a/tests/fuzzing/test_economics.py
+++ b/tests/fuzzing/test_economics.py
@@ -121,3 +121,13 @@ def test_routing_frontier_policy_invalid_types() -> None:
             tradeoff_preference="balanced",
             max_carbon_intensity_gco2eq_kwh="invalid",  # type: ignore[arg-type]
         )
+
+    # Test TypeError fallback
+    with pytest.raises(ValidationError, match=r"(?i)validation error"):
+        RoutingFrontierPolicy(
+            max_latency_ms=None,  # type: ignore[arg-type]
+            max_cost_magnitude_per_token=None,  # type: ignore[arg-type]
+            min_capability_score=None,  # type: ignore[arg-type]
+            tradeoff_preference="balanced",
+            max_carbon_intensity_gco2eq_kwh=None,
+        )

--- a/tests/fuzzing/test_economics.py
+++ b/tests/fuzzing/test_economics.py
@@ -105,3 +105,19 @@ def test_routing_frontier_policy(lat: int, cost: int, carbon: float) -> None:
 def test_escrow_policy(escrow: int) -> None:
     ep = EscrowPolicy(escrow_locked_magnitude=escrow, release_condition_metric="rc1", refund_target_node_id="n1")
     assert 0 <= ep.escrow_locked_magnitude <= 1000000000
+
+
+def test_routing_frontier_policy_invalid_types() -> None:
+    # Test that invalid types pass through pre-validation without a crash,
+    # and fail Pydantic's core validation safely instead of a 500 error.
+    try:
+        RoutingFrontierPolicy(
+            max_latency_ms="invalid",
+            max_cost_magnitude_per_token="invalid",
+            min_capability_score="invalid",
+            tradeoff_preference="balanced",
+            max_carbon_intensity_gco2eq_kwh="invalid",
+        )
+    except Exception as e:
+        # Pydantic's core validation error will be raised
+        assert "validation error" in str(e).lower()


### PR DESCRIPTION
Fixed the fatal TypeError crash when running `min`/`max` bounds pre-validation logic on uncoerced string payloads in `RoutingFrontierPolicy`. Safely casts and catches parse errors so standard Pydantic 422 validations can surface correctly.

---
*PR created automatically by Jules for task [11924942835959757864](https://jules.google.com/task/11924942835959757864) started by @gowthamrao*