### PR TITLE
Bug 4 and 12 - fix(ontology): enforce bounded payload limits to prevent OOM vulnerabilities

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -68,6 +68,7 @@
             "$ref": "#/$defs/AnyActionSpaceCapability"
           },
           "description": "The State Space (S) of the MDP, indexed by their unique capability CIDs.",
+          "maxProperties": 500,
           "propertyNames": {
             "maxLength": 255
           },
@@ -82,6 +83,7 @@
             "type": "array"
           },
           "description": "The Stochastic Transition Matrix (P).",
+          "maxProperties": 500,
           "propertyNames": {
             "maxLength": 255
           },
@@ -2245,7 +2247,7 @@
             "maxLength": 2000,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Allowed Fields",
           "type": "array"
         },
@@ -2351,7 +2353,7 @@
         },
         "viewport_size": {
           "description": "Capability Perimeters detailing bounding coordinates.",
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "minItems": 2,
           "prefixItems": [
             {
@@ -3225,7 +3227,7 @@
     },
     "CognitiveRoutingContract": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Overrides the default Softmax gating mechanism of a Sparse Mixture of Experts (MoE) architecture to enforce deterministic functional isolation.\n\nCAUSAL AFFORDANCE: Physically biases or mathematically masks out (-inf via `enforce_functional_isolation`) entire swaths of neural circuits, forcing continuous compute through highly specialized expert topological perimeters.\n\nEPISTEMIC BOUNDS: Limits structural instability by hard-bounding `dynamic_top_k` execution threads (`ge=1, le=1000000000`). The `expert_logit_biases` spatial dictionary is bounded by cardinality (`max_length=1000000000`) with tensor biases clamped to `[ge=-1000.0, le=1000.0]`.\n\nMCP ROUTING TRIGGERS: Sparse Mixture of Experts, Softmax Gating, Logit Biasing, Functional Expert Routing, FSM Masking",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Overrides the default Softmax gating mechanism of a Sparse Mixture of Experts (MoE) architecture to enforce deterministic functional isolation.\n\nCAUSAL AFFORDANCE: Physically biases or mathematically masks out (-inf via `enforce_functional_isolation`) entire swaths of neural circuits, forcing continuous compute through highly specialized expert topological perimeters.\n\nEPISTEMIC BOUNDS: Limits structural instability by hard-bounding `dynamic_top_k` execution threads (`ge=1, le=1000000000`). The `expert_logit_biases` spatial dictionary is bounded by cardinality (`max_length=1000`) with tensor biases clamped to `[ge=-1000.0, le=1000.0]`.\n\nMCP ROUTING TRIGGERS: Sparse Mixture of Experts, Softmax Gating, Logit Biasing, Functional Expert Routing, FSM Masking",
       "properties": {
         "dynamic_top_k": {
           "description": "The exact number of functional experts the router must activate per token. High values simulate deep cognitive strain.",
@@ -3248,7 +3250,7 @@
             "type": "number"
           },
           "description": "Explicit tensor biases applied to the router gate. Keys are expert IDs (e.g., 'expert_falsifier'), values are logit modifiers.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -3607,7 +3609,7 @@
             "maxLength": 255,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Capabilities",
           "type": "array"
         },
@@ -3651,7 +3653,7 @@
             "maxLength": 255,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Required Capabilities",
           "type": "array"
         },
@@ -3854,7 +3856,7 @@
     },
     "ConstitutionalPolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a discrete normative axiom within a Constitutional AI\nframework to prevent instrumental convergence. As a ...Policy suffix, this object defines\nrigid mathematical boundaries that the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Establishes a hard structural boundary that mathematically repels the\nswarm's generative trajectory away from forbidden semantic manifolds. Violation severity\nis classified via a strict Literal[\"low\", \"medium\", \"high\", \"critical\"] tier.\n\nEPISTEMIC BOUNDS: Geometrically restricts the state space by blacklisting specific\nexecution branches via the forbidden_intents array (max_length=1000000000),\ndeterministically sorted by @model_validator to preserve RFC 8785 canonical hashing.\nThe rule_id is bounded to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Constitutional AI, Value Alignment, Normative Axiom, Instrumental\nConvergence, Semantic Boundary",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a discrete normative axiom within a Constitutional AI\nframework to prevent instrumental convergence. As a ...Policy suffix, this object defines\nrigid mathematical boundaries that the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Establishes a hard structural boundary that mathematically repels the\nswarm's generative trajectory away from forbidden semantic manifolds. Violation severity\nis classified via a strict Literal[\"low\", \"medium\", \"high\", \"critical\"] tier.\n\nEPISTEMIC BOUNDS: Geometrically restricts the state space by blacklisting specific\nexecution branches via the forbidden_intents array (max_length=1000),\ndeterministically sorted by @model_validator to preserve RFC 8785 canonical hashing.\nThe rule_id is bounded to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Constitutional AI, Value Alignment, Normative Axiom, Instrumental\nConvergence, Semantic Boundary",
       "properties": {
         "rule_id": {
           "description": "Unique identifier for the constitutional rule.",
@@ -3887,7 +3889,7 @@
             "minLength": 1,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Forbidden Intents",
           "type": "array"
         }
@@ -4379,7 +4381,7 @@
             "type": "number"
           },
           "description": "The stateless routing gradient adjustments derived from the calculated regret, used to self-correct future routing.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -5293,7 +5295,7 @@
         "confidence_interval_95": {
           "anyOf": [
             {
-              "maxItems": 1000000000,
+              "maxItems": 1000,
               "minItems": 2,
               "prefixItems": [
                 {
@@ -5374,7 +5376,7 @@
             "$ref": "#/$defs/DocumentLayoutRegionState"
           },
           "description": "Dictionary mapping block_ids to their strict spatial definitions.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -5467,7 +5469,7 @@
             "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "The strict JSON Schema the human's input must satisfy before the graph can resume. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -5637,7 +5639,7 @@
             "type": "integer"
           },
           "description": "The strict allocation of compute budget bound to specific nodes.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "$ref": "#/$defs/NodeIdentifierState"
           },
@@ -6440,7 +6442,7 @@
           "items": {
             "$ref": "#/$defs/TemporalCheckpointState"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Checkpoints",
           "type": "array"
         },
@@ -6771,7 +6773,7 @@
     },
     "EpistemicSOPManifest": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encodes a macroscopic Petri net or Directed Acyclic Graph (DAG)\nformalizing standard operating procedures into mathematically traversable state\ntransitions. As a ...Manifest suffix, this defines a frozen, N-dimensional coordinate\nstate.\n\nCAUSAL AFFORDANCE: Physically bounds the executing agent (target_persona:\nProfileIdentifierState) to a deterministic sequence of CognitiveStateProfiles, unlocking\nthe ability for the orchestrator to dynamically evaluate execution via Process Reward\nModels (prm_evaluations: list[ProcessRewardContract]) at each topological node.\n\nEPISTEMIC BOUNDS: The cognitive_steps dictionary is constrained to max_length=1000000000\nto cap memory footprint. The @model_validator reject_ghost_nodes mathematically enforces\nreferential integrity, guaranteeing that no chronological_flow_edges AND no\nstructural_grammar_hashes point to an undefined state.\n\nMCP ROUTING TRIGGERS: Petri Net, Directed Acyclic Graph, Process Reward Model,\nTopological Flow, Referential Integrity",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encodes a macroscopic Petri net or Directed Acyclic Graph (DAG)\nformalizing standard operating procedures into mathematically traversable state\ntransitions. As a ...Manifest suffix, this defines a frozen, N-dimensional coordinate\nstate.\n\nCAUSAL AFFORDANCE: Physically bounds the executing agent (target_persona:\nProfileIdentifierState) to a deterministic sequence of CognitiveStateProfiles, unlocking\nthe ability for the orchestrator to dynamically evaluate execution via Process Reward\nModels (prm_evaluations: list[ProcessRewardContract]) at each topological node.\n\nEPISTEMIC BOUNDS: The cognitive_steps dictionary is constrained to max_length=1000\nto cap memory footprint. The @model_validator reject_ghost_nodes mathematically enforces\nreferential integrity, guaranteeing that no chronological_flow_edges AND no\nstructural_grammar_hashes point to an undefined state.\n\nMCP ROUTING TRIGGERS: Petri Net, Directed Acyclic Graph, Process Reward Model,\nTopological Flow, Referential Integrity",
       "properties": {
         "sop_id": {
           "description": "A Content Identifier (CID) for the Standard Operating Procedure.",
@@ -6790,7 +6792,7 @@
             "$ref": "#/$defs/CognitiveStateProfile"
           },
           "description": "Dictionary mapping step_ids to strict causal DAG constraints.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -7859,7 +7861,7 @@
             "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "Bounded dictionary representing the injected hallucination or observation.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -8135,7 +8137,7 @@
     },
     "FederatedDiscoveryManifest": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Governs the B2B Multi-Swarm Gossip Protocol, establishing the initial\nModel Context Protocol (MCP) broadcast endpoints for external discovery. As a ...Manifest\nsuffix, this is a declarative, frozen snapshot of N-dimensional geometry at a specific\npoint in time.\n\nCAUSAL AFFORDANCE: Emits a structured tensor beacon to neighboring swarms, authorizing\nthe initiation of an OntologicalHandshakeReceipt if the supported_ontologies hashes\nmathematically overlap.\n\nEPISTEMIC BOUNDS: Geometrically capped by broadcast_endpoints and supported_ontologies\nstring arrays (each max_length=1000000000). Both are explicitly sorted by the\n@model_validator (broadcast_endpoints by str key, supported_ontologies alphabetically)\nto guarantee invariant canonical RFC 8785 hashing across distinct environments.\n\nMCP ROUTING TRIGGERS: Gossip Protocol, Peer-to-Peer Discovery, Decentralized Federation,\nSemantic Broadcasting, Tensor Beacon",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Governs the B2B Multi-Swarm Gossip Protocol, establishing the initial\nModel Context Protocol (MCP) broadcast endpoints for external discovery. As a ...Manifest\nsuffix, this is a declarative, frozen snapshot of N-dimensional geometry at a specific\npoint in time.\n\nCAUSAL AFFORDANCE: Emits a structured tensor beacon to neighboring swarms, authorizing\nthe initiation of an OntologicalHandshakeReceipt if the supported_ontologies hashes\nmathematically overlap.\n\nEPISTEMIC BOUNDS: Geometrically capped by broadcast_endpoints and supported_ontologies\nstring arrays (each max_length=1000). Both are explicitly sorted by the\n@model_validator (broadcast_endpoints by str key, supported_ontologies alphabetically)\nto guarantee invariant canonical RFC 8785 hashing across distinct environments.\n\nMCP ROUTING TRIGGERS: Gossip Protocol, Peer-to-Peer Discovery, Decentralized Federation,\nSemantic Broadcasting, Tensor Beacon",
       "properties": {
         "broadcast_endpoints": {
           "description": "The explicit array of strictly bounded MCP URI broadcast endpoints.",
@@ -8143,7 +8145,7 @@
             "maxLength": 2000,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Broadcast Endpoints",
           "type": "array"
         },
@@ -8154,7 +8156,7 @@
             "minLength": 1,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Supported Ontologies",
           "type": "array"
         }
@@ -8335,7 +8337,7 @@
     },
     "GenerativeTaxonomyManifest": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a macroscopic Topological Data Analysis (TDA) manifold\nprojection, mapping continuous vector geometries into a discrete, traversable Directed\nAcyclic Graph (DAG). As a ...Manifest suffix, this defines a frozen, N-dimensional\ncoordinate state.\n\nCAUSAL AFFORDANCE: Projects the comprehensive Virtual File System (VFS) state to the\nhuman UI or agentic context, structurally proving the geometric relations of all\nsubordinate TaxonomicNodeStates.\n\nEPISTEMIC BOUNDS: The nodes matrix is physically capped at max_length=1000000000\nproperties to prevent memory overflow. The @model_validator mathematically verifies DAG\nintegrity by ensuring the root_node_id explicitly exists within the projection matrix,\npreventing ghost nodes.\n\nMCP ROUTING TRIGGERS: Manifold Learning, Topological Data Analysis, Directed Acyclic\nGraph, Generative Taxonomy, Holographic Projection",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a macroscopic Topological Data Analysis (TDA) manifold\nprojection, mapping continuous vector geometries into a discrete, traversable Directed\nAcyclic Graph (DAG). As a ...Manifest suffix, this defines a frozen, N-dimensional\ncoordinate state.\n\nCAUSAL AFFORDANCE: Projects the comprehensive Virtual File System (VFS) state to the\nhuman UI or agentic context, structurally proving the geometric relations of all\nsubordinate TaxonomicNodeStates.\n\nEPISTEMIC BOUNDS: The nodes matrix is physically capped at max_length=1000\nproperties to prevent memory overflow. The @model_validator mathematically verifies DAG\nintegrity by ensuring the root_node_id explicitly exists within the projection matrix,\npreventing ghost nodes.\n\nMCP ROUTING TRIGGERS: Manifold Learning, Topological Data Analysis, Directed Acyclic\nGraph, Generative Taxonomy, Holographic Projection",
       "properties": {
         "manifest_id": {
           "description": "Unique Content Identifier (CID) for this generated taxonomy.",
@@ -8358,7 +8360,7 @@
             "$ref": "#/$defs/TaxonomicNodeState"
           },
           "description": "Flat dictionary matrix containing all nodes within the manifold.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -9624,7 +9626,7 @@
             "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "The action proposed by the agent that requires approval.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -10660,7 +10662,7 @@
             "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "Arguments to fill the prompt template. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -10818,7 +10820,7 @@
     },
     "MacroGridProfile": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a Cartesian topological coordinator based on Edward Tufte's Small Multiples, organizing multiple discrete visual artifacts into a unified grid configuration.\n\nCAUSAL AFFORDANCE: Translates abstract UI panels into fixed 2D matrices (`layout_matrix`), forcing spatial determinism on the frontend rendering engine.\n\nEPISTEMIC BOUNDS: A strictly bounded `@model_validator` executes a referential integrity sweep, mathematically guaranteeing that every panel ID referenced in the `layout_matrix` (`max_length=1000000000`) corresponds to a verified object in the `panels` array, physically severing Ghost Panel hallucinations.\n\nMCP ROUTING TRIGGERS: Cartesian Coordinate System, Small Multiples, Spatial Topology, Referential Integrity, Layout Matrix",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a Cartesian topological coordinator based on Edward Tufte's Small Multiples, organizing multiple discrete visual artifacts into a unified grid configuration.\n\nCAUSAL AFFORDANCE: Translates abstract UI panels into fixed 2D matrices (`layout_matrix`), forcing spatial determinism on the frontend rendering engine.\n\nEPISTEMIC BOUNDS: A strictly bounded `@model_validator` executes a referential integrity sweep, mathematically guaranteeing that every panel ID referenced in the `layout_matrix` (`max_length=1000`) corresponds to a verified object in the `panels` array, physically severing Ghost Panel hallucinations.\n\nMCP ROUTING TRIGGERS: Cartesian Coordinate System, Small Multiples, Spatial Topology, Referential Integrity, Layout Matrix",
       "properties": {
         "layout_matrix": {
           "description": "A matrix defining the layout structure, using panel IDs.",
@@ -10829,7 +10831,7 @@
             },
             "type": "array"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Layout Matrix",
           "type": "array"
         },
@@ -10931,7 +10933,7 @@
             "minLength": 1,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Falsified Hypothesis Ids",
           "type": "array"
         },
@@ -11039,7 +11041,7 @@
     },
     "MemoizedNodeProfile": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Dynamic Programming principles to create a passive, cryptographic structural interlock pointing to a historically executed and verified graph branch.\n\nCAUSAL AFFORDANCE: Bypasses redundant thermodynamic compute expenditure by collapsing an entire sub-DAG execution into a single, O(1) state retrieval keyed by the `target_topology_hash`.\n\nEPISTEMIC BOUNDS: The cache-hit is mathematically locked to the exact `target_topology_hash` (`TopologyHashReceipt`), guaranteeing perfect graph isomorphism. The retrieved payload is physically constrained by `expected_output_schema` (`max_length=1000000000`). The type discriminator is locked to `Literal[\"memoized\"]`.\n\nMCP ROUTING TRIGGERS: Dynamic Programming, O(1) Retrieval, Cryptographic Cache, Graph Isomorphism, Compute Conservation",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Dynamic Programming principles to create a passive, cryptographic structural interlock pointing to a historically executed and verified graph branch.\n\nCAUSAL AFFORDANCE: Bypasses redundant thermodynamic compute expenditure by collapsing an entire sub-DAG execution into a single, O(1) state retrieval keyed by the `target_topology_hash`.\n\nEPISTEMIC BOUNDS: The cache-hit is mathematically locked to the exact `target_topology_hash` (`TopologyHashReceipt`), guaranteeing perfect graph isomorphism. The retrieved payload is physically constrained by `expected_output_schema` (`max_length=1000`). The type discriminator is locked to `Literal[\"memoized\"]`.\n\nMCP ROUTING TRIGGERS: Dynamic Programming, O(1) Retrieval, Cryptographic Cache, Graph Isomorphism, Compute Conservation",
       "properties": {
         "description": {
           "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
@@ -11154,7 +11156,7 @@
             "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "The strictly typed JSON Schema expected from the cached payload.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -11260,7 +11262,7 @@
         "bounding_box": {
           "anyOf": [
             {
-              "maxItems": 1000000000,
+              "maxItems": 1000,
               "minItems": 4,
               "prefixItems": [
                 {
@@ -11361,7 +11363,7 @@
           "items": {
             "type": "integer"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Shape",
           "type": "array"
         },
@@ -11840,7 +11842,7 @@
             "minLength": 1,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 250,
           "minItems": 2,
           "title": "Participant Node Ids",
           "type": "array"
@@ -11973,7 +11975,7 @@
     },
     "OverrideIntent": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Dictatorial Byzantine Fault Resolution mechanism. It is an absolute, zero-trust kinetic override that violently preempts autonomous algorithmic consensus or prediction market resolution.\n\nCAUSAL AFFORDANCE: Forces an absolute Pearlian do-operator intervention ($do(X=x)$). Physically shatters the active causal chain of the `target_node_id` and forcibly injects the `override_action` payload into the state vector, bypassing decentralized voting.\n\nEPISTEMIC BOUNDS: The blast radius is strictly confined to the `target_node_id`. The orchestrator must mathematically verify the `authorized_node_id` against the highest-tier W3C DID enterprise clearance before allowing the payload to overwrite the Epistemic Blackboard (`override_action` bounded `max_length=1000000000`).\n\nMCP ROUTING TRIGGERS: Dictatorial Override, Byzantine Fault Resolution, Pearlian Intervention, Causal Shattering, Zero-Trust Override",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Dictatorial Byzantine Fault Resolution mechanism. It is an absolute, zero-trust kinetic override that violently preempts autonomous algorithmic consensus or prediction market resolution.\n\nCAUSAL AFFORDANCE: Forces an absolute Pearlian do-operator intervention ($do(X=x)$). Physically shatters the active causal chain of the `target_node_id` and forcibly injects the `override_action` payload into the state vector, bypassing decentralized voting.\n\nEPISTEMIC BOUNDS: The blast radius is strictly confined to the `target_node_id`. The orchestrator must mathematically verify the `authorized_node_id` against the highest-tier W3C DID enterprise clearance before allowing the payload to overwrite the Epistemic Blackboard (`override_action` bounded `max_length=1000`).\n\nMCP ROUTING TRIGGERS: Dictatorial Override, Byzantine Fault Resolution, Pearlian Intervention, Causal Shattering, Zero-Trust Override",
       "properties": {
         "type": {
           "const": "override",
@@ -11995,7 +11997,7 @@
             "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "The exact payload forcefully injected into the state.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -12370,7 +12372,7 @@
     },
     "PredictionMarketState": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of an Automated Market Maker (AMM) utilizing Robin Hanson's Logarithmic Market Scoring Rule (LMSR) to guarantee infinite liquidity.\n\nCAUSAL AFFORDANCE: Aggregates `HypothesisStakeReceipt` vectors, allowing the orchestrator to track the shifting probability manifold and trigger market resolution when the AMM reaches the required convergence threshold.\n\nEPISTEMIC BOUNDS: `current_market_probabilities` is geometrically bounded by `max_length=1000000000`. `market_id` is restricted to a 128-char CID. `order_book` array is deterministically sorted by `agent_id` via `@model_validator`.\n\nMCP ROUTING TRIGGERS: Logarithmic Market Scoring Rule, Automated Market Maker, Prediction Market, Infinite Liquidity, Brier Score",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of an Automated Market Maker (AMM) utilizing Robin Hanson's Logarithmic Market Scoring Rule (LMSR) to guarantee infinite liquidity.\n\nCAUSAL AFFORDANCE: Aggregates `HypothesisStakeReceipt` vectors, allowing the orchestrator to track the shifting probability manifold and trigger market resolution when the AMM reaches the required convergence threshold.\n\nEPISTEMIC BOUNDS: `current_market_probabilities` is geometrically bounded by `max_length=1000`. `market_id` is restricted to a 128-char CID. `order_book` array is deterministically sorted by `agent_id` via `@model_validator`.\n\nMCP ROUTING TRIGGERS: Logarithmic Market Scoring Rule, Automated Market Maker, Prediction Market, Infinite Liquidity, Brier Score",
       "properties": {
         "market_id": {
           "description": "The deterministic capability pointer representing the prediction market.",
@@ -12409,7 +12411,7 @@
             "type": "string"
           },
           "description": "Mapping of hypothesis IDs to their current LMSR-calculated market price (probability) as stringified decimals.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -13418,7 +13420,7 @@
     },
     "SemanticDiscoveryIntent": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates zero-shot latent capability routing by computing the geometric Cosine Distance between the agent's epistemic deficit vector and the available tool manifold.\n\nCAUSAL AFFORDANCE: Unlocks the dynamic, runtime mounting of tools and MCP servers whose dense vector embeddings (`query_vector`) align mathematically with the query tensor, bypassing hardcoded tool schemas.\n\nEPISTEMIC BOUNDS: Mechanically rejects capabilities that fall below the `min_isometry_score` (`ge=-1.0, le=1.0`) boundary. The returned toolsets are strictly limited to the deterministically sorted `required_structural_types` array (`max_length=1000000000`), enforced by the `@model_validator`.\n\nMCP ROUTING TRIGGERS: Zero-Shot Tool Discovery, Capability Routing, Dense Vector Embedding, Epistemic Deficit Resolution",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates zero-shot latent capability routing by computing the geometric Cosine Distance between the agent's epistemic deficit vector and the available tool manifold.\n\nCAUSAL AFFORDANCE: Unlocks the dynamic, runtime mounting of tools and MCP servers whose dense vector embeddings (`query_vector`) align mathematically with the query tensor, bypassing hardcoded tool schemas.\n\nEPISTEMIC BOUNDS: Mechanically rejects capabilities that fall below the `min_isometry_score` (`ge=-1.0, le=1.0`) boundary. The returned toolsets are strictly limited to the deterministically sorted `required_structural_types` array (`max_length=1000`), enforced by the `@model_validator`.\n\nMCP ROUTING TRIGGERS: Zero-Shot Tool Discovery, Capability Routing, Dense Vector Embedding, Epistemic Deficit Resolution",
       "properties": {
         "type": {
           "const": "semantic_discovery",
@@ -13444,7 +13446,7 @@
             "maxLength": 255,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Required Structural Types",
           "type": "array"
         }
@@ -13932,7 +13934,7 @@
         "attributes": {
           "additionalProperties": true,
           "description": "Typed metadata bound to the event.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -14429,7 +14431,7 @@
     },
     "StdioTransportProfile": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Inter-Process Communication (IPC) utilizing POSIX standard streams to execute highly isolated, local binary sandboxing.\n\nCAUSAL AFFORDANCE: Physically spawns a child process restricted to the host's operating system namespace, mapping remote procedure calls directly into the binary's stdin/stdout descriptors via `command` (`max_length=2000`).\n\nEPISTEMIC BOUNDS: To prevent buffer overflow and command injection, `args` are structurally constrained (`max_length=1000000000`, string `max_length=2000`) and `env_vars` keys/values are strictly delimited via `StringConstraints` (`max_length=255` and `2000`).\n\nMCP ROUTING TRIGGERS: Inter-Process Communication, POSIX Standard Streams, Local Sandboxing, Binary Execution, Subprocess Spawn",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Inter-Process Communication (IPC) utilizing POSIX standard streams to execute highly isolated, local binary sandboxing.\n\nCAUSAL AFFORDANCE: Physically spawns a child process restricted to the host's operating system namespace, mapping remote procedure calls directly into the binary's stdin/stdout descriptors via `command` (`max_length=2000`).\n\nEPISTEMIC BOUNDS: To prevent buffer overflow and command injection, `args` are structurally constrained (`max_length=1000`, string `max_length=2000`) and `env_vars` keys/values are strictly delimited via `StringConstraints` (`max_length=255` and `2000`).\n\nMCP ROUTING TRIGGERS: Inter-Process Communication, POSIX Standard Streams, Local Sandboxing, Binary Execution, Subprocess Spawn",
       "properties": {
         "type": {
           "const": "stdio",
@@ -14450,7 +14452,7 @@
             "maxLength": 2000,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Args",
           "type": "array"
         },
@@ -14475,7 +14477,7 @@
     },
     "SteadyStateHypothesisState": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the baseline control group definition within\nChaos Engineering, leveraging Queueing Theory to model the expected systemic\nequilibrium. As a ...State suffix, this is a declarative, frozen snapshot of\nN-dimensional geometry.\n\nCAUSAL AFFORDANCE: Provides the deterministic baseline against which chaotic\nperturbations (e.g., ChaosExperimentTask) are measured, establishing temporal\nand procedural expectations for standard execution loops.\n\nEPISTEMIC BOUNDS: Latency expectations are continuously bounded by\nexpected_max_latency (ge=0.0, le=1000000000.0). The max_loops_allowed\n(le=1000000000) physically caps algorithmic cycles. The optional\nrequired_tool_usage (list[str] | None, default=None,\nmax_length=1000000000) is deterministically sorted via @model_validator\nsort_arrays to preserve RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Chaos Engineering, Queueing Theory, Steady-State\nEquilibrium, Control Group Baseline, Systemic Perturbation",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the baseline control group definition within\nChaos Engineering, leveraging Queueing Theory to model the expected systemic\nequilibrium. As a ...State suffix, this is a declarative, frozen snapshot of\nN-dimensional geometry.\n\nCAUSAL AFFORDANCE: Provides the deterministic baseline against which chaotic\nperturbations (e.g., ChaosExperimentTask) are measured, establishing temporal\nand procedural expectations for standard execution loops.\n\nEPISTEMIC BOUNDS: Latency expectations are continuously bounded by\nexpected_max_latency (ge=0.0, le=1000000000.0). The max_loops_allowed\n(le=1000000000) physically caps algorithmic cycles. The optional\nrequired_tool_usage (list[str] | None, default=None,\nmax_length=1000) is deterministically sorted via @model_validator\nsort_arrays to preserve RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Chaos Engineering, Queueing Theory, Steady-State\nEquilibrium, Control Group Baseline, Systemic Perturbation",
       "properties": {
         "expected_max_latency": {
           "description": "The expected maximum latency under normal conditions.",
@@ -14497,7 +14499,7 @@
                 "maxLength": 2000,
                 "type": "string"
               },
-              "maxItems": 1000000000,
+              "maxItems": 1000,
               "type": "array"
             },
             {
@@ -14559,7 +14561,7 @@
             "maxLength": 255,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Observed Variables",
           "type": "array"
         },
@@ -14569,7 +14571,7 @@
             "maxLength": 255,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Latent Variables",
           "type": "array"
         },
@@ -14782,7 +14784,7 @@
     },
     "System1ReflexPolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Kahneman's Dual-Process Theory (System 1) to execute\nrapid, heuristic-based reflex actions without invoking deep logical search trees. As a\n...Policy suffix, this enforces a rigid computational boundary.\n\nCAUSAL AFFORDANCE: Unlocks zero-shot execution of side-effect-free capabilities when\nthe working context matches established high-probability priors, intentionally bypassing\nexpensive System 2 Monte Carlo Tree Search (MCTS).\n\nEPISTEMIC BOUNDS: Execution is mathematically gated by the confidence_threshold\n(ge=0.0, le=1.0). The allowed_passive_tools array (max_length=1000000000,\nStringConstraints max_length=2000) strictly bounds the agent to non-mutating\ncapabilities, deterministically sorted via @model_validator.\n\nMCP ROUTING TRIGGERS: Dual-Process Theory, System 1 Heuristics, Zero-Shot Reflex,\nMetacognition, Amygdala Hijack Prevention",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Kahneman's Dual-Process Theory (System 1) to execute\nrapid, heuristic-based reflex actions without invoking deep logical search trees. As a\n...Policy suffix, this enforces a rigid computational boundary.\n\nCAUSAL AFFORDANCE: Unlocks zero-shot execution of side-effect-free capabilities when\nthe working context matches established high-probability priors, intentionally bypassing\nexpensive System 2 Monte Carlo Tree Search (MCTS).\n\nEPISTEMIC BOUNDS: Execution is mathematically gated by the confidence_threshold\n(ge=0.0, le=1.0). The allowed_passive_tools array (max_length=1000,\nStringConstraints max_length=2000) strictly bounds the agent to non-mutating\ncapabilities, deterministically sorted via @model_validator.\n\nMCP ROUTING TRIGGERS: Dual-Process Theory, System 1 Heuristics, Zero-Shot Reflex,\nMetacognition, Amygdala Hijack Prevention",
       "properties": {
         "confidence_threshold": {
           "description": "The confidence threshold required to execute a reflex action.",
@@ -14797,7 +14799,7 @@
             "maxLength": 2000,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Allowed Passive Tools",
           "type": "array"
         }
@@ -15568,7 +15570,7 @@
             "maxLength": 2000,
             "type": "string"
           },
-          "maxItems": 1000000000,
+          "maxItems": 1000,
           "title": "Identified Knowledge Gaps",
           "type": "array"
         },
@@ -15804,7 +15806,7 @@
             "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "The intended JSON-RPC payload. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -15840,7 +15842,7 @@
     },
     "ToolManifest": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the discrete formalization of a Gibsonian Affordance within the agent's Reinforcement Learning Action Space ($A$). As a ...Manifest suffix, this is a declarative, frozen N-dimensional coordinate of a capability.\n\nCAUSAL AFFORDANCE: Unlocks a specific, localized Pearlian Do-Operator intervention ($do(X=x)$) mapped to an external kinetic capability. Governed by side_effects, permissions, and an optional execution SLA.\n\nEPISTEMIC BOUNDS: The operational perimeter is rigidly confined by `input_schema` and `output_schema` (dictionaries bounded to `max_length=1000000000` properties). The `is_preemptible` boolean (default=False) establishes a physical Halting Problem limit by authorizing the orchestrator to abort execution mid-flight.\n\nMCP ROUTING TRIGGERS: Gibsonian Affordance, MDP Action Space, Pearlian Do-Operator, Capability-Based Security, Halting Problem",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the discrete formalization of a Gibsonian Affordance within the agent's Reinforcement Learning Action Space ($A$). As a ...Manifest suffix, this is a declarative, frozen N-dimensional coordinate of a capability.\n\nCAUSAL AFFORDANCE: Unlocks a specific, localized Pearlian Do-Operator intervention ($do(X=x)$) mapped to an external kinetic capability. Governed by side_effects, permissions, and an optional execution SLA.\n\nEPISTEMIC BOUNDS: The operational perimeter is rigidly confined by `input_schema` and `output_schema` (dictionaries bounded to `max_length=1000` properties). The `is_preemptible` boolean (default=False) establishes a physical Halting Problem limit by authorizing the orchestrator to abort execution mid-flight.\n\nMCP ROUTING TRIGGERS: Gibsonian Affordance, MDP Action Space, Pearlian Do-Operator, Capability-Based Security, Halting Problem",
       "properties": {
         "type": {
           "const": "native_tool",
@@ -15866,7 +15868,7 @@
             "$ref": "#/$defs/JsonPrimitiveState"
           },
           "description": "The strict JSON Schema dictionary defining the pure domain-specific arguments ($T$). The framework orchestrator will automatically wrap this in the ExecutionEnvelopeState at runtime.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -15879,7 +15881,7 @@
               "additionalProperties": {
                 "$ref": "#/$defs/JsonPrimitiveState"
               },
-              "maxProperties": 1000000000,
+              "maxProperties": 1000,
               "propertyNames": {
                 "maxLength": 255
               },
@@ -16216,7 +16218,7 @@
     },
     "UtilityJustificationGraphReceipt": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Multi-Attribute Utility Theory (MAUT) to capture the exact multi-dimensional trade-offs (Pareto vectors) of a given routing decision.\n\nCAUSAL AFFORDANCE: Provides explicit mathematical justification for an agent's trajectory. If the variance of the utility distribution exceeds the threshold, it physically forces the orchestrator to deploy the embedded ensemble specification for deterministic resolution.\n\nEPISTEMIC BOUNDS: The `superposition_variance_threshold` is physically clamped strictly above zero (`gt=0.0`, `le=1000000000.0`), as a variance of absolute 0.0 represents mathematical certainty, which physically precludes superposition geometry. Vector dictionaries are bounded purely by spatial cardinality (`max_length=1000000000`).\n\nMCP ROUTING TRIGGERS: Multi-Attribute Utility Theory, Pareto Efficiency, Variance Reduction, Fallback Superposition, Utility Routing",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Multi-Attribute Utility Theory (MAUT) to capture the exact multi-dimensional trade-offs (Pareto vectors) of a given routing decision.\n\nCAUSAL AFFORDANCE: Provides explicit mathematical justification for an agent's trajectory. If the variance of the utility distribution exceeds the threshold, it physically forces the orchestrator to deploy the embedded ensemble specification for deterministic resolution.\n\nEPISTEMIC BOUNDS: The `superposition_variance_threshold` is physically clamped strictly above zero (`gt=0.0`, `le=1000000000.0`), as a variance of absolute 0.0 represents mathematical certainty, which physically precludes superposition geometry. Vector dictionaries are bounded purely by spatial cardinality (`max_length=1000`).\n\nMCP ROUTING TRIGGERS: Multi-Attribute Utility Theory, Pareto Efficiency, Variance Reduction, Fallback Superposition, Utility Routing",
       "properties": {
         "optimizing_vectors": {
           "additionalProperties": {
@@ -16225,7 +16227,7 @@
             "type": "number"
           },
           "description": "Multi-dimensional continuous values representing optimizations.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },
@@ -16239,7 +16241,7 @@
             "type": "number"
           },
           "description": "Multi-dimensional continuous values representing degradations.",
-          "maxProperties": 1000000000,
+          "maxProperties": 1000,
           "propertyNames": {
             "maxLength": 255
           },

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -456,6 +456,15 @@ class StateVectorProfile(CoreasonBaseState):
         description="A flag allowing the output to only return the keys in mutable_memory that changed, rather than forcing the entire array back up the network.",
     )
 
+    @field_validator("mutable_memory", "read_only_context", mode="before")
+    @classmethod
+    def validate_memory_bounds(cls, v: Any) -> Any:
+        """
+        Enforces system-wide volumetric constraints (depth/node count)
+        on state memory to prevent OOM and recursion depth failures.
+        """
+        return _validate_payload_bounds(v)
+
 
 class ExecutionEnvelopeState[T](CoreasonBaseState):
     """
@@ -1164,7 +1173,7 @@ class ComputeEngineProfile(CoreasonBaseState):
     provider: str = Field(max_length=2000, description="The name of the provider hosting the model.")
     context_window_size: int = Field(le=1000000000, description="The maximum context window size in tokens.")
     capabilities: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="The explicit, structurally bounded array of capabilities authorized for this model.",
     )
     rate_card: ComputeRateContract = Field(description="The economic cost definition associated with the model.")
@@ -1405,7 +1414,7 @@ class CognitiveRoutingContract(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Physically biases or mathematically masks out (-inf via `enforce_functional_isolation`) entire swaths of neural circuits, forcing continuous compute through highly specialized expert topological perimeters.
 
-    EPISTEMIC BOUNDS: Limits structural instability by hard-bounding `dynamic_top_k` execution threads (`ge=1, le=1000000000`). The `expert_logit_biases` spatial dictionary is bounded by cardinality (`max_length=1000000000`) with tensor biases clamped to `[ge=-1000.0, le=1000.0]`.
+    EPISTEMIC BOUNDS: Limits structural instability by hard-bounding `dynamic_top_k` execution threads (`ge=1, le=1000000000`). The `expert_logit_biases` spatial dictionary is bounded by cardinality (`max_length=1000`) with tensor biases clamped to `[ge=-1000.0, le=1000.0]`.
 
     MCP ROUTING TRIGGERS: Sparse Mixture of Experts, Softmax Gating, Logit Biasing, Functional Expert Routing, FSM Masking
 
@@ -1424,7 +1433,7 @@ class CognitiveRoutingContract(CoreasonBaseState):
     expert_logit_biases: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[float, Field(ge=-1000.0, le=1000.0)]
     ] = Field(
-        max_length=1000000000,
+        max_length=1000,
         default_factory=dict,
         description="Explicit tensor biases applied to the router gate. Keys are expert IDs (e.g., 'expert_falsifier'), values are logit modifiers.",
     )
@@ -1507,7 +1516,7 @@ class ConstitutionalPolicy(CoreasonBaseState):
     is classified via a strict Literal["low", "medium", "high", "critical"] tier.
 
     EPISTEMIC BOUNDS: Geometrically restricts the state space by blacklisting specific
-    execution branches via the forbidden_intents array (max_length=1000000000),
+    execution branches via the forbidden_intents array (max_length=1000),
     deterministically sorted by @model_validator to preserve RFC 8785 canonical hashing.
     The rule_id is bounded to a 128-char CID.
 
@@ -1528,7 +1537,7 @@ class ConstitutionalPolicy(CoreasonBaseState):
         description="The categorical magnitude of the systemic breach enacted upon rule violation."
     )
     forbidden_intents: list[Annotated[str, StringConstraints(min_length=1)]] = Field(
-        max_length=1000000000, description="The explicit, structurally bounded set of forbidden semantic intents."
+        max_length=1000, description="The explicit, structurally bounded set of forbidden semantic intents."
     )
 
     @model_validator(mode="after")
@@ -1941,7 +1950,7 @@ class MultimodalTokenAnchorState(CoreasonBaseState):
         description="The explicit array of SHA-256 hashes corresponding to specific VQ-VAE visual patches attended to.",
     )
     bounding_box: tuple[float, float, float, float] | None = Field(
-        max_length=1000000000,
+        max_length=1000,
         default=None,
         description="The strictly typed [x_min, y_min, x_max, y_max] normalized coordinate matrix.",
     )
@@ -2374,7 +2383,7 @@ class ToolManifest(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Unlocks a specific, localized Pearlian Do-Operator intervention ($do(X=x)$) mapped to an external kinetic capability. Governed by side_effects, permissions, and an optional execution SLA.
 
-    EPISTEMIC BOUNDS: The operational perimeter is rigidly confined by `input_schema` and `output_schema` (dictionaries bounded to `max_length=1000000000` properties). The `is_preemptible` boolean (default=False) establishes a physical Halting Problem limit by authorizing the orchestrator to abort execution mid-flight.
+    EPISTEMIC BOUNDS: The operational perimeter is rigidly confined by `input_schema` and `output_schema` (dictionaries bounded to `max_length=1000` properties). The `is_preemptible` boolean (default=False) establishes a physical Halting Problem limit by authorizing the orchestrator to abort execution mid-flight.
 
     MCP ROUTING TRIGGERS: Gibsonian Affordance, MDP Action Space, Pearlian Do-Operator, Capability-Based Security, Halting Problem
 
@@ -2388,12 +2397,12 @@ class ToolManifest(CoreasonBaseState):
         description="The mathematically bounded semantic projection defining the tool's causal affordances.",
     )
     input_schema: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="The strict JSON Schema dictionary defining the pure domain-specific arguments ($T$). The framework orchestrator will automatically wrap this in the ExecutionEnvelopeState at runtime.",
     )
     output_schema: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] | None = Field(
         default=None,
-        max_length=1000000000,
+        max_length=1000,
         description="The strict JSON Schema dictionary defining the pure domain-specific arguments ($T$). The framework orchestrator will automatically wrap this in the ExecutionEnvelopeState at runtime.",
     )
     side_effects: SideEffectProfile = Field(
@@ -2473,7 +2482,7 @@ class FederatedDiscoveryManifest(CoreasonBaseState):
     mathematically overlap.
 
     EPISTEMIC BOUNDS: Geometrically capped by broadcast_endpoints and supported_ontologies
-    string arrays (each max_length=1000000000). Both are explicitly sorted by the
+    string arrays (each max_length=1000). Both are explicitly sorted by the
     @model_validator (broadcast_endpoints by str key, supported_ontologies alphabetically)
     to guarantee invariant canonical RFC 8785 hashing across distinct environments.
 
@@ -2482,10 +2491,10 @@ class FederatedDiscoveryManifest(CoreasonBaseState):
     """
 
     broadcast_endpoints: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        max_length=1000000000, description="The explicit array of strictly bounded MCP URI broadcast endpoints."
+        max_length=1000, description="The explicit array of strictly bounded MCP URI broadcast endpoints."
     )
     supported_ontologies: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="The explicit array of cryptographic hashes defining acceptable domain ontologies.",
     )
 
@@ -2988,7 +2997,7 @@ class BoundedInterventionScopePolicy(CoreasonBaseState):
     """
 
     allowed_fields: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="The explicit whitelist of top-level JSON pointers mathematically open to mutation.",
     )
     json_schema_whitelist: dict[
@@ -3168,7 +3177,7 @@ class BrowserDOMState(CoreasonBaseState):
         return url
 
     viewport_size: tuple[int, int] = Field(
-        max_length=1000000000, description="Capability Perimeters detailing bounding coordinates."
+        max_length=1000, description="Capability Perimeters detailing bounding coordinates."
     )
     dom_hash: str = Field(
         min_length=1,
@@ -3534,7 +3543,7 @@ class CounterfactualRegretEvent(BaseStateEvent):
     policy_mutation_gradients: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[float, Field(ge=-1000.0, le=1000.0)]
     ] = Field(
-        max_length=1000000000,
+        max_length=1000,
         default_factory=dict,
         description="The stateless routing gradient adjustments derived from the calculated regret, used to self-correct future routing.",
     )
@@ -3795,7 +3804,7 @@ class DistributionProfile(CoreasonBaseState):
         le=1000000000.0, default=None, description="The mathematical variance (sigma squared)."
     )
     confidence_interval_95: tuple[float, float] | None = Field(
-        max_length=1000000000, default=None, description="The 95% probability bounds."
+        max_length=1000, default=None, description="The 95% probability bounds."
     )
 
     @model_validator(mode="after")
@@ -3892,7 +3901,7 @@ class DocumentLayoutManifest(CoreasonBaseState):
     """
 
     blocks: dict[Annotated[str, StringConstraints(max_length=255)], DocumentLayoutRegionState] = Field(
-        max_length=1000000000, description="Dictionary mapping block_ids to their strict spatial definitions."
+        max_length=1000, description="Dictionary mapping block_ids to their strict spatial definitions."
     )
     chronological_flow_edges: list[tuple[str, str]] = Field(
         default_factory=list,
@@ -4040,7 +4049,7 @@ class SemanticDiscoveryIntent(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Unlocks the dynamic, runtime mounting of tools and MCP servers whose dense vector embeddings (`query_vector`) align mathematically with the query tensor, bypassing hardcoded tool schemas.
 
-    EPISTEMIC BOUNDS: Mechanically rejects capabilities that fall below the `min_isometry_score` (`ge=-1.0, le=1.0`) boundary. The returned toolsets are strictly limited to the deterministically sorted `required_structural_types` array (`max_length=1000000000`), enforced by the `@model_validator`.
+    EPISTEMIC BOUNDS: Mechanically rejects capabilities that fall below the `min_isometry_score` (`ge=-1.0, le=1.0`) boundary. The returned toolsets are strictly limited to the deterministically sorted `required_structural_types` array (`max_length=1000`), enforced by the `@model_validator`.
 
     MCP ROUTING TRIGGERS: Zero-Shot Tool Discovery, Capability Routing, Dense Vector Embedding, Epistemic Deficit Resolution
 
@@ -4056,7 +4065,7 @@ class SemanticDiscoveryIntent(CoreasonBaseState):
         ge=-1.0, le=1.0, description="The minimum cosine similarity required to authorize a capability mount."
     )
     required_structural_types: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="The strict array of strings defining topological limits on the discovered tools.",
     )
 
@@ -4085,7 +4094,7 @@ class DraftingIntent(CoreasonBaseState):
         max_length=2000, description="The prompt explaining what information the swarm is missing."
     )
     resolution_schema: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="The strict JSON Schema the human's input must satisfy before the graph can resume. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
     )
     timeout_action: Literal["rollback", "proceed_default", "terminate"] = Field(
@@ -5288,7 +5297,7 @@ class DynamicRoutingManifest(CoreasonBaseState):
         default_factory=list, description="The declarative array of steps the orchestrator is mandated to skip."
     )
     branch_budgets_magnitude: dict[NodeIdentifierState, int] = Field(
-        max_length=1000000000, description="The strict allocation of compute budget bound to specific nodes."
+        max_length=1000, description="The strict allocation of compute budget bound to specific nodes."
     )
 
     @model_validator(mode="after")
@@ -5619,7 +5628,7 @@ class GenerativeTaxonomyManifest(CoreasonBaseState):
     human UI or agentic context, structurally proving the geometric relations of all
     subordinate TaxonomicNodeStates.
 
-    EPISTEMIC BOUNDS: The nodes matrix is physically capped at max_length=1000000000
+    EPISTEMIC BOUNDS: The nodes matrix is physically capped at max_length=1000
     properties to prevent memory overflow. The @model_validator mathematically verifies DAG
     integrity by ensuring the root_node_id explicitly exists within the projection matrix,
     preventing ghost nodes.
@@ -5641,7 +5650,7 @@ class GenerativeTaxonomyManifest(CoreasonBaseState):
         description="The globally unique decentralized identifier (DID) anchoring the top-level TaxonomicNodeState initiating the tree.",
     )
     nodes: dict[Annotated[str, StringConstraints(max_length=255)], TaxonomicNodeState] = Field(
-        max_length=1000000000, description="Flat dictionary matrix containing all nodes within the manifold."
+        max_length=1000, description="Flat dictionary matrix containing all nodes within the manifold."
     )
 
     @model_validator(mode="after")
@@ -5859,7 +5868,7 @@ class InterventionIntent(CoreasonBaseState):
     )
     context_summary: str = Field(max_length=2000, description="A summary of the context requiring intervention.")
     proposed_action: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        max_length=1000000000, description="The action proposed by the agent that requires approval."
+        max_length=1000, description="The action proposed by the agent that requires approval."
     )
     adjudication_deadline: float = Field(
         ge=0.0, le=253402300799.0, description="The deadline for adjudication, represented as a UNIX timestamp."
@@ -6102,7 +6111,7 @@ class MemoizedNodeProfile(BaseNodeProfile):
 
     CAUSAL AFFORDANCE: Bypasses redundant thermodynamic compute expenditure by collapsing an entire sub-DAG execution into a single, O(1) state retrieval keyed by the `target_topology_hash`.
 
-    EPISTEMIC BOUNDS: The cache-hit is mathematically locked to the exact `target_topology_hash` (`TopologyHashReceipt`), guaranteeing perfect graph isomorphism. The retrieved payload is physically constrained by `expected_output_schema` (`max_length=1000000000`). The type discriminator is locked to `Literal["memoized"]`.
+    EPISTEMIC BOUNDS: The cache-hit is mathematically locked to the exact `target_topology_hash` (`TopologyHashReceipt`), guaranteeing perfect graph isomorphism. The retrieved payload is physically constrained by `expected_output_schema` (`max_length=1000`). The type discriminator is locked to `Literal["memoized"]`.
 
     MCP ROUTING TRIGGERS: Dynamic Programming, O(1) Retrieval, Cryptographic Cache, Graph Isomorphism, Compute Conservation
 
@@ -6113,7 +6122,7 @@ class MemoizedNodeProfile(BaseNodeProfile):
         description="The exact SHA-256 fingerprint of the executed topology."
     )
     expected_output_schema: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        max_length=1000000000, description="The strictly typed JSON Schema expected from the cached payload."
+        max_length=1000, description="The strictly typed JSON Schema expected from the cached payload."
     )
 
 
@@ -6536,10 +6545,10 @@ class ActionSpaceManifest(CoreasonBaseState):
         description="The unique identifier for this curated environment of tools.",
     )
     capabilities: dict[Annotated[str, StringConstraints(max_length=255)], AnyActionSpaceCapability] = Field(
-        description="The State Space (S) of the MDP, indexed by their unique capability CIDs."
+        max_length=500, description="The State Space (S) of the MDP, indexed by their unique capability CIDs."
     )
     transition_matrix: dict[Annotated[str, StringConstraints(max_length=255)], list[AnyTransitionEdge]] = Field(
-        description="The Stochastic Transition Matrix (P)."
+        max_length=500, description="The Stochastic Transition Matrix (P)."
     )
     entry_point_id: str = Field(description="Defines the initial state (S_0) of the MDP.")
     kinetic_separation: KineticSeparationPolicy | None = Field(
@@ -6757,7 +6766,7 @@ class MCPPromptReferenceState(CoreasonBaseState):
     )
     prompt_name: str = Field(..., max_length=2000, description="The name of the prompt template.")
     arguments: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        max_length=1000000000,
+        max_length=1000,
         default_factory=dict,
         description="Arguments to fill the prompt template. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
     )
@@ -6817,7 +6826,7 @@ class MacroGridProfile(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Translates abstract UI panels into fixed 2D matrices (`layout_matrix`), forcing spatial determinism on the frontend rendering engine.
 
-    EPISTEMIC BOUNDS: A strictly bounded `@model_validator` executes a referential integrity sweep, mathematically guaranteeing that every panel ID referenced in the `layout_matrix` (`max_length=1000000000`) corresponds to a verified object in the `panels` array, physically severing Ghost Panel hallucinations.
+    EPISTEMIC BOUNDS: A strictly bounded `@model_validator` executes a referential integrity sweep, mathematically guaranteeing that every panel ID referenced in the `layout_matrix` (`max_length=1000`) corresponds to a verified object in the `panels` array, physically severing Ghost Panel hallucinations.
 
     MCP ROUTING TRIGGERS: Cartesian Coordinate System, Small Multiples, Spatial Topology, Referential Integrity, Layout Matrix
 
@@ -6825,7 +6834,7 @@ class MacroGridProfile(CoreasonBaseState):
 
     layout_matrix: list[list[Annotated[str, StringConstraints(max_length=255)]]] = Field(
         # Note: layout_matrix is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
-        max_length=1000000000,
+        max_length=1000,
         description="A matrix defining the layout structure, using panel IDs.",
     )
     panels: list[AnyPanelProfile] = Field(
@@ -6873,7 +6882,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:
@@ -6903,7 +6912,7 @@ class MarketResolutionState(CoreasonBaseState):
         min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$", description="The hypothesis ID that was verified."
     )
     falsified_hypothesis_ids: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
-        max_length=1000000000, description="The hypothesis IDs that were falsified."
+        max_length=1000, description="The hypothesis IDs that were falsified."
     )
     payout_distribution: dict[Annotated[str, StringConstraints(max_length=255)], Annotated[int, Field(ge=0)]] = Field(
         description="The deterministic mapping of agent IDs to their earned compute budget/magnitude based on Brier scoring."
@@ -7072,7 +7081,7 @@ class NDimensionalTensorManifest(CoreasonBaseState):
     """
 
     structural_type: TensorStructuralFormatProfile = Field(..., description="Structural type of the tensor elements.")
-    shape: tuple[int, ...] = Field(..., max_length=1000000000, description="N-Dimensional shape tuple.")
+    shape: tuple[int, ...] = Field(..., max_length=1000, description="N-Dimensional shape tuple.")
     vram_footprint_bytes: int = Field(..., le=100000000000, description="Exact byte size of the uncompressed tensor.")
     merkle_root: str = Field(
         ...,
@@ -7232,7 +7241,7 @@ class OntologicalHandshakeReceipt(CoreasonBaseState):
         description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this protocol handshake to the Merkle-DAG.",
     )
     participant_node_ids: list[Annotated[str, StringConstraints(min_length=1, max_length=128)]] = Field(
-        max_length=1000000000, min_length=2, description="The agents establishing semantic alignment."
+        max_length=250, min_length=2, description="The agents establishing semantic alignment."
     )
     measured_cosine_similarity: float = Field(
         ge=-1.0, le=1.0, description="The calculated geometric alignment of the agents' core definitions."
@@ -7312,7 +7321,7 @@ class OverrideIntent(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Forces an absolute Pearlian do-operator intervention ($do(X=x)$). Physically shatters the active causal chain of the `target_node_id` and forcibly injects the `override_action` payload into the state vector, bypassing decentralized voting.
 
-    EPISTEMIC BOUNDS: The blast radius is strictly confined to the `target_node_id`. The orchestrator must mathematically verify the `authorized_node_id` against the highest-tier W3C DID enterprise clearance before allowing the payload to overwrite the Epistemic Blackboard (`override_action` bounded `max_length=1000000000`).
+    EPISTEMIC BOUNDS: The blast radius is strictly confined to the `target_node_id`. The orchestrator must mathematically verify the `authorized_node_id` against the highest-tier W3C DID enterprise clearance before allowing the payload to overwrite the Epistemic Blackboard (`override_action` bounded `max_length=1000`).
 
     MCP ROUTING TRIGGERS: Dictatorial Override, Byzantine Fault Resolution, Pearlian Intervention, Causal Shattering, Zero-Trust Override
 
@@ -7324,7 +7333,7 @@ class OverrideIntent(CoreasonBaseState):
     )
     target_node_id: NodeIdentifierState = Field(description="The NodeIdentifierState being forcefully overridden.")
     override_action: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        max_length=1000000000, description="The exact payload forcefully injected into the state."
+        max_length=1000, description="The exact payload forcefully injected into the state."
     )
     justification: str = Field(
         max_length=2000, description="Cryptographic audit justification for bypassing algorithmic consensus."
@@ -7420,7 +7429,7 @@ class PredictionMarketState(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Aggregates `HypothesisStakeReceipt` vectors, allowing the orchestrator to track the shifting probability manifold and trigger market resolution when the AMM reaches the required convergence threshold.
 
-    EPISTEMIC BOUNDS: `current_market_probabilities` is geometrically bounded by `max_length=1000000000`. `market_id` is restricted to a 128-char CID. `order_book` array is deterministically sorted by `agent_id` via `@model_validator`.
+    EPISTEMIC BOUNDS: `current_market_probabilities` is geometrically bounded by `max_length=1000`. `market_id` is restricted to a 128-char CID. `order_book` array is deterministically sorted by `agent_id` via `@model_validator`.
 
     MCP ROUTING TRIGGERS: Logarithmic Market Scoring Rule, Automated Market Maker, Prediction Market, Infinite Liquidity, Brier Score
 
@@ -7449,7 +7458,7 @@ class PredictionMarketState(CoreasonBaseState):
     current_market_probabilities: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[str, StringConstraints(max_length=255)]
     ] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="Mapping of hypothesis IDs to their current LMSR-calculated market price (probability) as stringified decimals.",
     )
 
@@ -7565,7 +7574,7 @@ class EpistemicSOPManifest(CoreasonBaseState):
     the ability for the orchestrator to dynamically evaluate execution via Process Reward
     Models (prm_evaluations: list[ProcessRewardContract]) at each topological node.
 
-    EPISTEMIC BOUNDS: The cognitive_steps dictionary is constrained to max_length=1000000000
+    EPISTEMIC BOUNDS: The cognitive_steps dictionary is constrained to max_length=1000
     to cap memory footprint. The @model_validator reject_ghost_nodes mathematically enforces
     referential integrity, guaranteeing that no chronological_flow_edges AND no
     structural_grammar_hashes point to an undefined state.
@@ -7584,7 +7593,7 @@ class EpistemicSOPManifest(CoreasonBaseState):
         description="The deterministic cognitive routing boundary for the persona executing the SOP."
     )
     cognitive_steps: dict[Annotated[str, StringConstraints(max_length=255)], CognitiveStateProfile] = Field(
-        max_length=1000000000, description="Dictionary mapping step_ids to strict causal DAG constraints."
+        max_length=1000, description="Dictionary mapping step_ids to strict causal DAG constraints."
     )
     structural_grammar_hashes: dict[Annotated[str, StringConstraints(max_length=255)], str] = Field(
         description="Dictionary mapping step_ids to SHA-256 hashes of strict Context-Free Grammars or JSON Schemas."
@@ -7669,7 +7678,7 @@ class ComputeProvisioningIntent(CoreasonBaseState):
         return values
 
     required_capabilities: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
-        max_length=1000000000, description="The minimal functional capabilities required by the requested compute."
+        max_length=1000, description="The minimal functional capabilities required by the requested compute."
     )
     qos_class: QoSClassificationProfile = Field(
         default="interactive",
@@ -7975,7 +7984,7 @@ class ExogenousEpistemicEvent(CoreasonBaseState):
         description="Strictly bounded mathematical quantification of the epistemic decay or Variational Free Energy.",
     )
     synthetic_payload: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        max_length=1000000000, description="Bounded dictionary representing the injected hallucination or observation."
+        max_length=1000, description="Bounded dictionary representing the injected hallucination or observation."
     )
     escrow: SimulationEscrowContract = Field(description="The cryptographic Proof-of-Stake funding the shock.")
 
@@ -8003,7 +8012,7 @@ class SpanEvent(CoreasonBaseState):
         ge=0, le=253402300799000000000, description="The precise temporal execution point."
     )
     attributes: dict[Annotated[str, StringConstraints(max_length=255)], Any] = Field(
-        max_length=1000000000, default_factory=dict, description="Typed metadata bound to the event."
+        max_length=1000, default_factory=dict, description="Typed metadata bound to the event."
     )
 
 
@@ -8169,7 +8178,7 @@ class StdioTransportProfile(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Physically spawns a child process restricted to the host's operating system namespace, mapping remote procedure calls directly into the binary's stdin/stdout descriptors via `command` (`max_length=2000`).
 
-    EPISTEMIC BOUNDS: To prevent buffer overflow and command injection, `args` are structurally constrained (`max_length=1000000000`, string `max_length=2000`) and `env_vars` keys/values are strictly delimited via `StringConstraints` (`max_length=255` and `2000`).
+    EPISTEMIC BOUNDS: To prevent buffer overflow and command injection, `args` are structurally constrained (`max_length=1000`, string `max_length=2000`) and `env_vars` keys/values are strictly delimited via `StringConstraints` (`max_length=255` and `2000`).
 
     MCP ROUTING TRIGGERS: Inter-Process Communication, POSIX Standard Streams, Local Sandboxing, Binary Execution, Subprocess Spawn
 
@@ -8179,7 +8188,7 @@ class StdioTransportProfile(CoreasonBaseState):
     command: str = Field(..., max_length=2000, description="The command executable to run (e.g., 'node', 'python').")
     args: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
         # Note: args is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
-        max_length=1000000000,
+        max_length=1000,
         default_factory=list,
         description="The explicit array of arguments to pass to the command.",
     )
@@ -8206,7 +8215,7 @@ class SteadyStateHypothesisState(CoreasonBaseState):
     expected_max_latency (ge=0.0, le=1000000000.0). The max_loops_allowed
     (le=1000000000) physically caps algorithmic cycles. The optional
     required_tool_usage (list[str] | None, default=None,
-    max_length=1000000000) is deterministically sorted via @model_validator
+    max_length=1000) is deterministically sorted via @model_validator
     sort_arrays to preserve RFC 8785 canonical hashing.
 
     MCP ROUTING TRIGGERS: Chaos Engineering, Queueing Theory, Steady-State
@@ -8220,7 +8229,7 @@ class SteadyStateHypothesisState(CoreasonBaseState):
         le=1000000000, description="The maximum allowed loops for the swarm to reach a conclusion."
     )
     required_tool_usage: list[Annotated[str, StringConstraints(max_length=2000)]] | None = Field(
-        max_length=1000000000, default=None, description="The strict array of required tools that must be utilized."
+        max_length=1000, default=None, description="The strict array of required tools that must be utilized."
     )
 
     @model_validator(mode="after")
@@ -8282,10 +8291,10 @@ class StructuralCausalGraphProfile(CoreasonBaseState):
     """
 
     observed_variables: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
-        max_length=1000000000, description="The nodes in the DAG that the agent can passively measure."
+        max_length=1000, description="The nodes in the DAG that the agent can passively measure."
     )
     latent_variables: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
-        max_length=1000000000, description="The unobserved confounders the agent suspects exist."
+        max_length=1000, description="The unobserved confounders the agent suspects exist."
     )
     causal_edges: list[CausalDirectedEdgeState] = Field(description="The declared topological mapping of causality.")
 
@@ -8395,7 +8404,7 @@ class System1ReflexPolicy(CoreasonBaseState):
     expensive System 2 Monte Carlo Tree Search (MCTS).
 
     EPISTEMIC BOUNDS: Execution is mathematically gated by the confidence_threshold
-    (ge=0.0, le=1.0). The allowed_passive_tools array (max_length=1000000000,
+    (ge=0.0, le=1.0). The allowed_passive_tools array (max_length=1000,
     StringConstraints max_length=2000) strictly bounds the agent to non-mutating
     capabilities, deterministically sorted via @model_validator.
 
@@ -8407,7 +8416,7 @@ class System1ReflexPolicy(CoreasonBaseState):
         ge=0.0, le=1.0, description="The confidence threshold required to execute a reflex action."
     )
     allowed_passive_tools: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        max_length=1000000000, description="The explicit, bounded array of strictly non-mutating tool capabilities."
+        max_length=1000, description="The explicit, bounded array of strictly non-mutating tool capabilities."
     )
 
     @model_validator(mode="after")
@@ -8689,7 +8698,7 @@ class TheoryOfMindSnapshot(CoreasonBaseState):
         description="The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses."
     )
     identified_knowledge_gaps: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="Specific topics or logical premises the target agent is assumed to be missing.",
     )
 
@@ -8725,7 +8734,7 @@ class ToolInvocationEvent(BaseStateEvent):
     )
     tool_name: str = Field(max_length=2000, description="The exact tool targeted in the ActionSpaceManifest.")
     parameters: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] = Field(
-        max_length=1000000000,
+        max_length=1000,
         description="The intended JSON-RPC payload. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
     )
     authorized_budget_magnitude: int = Field(
@@ -8813,7 +8822,7 @@ class UtilityJustificationGraphReceipt(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Provides explicit mathematical justification for an agent's trajectory. If the variance of the utility distribution exceeds the threshold, it physically forces the orchestrator to deploy the embedded ensemble specification for deterministic resolution.
 
-    EPISTEMIC BOUNDS: The `superposition_variance_threshold` is physically clamped strictly above zero (`gt=0.0`, `le=1000000000.0`), as a variance of absolute 0.0 represents mathematical certainty, which physically precludes superposition geometry. Vector dictionaries are bounded purely by spatial cardinality (`max_length=1000000000`).
+    EPISTEMIC BOUNDS: The `superposition_variance_threshold` is physically clamped strictly above zero (`gt=0.0`, `le=1000000000.0`), as a variance of absolute 0.0 represents mathematical certainty, which physically precludes superposition geometry. Vector dictionaries are bounded purely by spatial cardinality (`max_length=1000`).
 
     MCP ROUTING TRIGGERS: Multi-Attribute Utility Theory, Pareto Efficiency, Variance Reduction, Fallback Superposition, Utility Routing
     """
@@ -8821,14 +8830,14 @@ class UtilityJustificationGraphReceipt(CoreasonBaseState):
     optimizing_vectors: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[float, Field(ge=-1000.0, le=1000.0)]
     ] = Field(
-        max_length=1000000000,
+        max_length=1000,
         default_factory=dict,
         description="Multi-dimensional continuous values representing optimizations.",
     )
     degrading_vectors: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[float, Field(ge=-1000.0, le=1000.0)]
     ] = Field(
-        max_length=1000000000,
+        max_length=1000,
         default_factory=dict,
         description="Multi-dimensional continuous values representing degradations.",
     )
@@ -11431,7 +11440,7 @@ class EpistemicLedgerState(CoreasonBaseState):
         description="A strict sequence of CIDs representing historical nodes that have been severed from the causal graph via defeasible logic.",
     )
     checkpoints: list[TemporalCheckpointState] = Field(
-        max_length=1000000000, default_factory=list, description="Hard temporal anchors allowing state restoration."
+        max_length=1000, default_factory=list, description="Hard temporal anchors allowing state restoration."
     )
     active_rollbacks: list[RollbackIntent] = Field(
         default_factory=list, description="Causal invalidations actively enforced on the execution tree."

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -6882,7 +6882,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:

--- a/tests/contracts/test_ontology_payload_bounds.py
+++ b/tests/contracts/test_ontology_payload_bounds.py
@@ -133,7 +133,6 @@ def test_state_vector_memory_bounds() -> None:
     assert s.mutable_memory == {"test": "abc"}
     assert s.read_only_context == {"rules": "abc"}
 
-
     huge_dict: dict[str, Any] = {}
     for i in range(10001):
         huge_dict[f"key_{i}"] = i

--- a/tests/contracts/test_ontology_payload_bounds.py
+++ b/tests/contracts/test_ontology_payload_bounds.py
@@ -122,10 +122,12 @@ def test_payload_bounds_invalid_type_nested() -> None:
     with pytest.raises(ValueError, match="Payload value must be a valid JSON primitive, got CustomObj"):
         _validate_payload_bounds(payload)  # type: ignore
 
+
 def test_state_vector_memory_bounds():
-    from coreason_manifest.spec.ontology import StateVectorProfile
     import pytest
     from pydantic import ValidationError
+
+    from coreason_manifest.spec.ontology import StateVectorProfile
 
     s = StateVectorProfile(mutable_memory={"test": "abc"}, read_only_context={"rules": "abc"})
     assert s.mutable_memory == {"test": "abc"}

--- a/tests/contracts/test_ontology_payload_bounds.py
+++ b/tests/contracts/test_ontology_payload_bounds.py
@@ -121,3 +121,24 @@ def test_payload_bounds_invalid_type_nested() -> None:
 
     with pytest.raises(ValueError, match="Payload value must be a valid JSON primitive, got CustomObj"):
         _validate_payload_bounds(payload)  # type: ignore
+
+def test_state_vector_memory_bounds():
+    from coreason_manifest.spec.ontology import StateVectorProfile
+    import pytest
+    from pydantic import ValidationError
+
+    s = StateVectorProfile(mutable_memory={"test": "abc"}, read_only_context={"rules": "abc"})
+    assert s.mutable_memory == {"test": "abc"}
+    assert s.read_only_context == {"rules": "abc"}
+
+    huge_dict = {}
+    for i in range(10001):
+        huge_dict[f"key_{i}"] = i
+
+    with pytest.raises(ValidationError) as exc_info:
+        StateVectorProfile(mutable_memory=huge_dict)
+    assert "Payload volume exceeds absolute hardware limit" in str(exc_info.value)
+
+    with pytest.raises(ValidationError) as exc_info:
+        StateVectorProfile(read_only_context=huge_dict)
+    assert "Payload volume exceeds absolute hardware limit" in str(exc_info.value)

--- a/tests/contracts/test_ontology_payload_bounds.py
+++ b/tests/contracts/test_ontology_payload_bounds.py
@@ -123,7 +123,7 @@ def test_payload_bounds_invalid_type_nested() -> None:
         _validate_payload_bounds(payload)  # type: ignore
 
 
-def test_state_vector_memory_bounds():
+def test_state_vector_memory_bounds() -> None:
     import pytest
     from pydantic import ValidationError
 
@@ -133,7 +133,8 @@ def test_state_vector_memory_bounds():
     assert s.mutable_memory == {"test": "abc"}
     assert s.read_only_context == {"rules": "abc"}
 
-    huge_dict = {}
+
+    huge_dict: dict[str, Any] = {}
     for i in range(10001):
         huge_dict[f"key_{i}"] = i
 

--- a/tests/test_execution_envelope.py
+++ b/tests/test_execution_envelope.py
@@ -121,7 +121,7 @@ def test_action_space_manifest_rejects_custom_state() -> None:
     )
 
 
-def test_state_vector_memory_bounds():
+def test_state_vector_memory_bounds() -> None:
     import pytest
     from pydantic import ValidationError
 
@@ -133,7 +133,9 @@ def test_state_vector_memory_bounds():
     assert s.read_only_context == {"rules": "abc"}
 
     # It should fail with huge payloads exceeding nodes
-    huge_dict = {}
+    from typing import Any
+
+    huge_dict: dict[str, Any] = {}
     for i in range(10001):
         huge_dict[f"key_{i}"] = i
 

--- a/tests/test_execution_envelope.py
+++ b/tests/test_execution_envelope.py
@@ -120,10 +120,12 @@ def test_action_space_manifest_rejects_custom_state() -> None:
         },
     )
 
+
 def test_state_vector_memory_bounds():
-    from coreason_manifest.spec.ontology import StateVectorProfile
     import pytest
     from pydantic import ValidationError
+
+    from coreason_manifest.spec.ontology import StateVectorProfile
 
     # It should pass with small valid dictionaries
     s = StateVectorProfile(mutable_memory={"test": "abc"}, read_only_context={"rules": "abc"})

--- a/tests/test_execution_envelope.py
+++ b/tests/test_execution_envelope.py
@@ -119,3 +119,26 @@ def test_action_space_manifest_rejects_custom_state() -> None:
             )
         },
     )
+
+def test_state_vector_memory_bounds():
+    from coreason_manifest.spec.ontology import StateVectorProfile
+    import pytest
+    from pydantic import ValidationError
+
+    # It should pass with small valid dictionaries
+    s = StateVectorProfile(mutable_memory={"test": "abc"}, read_only_context={"rules": "abc"})
+    assert s.mutable_memory == {"test": "abc"}
+    assert s.read_only_context == {"rules": "abc"}
+
+    # It should fail with huge payloads exceeding nodes
+    huge_dict = {}
+    for i in range(10001):
+        huge_dict[f"key_{i}"] = i
+
+    with pytest.raises(ValidationError) as exc_info:
+        StateVectorProfile(mutable_memory=huge_dict)
+    assert "Payload volume exceeds absolute hardware limit" in str(exc_info.value)
+
+    with pytest.raises(ValidationError) as exc_info:
+        StateVectorProfile(read_only_context=huge_dict)
+    assert "Payload volume exceeds absolute hardware limit" in str(exc_info.value)


### PR DESCRIPTION
This pull request addresses Bug 4 and Bug 14 (Out-of-Memory / JSON-Bombing Vulnerabilities) by applying the `_validate_payload_bounds` validator to unbounded memory fields in the `StateVectorProfile` and significantly reducing the astronomically high `max_length` limits (1,000,000,000) on static ontology models to more reasonable bounds (1000, 500, 250) based on their business requirements.

---
*PR created automatically by Jules for task [7171576042870854068](https://jules.google.com/task/7171576042870854068) started by @gowthamrao*