### PR TITLE
🛡️ Sentinel: [HIGH] Fix XSS vulnerability in markdown URI scheme validator

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -5816,7 +5816,12 @@ class InsightCardProfile(CoreasonBaseState):
     @classmethod
     def _prevent_malicious_uri_schemes(cls, v: str) -> str:
         """AGENT INSTRUCTION: Statically sever XSS vectors embedded in markdown links."""
-        if re.search("\\]\\(\\s*(javascript|vbscript|data):", v, flags=re.IGNORECASE):
+        import html
+
+        # Decode HTML entities and strip out all whitespace/control characters to prevent filter bypass
+        v_decoded = html.unescape(v)
+        v_clean = re.sub(r"[\s\x00-\x1f\x7f]+", "", v_decoded)
+        if re.search("\\]\\((javascript|vbscript|data):", v_clean, flags=re.IGNORECASE):
             raise ValueError("Malicious executable link scheme detected in markdown content")
         return v
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix XSS Vulnerability in Markdown Links

🚨 Severity: HIGH
💡 Vulnerability: The markdown content validator `_prevent_malicious_uri_schemes` only relied on a naive regex pattern `r"\]\(\s*(javascript|vbscript|data):"` to identify malicious URI schemes. This can be easily bypassed using whitespace, tabs, and HTML entities within the URL scheme string (e.g. `[click](j&#x41;vascript:alert(1))`).
🎯 Impact: Attackers could inject arbitrary javascript via maliciously formatted links that bypass the regex, leading to Stored XSS if the content is rendered in a web client.
🔧 Fix: Updated the validator to use `html.unescape` and completely strip out all whitespace/control characters before performing the regex check against `javascript`, `vbscript`, and `data` schemes.
✅ Verification: Tested against multiple bypass techniques including spaces before colon, space interpolation, tabs, newlines, and encoded entities. All tests pass locally.

---
*PR created automatically by Jules for task [9086406986843064968](https://jules.google.com/task/9086406986843064968) started by @gowthamrao*