### PR TITLE
🛡️ Sentinel: [HIGH] Fix CPU exhaustion vulnerability via `ast.Pow`

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -347,6 +347,8 @@ def verify_ast_safety(payload: str) -> bool:
     for node in ast.walk(tree):
         if not isinstance(node, allowlist):
             raise ValueError(f"Kinetic execution bleed detected. Forbidden AST node: {type(node).__name__}")
+        if isinstance(node, ast.Pow):
+            raise ValueError("Kinetic execution bleed detected. Forbidden AST node: Pow")
 
     return True
 

--- a/tests/contracts/test_algebra_coverage.py
+++ b/tests/contracts/test_algebra_coverage.py
@@ -530,6 +530,8 @@ def test_verify_ast_safety() -> None:
     assert verify_ast_safety("1 + 1")
     with pytest.raises(ValueError, match="Kinetic execution bleed"):
         verify_ast_safety("__import__('os')")
+    with pytest.raises(ValueError, match="Forbidden AST node: Pow"):
+        verify_ast_safety("2 ** 100")
     with pytest.raises(ValueError, match="not valid syntax"):
         verify_ast_safety("invalid syntax +")
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `verify_ast_safety` utility allowed the `ast.Pow` operator. Python's handling of arbitrarily large integers means allowing the power operator in mathematical evaluation can lead to uncontrolled resource consumption (e.g., `2**100000000`), a form of Denial of Service (DoS) vulnerability.
🎯 Impact: An attacker could craft a malicious dynamic template or string that uses exponential calculations to exhaust the CPU and crash the application.
🔧 Fix: We added an explicit check for `ast.Pow` inside the `ast.walk` loop in `verify_ast_safety` to mathematically ban the operation and prevent execution bleed. We updated the test coverage to enforce this rule.
✅ Verification: Ensure the test suite passes, including the new unit test asserting `Forbidden AST node: Pow` for `2**100`.

---
*PR created automatically by Jules for task [3707897994902548616](https://jules.google.com/task/3707897994902548616) started by @gowthamrao*