### PR TITLE
⚡ Bolt: Extract AST allowlist out of validate_tstring

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -829,6 +829,18 @@ class VolumetricEdgeProfile(CoreasonBaseState):
     )
 
 
+_TSTRING_AST_ALLOWLIST: tuple[type, ...] = (
+    ast.Module,
+    ast.Expr,
+    ast.Constant,
+    ast.Name,
+    ast.Load,
+    ast.FormattedValue,
+    ast.JoinedStr,
+    ast.Expression,
+)
+
+
 class DynamicLayoutManifest(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: Encapsulates a Python 3.14 t-string template as an Abstract Syntax Tree (AST) artifact for declarative, zero-trust UI evaluation.
@@ -857,21 +869,10 @@ class DynamicLayoutManifest(CoreasonBaseState):
 
         MCP ROUTING TRIGGERS: Automata Theory, Abstract Syntax Tree, ACE Prevention, Turing-Incomplete Subgraph, Declarative Interpolation
         """
-        allowed_nodes = (
-            ast.Module,
-            ast.Expr,
-            ast.Constant,
-            ast.Name,
-            ast.Load,
-            ast.FormattedValue,
-            ast.JoinedStr,
-            ast.Expression,
-        )
-
         try:
             tree = ast.parse(v, mode="exec")
             for node in ast.walk(tree):
-                if not isinstance(node, allowed_nodes):
+                if not isinstance(node, _TSTRING_AST_ALLOWLIST):
                     raise ValueError(f"Kinetic execution bleed detected: Forbidden AST node {type(node).__name__}")
         except SyntaxError:
             pass
@@ -880,7 +881,7 @@ class DynamicLayoutManifest(CoreasonBaseState):
         try:
             f_tree = ast.parse(f"f'''{v_escaped}'''", mode="eval")
             for node in ast.walk(f_tree):
-                if not isinstance(node, allowed_nodes):
+                if not isinstance(node, _TSTRING_AST_ALLOWLIST):
                     raise ValueError(f"Kinetic execution bleed detected: Forbidden AST node {type(node).__name__}")
         except SyntaxError:
             pass

--- a/tests/contracts/test_ontology_validators.py
+++ b/tests/contracts/test_ontology_validators.py
@@ -220,7 +220,8 @@ def test_dynamic_layout_manifest_syntax_error() -> None:
 
 
 @pytest.mark.parametrize(
-    ("tstring", "bad_node"), [("f'{a()} {b}'", "Call"), ("print('hello')", "Call"), ("import os", "Import")]
+    ("tstring", "bad_node"),
+    [("f'{a()} {b}'", "Call"), ("print('hello')", "Call"), ("import os", "Import"), ("<html>{a()}</html>", "Call")],
 )
 def test_dynamic_layout_manifest_kinetic_bleed(tstring: str, bad_node: str) -> None:
     with pytest.raises(ValidationError, match=rf"Kinetic execution bleed detected: Forbidden AST node {bad_node}"):


### PR DESCRIPTION
💡 What: Moved the static `allowed_nodes` tuple inside `DynamicLayoutManifest.validate_tstring` to a module-level constant `_TSTRING_AST_ALLOWLIST`.
🎯 Why: Inside the class method, a tuple is allocated every single time the validation function runs. This is redundant memory allocation and incurs per-call overhead for a hot path method parsing ASTs.
📊 Impact: Reduces per-call overhead and avoids redundant memory allocations when running `validate_tstring`. It eliminates `LOAD_GLOBAL` and `BUILD_TUPLE` bytecode instructions on every execution.
🔬 Measurement: Verify using `dis.dis` that `allowed_nodes` is no longer constructed within the method, and run `pytest` to ensure functionality remains identical.

---
*PR created automatically by Jules for task [14808199047231620033](https://jules.google.com/task/14808199047231620033) started by @gowthamrao*