### PR TITLE
⚡ Bolt: Add LRU cache to get_ontology_schema

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -12,3 +12,7 @@
 ## 2026-03-27 - [Caching Canonical Payload Serialization]
 **Learning:** Pydantic's `model_dump(mode="json")` and `json.dumps()` serialization are inherently expensive, particularly on nested dictionary graphs and classes that undergo constant hashing checks. Since `CoreasonBaseState` strictly enforces `frozen=True` rendering models fully immutable upon creation, the result of `model_dump_canonical()` will never change for the entire lifecycle of an object.
 **Action:** For heavily-hashed base structures where immutability is guaranteed at instantiation (`frozen=True`), cache the canonical byte payload natively using `object.__setattr__(self, "_cached_canonical_dump", canonical_dump)` inside `model_dump_canonical()`. This skips repetitive recursive serializations in subsequent calls, bypassing deep Pydantic validation boundaries on reads.
+
+## 2026-03-30 - Caching Pydantic JSON Schema Generation
+**Learning:** Generating JSON schema dynamically from a large set of Pydantic models using `models_json_schema` is computationally expensive because Pydantic has to perform deep reflection and loop through models each time it is called. When called repeatedly (e.g., in loops or CLI invocations), it creates a severe performance bottleneck.
+**Action:** When a function computes a large schema deterministically from static module contents, decorate it with `@functools.lru_cache(maxsize=1)` so that the massive schema generation only happens once per process, drastically speeding up subsequent retrievals.

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -13,6 +13,7 @@
 import ast
 import base64
 import copy
+import functools
 import hashlib
 import math
 import struct
@@ -125,8 +126,8 @@ def project_manifest_to_markdown(manifest: WorkflowManifest) -> str:
     return "\n".join(lines)
 
 
-def get_ontology_schema() -> dict[str, Any]:
-    """Dynamically generate the CoReason ontology JSON schema."""
+@functools.lru_cache(maxsize=1)
+def _get_ontology_schema_cached() -> dict[str, Any]:
     models_to_export: list[type[CoreasonBaseState]] = []
 
     for name in sorted(dir(ontology)):
@@ -149,6 +150,11 @@ def get_ontology_schema() -> dict[str, Any]:
     )
 
     return top_level_schema
+
+
+def get_ontology_schema() -> dict[str, Any]:
+    """Dynamically generate the CoReason ontology JSON schema."""
+    return copy.deepcopy(_get_ontology_schema_cached())
 
 
 def validate_payload(step: str, payload_bytes: bytes) -> BaseModel:

--- a/tests/contracts/test_algebra_coverage.py
+++ b/tests/contracts/test_algebra_coverage.py
@@ -598,6 +598,7 @@ def test_calculate_latent_alignment_errors() -> None:
 @patch("coreason_manifest.utils.algebra.models_json_schema")
 def test_get_ontology_schema_empty(mock_schema: Mock) -> None:
     from coreason_manifest.utils.algebra import _get_ontology_schema_cached
+
     _get_ontology_schema_cached.cache_clear()
     try:
         mock_schema.return_value = (None, {})

--- a/tests/contracts/test_algebra_coverage.py
+++ b/tests/contracts/test_algebra_coverage.py
@@ -597,8 +597,13 @@ def test_calculate_latent_alignment_errors() -> None:
 
 @patch("coreason_manifest.utils.algebra.models_json_schema")
 def test_get_ontology_schema_empty(mock_schema: Mock) -> None:
-    mock_schema.return_value = (None, {})
-    assert get_ontology_schema() == {}
+    from coreason_manifest.utils.algebra import _get_ontology_schema_cached
+    _get_ontology_schema_cached.cache_clear()
+    try:
+        mock_schema.return_value = (None, {})
+        assert get_ontology_schema() == {}
+    finally:
+        _get_ontology_schema_cached.cache_clear()
 
 
 def test_calculate_latent_alignment_invalid_base64() -> None:


### PR DESCRIPTION
Added `@functools.lru_cache` to `_get_ontology_schema_cached` in `src/coreason_manifest/utils/algebra.py` to prevent redundant computations of `models_json_schema()`, generating huge speedups on consecutive calls. The returned dict is deepcopied to prevent mutations from callers.

---
*PR created automatically by Jules for task [3050247301232529228](https://jules.google.com/task/3050247301232529228) started by @gowthamrao*