### PR TITLE
🛡️ Sentinel: [MEDIUM] Add timeout to urlopen in swarm_watchdog.py

### DIFF
--- a/scripts/swarm_watchdog.py
+++ b/scripts/swarm_watchdog.py
@@ -60,7 +60,8 @@ def main() -> None:
 
     try:
         if source.startswith(("http://", "https://")):
-            with urllib.request.urlopen(source) as response:  # noqa: S310
+            # Security fix: Added timeout to prevent hanging on unresponsive servers
+            with urllib.request.urlopen(source, timeout=10) as response:  # noqa: S310
                 schema_dict = json.loads(response.read().decode("utf-8"))
         else:
             with open(source, encoding="utf-8") as f:


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `scripts/swarm_watchdog.py` file uses `urllib.request.urlopen` to fetch an external JSON schema without specifying a timeout parameter.
🎯 Impact: If the external server is unresponsive or slow, the script could hang indefinitely, leading to a Denial-of-Service (DoS) risk or stalled CI/CD pipelines.
🔧 Fix: Added a `timeout=10` parameter to the `urllib.request.urlopen` call to ensure the request fails safely if the server does not respond in time.
✅ Verification: Ran `uv run ruff check scripts/` and `uv run pytest` to ensure no errors or regressions were introduced.

---
*PR created automatically by Jules for task [290536549794700687](https://jules.google.com/task/290536549794700687) started by @gowthamrao*