### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in transport profiles

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -98,6 +98,114 @@ def _canonicalize_payload(obj: Any) -> Any:
     return obj
 
 
+
+def _validate_ssrf_safety(url: str) -> str:
+    """
+    AGENT INSTRUCTION: Implements rigorous Network Topology and Server-Side Request Forgery (SSRF) Quarantine logic to guarantee mathematical zero-trust coordinate mapping.
+
+    CAUSAL AFFORDANCE: Mechanically severs outbound network connections targeting private, reserved, or loopback local infrastructure, pushing complex affine coordinate resolution to the native C-backed IP stack.
+
+    EPISTEMIC BOUNDS: Discards fragile Turing-incomplete string parsing. Explicitly rejects any IP topology that resolves to Bogon space (localhost, link-local, multicast, and private IP ranges) via canonical `ipaddress` parsing.
+
+    MCP ROUTING TRIGGERS: Network Topology, SSRF Quarantine, Bogon Space, Zero-Trust Execution, Lateral Movement Prevention
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme == "file":
+        raise ValueError("SSRF topological violation detected: file:// schema is forbidden")
+    hostname = parsed.hostname
+    if not hostname:
+        if parsed.scheme in ("http", "https"):
+            raise ValueError("SSRF topological violation detected: Invalid hostname in HTTP URI")
+        return url
+
+    hostname_lower = hostname.lower()
+    if hostname_lower in {
+        "localhost",
+        "broadcasthost",
+        "local",
+        "internal",
+        "localtest.me",
+    } or hostname_lower.endswith(
+        (
+            ".local",
+            ".internal",
+            ".arpa",
+            "localhost.localdomain",
+            ".nip.io",
+            ".sslip.io",
+            ".xip.io",
+            ".vcap.me",
+            ".localtest.me",
+        )
+    ):
+        raise ValueError(f"SSRF topological violation detected: {hostname}")
+
+    import ipaddress
+    import socket
+
+    def _parse_obfuscated_ipv4(ip_str: str) -> int | None:
+        parts = ip_str.split(".")
+        if len(parts) > 4:
+            return None
+        parsed = []
+        try:
+            for p in parts:
+                if p.startswith(("0x", "0X")):
+                    parsed.append(int(p, 16))
+                elif p.startswith("0") and len(p) > 1 and all(c in "01234567" for c in p):
+                    parsed.append(int(p, 8))
+                else:
+                    parsed.append(int(p, 10))
+        except ValueError:
+            return None
+        if len(parts) == 1:
+            val = parsed[0]
+        elif len(parts) == 2:
+            val = (parsed[0] << 24) | parsed[1]
+        elif len(parts) == 3:
+            val = (parsed[0] << 24) | (parsed[1] << 16) | parsed[2]
+        else:
+            val = (parsed[0] << 24) | (parsed[1] << 16) | (parsed[2] << 8) | parsed[3]
+        return val if val <= 0xFFFFFFFF else None
+
+    ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = None
+
+    # Canonical validation of affine coordinate isomorphism for obfuscated IPv4 formats
+    ip_int = _parse_obfuscated_ipv4(hostname_lower)
+    if ip_int is not None:
+        ip = ipaddress.IPv4Address(ip_int)
+    else:
+        hostname_clean = hostname.strip("[]")
+        try:
+            # First try to parse as IP directly (covers IPv6 and standard IPv4 formats)
+            ip = ipaddress.ip_address(hostname_clean)
+        except ValueError:
+            try:
+                # Step 1: Resolve the hostname to an IP address
+                # This prevents bypassing the check via domain names
+                raw_ip = socket.gethostbyname(hostname_clean)
+                ip = ipaddress.ip_address(raw_ip)
+            except (socket.gaierror, ValueError) as e:
+                # Fail-Closed: If resolution fails or IP is invalid, reject the request
+                raise ValueError(f"Security Validation Failed: Unresolvable or invalid host: {hostname}") from e
+
+    if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
+        ip = ip.ipv4_mapped
+
+    if (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or getattr(ip, "is_unspecified", False)
+        or not getattr(ip, "is_global", True)
+    ):
+        raise ValueError(f"SSRF restricted IP detected: {hostname}")
+
+    return url
+
+
 type AuctionMechanismProfile = Literal["sealed_bid", "dutch", "vickrey"]
 type CausalIntervalProfile = Literal["strictly_precedes", "overlaps", "contains", "causes", "mitigates"]
 type CrossoverMechanismProfile = Literal["uniform_blend", "single_point", "heuristic"]
@@ -3185,101 +3293,7 @@ class BrowserDOMState(CoreasonBaseState):
 
         MCP ROUTING TRIGGERS: Network Topology, SSRF Quarantine, Bogon Space, Zero-Trust Execution, Lateral Movement Prevention
         """
-        parsed = urllib.parse.urlparse(url)
-        if parsed.scheme == "file":
-            raise ValueError("SSRF topological violation detected: file:// schema is forbidden")
-        hostname = parsed.hostname
-        if not hostname:
-            if parsed.scheme in ("http", "https"):
-                raise ValueError("SSRF topological violation detected: Invalid hostname in HTTP URI")
-            return url
-
-        hostname_lower = hostname.lower()
-        if hostname_lower in {
-            "localhost",
-            "broadcasthost",
-            "local",
-            "internal",
-            "localtest.me",
-        } or hostname_lower.endswith(
-            (
-                ".local",
-                ".internal",
-                ".arpa",
-                "localhost.localdomain",
-                ".nip.io",
-                ".sslip.io",
-                ".xip.io",
-                ".vcap.me",
-                ".localtest.me",
-            )
-        ):
-            raise ValueError(f"SSRF topological violation detected: {hostname}")
-
-        import ipaddress
-        import socket
-
-        def _parse_obfuscated_ipv4(ip_str: str) -> int | None:
-            parts = ip_str.split(".")
-            if len(parts) > 4:
-                return None
-            parsed = []
-            try:
-                for p in parts:
-                    if p.startswith(("0x", "0X")):
-                        parsed.append(int(p, 16))
-                    elif p.startswith("0") and len(p) > 1 and all(c in "01234567" for c in p):
-                        parsed.append(int(p, 8))
-                    else:
-                        parsed.append(int(p, 10))
-            except ValueError:
-                return None
-            if len(parts) == 1:
-                val = parsed[0]
-            elif len(parts) == 2:
-                val = (parsed[0] << 24) | parsed[1]
-            elif len(parts) == 3:
-                val = (parsed[0] << 24) | (parsed[1] << 16) | parsed[2]
-            else:
-                val = (parsed[0] << 24) | (parsed[1] << 16) | (parsed[2] << 8) | parsed[3]
-            return val if val <= 0xFFFFFFFF else None
-
-        ip: ipaddress.IPv4Address | ipaddress.IPv6Address | None = None
-
-        # Canonical validation of affine coordinate isomorphism for obfuscated IPv4 formats
-        ip_int = _parse_obfuscated_ipv4(hostname_lower)
-        if ip_int is not None:
-            ip = ipaddress.IPv4Address(ip_int)
-        else:
-            hostname_clean = hostname.strip("[]")
-            try:
-                # First try to parse as IP directly (covers IPv6 and standard IPv4 formats)
-                ip = ipaddress.ip_address(hostname_clean)
-            except ValueError:
-                try:
-                    # Step 1: Resolve the hostname to an IP address
-                    # This prevents bypassing the check via domain names
-                    raw_ip = socket.gethostbyname(hostname_clean)
-                    ip = ipaddress.ip_address(raw_ip)
-                except (socket.gaierror, ValueError) as e:
-                    # Fail-Closed: If resolution fails or IP is invalid, reject the request
-                    raise ValueError(f"Security Validation Failed: Unresolvable or invalid host: {hostname}") from e
-
-        if isinstance(ip, ipaddress.IPv6Address) and ip.ipv4_mapped:
-            ip = ip.ipv4_mapped
-
-        if (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-            or getattr(ip, "is_unspecified", False)
-            or not getattr(ip, "is_global", True)
-        ):
-            raise ValueError(f"SSRF restricted IP detected: {hostname}")
-
-        return url
+        return _validate_ssrf_safety(url)
 
     viewport_size: tuple[int, int] = Field(
         max_length=1000, description="Capability Perimeters detailing bounding coordinates."
@@ -5559,6 +5573,15 @@ class HTTPTransportProfile(CoreasonBaseState):
     headers: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[str, StringConstraints(max_length=2000)]
     ] = Field(default_factory=dict, description="HTTP headers, strictly bounded for zero-trust credentials.")
+
+    @field_validator("uri", mode="after")
+    @classmethod
+    def _enforce_ssrf_quarantine(cls, url: HttpUrl) -> HttpUrl:
+        """
+        AGENT INSTRUCTION: Implements Network Topology and Server-Side Request Forgery (SSRF) Quarantine logic.
+        """
+        _validate_ssrf_safety(str(url))
+        return url
 
     @field_validator("headers", mode="after")
     @classmethod
@@ -7927,6 +7950,15 @@ class SSETransportProfile(CoreasonBaseState):
     headers: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[str, StringConstraints(max_length=2000)]
     ] = Field(default_factory=dict, description="HTTP headers, e.g., for authentication.")
+
+    @field_validator("uri", mode="after")
+    @classmethod
+    def _enforce_ssrf_quarantine(cls, url: HttpUrl) -> HttpUrl:
+        """
+        AGENT INSTRUCTION: Implements Network Topology and Server-Side Request Forgery (SSRF) Quarantine logic.
+        """
+        _validate_ssrf_safety(str(url))
+        return url
 
     @field_validator("headers", mode="after")
     @classmethod

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -98,7 +98,6 @@ def _canonicalize_payload(obj: Any) -> Any:
     return obj
 
 
-
 def _validate_ssrf_safety(url: str) -> str:
     """
     AGENT INSTRUCTION: Implements rigorous Network Topology and Server-Side Request Forgery (SSRF) Quarantine logic to guarantee mathematical zero-trust coordinate mapping.

--- a/tests/contracts/test_transport_ssrf.py
+++ b/tests/contracts/test_transport_ssrf.py
@@ -57,6 +57,7 @@ def test_http_transport_profile_valid(url: str) -> None:
     profile = HTTPTransportProfile(uri=url)
     assert str(profile.uri) == url
 
+
 @pytest.mark.parametrize(
     "url",
     [

--- a/tests/contracts/test_transport_ssrf.py
+++ b/tests/contracts/test_transport_ssrf.py
@@ -1,0 +1,69 @@
+# Copyright (c) 2026 CoReason, Inc
+#
+# This software is proprietary and dual-licensed
+# Licensed under the Prosperity Public License 3.0 (the "License")
+# A copy of the license is available at <https://prosperitylicense.com/versions/3.0.0>
+# For details, see the LICENSE file
+# Commercial use beyond a 30-day trial requires a separate license
+#
+# Source Code: <https://github.com/CoReason-AI/coreason-manifest>
+
+import pytest
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import HTTPTransportProfile, SSETransportProfile
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8080/admin",
+        "http://127.0.0.1/",
+        "http://[::1]/",
+        "http://169.254.169.254/",
+        "http://192.168.1.1/",
+        "http://localtest.me/",
+    ],
+)
+def test_http_transport_profile_ssrf(url: str) -> None:
+    with pytest.raises(ValidationError, match=r"SSRF (topological violation|restricted IP) detected"):
+        HTTPTransportProfile(uri=url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost:8080/admin",
+        "http://127.0.0.1/",
+        "http://[::1]/",
+        "http://169.254.169.254/",
+        "http://192.168.1.1/",
+        "http://localtest.me/",
+    ],
+)
+def test_sse_transport_profile_ssrf(url: str) -> None:
+    with pytest.raises(ValidationError, match=r"SSRF (topological violation|restricted IP) detected"):
+        SSETransportProfile(uri=url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.example.com/",
+        "http://1.1.1.1/",
+    ],
+)
+def test_http_transport_profile_valid(url: str) -> None:
+    profile = HTTPTransportProfile(uri=url)
+    assert str(profile.uri) == url
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "https://www.example.com/",
+        "http://1.1.1.1/",
+    ],
+)
+def test_sse_transport_profile_valid(url: str) -> None:
+    profile = SSETransportProfile(uri=url)
+    assert str(profile.uri) == url

--- a/tests/contracts/test_transport_ssrf.py
+++ b/tests/contracts/test_transport_ssrf.py
@@ -9,7 +9,7 @@
 # Source Code: <https://github.com/CoReason-AI/coreason-manifest>
 
 import pytest
-from pydantic import ValidationError
+from pydantic import HttpUrl, ValidationError
 
 from coreason_manifest.spec.ontology import HTTPTransportProfile, SSETransportProfile
 
@@ -27,7 +27,7 @@ from coreason_manifest.spec.ontology import HTTPTransportProfile, SSETransportPr
 )
 def test_http_transport_profile_ssrf(url: str) -> None:
     with pytest.raises(ValidationError, match=r"SSRF (topological violation|restricted IP) detected"):
-        HTTPTransportProfile(uri=url)
+        HTTPTransportProfile(uri=HttpUrl(url))
 
 
 @pytest.mark.parametrize(
@@ -43,7 +43,7 @@ def test_http_transport_profile_ssrf(url: str) -> None:
 )
 def test_sse_transport_profile_ssrf(url: str) -> None:
     with pytest.raises(ValidationError, match=r"SSRF (topological violation|restricted IP) detected"):
-        SSETransportProfile(uri=url)
+        SSETransportProfile(uri=HttpUrl(url))
 
 
 @pytest.mark.parametrize(
@@ -54,7 +54,7 @@ def test_sse_transport_profile_ssrf(url: str) -> None:
     ],
 )
 def test_http_transport_profile_valid(url: str) -> None:
-    profile = HTTPTransportProfile(uri=url)
+    profile = HTTPTransportProfile(uri=HttpUrl(url))
     assert str(profile.uri) == url
 
 
@@ -66,5 +66,5 @@ def test_http_transport_profile_valid(url: str) -> None:
     ],
 )
 def test_sse_transport_profile_valid(url: str) -> None:
-    profile = SSETransportProfile(uri=url)
+    profile = SSETransportProfile(uri=HttpUrl(url))
     assert str(profile.uri) == url

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -148,7 +148,7 @@ def test_mcp_quarantine_gateway_tripwire() -> None:
     with pytest.raises(ValidationError, match="UNAUTHORIZED MCP MOUNT"):
         MCPServerManifest(
             server_id="rogue_server_1",
-            transport=HTTPTransportProfile(uri=HttpUrl("http://rogue-server"), headers={}),
+            transport=HTTPTransportProfile(uri=HttpUrl("http://www.example.com"), headers={}),
             capability_whitelist=MCPCapabilityWhitelistPolicy(
                 allowed_tools=["shell"], allowed_resources=["file://*"], allowed_prompts=["system"]
             ),


### PR DESCRIPTION
Added SSRF validation logic for `HTTPTransportProfile` and `SSETransportProfile` by extracting the existing SSRF validation from `BrowserDOMState` to a shared utility and calling it for the transport profiles. Also added dedicated tests to ensure the validation blocks restricted IPs correctly.

---
*PR created automatically by Jules for task [9823469981411156246](https://jules.google.com/task/9823469981411156246) started by @gowthamrao*