### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF parser differential bypass

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -109,6 +109,14 @@ def _validate_ssrf_safety(url: str) -> str:
     if parsed.scheme == "file":
         raise ValueError("SSRF topological violation detected: file:// schema is forbidden")
     hostname = parsed.hostname
+
+    if not hostname and parsed.scheme:
+        path = parsed.path.lstrip("/")
+        if path:
+            fallback_url = f"//{path}"
+            fallback_parsed = urllib.parse.urlparse(fallback_url)
+            hostname = fallback_parsed.hostname
+
     if not hostname:
         if parsed.scheme in ("http", "https"):
             raise ValueError("SSRF topological violation detected: Invalid hostname in HTTP URI")

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -110,7 +110,7 @@ def _validate_ssrf_safety(url: str) -> str:
         raise ValueError("SSRF topological violation detected: file:// schema is forbidden")
     hostname = parsed.hostname
 
-    if not hostname and parsed.scheme:
+    if not hostname and parsed.scheme in ("http", "https", "ftp", "sftp", "dict", "gopher", "ldap", "redis", "wss", "ws"):
         path = parsed.path.lstrip("/")
         if path:
             fallback_url = f"//{path}"

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -110,7 +110,18 @@ def _validate_ssrf_safety(url: str) -> str:
         raise ValueError("SSRF topological violation detected: file:// schema is forbidden")
     hostname = parsed.hostname
 
-    if not hostname and parsed.scheme in ("http", "https", "ftp", "sftp", "dict", "gopher", "ldap", "redis", "wss", "ws"):
+    if not hostname and parsed.scheme in (
+        "http",
+        "https",
+        "ftp",
+        "sftp",
+        "dict",
+        "gopher",
+        "ldap",
+        "redis",
+        "wss",
+        "ws",
+    ):
         path = parsed.path.lstrip("/")
         if path:
             fallback_url = f"//{path}"

--- a/tests/contracts/test_transport_ssrf.py
+++ b/tests/contracts/test_transport_ssrf.py
@@ -65,6 +65,23 @@ def test_http_transport_profile_valid(url: str) -> None:
 @pytest.mark.parametrize(
     "url",
     [
+        "dict:///127.0.0.1:11211/",
+        "gopher:///127.0.0.1:11211/",
+        "ftp:/127.0.0.1",
+        "sftp:127.0.0.1",
+        "ldap://localhost:389",
+    ],
+)
+def test_raw_ssrf_safety_malformed_schemes(url: str) -> None:
+    from coreason_manifest.spec.ontology import _validate_ssrf_safety
+
+    with pytest.raises(ValueError, match=r"SSRF (topological violation|restricted IP) detected"):
+        _validate_ssrf_safety(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
         "https://www.example.com/",
         "http://1.1.1.1/",
     ],

--- a/tests/contracts/test_transport_ssrf.py
+++ b/tests/contracts/test_transport_ssrf.py
@@ -23,6 +23,8 @@ from coreason_manifest.spec.ontology import HTTPTransportProfile, SSETransportPr
         "http://169.254.169.254/",
         "http://192.168.1.1/",
         "http://localtest.me/",
+        "http:127.0.0.1",
+        "http:/127.0.0.1",
     ],
 )
 def test_http_transport_profile_ssrf(url: str) -> None:
@@ -39,6 +41,8 @@ def test_http_transport_profile_ssrf(url: str) -> None:
         "http://169.254.169.254/",
         "http://192.168.1.1/",
         "http://localtest.me/",
+        "http:127.0.0.1",
+        "http:/127.0.0.1",
     ],
 )
 def test_sse_transport_profile_ssrf(url: str) -> None:


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Server-Side Request Forgery (SSRF) parser differential bypass. Python's `urllib.parse.urlparse` fails to extract the `hostname` (returning `None`) for certain malformed schemas (e.g., `dict:///127.0.0.1:11211/`, `gopher:///`, `http:127.0.0.1`). This bypasses the security check while potentially being normalized and accepted by underlying networking libraries like `urllib.request`.
🎯 **Impact:** An attacker could bypass the `_validate_ssrf_safety` checks using malformed URLs (like `dict:///127.0.0.1:11211/` or `ftp:/169.254.169.254`), allowing them to make unauthorized requests to internal infrastructure, private APIs, or sensitive services like AWS metadata endpoints.
🔧 **Fix:** Implemented a fallback parsing mechanism in `_validate_ssrf_safety`. If the `hostname` is missing but a `scheme` is present, it extracts the `path`, strips leading slashes, and re-parses it with a prepended `//`. This forces `urlparse` to correctly extract the hidden hostname so it can be evaluated by the existing SSRF blocklist logic.
✅ **Verification:** Verified via test scripts that bypassed URLs (e.g., `dict:///127.0.0.1:11211/`) are now properly blocked and flagged as "SSRF restricted IP detected: 127.0.0.1", while valid external URLs (e.g., `http://google.com`) are still allowed. The main test suite (`uv run pytest`) passes with no regressions.

---
*PR created automatically by Jules for task [13366304531413778748](https://jules.google.com/task/13366304531413778748) started by @gowthamrao*