### PR TITLE
feat(ontology): Epistemic Profiling and Grounding Framework

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1295,7 +1295,8 @@
           "persistence_commit": "#/$defs/PersistenceCommitReceipt",
           "system_fault": "#/$defs/SystemFaultEvent",
           "token_burn": "#/$defs/TokenBurnReceipt",
-          "tool_invocation": "#/$defs/ToolInvocationEvent"
+          "tool_invocation": "#/$defs/ToolInvocationEvent",
+          "transmutation_observation": "#/$defs/TransmutationObservationEvent"
         },
         "propertyName": "type"
       },
@@ -1356,6 +1357,9 @@
         },
         {
           "$ref": "#/$defs/IntentClassificationReceipt"
+        },
+        {
+          "$ref": "#/$defs/TransmutationObservationEvent"
         }
       ]
     },
@@ -6468,6 +6472,52 @@
       "title": "EpistemicLedgerState",
       "type": "object"
     },
+    "EpistemicMappingContract": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Homotopy Type Theory (HoTT) and Profunctor Optics to establish a rigid mathematical bridge between a high-entropy source dialect and a universal target ontology. As a ...Contract suffix, this defines a rigid mathematical boundary.\n\nCAUSAL AFFORDANCE: Authorizes the translation engine to map external geometries into the swarm's Hollow Data Plane without executing arbitrary procedural code. It relies exclusively on deterministic Lens and Prism compositions.\n\nEPISTEMIC BOUNDS: The source_dialect_keys and target_dids arrays are deterministically sorted by the @model_validator to prevent Byzantine Hash poisoning. The optical_mapping_sequence explicitly invokes the Topological Exemption, physically preserving the chronological execution order of the crosswalk.\n\nMCP ROUTING TRIGGERS: Homotopy Type Theory, Profunctor Optics, Univalent Foundations, Semantic Crosswalking, Latent Isomorphism",
+      "properties": {
+        "contract_cid": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Contract Cid",
+          "type": "string"
+        },
+        "source_dialect_keys": {
+          "description": "The explicit array of incoming exogenous dimensions or properties.",
+          "items": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "title": "Source Dialect Keys",
+          "type": "array"
+        },
+        "target_dids": {
+          "description": "The mathematically verified universal coordinates (W3C DIDs) acting as the target ontology.",
+          "items": {
+            "$ref": "#/$defs/NodeCIDState"
+          },
+          "title": "Target Dids",
+          "type": "array"
+        },
+        "optical_mapping_sequence": {
+          "description": "The chronological sequence of Profunctor Optics (Lenses and Prisms) used to safely bridge the data.",
+          "items": {
+            "$ref": "#/$defs/OpticalMappingContract"
+          },
+          "title": "Optical Mapping Sequence",
+          "type": "array"
+        }
+      },
+      "required": [
+        "contract_cid",
+        "source_dialect_keys",
+        "target_dids",
+        "optical_mapping_sequence"
+      ],
+      "title": "EpistemicMappingContract",
+      "type": "object"
+    },
     "EpistemicPromotionEvent": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents Hippocampal-Neocortical Consolidation, proving the successful extraction and transfer of generalized knowledge from short-term episodic traces into the permanent semantic graph.\n\nCAUSAL AFFORDANCE: Emits a permanent Merkle-DAG coordinate (`crystallized_semantic_node_id`) that downstream agents can zero-shot reference, severing the need to reload raw source logs into active context.\n\nEPISTEMIC BOUNDS: Mathematical chain of custody bound to the strictly sorted array of `source_episodic_event_cids`. Token efficiency proven by `compression_ratio` float (`le=1.0`) guaranteeing Shannon Entropy reduction.\n\nMCP ROUTING TRIGGERS: Hippocampal Consolidation, Knowledge Distillation, Semantic Memory, Shannon Entropy Compression, Epistemic Promotion",
@@ -8266,6 +8316,47 @@
         "cache_priority_weight"
       ],
       "title": "FederatedPeftContract",
+      "type": "object"
+    },
+    "FederatedSourceProfile": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot utilizing Topological Data Analysis (TDA) to quantify the shape and entropy of an exogenous data manifold prior to kinetic processing. As a ...Profile suffix, this defines a rigid mathematical boundary.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to preemptively calculate the thermodynamic compute budget (VRAM footprint and token limits) required to load the payload, bypassing execution if the volume exceeds hardware constraints.\n\nEPISTEMIC BOUNDS: Spatial geometry is rigidly clamped by manifold_cardinality_nodes and manifold_cardinality_edges (ge=0, le=1000000000). The @model_validator validate_simplicial_geometry mathematically prevents the instantiation of impossible topologies (edges existing without nodes).\n\nMCP ROUTING TRIGGERS: Topological Data Analysis, Betti Numbers, Shannon Entropy, Exogenous Manifold, Simplicial Complex",
+      "properties": {
+        "exogenous_dialect_uri": {
+          "description": "The URI or structural pointer to the exogenous schema dialect.",
+          "maxLength": 2048,
+          "title": "Exogenous Dialect Uri",
+          "type": "string"
+        },
+        "manifold_cardinality_nodes": {
+          "description": "The absolute count of 0-simplices (entities/rows) in the source manifold.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Manifold Cardinality Nodes",
+          "type": "integer"
+        },
+        "manifold_cardinality_edges": {
+          "description": "The absolute count of 1-simplices (relationships/foreign keys) in the source manifold.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Manifold Cardinality Edges",
+          "type": "integer"
+        },
+        "shannon_entropy_index": {
+          "description": "A normalized scalar measuring the aleatoric noise (unstructured fields, nulls) within the payload.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Shannon Entropy Index",
+          "type": "number"
+        }
+      },
+      "required": [
+        "exogenous_dialect_uri",
+        "manifold_cardinality_nodes",
+        "manifold_cardinality_edges",
+        "shannon_entropy_index"
+      ],
+      "title": "FederatedSourceProfile",
       "type": "object"
     },
     "FederatedStateSnapshot": {
@@ -16860,6 +16951,65 @@
         "compute_weight_magnitude"
       ],
       "title": "TransitionEdgeProfile",
+      "type": "object"
+    },
+    "TransmutationObservationEvent": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact recording the passive assessment and topological profiling of an exogenous dataset prior to kinetic mutation. As an ...Event suffix, this is an append-only coordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Injects the verified exogenous structural profile into the EpistemicLedgerState, allowing the orchestrator to determine if the bayesian_surprise_score requires the escalation of Test-Time Compute (System 2) to resolve semantic ambiguity.\n\nEPISTEMIC BOUNDS: The bayesian_surprise_score is strictly clamped to a continuous float space (ge=0.0, le=1.0). Topologically anchored to the event_cid (128-char CID regex).\n\nMCP ROUTING TRIGGERS: Source Entropy Measurement, Passive Profiling, Kullback-Leibler Divergence, Epistemic Baseline, Bayesian Surprise",
+      "properties": {
+        "event_cid": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Event Cid",
+          "type": "string"
+        },
+        "prior_event_hash": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Prior Event Hash"
+        },
+        "timestamp": {
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "type": {
+          "const": "transmutation_observation",
+          "default": "transmutation_observation",
+          "title": "Type",
+          "type": "string"
+        },
+        "observed_manifold": {
+          "$ref": "#/$defs/FederatedSourceProfile",
+          "description": "The quantified geometric measurement of the exogenous dataset."
+        },
+        "bayesian_surprise_score": {
+          "description": "The Kullback-Leibler divergence between the new exogenous manifold and the swarm's existing baseline.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Bayesian Surprise Score",
+          "type": "number"
+        }
+      },
+      "required": [
+        "event_cid",
+        "timestamp",
+        "observed_manifold",
+        "bayesian_surprise_score"
+      ],
+      "title": "TransmutationObservationEvent",
       "type": "object"
     },
     "TruthMaintenancePolicy": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -6481,6 +6481,36 @@ class OpticalMappingContract(CoreasonBaseState):
     strict_isomorphism: bool = Field(default=True, description="If true, mathematically forbids type coercion.")
 
 
+class EpistemicMappingContract(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Formalizes Homotopy Type Theory (HoTT) and Profunctor Optics to establish a rigid mathematical bridge between a high-entropy source dialect and a universal target ontology. As a ...Contract suffix, this defines a rigid mathematical boundary.
+
+    CAUSAL AFFORDANCE: Authorizes the translation engine to map external geometries into the swarm's Hollow Data Plane without executing arbitrary procedural code. It relies exclusively on deterministic Lens and Prism compositions.
+
+    EPISTEMIC BOUNDS: The source_dialect_keys and target_dids arrays are deterministically sorted by the @model_validator to prevent Byzantine Hash poisoning. The optical_mapping_sequence explicitly invokes the Topological Exemption, physically preserving the chronological execution order of the crosswalk.
+
+    MCP ROUTING TRIGGERS: Homotopy Type Theory, Profunctor Optics, Univalent Foundations, Semantic Crosswalking, Latent Isomorphism
+    """
+
+    contract_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    source_dialect_keys: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
+        description="The explicit array of incoming exogenous dimensions or properties."
+    )
+    target_dids: list[NodeCIDState] = Field(
+        description="The mathematically verified universal coordinates (W3C DIDs) acting as the target ontology."
+    )
+    optical_mapping_sequence: list[OpticalMappingContract] = Field(
+        description="The chronological sequence of Profunctor Optics (Lenses and Prisms) used to safely bridge the data."
+    )
+    # Note: optical_mapping_sequence is a structurally ordered sequence (Topological Exemption) and MUST NOT be sorted.
+
+    @model_validator(mode="after")
+    def _enforce_canonical_sort(self) -> Self:
+        object.__setattr__(self, "source_dialect_keys", sorted(self.source_dialect_keys))
+        object.__setattr__(self, "target_dids", sorted(self.target_dids))
+        return self
+
+
 class MCPServerManifest(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: Represents a cryptographically verifiable Distributed RPC substrate mapping within the Actor Model, binding an external Model Context Protocol (MCP) manifold into the swarm's local topology under strict Object-Capability (OCap) rules.
@@ -12131,6 +12161,70 @@ class DifferentiableLogicConstraint(CoreasonBaseState):
     )
 
 
+class FederatedSourceProfile(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A declarative, frozen snapshot utilizing Topological Data Analysis (TDA) to quantify the shape and entropy of an exogenous data manifold prior to kinetic processing. As a ...Profile suffix, this defines a rigid mathematical boundary.
+
+    CAUSAL AFFORDANCE: Authorizes the orchestrator to preemptively calculate the thermodynamic compute budget (VRAM footprint and token limits) required to load the payload, bypassing execution if the volume exceeds hardware constraints.
+
+    EPISTEMIC BOUNDS: Spatial geometry is rigidly clamped by manifold_cardinality_nodes and manifold_cardinality_edges (ge=0, le=1000000000). The @model_validator validate_simplicial_geometry mathematically prevents the instantiation of impossible topologies (edges existing without nodes).
+
+    MCP ROUTING TRIGGERS: Topological Data Analysis, Betti Numbers, Shannon Entropy, Exogenous Manifold, Simplicial Complex
+    """
+
+    exogenous_dialect_uri: Annotated[str, StringConstraints(max_length=2048)] = Field(
+        description="The URI or structural pointer to the exogenous schema dialect."
+    )
+    manifold_cardinality_nodes: int = Field(
+        ge=0, le=1000000000, description="The absolute count of 0-simplices (entities/rows) in the source manifold."
+    )
+    manifold_cardinality_edges: int = Field(
+        ge=0,
+        le=1000000000,
+        description="The absolute count of 1-simplices (relationships/foreign keys) in the source manifold.",
+    )
+    shannon_entropy_index: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="A normalized scalar measuring the aleatoric noise (unstructured fields, nulls) within the payload.",
+    )
+
+    @model_validator(mode="after")
+    def validate_simplicial_geometry(self) -> Self:
+        if self.manifold_cardinality_edges > 0 and self.manifold_cardinality_nodes < 2:
+            raise ValueError(
+                "Topological Contradiction: A manifold with edges (> 0) must possess at least 2 nodes to form valid 1-simplices."
+            )
+        return self
+
+
+class TransmutationObservationEvent(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A cryptographically frozen historical fact recording the passive assessment and topological profiling of an exogenous dataset prior to kinetic mutation. As an ...Event suffix, this is an append-only coordinate on the Merkle-DAG.
+
+    CAUSAL AFFORDANCE: Injects the verified exogenous structural profile into the EpistemicLedgerState, allowing the orchestrator to determine if the bayesian_surprise_score requires the escalation of Test-Time Compute (System 2) to resolve semantic ambiguity.
+
+    EPISTEMIC BOUNDS: The bayesian_surprise_score is strictly clamped to a continuous float space (ge=0.0, le=1.0). Topologically anchored to the event_cid (128-char CID regex).
+
+    MCP ROUTING TRIGGERS: Source Entropy Measurement, Passive Profiling, Kullback-Leibler Divergence, Epistemic Baseline, Bayesian Surprise
+    """
+
+    event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    prior_event_hash: (
+        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
+    ) = Field(default=None)
+    timestamp: float = Field(ge=0.0, le=253402300799.0)
+    type: Literal["transmutation_observation"] = Field(default="transmutation_observation")
+    observed_manifold: FederatedSourceProfile = Field(
+        description="The quantified geometric measurement of the exogenous dataset."
+    )
+    bayesian_surprise_score: float = Field(
+        ge=0.0,
+        le=1.0,
+        description="The Kullback-Leibler divergence between the new exogenous manifold and the swarm's existing baseline.",
+    )
+
+
 type AnyStateEvent = Annotated[
     ObservationEvent
     | BeliefMutationEvent
@@ -12150,7 +12244,8 @@ type AnyStateEvent = Annotated[
     | CognitiveRewardEvaluationReceipt
     | EpistemicFlowStateReceipt
     | CausalExplanationEvent
-    | IntentClassificationReceipt,
+    | IntentClassificationReceipt
+    | TransmutationObservationEvent,
     Field(discriminator="type", description="A discriminated union of state events."),
 ]
 
@@ -12478,3 +12573,7 @@ NeurosymbolicInferenceRequest.model_rebuild()
 
 EpistemicUpsamplingTask.model_rebuild()
 VolumetricPartitionSubscription.model_rebuild()
+
+FederatedSourceProfile.model_rebuild()
+TransmutationObservationEvent.model_rebuild()
+EpistemicMappingContract.model_rebuild()


### PR DESCRIPTION
Implements EPIC 1: Information Science (Epistemic Profiling & Grounding).

This pull request introduces three new foundational schemas (`FederatedSourceProfile`, `TransmutationObservationEvent`, and `EpistemicMappingContract`) extending `CoreasonBaseState`. They implement explicit bounding mechanisms for exogenous data entropy and formalize mathematical schema conversions using Topological Data Analysis and Homotopy Type Theory, adhering strictly to the shared kernel architectural directives (no CRUD, RFC 8785 canonical sort, topological exemption inline comments).

---
*PR created automatically by Jules for task [17310333140529843357](https://jules.google.com/task/17310333140529843357) started by @gowthamrao*