### PR TITLE
fix: enforce categorical suffix law for ontology classes

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+[lint]
+extend-ignore = ["N818"]

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -153,18 +153,18 @@ type CrossoverMechanismProfile = Literal["uniform_blend", "single_point", "heuri
 _CLEARANCE_MAPPING: dict[str, int] = {"public": 0, "internal": 1, "confidential": 2, "restricted": 3}
 
 
-class ComputeTier(StrEnum):
+class ComputeTierProfile(StrEnum):
     KINETIC = "KINETIC"
     ORACLE = "ORACLE"
 
 
-class AcceleratorType(StrEnum):
+class AcceleratorTypeProfile(StrEnum):
     FP8_TENSOR = "FP8_TENSOR"
     BF16_TENSOR = "BF16_TENSOR"
     CUDA_FP32 = "CUDA_FP32"
 
 
-class EpistemicSecurity(StrEnum):
+class EpistemicSecurityProfile(StrEnum):
     STANDARD = "STANDARD"
     CONFIDENTIAL = "CONFIDENTIAL"
 
@@ -447,7 +447,7 @@ def _inject_workflow_examples(schema: dict[str, Any]) -> None:
     ]
 
 
-class RefusalToReasonError(ValueError):
+class RefusalToReasonEvent(ValueError):
     """Exception raised when inference is aborted due to severe semantic degradation."""
 
 
@@ -6164,13 +6164,13 @@ class HardwareProfile(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Instructs the orchestrator's provisioning layer to allocate exact silicon resources (Compute Tier, VRAM, and Accelerator Type) before allowing the node to execute generative operations.
 
-    EPISTEMIC BOUNDS: VRAM allocation is physically bounded by min_vram_gb (gt=0.0). The literal enumerations ComputeTier and AcceleratorType mathematically prevent the hallucination of non-existent silicon. The provider_whitelist is deterministically sorted for invariant RFC 8785 hashing.
+    EPISTEMIC BOUNDS: VRAM allocation is physically bounded by min_vram_gb (gt=0.0). The literal enumerations ComputeTierProfile and AcceleratorTypeProfile mathematically prevent the hallucination of non-existent silicon. The provider_whitelist is deterministically sorted for invariant RFC 8785 hashing.
 
     MCP ROUTING TRIGGERS: Thermodynamic Bounding, VRAM Allocation, Spot Market Routing, Hardware Provisioning, Silicon Constraints
     """
 
-    compute_tier: ComputeTier = Field(
-        default=ComputeTier.KINETIC,
+    compute_tier: ComputeTierProfile = Field(
+        default=ComputeTierProfile.KINETIC,
         description="The discrete architectural boundary of the node (KINETIC for edge/consumer, ORACLE for datacenter).",
     )
     min_vram_gb: float = Field(
@@ -6178,8 +6178,8 @@ class HardwareProfile(CoreasonBaseState):
         default=8.0,
         description="The absolute physical minimum Video RAM required to load this node's latent space.",
     )
-    accelerator_type: AcceleratorType = Field(
-        default=AcceleratorType.BF16_TENSOR,
+    accelerator_type: AcceleratorTypeProfile = Field(
+        default=AcceleratorTypeProfile.BF16_TENSOR,
         description="The rigid silicon precision format required to execute this node's neural circuits.",
     )
     provider_whitelist: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
@@ -6204,8 +6204,8 @@ class SecurityProfile(CoreasonBaseState):
     MCP ROUTING TRIGGERS: Sovereign Execution, Trusted Execution Environment, Egress Obfuscation, Mixnet Routing, Network Isolation
     """
 
-    epistemic_security: EpistemicSecurity = Field(
-        default=EpistemicSecurity.STANDARD,
+    epistemic_security: EpistemicSecurityProfile = Field(
+        default=EpistemicSecurityProfile.STANDARD,
         description="The level of hardware-enforced cryptographic isolation required (STANDARD or CONFIDENTIAL).",
     )
     network_isolation: bool = Field(
@@ -9875,12 +9875,12 @@ class AgentNodeProfile(CoreasonBaseState):
         Enforces Thermodynamic, Sovereign Execution, and Network Topology paradox traps.
         """
 
-        if self.hardware.compute_tier == ComputeTier.KINETIC and self.hardware.min_vram_gb > 24.0:
+        if self.hardware.compute_tier == ComputeTierProfile.KINETIC and self.hardware.min_vram_gb > 24.0:
             raise ValueError(
                 "Thermodynamic Constraint Violated: KINETIC tier cannot exceed 24.0 GB VRAM. Escalate to ORACLE tier."
             )
 
-        if self.security.epistemic_security == EpistemicSecurity.CONFIDENTIAL and not set(
+        if self.security.epistemic_security == EpistemicSecurityProfile.CONFIDENTIAL and not set(
             self.hardware.provider_whitelist
         ).issubset(_TRUSTED_ENVIRONMENTS):
             invalid_targets = set(self.hardware.provider_whitelist) - _TRUSTED_ENVIRONMENTS
@@ -12478,7 +12478,7 @@ class NeurosymbolicInferenceRequest(CoreasonBaseState):
     @model_validator(mode="after")
     def validate_epistemic_gap(self) -> Self:
         if self.uncertainty_profile.epistemic_knowledge_gap >= self.sla.minimum_fidelity_threshold:
-            raise RefusalToReasonError(
+            raise RefusalToReasonEvent(
                 "Inference aborted due to severe semantic degradation. Epistemic gap exceeds SLA."
             )
         return self

--- a/tests/contracts/test_ontology_validators.py
+++ b/tests/contracts/test_ontology_validators.py
@@ -21,7 +21,7 @@ from coreason_manifest.spec.ontology import (
     CognitiveUncertaintyProfile,
     ComputeEngineProfile,
     ComputeRateContract,
-    ComputeTier,
+    ComputeTierProfile,
     ConsensusPolicy,
     ConstrainedDecodingPolicy,
     ContextualizedSourceEntity,
@@ -31,7 +31,7 @@ from coreason_manifest.spec.ontology import (
     DynamicLayoutManifest,
     EphemeralNamespacePartitionState,
     EpistemicCompressionSLA,
-    EpistemicSecurity,
+    EpistemicSecurityProfile,
     EpistemicUpsamplingTask,
     GradingCriterionProfile,
     HardwareProfile,
@@ -814,16 +814,16 @@ def test_kinematic_delta_manifest_sorting() -> None:
 def test_agent_node_profile_success() -> None:
     """Test that default values instantiate cleanly without triggering traps."""
     agent = AgentNodeProfile(description="Test agent")
-    assert agent.hardware.compute_tier == ComputeTier.KINETIC
+    assert agent.hardware.compute_tier == ComputeTierProfile.KINETIC
     assert agent.hardware.min_vram_gb == 8.0
-    assert agent.security.epistemic_security == EpistemicSecurity.STANDARD
+    assert agent.security.epistemic_security == EpistemicSecurityProfile.STANDARD
 
 
 def test_agent_node_profile_thermodynamic_paradox() -> None:
     """Test that KINETIC tier cannot exceed 24.0 GB VRAM."""
     with pytest.raises(ValueError, match="Thermodynamic Constraint Violated"):
         AgentNodeProfile(
-            description="Test agent", hardware=HardwareProfile(compute_tier=ComputeTier.KINETIC, min_vram_gb=25.0)
+            description="Test agent", hardware=HardwareProfile(compute_tier=ComputeTierProfile.KINETIC, min_vram_gb=25.0)
         )
 
 
@@ -833,16 +833,16 @@ def test_agent_node_profile_sovereign_execution_paradox() -> None:
         AgentNodeProfile(
             description="Test agent",
             hardware=HardwareProfile(provider_whitelist=["vast", "aws"]),
-            security=SecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+            security=SecurityProfile(epistemic_security=EpistemicSecurityProfile.CONFIDENTIAL),
         )
 
     # Success case for CONFIDENTIAL
     agent = AgentNodeProfile(
         description="Test agent",
         hardware=HardwareProfile(provider_whitelist=["aws", "gcp"]),
-        security=SecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+        security=SecurityProfile(epistemic_security=EpistemicSecurityProfile.CONFIDENTIAL),
     )
-    assert agent.security.epistemic_security == EpistemicSecurity.CONFIDENTIAL
+    assert agent.security.epistemic_security == EpistemicSecurityProfile.CONFIDENTIAL
 
 
 def test_sovereign_execution_allows_localhost_and_bare_metal() -> None:
@@ -850,10 +850,10 @@ def test_sovereign_execution_allows_localhost_and_bare_metal() -> None:
     profile = AgentNodeProfile(
         description="Secure local ETL agent for proprietary schemas.",
         hardware=HardwareProfile(provider_whitelist=["localhost", "bare-metal"]),
-        security=SecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+        security=SecurityProfile(epistemic_security=EpistemicSecurityProfile.CONFIDENTIAL),
     )
     # If the validation passes without raising ValueError, the contract holds.
-    assert profile.security.epistemic_security == EpistemicSecurity.CONFIDENTIAL
+    assert profile.security.epistemic_security == EpistemicSecurityProfile.CONFIDENTIAL
     assert "localhost" in profile.hardware.provider_whitelist
 
 

--- a/tests/fuzzing/test_instantiation_bounds.py
+++ b/tests/fuzzing/test_instantiation_bounds.py
@@ -19,12 +19,12 @@ from coreason_manifest.spec.ontology import (
     AgentNodeProfile,
     BrowserDOMState,
     CognitiveUncertaintyProfile,
-    ComputeTier,
+    ComputeTierProfile,
     ContextualizedSourceEntity,
     DAGTopologyManifest,
     DataFidelityReceipt,
     EpistemicCompressionSLA,
-    EpistemicSecurity,
+    EpistemicSecurityProfile,
     HardwareProfile,
     MultimodalTokenAnchorState,
     NeurosymbolicInferenceRequest,
@@ -279,7 +279,7 @@ def test_fuzz_thermodynamic_paradox(min_vram_gb: float) -> None:
     with pytest.raises((ValueError, ValidationError), match="Thermodynamic Constraint Violated"):
         AgentNodeProfile(
             description="Fuzz test agent",
-            hardware=HardwareProfile(compute_tier=ComputeTier.KINETIC, min_vram_gb=min_vram_gb),
+            hardware=HardwareProfile(compute_tier=ComputeTierProfile.KINETIC, min_vram_gb=min_vram_gb),
         )
 
 
@@ -300,15 +300,15 @@ def test_fuzz_sovereign_execution_paradox(provider_whitelist: list[str]) -> None
             AgentNodeProfile(
                 description="Fuzz test agent",
                 hardware=HardwareProfile(provider_whitelist=provider_whitelist),
-                security=SecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+                security=SecurityProfile(epistemic_security=EpistemicSecurityProfile.CONFIDENTIAL),
             )
     else:
         agent = AgentNodeProfile(
             description="Fuzz test agent",
             hardware=HardwareProfile(provider_whitelist=provider_whitelist),
-            security=SecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+            security=SecurityProfile(epistemic_security=EpistemicSecurityProfile.CONFIDENTIAL),
         )
-        assert agent.security.epistemic_security == EpistemicSecurity.CONFIDENTIAL
+        assert agent.security.epistemic_security == EpistemicSecurityProfile.CONFIDENTIAL
         assert agent.hardware.provider_whitelist == sorted(provider_whitelist)
 
 


### PR DESCRIPTION
The codebase had several classes in `ontology.py` that did not conform to the categorical suffix law specified in the AGENTS.md document, which mandates ending with `...Receipt`, `...Event`, `...Intent`, `...Policy`, `...Contract`, `...SLA`, `...State`, `...Snapshot`, `...Manifest`, or `...Profile`.

This pull request renames:
- `ComputeTier` -> `ComputeTierProfile`
- `AcceleratorType` -> `AcceleratorTypeProfile`
- `EpistemicSecurity` -> `EpistemicSecurityProfile`
- `RefusalToReasonError` -> `RefusalToReasonEvent`

It also updates the related occurrences in the test codebase and ignores the N818 Ruff rule to permit exceptions named without the "Error" suffix.

---
*PR created automatically by Jules for task [8776988637105039210](https://jules.google.com/task/8776988637105039210) started by @gowthamrao*