### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix dual-stack SSRF bypass in transport validation

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -126,21 +126,22 @@ def _validate_ssrf_safety(url: str) -> str:
             raise ValueError(f"SSRF restricted IP detected: {hostname}") from None
 
     try:
-        raw_ip = socket.gethostbyname(hostname_clean)
-        ip = ipaddress.ip_address(raw_ip)
+        addrinfo = socket.getaddrinfo(hostname_clean, None)
+        ips = [ipaddress.ip_address(info[4][0]) for info in addrinfo]
     except (socket.gaierror, ValueError) as e:
         raise ValueError(f"Security Validation Failed: Unresolvable or invalid host: {hostname}") from e
 
-    if (
-        ip.is_private
-        or ip.is_loopback
-        or ip.is_multicast
-        or getattr(ip, "is_link_local", False)
-        or getattr(ip, "is_reserved", False)
-        or getattr(ip, "is_unspecified", False)
-        or not getattr(ip, "is_global", True)
-    ):
-        raise ValueError(f"SSRF restricted IP detected: {hostname}") from None
+    for ip in ips:
+        if (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_multicast
+            or getattr(ip, "is_link_local", False)
+            or getattr(ip, "is_reserved", False)
+            or getattr(ip, "is_unspecified", False)
+            or not getattr(ip, "is_global", True)
+        ):
+            raise ValueError(f"SSRF restricted IP detected: {hostname}") from None
 
     return url
 

--- a/tests/contracts/test_transport_ssrf.py
+++ b/tests/contracts/test_transport_ssrf.py
@@ -23,6 +23,8 @@ from coreason_manifest.spec.ontology import HTTPTransportProfile, SSETransportPr
         "http://169.254.169.254/",
         "http://192.168.1.1/",
         "http://localtest.me/",
+        "http://127.0.0.1.nip.io/",
+        "http://[0:0:0:0:0:FFFF:127.0.0.1]/",
     ],
 )
 def test_http_transport_profile_ssrf(url: str) -> None:
@@ -42,6 +44,8 @@ def test_http_transport_profile_ssrf(url: str) -> None:
         "http://169.254.169.254/",
         "http://192.168.1.1/",
         "http://localtest.me/",
+        "http://127.0.0.1.nip.io/",
+        "http://[0:0:0:0:0:FFFF:127.0.0.1]/",
     ],
 )
 def test_sse_transport_profile_ssrf(url: str) -> None:


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `_validate_ssrf_safety` network filter relied on `socket.gethostbyname`, which only resolves IPv4 addresses. An attacker could bypass the SSRF filter entirely by routing traffic through an IPv6 loopback or private address, as the filter would only evaluate the IPv4 component.
🎯 Impact: This dual-stack SSRF bypass allowed arbitrary internal requests (e.g., against `localhost` or metadata endpoints) over IPv6, circumventing the mathematical zero-trust network boundaries of the application.
🔧 Fix: Updated the DNS resolution function to use `socket.getaddrinfo`, which captures both IPv4 and IPv6 records. The SSRF filter now iterates over *all* resolved IP addresses for a given hostname, raising an exception if *any* IP resolves to a restricted/private loopback range.
✅ Verification: Ran `uv run pytest` testing dual stack loopbacks and `nip.io` resolvers successfully.

---
*PR created automatically by Jules for task [16265336394532694751](https://jules.google.com/task/16265336394532694751) started by @gowthamrao*