### PR TITLE
Fix ontology class suffix violations

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -4,10 +4,11 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes syntactic failure geometries, replacing unstructured tracebacks with deterministic, high-dimensional loss vectors.\n\n    CAUSAL AFFORDANCE: Executes deterministic code repair strategies by supplying the generative optimization mechanism with precise structural node pointers indicating syntax fractures.\n\n    EPISTEMIC BOUNDS: Bounded structurally via a 128-char compilation ID and precise AST string pointers clamped to 2000 chars. Vector magnitudes define the specific error distance.\n\n    MCP ROUTING TRIGGERS: AST Pointer, Generative Repair, Syntax Falsification, High-Dimensional Loss, Structural Gradient",
       "properties": {
-        "actual_type_geometry": {
-          "description": "The physical contravariant type string encountered at the structural fracture point.",
-          "maxLength": 2000,
-          "title": "Actual Type Geometry",
+        "compilation_attempt_id": {
+          "description": "The deterministic cryptographic coordinate linking the failure geometry to the execution timeline.",
+          "maxLength": 128,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Compilation Attempt Id",
           "type": "string"
         },
         "ast_node_pointer": {
@@ -16,17 +17,16 @@
           "title": "Ast Node Pointer",
           "type": "string"
         },
-        "compilation_attempt_id": {
-          "description": "The deterministic cryptographic coordinate linking the failure geometry to the execution timeline.",
-          "maxLength": 128,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Compilation Attempt Id",
-          "type": "string"
-        },
         "expected_type_geometry": {
           "description": "The explicit structural definition of the mathematical covariant bound requirement.",
           "maxLength": 2000,
           "title": "Expected Type Geometry",
+          "type": "string"
+        },
+        "actual_type_geometry": {
+          "description": "The physical contravariant type string encountered at the structural fracture point.",
+          "maxLength": 2000,
+          "title": "Actual Type Geometry",
           "type": "string"
         },
         "structural_loss_vector": {
@@ -65,6 +65,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a hardware-level Representation Engineering (RepE) directive to mechanically manipulate latent dimensions via forward-pass tensor injection.\n\nCAUSAL AFFORDANCE: Physically forces an additive, ablation, or clamping operation onto the model's residual stream at specific `injection_layers`, steering the generator away from unstable hallucination geometries prior to token projection.\n\nEPISTEMIC BOUNDS: Cryptographically locked by `steering_vector_hash` (SHA-256 pattern `^[a-f0-9]{64}$`). `scaling_factor` is bounded above (`le=100.0`) but unbounded below, permitting negative magnitudes for ablation. The `@model_validator` deterministically sorts `injection_layers` (each `ge=0`).\n\nMCP ROUTING TRIGGERS: Representation Engineering, RepE, Activation Steering, Residual Stream Ablation, Concept Vectors",
       "properties": {
+        "steering_vector_hash": {
+          "description": "The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Steering Vector Hash",
+          "type": "string"
+        },
         "injection_layers": {
           "description": "The specific transformer layer indices where this vector must be applied.",
           "items": {
@@ -80,14 +88,6 @@
           "maximum": 100.0,
           "title": "Scaling Factor",
           "type": "number"
-        },
-        "steering_vector_hash": {
-          "description": "The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Steering Vector Hash",
-          "type": "string"
         },
         "vector_modality": {
           "description": "The tensor operation to perform: add the vector, subtract it, or clamp activations to its bounds.",
@@ -113,32 +113,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the formal Fristonian Active Inference policy for an autonomous agent, mandating the minimization of Expected Free Energy through targeted epistemic foraging. As a ...Contract suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Unlocks kinetic tool execution strictly for the purpose of empirical observation, routing compute to maximize epistemic certainty (Shannon Information Gain) regarding a specific hypothesis to collapse the probability wave.\n\nEPISTEMIC BOUNDS: Mathematically constrained by expected_information_gain (a continuous float bounded between ge=0.0 and le=1.0 representing Shannon entropy reduction) and an economic execution_cost_budget_magnitude cap (ge=0, le=1000000000) to prevent thermodynamic runaway.\n\nMCP ROUTING TRIGGERS: Active Inference, Expected Free Energy, Epistemic Foraging, Fristonian Mechanics, Shannon Entropy Reduction",
       "properties": {
-        "execution_cost_budget_magnitude": {
-          "description": "The maximum economic expenditure authorized to run this specific scientific test.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Execution Cost Budget Magnitude",
-          "type": "integer"
-        },
-        "expected_information_gain": {
-          "description": "The mathematically estimated reduction in Epistemic Uncertainty (entropy) this tool call will yield.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Expected Information Gain",
-          "type": "number"
-        },
-        "selected_tool_name": {
-          "description": "The exact tool from the CognitiveActionSpaceManifest allocated for this experiment.",
-          "maxLength": 2000,
-          "title": "Selected Tool Name",
-          "type": "string"
-        },
-        "target_condition_id": {
-          "description": "The specific FalsificationContract being tested.",
+        "task_cid": {
+          "description": "Unique identifier for this active inference execution.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Condition Id",
+          "title": "Task Cid",
           "type": "string"
         },
         "target_hypothesis_id": {
@@ -149,13 +129,33 @@
           "title": "Target Hypothesis Id",
           "type": "string"
         },
-        "task_cid": {
-          "description": "Unique identifier for this active inference execution.",
+        "target_condition_id": {
+          "description": "The specific FalsificationContract being tested.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Cid",
+          "title": "Target Condition Id",
           "type": "string"
+        },
+        "selected_tool_name": {
+          "description": "The exact tool from the CognitiveActionSpaceManifest allocated for this experiment.",
+          "maxLength": 2000,
+          "title": "Selected Tool Name",
+          "type": "string"
+        },
+        "expected_information_gain": {
+          "description": "The mathematically estimated reduction in Epistemic Uncertainty (entropy) this tool call will yield.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Expected Information Gain",
+          "type": "number"
+        },
+        "execution_cost_budget_magnitude": {
+          "description": "The maximum economic expenditure authorized to run this specific scientific test.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Execution Cost Budget Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -173,6 +173,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Social Choice Theory to resolve the Condorcet Paradox. Triggers a Mixed-Initiative forced resolution to break an epistemic deadlock within a Council topology.\n\nCAUSAL AFFORDANCE: Halts the active execution DAG and forces an external oracle (human or system) to act as a Dictatorial tie-breaker, definitively collapsing the probability wave of competing claims in a Multi-Criteria Decision Analysis (MCDA) framework.\n\nEPISTEMIC BOUNDS: The state space is bounded by `deadlocked_claims` (`min_length=2, max_length=86400000`). The `resolution_schema` is mathematically bounded against recursive JSON-bombing by the `enforce_payload_topology` hook, physically preventing Automata Intersection deadlocks.\n\nMCP ROUTING TRIGGERS: Social Choice Theory, Condorcet Paradox, MCDA Deadlock, Dictatorial Resolution, Tie-Breaking Heuristic",
       "properties": {
+        "topology_class": {
+          "const": "forced_adjudication",
+          "default": "forced_adjudication",
+          "description": "Discriminator for breaking deadlocks within a CouncilTopologyManifest.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "deadlocked_claims": {
           "description": "The conflicting claim IDs or proposals the human must choose between.",
           "items": {
@@ -205,13 +212,6 @@
           ],
           "title": "Timeout Action",
           "type": "string"
-        },
-        "topology_class": {
-          "const": "forced_adjudication",
-          "default": "forced_adjudication",
-          "description": "Discriminator for breaking deadlocks within a CouncilTopologyManifest.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -226,6 +226,25 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the\ndefinitive collapse of an MCDA evaluation, acting as a verified Outcome Reward Model\n(ORM) signal. As a ...Receipt suffix, this is an append-only coordinate on the\nMerkle-DAG.\n\nCAUSAL AFFORDANCE: Commits the calculated score and boolean passed verdict to the\nEpistemic Ledger, permanently binding the deterministic evaluation to the specific\ntarget_node_cid (NodeCIDState) and authorizing downstream policy updates.\n\nEPISTEMIC BOUNDS: The evaluation outcome is strictly bounded to an integer score\n(ge=0, le=100). The underlying deductive proof (reasoning) is physically capped at\nmax_length=2000. The entire receipt is cryptographically locked to the originating\nrubric_cid CID (128-char regex).\n\nMCP ROUTING TRIGGERS: Cryptographic Verdict, Deterministic Proof, Grading Execution,\nEpistemic Commitment, Audit Trail",
       "properties": {
+        "rubric_cid": {
+          "description": "The cryptographic pointer to the rubric dictating adjudication.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Rubric Cid",
+          "type": "string"
+        },
+        "target_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The deterministic capability pointer representing the node that was evaluated."
+        },
+        "score": {
+          "description": "The final score assigned based on the rubric.",
+          "maximum": 100,
+          "minimum": 0,
+          "title": "Score",
+          "type": "integer"
+        },
         "passed": {
           "description": "Indicates whether the evaluation passed the threshold.",
           "title": "Passed",
@@ -236,25 +255,6 @@
           "maxLength": 2000,
           "title": "Reasoning",
           "type": "string"
-        },
-        "rubric_cid": {
-          "description": "The cryptographic pointer to the rubric dictating adjudication.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Rubric Cid",
-          "type": "string"
-        },
-        "score": {
-          "description": "The final score assigned based on the rubric.",
-          "maximum": 100,
-          "minimum": 0,
-          "title": "Score",
-          "type": "integer"
-        },
-        "target_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The deterministic capability pointer representing the node that was evaluated."
         }
       },
       "required": [
@@ -271,6 +271,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes an Aggregation Function for Multi-Criteria Decision\nAnalysis (MCDA), compiling multiple utility dimensions into a definitive evaluation\nboundary for the swarm. As a ...Profile suffix, this defines a rigid mathematical\nboundary.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's verification engine on how to\ncalculate the total weighted score of a generated trajectory, triggering a\ndeterministic boolean pass/fail gate based on the aggregate sum.\n\nEPISTEMIC BOUNDS: The success condition is mathematically locked by passing_threshold\n(ge=0.0, le=100.0). The rubric_cid is a 128-char CID anchor. The @model_validator\nsort_arrays deterministically sorts the criteria array by criterion_cid, guaranteeing\ninvariant RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Evaluation Manifold, Threshold Gating, Deterministic Rubric,\nRFC 8785 Canonicalization, Binary State Transition",
       "properties": {
+        "rubric_cid": {
+          "description": "Unique identifier for the rubric.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Rubric Cid",
+          "type": "string"
+        },
         "criteria": {
           "description": "The explicit array of strict evaluation criteria defining the rubric.",
           "items": {
@@ -285,14 +293,6 @@
           "minimum": 0.0,
           "title": "Passing Threshold",
           "type": "number"
-        },
-        "rubric_cid": {
-          "description": "Unique identifier for the rubric.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Rubric Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -307,25 +307,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Aggregates the full Adversarial Emulation geometry, composing\nKinematicNoiseProfile (pointer perturbation) and EnvironmentalSpoofingProfile\n(browser fingerprint masking) into a unified anti-detection manifold governed by\na generative imitation learning persona. As a ...Profile suffix, this is a\ndeclarative, frozen snapshot of an N-dimensional emulation coordinate.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator's Spatial Kinematics engine to\nsimultaneously inject stochastic pointer noise and spoof environmental telemetry,\nachieving a target emulation_fidelity_target score against anti-bot heuristics\nwhile behaviorally mimicking the selected generative_persona.\n\nEPISTEMIC BOUNDS: The emulation_fidelity_target is strictly clamped to the\nnormalized probability range (ge=0.0, le=1.0). Both sub-profiles are optional\n(default=None), allowing partial emulation geometries. The generative_persona\nis locked to a Literal automaton [\"hesitant_novice\", \"fast_expert\",\n\"distracted_browser\"].\n\nMCP ROUTING TRIGGERS: Adversarial Emulation, Anti-Bot Evasion, Imitation\nLearning, Browser Fingerprint Spoofing, Emulation Fidelity",
       "properties": {
-        "emulation_fidelity_target": {
-          "description": "The target normalized score for human-likeness against anti-bot heuristic classifiers.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Emulation Fidelity Target",
-          "type": "number"
-        },
-        "environmental_spoofing": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EnvironmentalSpoofingProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The browser fingerprint and environmental telemetry spoofing geometry."
-        },
         "generative_persona": {
           "default": "fast_expert",
           "description": "The imitation learning persona governing the behavioral emulation profile.",
@@ -348,6 +329,25 @@
           ],
           "default": null,
           "description": "The stochastic pointer trajectory perturbation profile for human-like motor control emulation."
+        },
+        "environmental_spoofing": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EnvironmentalSpoofingProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The browser fingerprint and environmental telemetry spoofing geometry."
+        },
+        "emulation_fidelity_target": {
+          "description": "The target normalized score for human-likeness against anti-bot heuristic classifiers.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Emulation Fidelity Target",
+          "type": "number"
         }
       },
       "required": [
@@ -360,9 +360,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Zero-Cost Macro abstraction that mathematically projects a Zero-Sum Minimax game into a rigid Red/Blue team CouncilTopologyManifest. As a ...Manifest suffix, this defines a frozen coordinate of a topological structure.\n\nCAUSAL AFFORDANCE: Deterministically compiles into a fully bounded Council topology, forcing the generative router to evaluate claims through adversarial debate before the orchestrator resolves equilibrium via the designated market rules.\n\nEPISTEMIC BOUNDS: The @model_validator verify_disjoint_sets mathematically guarantees that blue_team_cids, red_team_cids, and the adjudicator_cid are strictly disjoint to prevent self-dealing or topological paradoxes. Arrays are deterministically sorted to preserve RFC 8785 canonical hashes.\n\nMCP ROUTING TRIGGERS: Zero-Sum Minimax Game, Red Team vs Blue Team, Macro Abstraction, Generative Adversarial Networks, Topological Compilation",
       "properties": {
-        "adjudicator_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The neutral node responsible for synthesizing the market resolution."
+        "topology_class": {
+          "const": "macro_adversarial",
+          "default": "macro_adversarial",
+          "description": "Discriminator for adversarial macro.",
+          "title": "Topology Class",
+          "type": "string"
         },
         "blue_team_cids": {
           "description": "Nodes assigned to the Blue Team.",
@@ -373,10 +376,6 @@
           "title": "Blue Team Cids",
           "type": "array"
         },
-        "market_rules": {
-          "$ref": "#/$defs/PredictionMarketPolicy",
-          "description": "The mathematical AMM rules for the debate."
-        },
         "red_team_cids": {
           "description": "Nodes assigned to the Red Team.",
           "items": {
@@ -386,12 +385,13 @@
           "title": "Red Team Cids",
           "type": "array"
         },
-        "topology_class": {
-          "const": "macro_adversarial",
-          "default": "macro_adversarial",
-          "description": "Discriminator for adversarial macro.",
-          "title": "Topology Class",
-          "type": "string"
+        "adjudicator_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The neutral node responsible for synthesizing the market resolution."
+        },
+        "market_rules": {
+          "$ref": "#/$defs/PredictionMarketPolicy",
+          "description": "The mathematical AMM rules for the debate."
         }
       },
       "required": [
@@ -417,6 +417,22 @@
         }
       ],
       "properties": {
+        "simulation_id": {
+          "description": "The unique identifier for this red-team experiment.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Simulation Id",
+          "type": "string"
+        },
+        "target_node_cid": {
+          "description": "The exact NodeCIDState the 'Judas Node' will attempt to compromise.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Node Cid",
+          "type": "string"
+        },
         "attack_vector": {
           "description": "The mathematically predictable category of structural sabotage being simulated.",
           "enum": [
@@ -426,28 +442,6 @@
             "tool_poisoning"
           ],
           "title": "Attack Vector",
-          "type": "string"
-        },
-        "expected_firewall_trip": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The exact rule_cid of the InformationFlowPolicy or Governance bound expected to block this attack. Governing automated test assertions.",
-          "title": "Expected Firewall Trip"
-        },
-        "simulation_id": {
-          "description": "The unique identifier for this red-team experiment.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Simulation Id",
           "type": "string"
         },
         "synthetic_payload": {
@@ -469,13 +463,19 @@
           "maxLength": 100000,
           "title": "Synthetic Payload"
         },
-        "target_node_cid": {
-          "description": "The exact NodeCIDState the 'Judas Node' will attempt to compromise.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Node Cid",
-          "type": "string"
+        "expected_firewall_trip": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The exact rule_cid of the InformationFlowPolicy or Governance bound expected to block this attack. Governing automated test assertions.",
+          "title": "Expected Firewall Trip"
         }
       },
       "required": [
@@ -491,6 +491,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Serves as the definitive Artificial Intelligence Bill of Materials (AI-BOM), mapping the agent's exact training provenance and capability matrix onto the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Establishes the agent's physical identity passport, authorizing the orchestrator to mount the node into a swarm topology only if its `training_lineage_hash` satisfies the zero-trust alignment policy.\n\nEPISTEMIC BOUNDS: Supply-chain vulnerabilities are mathematically severed by anchoring `training_lineage_hash` and `capability_merkle_root` to immutable SHA-256 bounds (`^[a-f0-9]{64}$`). The `@model_validator` deterministically sorts `credential_presentations` by `issuer_did` for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: AI-BOM, Merkle-DAG Provenance, Supply-Chain Security, Cryptographic Passport, Deterministic Sorting",
       "properties": {
+        "training_lineage_hash": {
+          "description": "The exact SHA-256 Merkle root of the agent's training lineage.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Training Lineage Hash",
+          "type": "string"
+        },
+        "developer_signature": {
+          "description": "The cryptographic signature of the developer/vendor.",
+          "maxLength": 2000,
+          "title": "Developer Signature",
+          "type": "string"
+        },
         "capability_merkle_root": {
           "description": "The SHA-256 Merkle root of the agent's verified semantic capabilities.",
           "maxLength": 128,
@@ -505,20 +519,6 @@
           },
           "title": "Credential Presentations",
           "type": "array"
-        },
-        "developer_signature": {
-          "description": "The cryptographic signature of the developer/vendor.",
-          "maxLength": 2000,
-          "title": "Developer Signature",
-          "type": "string"
-        },
-        "training_lineage_hash": {
-          "description": "The exact SHA-256 Merkle root of the agent's training lineage.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Training Lineage Hash",
-          "type": "string"
         }
       },
       "required": [
@@ -541,20 +541,6 @@
           "title": "Agent Cid",
           "type": "string"
         },
-        "confidence_score": {
-          "description": "The node's epistemic certainty of success.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Confidence Score",
-          "type": "number"
-        },
-        "estimated_carbon_gco2eq": {
-          "description": "The agent's mathematical projection of the environmental cost to execute this inference task.",
-          "maximum": 10000.0,
-          "minimum": 0.0,
-          "title": "Estimated Carbon Gco2Eq",
-          "type": "number"
-        },
         "estimated_cost_magnitude": {
           "description": "The node's calculated cost to fulfill the task.",
           "maximum": 1000000000,
@@ -567,6 +553,20 @@
           "minimum": 0,
           "title": "Estimated Latency Ms",
           "type": "integer"
+        },
+        "estimated_carbon_gco2eq": {
+          "description": "The agent's mathematical projection of the environmental cost to execute this inference task.",
+          "maximum": 10000.0,
+          "minimum": 0.0,
+          "title": "Estimated Carbon Gco2Eq",
+          "type": "number"
+        },
+        "confidence_score": {
+          "description": "The node's epistemic certainty of success.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Score",
+          "type": "number"
         }
       },
       "required": [
@@ -583,20 +583,11 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a unidirectional telemetry pipeline projecting internal swarm kinematics across the Markov Blanket without inducing causal feedback loops.\n\nCAUSAL AFFORDANCE: Emits an ephemeral, 1D representation of the active probability distribution and execution progress to the external UI plane without halting the underlying generative trajectory.\n\nEPISTEMIC BOUNDS: Semantic `status_message` structurally clamped to `max_length=2000`. The continuous `progress` metric bounded by float limits (`le=1000000000.0`) allowing it to represent 0.0-1.0 ratios or exact token counts. The `thermodynamic_burn_rate` is physically bounded (`ge=0.0`), and `epistemic_entropy_score` is normalized (`ge=0.0, le=1.0`).\n\nMCP ROUTING TRIGGERS: Markov Blanket, Ephemeral Projection, Continuous Observability, Kinetic Execution State, UI Telemetry",
       "properties": {
-        "epistemic_entropy_score": {
-          "anyOf": [
-            {
-              "maximum": 1.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The normalized Shannon Entropy of the active execution, mapped to UI color gradients (e.g., high entropy = amber warning).",
-          "title": "Epistemic Entropy Score"
+        "status_message": {
+          "description": "The semantic 1D string projection representing the active kinetic execution state.",
+          "maxLength": 2000,
+          "title": "Status Message",
+          "type": "string"
         },
         "progress": {
           "anyOf": [
@@ -612,12 +603,6 @@
           "description": "The progress ratio from 0.0 to 1.0, or None if indeterminate.",
           "title": "Progress"
         },
-        "status_message": {
-          "description": "The semantic 1D string projection representing the active kinetic execution state.",
-          "maxLength": 2000,
-          "title": "Status Message",
-          "type": "string"
-        },
         "thermodynamic_burn_rate": {
           "anyOf": [
             {
@@ -631,6 +616,21 @@
           "default": null,
           "description": "The instantaneous token compute cost velocity, mapped to UI emission intensity.",
           "title": "Thermodynamic Burn Rate"
+        },
+        "epistemic_entropy_score": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The normalized Shannon Entropy of the active execution, mapped to UI color gradients (e.g., high entropy = amber warning).",
+          "title": "Epistemic Entropy Score"
         }
       },
       "required": [
@@ -643,19 +643,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Structure-Mapping Theory (Gentner) to execute\nsystemic cross-domain lateral thinking. As a ...Task suffix, this represents an\nauthorized kinetic execution trigger or test-time compute branch.\n\nCAUSAL AFFORDANCE: Forces the generative router to bridge the target_domain\n(max_length=2000) with an unrelated source_domain (max_length=2000) by finding\nrelational isomorphisms, actively injecting out-of-distribution abstractions. The\ntask_cid (128-char CID) anchors the task.\n\nEPISTEMIC BOUNDS: The cognitive leap is physically forced by the\ndivergence_temperature_override (ge=0.0, le=10.0), shifting the sampling\ndistribution. The structural rigor is bounded by required_isomorphisms (ge=1,\nle=86400000), demanding an exact count of valid mappings.\n\nMCP ROUTING TRIGGERS: Structure-Mapping Theory, Lateral Thinking, Relational\nIsomorphism, Cross-Domain Abstraction, High-Temperature Divergence",
       "properties": {
-        "divergence_temperature_override": {
-          "description": "The specific high-temperature sampling override required to force this creative leap.",
-          "maximum": 10.0,
-          "minimum": 0.0,
-          "title": "Divergence Temperature Override",
-          "type": "number"
-        },
-        "required_isomorphisms": {
-          "description": "The exact number of structural/logical mappings the agent must successfully bridge between the two domains.",
-          "maximum": 86400000,
-          "minimum": 1,
-          "title": "Required Isomorphisms",
-          "type": "integer"
+        "task_cid": {
+          "description": "Unique identifier for this lateral thinking task.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Cid",
+          "type": "string"
         },
         "source_domain": {
           "description": "The unrelated abstract concept space (e.g., 'thermodynamics', 'mycelial networks').",
@@ -669,13 +663,19 @@
           "title": "Target Domain",
           "type": "string"
         },
-        "task_cid": {
-          "description": "Unique identifier for this lateral thinking task.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Cid",
-          "type": "string"
+        "required_isomorphisms": {
+          "description": "The exact number of structural/logical mappings the agent must successfully bridge between the two domains.",
+          "maximum": 86400000,
+          "minimum": 1,
+          "title": "Required Isomorphisms",
+          "type": "integer"
+        },
+        "divergence_temperature_override": {
+          "description": "The specific high-temperature sampling override required to force this creative leap.",
+          "maximum": 10.0,
+          "minimum": 0.0,
+          "title": "Divergence Temperature Override",
+          "type": "number"
         }
       },
       "required": [
@@ -999,6 +999,30 @@
           "title": "Capability Id",
           "type": "string"
         },
+        "time_complexity_class": {
+          "description": "The formal Big-O mathematical class mathematically bounding temporal execution limits.",
+          "enum": [
+            "O(1)",
+            "O(log N)",
+            "O(N)",
+            "O(N log N)",
+            "O(N^2)",
+            "O(2^N)"
+          ],
+          "title": "Time Complexity Class",
+          "type": "string"
+        },
+        "space_complexity_class": {
+          "description": "The formal Big-O mathematical class representing the asymptotic structural memory geometry.",
+          "enum": [
+            "O(1)",
+            "O(log N)",
+            "O(N)",
+            "O(N^2)"
+          ],
+          "title": "Space Complexity Class",
+          "type": "string"
+        },
         "peak_vram_bytes": {
           "description": "The strict absolute integer measurement bounding thermodynamic memory allocations.",
           "maximum": 100000000000,
@@ -1012,30 +1036,6 @@
           "minimum": 0,
           "title": "Simulated Cpu Cycles",
           "type": "integer"
-        },
-        "space_complexity_class": {
-          "description": "The formal Big-O mathematical class representing the asymptotic structural memory geometry.",
-          "enum": [
-            "O(1)",
-            "O(log N)",
-            "O(N)",
-            "O(N^2)"
-          ],
-          "title": "Space Complexity Class",
-          "type": "string"
-        },
-        "time_complexity_class": {
-          "description": "The formal Big-O mathematical class mathematically bounding temporal execution limits.",
-          "enum": [
-            "O(1)",
-            "O(log N)",
-            "O(N)",
-            "O(N log N)",
-            "O(N^2)",
-            "O(2^N)"
-          ],
-          "title": "Time Complexity Class",
-          "type": "string"
         }
       },
       "required": [
@@ -1080,15 +1080,15 @@
           "$ref": "#/$defs/AuctionMechanismProfile",
           "description": "The market mechanism governing the auction."
         },
+        "tie_breaker": {
+          "$ref": "#/$defs/TieBreakerPolicy",
+          "description": "The deterministic rule for resolving tied bids."
+        },
         "max_bidding_window_ms": {
           "description": "The absolute timeout in milliseconds for nodes to submit proposals.",
           "maximum": 86400000,
           "title": "Max Bidding Window Ms",
           "type": "integer"
-        },
-        "tie_breaker": {
-          "$ref": "#/$defs/TieBreakerPolicy",
-          "description": "The deterministic rule for resolving tied bids."
         }
       },
       "required": [
@@ -1107,6 +1107,14 @@
           "$ref": "#/$defs/TaskAnnouncementIntent",
           "description": "The original call for proposals."
         },
+        "bids": {
+          "description": "The array of received bids.",
+          "items": {
+            "$ref": "#/$defs/AgentBidIntent"
+          },
+          "title": "Bids",
+          "type": "array"
+        },
         "award": {
           "anyOf": [
             {
@@ -1118,14 +1126,6 @@
           ],
           "default": null,
           "description": "The final cryptographic receipt of the auction, if resolved."
-        },
-        "bids": {
-          "description": "The array of received bids.",
-          "items": {
-            "$ref": "#/$defs/AgentBidIntent"
-          },
-          "title": "Bids",
-          "type": "array"
         },
         "clearing_timeout": {
           "description": "Maximum wait time for auction settlement.",
@@ -1154,31 +1154,15 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Queueing Theory and the Token Bucket algorithm to\nmathematically regulate the thermodynamic flow of compute across topological\nboundaries. As a ...Policy suffix, this defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Forces the orchestrator to yield execution threads, shed load,\nor trip circuit breakers when temporal velocity (max_tokens_per_minute,\nmax_requests_per_minute) or spatial queues (max_queue_depth) reach physical\nsaturation. Optional token_budget_per_branch and max_concurrent_tool_invocations\nfurther constrain parallel execution.\n\nEPISTEMIC BOUNDS: Physical system limits are rigidly clamped by integer bounds\n(le=1000000000) on max_queue_depth, token_budget_per_branch,\nmax_tokens_per_minute (gt=0), max_requests_per_minute (gt=0), and\nmax_concurrent_tool_invocations (gt=0). Temporal liveness is bounded by\nmax_uninterruptible_span_ms (le=86400000, gt=0). All rate fields are Optional\n(default=None).\n\nMCP ROUTING TRIGGERS: Queueing Theory, Token Bucket, Backpressure, Load\nShedding, Thermodynamic Flow Control",
       "properties": {
-        "max_concurrent_tool_invocations": {
-          "anyOf": [
-            {
-              "exclusiveMinimum": 0,
-              "maximum": 1000000000,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical integer ceiling to prevent Sybil-like parallel mutations against the CognitiveActionSpaceManifest.",
-          "title": "Max Concurrent Tool Invocations"
-        },
         "max_queue_depth": {
           "description": "The maximum number of unprocessed messages/observations allowed between connected nodes before yielding.",
           "maximum": 1000000000,
           "title": "Max Queue Depth",
           "type": "integer"
         },
-        "max_requests_per_minute": {
+        "token_budget_per_branch": {
           "anyOf": [
             {
-              "exclusiveMinimum": 0,
               "maximum": 1000000000,
               "type": "integer"
             },
@@ -1187,8 +1171,8 @@
             }
           ],
           "default": null,
-          "description": "The maximum kinetic velocity of API requests allowed.",
-          "title": "Max Requests Per Minute"
+          "description": "The maximum token cost allowed per execution branch before rate-limiting.",
+          "title": "Token Budget Per Branch"
         },
         "max_tokens_per_minute": {
           "anyOf": [
@@ -1205,6 +1189,21 @@
           "description": "The maximum kinetic velocity of token consumption allowed before the circuit breaker trips.",
           "title": "Max Tokens Per Minute"
         },
+        "max_requests_per_minute": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "maximum": 1000000000,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum kinetic velocity of API requests allowed.",
+          "title": "Max Requests Per Minute"
+        },
         "max_uninterruptible_span_ms": {
           "anyOf": [
             {
@@ -1220,9 +1219,10 @@
           "description": "Systemic heartbeat constraint. A node cannot lock the thread longer than this without yielding to poll for BargeInInterruptEvents.",
           "title": "Max Uninterruptible Span Ms"
         },
-        "token_budget_per_branch": {
+        "max_concurrent_tool_invocations": {
           "anyOf": [
             {
+              "exclusiveMinimum": 0,
               "maximum": 1000000000,
               "type": "integer"
             },
@@ -1231,8 +1231,8 @@
             }
           ],
           "default": null,
-          "description": "The maximum token cost allowed per execution branch before rate-limiting.",
-          "title": "Token Budget Per Branch"
+          "description": "The mathematical integer ceiling to prevent Sybil-like parallel mutations against the CognitiveActionSpaceManifest.",
+          "title": "Max Concurrent Tool Invocations"
         }
       },
       "required": [
@@ -1245,16 +1245,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encodes an asynchronous hardware interrupt or exogenous sensory spike that forces a premature probability wave collapse on an active generation trajectory.\n\nCAUSAL AFFORDANCE: Physically severs the continuous multimodal sequence of the `target_event_cid`, injecting the `retained_partial_payload` into the Epistemic Quarantine and forcing the orchestrator to execute the `epistemic_disposition`.\n\nEPISTEMIC BOUNDS: Topologically anchored to `target_event_cid` via a strict 128-char CID regex. The `retained_partial_payload` is volumetrically clamped by the `enforce_payload_topology` hook to prevent VRAM exhaustion.\n\nMCP ROUTING TRIGGERS: Asynchronous Interrupt, Generative Severing, Context Switching, Defeasible Disposition, Wave Collapse",
       "properties": {
-        "epistemic_disposition": {
-          "description": "Explicit instruction to the orchestrator on how to patch the shared state blackboard with the partial payload.",
-          "enum": [
-            "discard",
-            "retain_as_context",
-            "mark_as_falsified"
-          ],
-          "title": "Epistemic Disposition",
-          "type": "string"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -1278,6 +1268,40 @@
           "default": null,
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "topology_class": {
+          "const": "barge_in",
+          "default": "barge_in",
+          "description": "Discriminator type for a barge-in interruption event.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "target_event_cid": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the active node generation cycle that was killed in the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Event Cid",
+          "type": "string"
+        },
+        "sensory_trigger": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EmbodiedSensoryVectorProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The continuous multimodal trigger (e.g., audio spike, user saying 'stop') that justified the interruption."
         },
         "retained_partial_payload": {
           "anyOf": [
@@ -1306,38 +1330,14 @@
           "description": "The 'stutter' state: the incomplete fragment of thought or text appended before the kill signal. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
           "title": "Retained Partial Payload"
         },
-        "sensory_trigger": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EmbodiedSensoryVectorProfile"
-            },
-            {
-              "type": "null"
-            }
+        "epistemic_disposition": {
+          "description": "Explicit instruction to the orchestrator on how to patch the shared state blackboard with the partial payload.",
+          "enum": [
+            "discard",
+            "retain_as_context",
+            "mark_as_falsified"
           ],
-          "default": null,
-          "description": "The continuous multimodal trigger (e.g., audio spike, user saying 'stop') that justified the interruption."
-        },
-        "target_event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the active node generation cycle that was killed in the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Event Cid",
-          "type": "string"
-        },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "topology_class": {
-          "const": "barge_in",
-          "default": "barge_in",
-          "description": "Discriminator type for a barge-in interruption event.",
-          "title": "Topology Class",
+          "title": "Epistemic Disposition",
           "type": "string"
         }
       },
@@ -1354,14 +1354,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Bayesian Belief Updating and Pearlian Causal Tracing by synthesizing internal cognitive shifts into discrete, hashable facts.\n\nCAUSAL AFFORDANCE: Projects a synthesized conclusion into the shared topology, binding the new belief to `causal_attributions`.\n\nEPISTEMIC BOUNDS: Structural validation is enforced via nested schema instantiation. `payload` is volumetrically clamped by `@field_validator`. `quorum_signatures` prevents Sybil attacks via `@model_validator` `enforce_sybil_resistance`.\n\nMCP ROUTING TRIGGERS: Bayesian Belief Updating, Causal Tracing, Cognitive Synthesis, Merkle-DAG Coordinate, Non-Monotonic Leap",
       "properties": {
-        "causal_attributions": {
-          "description": "Immutable audit trail of prior states that forced this specific cognitive synthesis.",
-          "items": {
-            "$ref": "#/$defs/CausalAttributionState"
-          },
-          "title": "Causal Attributions",
-          "type": "array"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -1369,41 +1361,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "hardware_attestation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HardwareEnclaveReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The physical hardware root-of-trust proving this belief was synthesized in a secure enclave."
-        },
-        "neural_audit": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NeuralAuditAttestationReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical brain-scan proving exactly which neural circuits fired to append this event."
-        },
-        "payload": {
-          "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitiveState"
-          },
-          "description": "Topologically Bounded Latent Spaces capturing the semantic representation of the agent's internal cognitive shift or synthesis that anchor statistical probability to a definitive causal event hash. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Payload",
-          "type": "object"
         },
         "prior_event_hash": {
           "anyOf": [
@@ -1421,39 +1378,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "quorum_signatures": {
-          "description": "The deterministic execution signatures from the peer nodes that validated this belief.",
-          "items": {
-            "maxLength": 10000,
-            "type": "string"
-          },
-          "title": "Quorum Signatures",
-          "type": "array"
-        },
-        "scratchpad_trace": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LatentScratchpadReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic record of the non-monotonic internal monologue that justifies this belief."
-        },
-        "source_node_cid": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeCIDState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The specific topological node that synthesized this belief assertion."
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -1468,17 +1392,48 @@
           "title": "Topology Class",
           "type": "string"
         },
-        "uncertainty_profile": {
+        "payload": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonPrimitiveState"
+          },
+          "description": "Topologically Bounded Latent Spaces capturing the semantic representation of the agent's internal cognitive shift or synthesis that anchor statistical probability to a definitive causal event hash. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Payload",
+          "type": "object"
+        },
+        "source_node_cid": {
           "anyOf": [
             {
-              "$ref": "#/$defs/CognitiveUncertaintyProfile"
+              "$ref": "#/$defs/NodeCIDState"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The mathematical quantification of doubt associated with this synthesized belief."
+          "description": "The specific topological node that synthesized this belief assertion."
+        },
+        "causal_attributions": {
+          "description": "Immutable audit trail of prior states that forced this specific cognitive synthesis.",
+          "items": {
+            "$ref": "#/$defs/CausalAttributionState"
+          },
+          "title": "Causal Attributions",
+          "type": "array"
+        },
+        "hardware_attestation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HardwareEnclaveReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The physical hardware root-of-trust proving this belief was synthesized in a secure enclave."
         },
         "zk_proof": {
           "anyOf": [
@@ -1491,6 +1446,51 @@
           ],
           "default": null,
           "description": "The mathematical attestation proving this belief synthesis was appended securely without model-downgrade fraud."
+        },
+        "uncertainty_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CognitiveUncertaintyProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical quantification of doubt associated with this synthesized belief."
+        },
+        "scratchpad_trace": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LatentScratchpadReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic record of the non-monotonic internal monologue that justifies this belief."
+        },
+        "neural_audit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NeuralAuditAttestationReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical brain-scan proving exactly which neural circuits fired to append this event."
+        },
+        "quorum_signatures": {
+          "description": "The deterministic execution signatures from the peer nodes that validated this belief.",
+          "items": {
+            "maxLength": 10000,
+            "type": "string"
+          },
+          "title": "Quorum Signatures",
+          "type": "array"
         }
       },
       "required": [
@@ -1538,26 +1538,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces the formal JSON-RPC 2.0 specification as a stateless,\ndeterministic message-passing protocol, acting as the primary algorithmic firewall\nat the Zero-Trust network boundary. As an ...Intent suffix, this represents an\nauthorized kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Unlocks remote procedure execution while preventing JSON Bombing\nand Algorithmic Complexity Attacks. The method field (max_length=1000) specifies the\nRPC target. The id field binds request-response correlation.\n\nEPISTEMIC BOUNDS: The `params` field is routed through the volumetric hardware guillotine\n(`enforce_payload_topology`), mathematically capping the payload to an absolute $O(N)$\nvolume of 10,000 nodes. This replaces the legacy 1D-depth constraints that permitted\ngeometric volume explosions. The `jsonrpc` field is a rigid Literal[\"2.0\"] automaton.\nThe `id` is topologically locked to a 128-char CID regex or an integer (le=1000000000) or None.\n\nMCP ROUTING TRIGGERS: JSON-RPC 2.0, Stateless RPC, Algorithmic Complexity Attack,\nJSON Bombing Prevention, Deterministic Finite Automaton",
       "properties": {
-        "id": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "maximum": 1000000000,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Unique request identifier.",
-          "title": "Id"
-        },
         "jsonrpc": {
           "const": "2.0",
           "description": "JSON-RPC version.",
@@ -1589,6 +1569,26 @@
           "default": null,
           "description": "Payload parameters. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
           "title": "Params"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
+            },
+            {
+              "maximum": 1000000000,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Unique request identifier.",
+          "title": "Id"
         }
       },
       "required": [
@@ -1602,47 +1602,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the exogenous structural boundary of a headless browser environment within a Partially Observable Markov Decision Process (POMDP).\n\nCAUSAL AFFORDANCE: Exposes the deterministic coordinate space (`viewport_size`, `dom_hash`, `accessibility_tree_hash`) enabling spatial kinematics and visual grounding.\n\nEPISTEMIC BOUNDS: Enforces strict Server-Side Request Forgery (SSRF) quarantine via the `@field_validator` `_enforce_spatial_safety`, mathematically isolating the agent from Bogon/private IP space. `dom_hash` rigidly locked to SHA-256 pattern.\n\nMCP ROUTING TRIGGERS: Exogenous Perturbation, DOM Topography, SSRF Quarantine, Spatial Execution Bound, Accessibility Tree",
       "properties": {
-        "accessibility_tree_hash": {
-          "description": "The SHA-256 hash of the accessibility tree defining Exogenous Perturbations to the state space.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Accessibility Tree Hash",
+        "topology_class": {
+          "const": "browser",
+          "default": "browser",
+          "description": "Discriminator for Causal Actuators representing structural shifts.",
+          "title": "Topology Class",
           "type": "string"
         },
         "current_url": {
           "description": "Spatial Execution Bounds where the agent interacts.",
           "maxLength": 2000,
           "title": "Current Url",
-          "type": "string"
-        },
-        "dom_hash": {
-          "description": "The SHA-256 hash acting as the structural manifestation vector.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Dom Hash",
-          "type": "string"
-        },
-        "screenshot_cid": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the snapshot representation.",
-          "title": "Screenshot Cid"
-        },
-        "topology_class": {
-          "const": "browser",
-          "default": "browser",
-          "description": "Discriminator for Causal Actuators representing structural shifts.",
-          "title": "Topology Class",
           "type": "string"
         },
         "viewport_size": {
@@ -1659,6 +1629,36 @@
           ],
           "title": "Viewport Size",
           "type": "array"
+        },
+        "dom_hash": {
+          "description": "The SHA-256 hash acting as the structural manifestation vector.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Dom Hash",
+          "type": "string"
+        },
+        "accessibility_tree_hash": {
+          "description": "The SHA-256 hash of the accessibility tree defining Exogenous Perturbations to the state space.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Accessibility Tree Hash",
+          "type": "string"
+        },
+        "screenshot_cid": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the snapshot representation.",
+          "title": "Screenshot Cid"
         }
       },
       "required": [
@@ -1680,22 +1680,6 @@
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
-          "type": "string"
-        },
-        "exhausted_escrow_id": {
-          "description": "A string representing the original escrow boundary breached.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Exhausted Escrow Id",
-          "type": "string"
-        },
-        "final_burn_receipt_id": {
-          "description": "A string pointing to the exact TokenBurnReceipt CID that pushed the state over the limit.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Final Burn Receipt Id",
           "type": "string"
         },
         "prior_event_hash": {
@@ -1727,6 +1711,22 @@
           "description": "Discriminator type for a budget exhaustion event.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "exhausted_escrow_id": {
+          "description": "A string representing the original escrow boundary breached.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Exhausted Escrow Id",
+          "type": "string"
+        },
+        "final_burn_receipt_id": {
+          "description": "A string pointing to the exact TokenBurnReceipt CID that pushed the state over the limit.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Final Burn Receipt Id",
+          "type": "string"
         }
       },
       "required": [
@@ -1754,14 +1754,6 @@
           "$ref": "#/$defs/NodeCIDState",
           "description": "The exact extraction step in the DAG that was mathematically starved of compute."
         },
-        "cryptographic_null_hash": {
-          "description": "The SHA-256 null-hash representing the skipped state to satisfy the Epistemic Ledger.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Cryptographic Null Hash",
-          "type": "string"
-        },
         "justification": {
           "description": "The deterministic reason the orchestrator severed this execution branch.",
           "enum": [
@@ -1770,6 +1762,14 @@
             "sla_timeout"
           ],
           "title": "Justification",
+          "type": "string"
+        },
+        "cryptographic_null_hash": {
+          "description": "The SHA-256 null-hash representing the skipped state to satisfy the Epistemic Ledger.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Cryptographic Null Hash",
           "type": "string"
         }
       },
@@ -1786,6 +1786,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Create a zero-cost macro abstraction that unrolls the entire Zero-to-One generation, verification, and profiling loop.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to physically bind the ephemeral tool-creation workflow into a rigid DAG topology, enabling full cryptographic observability over the dynamic synthesis of capabilities.\n\nEPISTEMIC BOUNDS: Binds the execution state to a closed, finite mathematical matrix where every constituent node (generator, fuzzer, profiler) must resolve before the final capability is materialized onto the Hollow Data Plane.\n\nMCP ROUTING TRIGGERS: Tool Synthesis, Capability Generation, Verification Matrix, Ephemeral Execution, Macro Topology",
       "properties": {
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -1799,42 +1821,6 @@
           "default": null,
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "formal_verifier_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The formal verifier system node."
-        },
-        "fuzzing_engine_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The fuzzing engine system node."
-        },
-        "generator_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The agent writing the code."
-        },
-        "human_supervisor_cid": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeCIDState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The W3C DID of the human oracle required to cryptographically sign off on the forged capability."
         },
         "justification": {
           "anyOf": [
@@ -1850,16 +1836,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -1870,30 +1846,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -1907,9 +1859,29 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
-        "target_epistemic_deficit": {
-          "$ref": "#/$defs/SemanticDiscoveryIntent",
-          "description": "The target epistemic deficit."
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
         },
         "topology_class": {
           "const": "macro_forge",
@@ -1917,6 +1889,34 @@
           "description": "Discriminator for forge macro.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "target_epistemic_deficit": {
+          "$ref": "#/$defs/SemanticDiscoveryIntent",
+          "description": "The target epistemic deficit."
+        },
+        "generator_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The agent writing the code."
+        },
+        "formal_verifier_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The formal verifier system node."
+        },
+        "fuzzing_engine_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The fuzzing engine system node."
+        },
+        "human_supervisor_cid": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeCIDState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The W3C DID of the human oracle required to cryptographically sign off on the forged capability."
         }
       },
       "required": [
@@ -1944,13 +1944,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Pearlian causal tracing, linking a localized cognitive\nsynthesis back to its historical Merkle-DAG origin. As a ...State suffix, this is a\ndeclarative, frozen snapshot of a causal connection at a point in time.\n\nCAUSAL AFFORDANCE: Authorizes the assignment of fractional attention or influence\nweights to prior events, establishing a Directed Acyclic Graph (DAG) of causal lineage.\n\nEPISTEMIC BOUNDS: The influence_weight is mathematically bounded to a continuous\nprobability distribution (ge=0.0, le=1.0). The source_event_cid is locked to a 128-char\nCID regex (^[a-zA-Z0-9_.:-]+$).\n\nMCP ROUTING TRIGGERS: Pearlian Causal Tracing, Directed Acyclic Graph, Causal Lineage,\nAttention Weighting, Influence Distribution",
       "properties": {
-        "influence_weight": {
-          "description": "The mathematical attention/importance weight (0.0 to 1.0) assigned to this source by the agent.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Influence Weight",
-          "type": "number"
-        },
         "source_event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the source event in the Merkle-DAG.",
           "maxLength": 128,
@@ -1958,6 +1951,13 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Source Event Cid",
           "type": "string"
+        },
+        "influence_weight": {
+          "description": "The mathematical attention/importance weight (0.0 to 1.0) assigned to this source by the agent.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Influence Weight",
+          "type": "number"
         }
       },
       "required": [
@@ -1971,17 +1971,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Judea Pearl's Structural Causal Models (SCMs)\nand d-separation mechanics to map exact topological relationships between\nvariables. As a ...State suffix, this is a frozen, declarative connection\nvector.\n\nCAUSAL AFFORDANCE: Empowers the orchestrator's traversal engine to construct\ninterventional graphs for the Do-Operator (P(y|do(x))), isolating direct\ncauses from latent confounders during active inference or counterfactual\nregret simulation.\n\nEPISTEMIC BOUNDS: The edge_class physically restricts topological connections\nto the Pearlian Literal automaton [\"direct_cause\", \"confounder\", \"collider\",\n\"mediator\"]. The source_variable and target_variable are bounded by\nmin_length=1 (no max_length) to prevent ghost pointer allocation.\n\nMCP ROUTING TRIGGERS: Structural Causal Models, Pearlian Causality,\nd-separation, Do-Calculus, Directed Edge",
       "properties": {
-        "edge_class": {
-          "description": "The specific Pearlian topological relationship between the two variables.",
-          "enum": [
-            "direct_cause",
-            "confounder",
-            "collider",
-            "mediator"
-          ],
-          "title": "Edge Class",
-          "type": "string"
-        },
         "source_variable": {
           "description": "The independent variable $X$.",
           "maxLength": 255,
@@ -2007,6 +1996,17 @@
           ],
           "default": null,
           "description": "The continuous parametric spline defining the physical connection manifold."
+        },
+        "edge_class": {
+          "description": "The specific Pearlian topological relationship between the two variables.",
+          "enum": [
+            "direct_cause",
+            "confounder",
+            "collider",
+            "mediator"
+          ],
+          "title": "Edge Class",
+          "type": "string"
         }
       },
       "required": [
@@ -2021,18 +2021,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the\nmacroscopic factorization of a collective swarm outcome into its constituent causal\ncomponents. As an ...Event suffix, this is an append-only coordinate on the\nMerkle-DAG.\n\nCAUSAL AFFORDANCE: Commits the system-level CollectiveIntelligenceProfile and the\nindividual ShapleyAttributionReceipt array to the Epistemic Ledger, finalizing the\ncredit assignment for a target_outcome_event_id.\n\nEPISTEMIC BOUNDS: The target_outcome_event_id is locked to a 128-char CID regex. The\n@model_validator mathematically enforces deterministic canonical hashing by sorting the\nagent_attributions array by target_node_cid (NodeCIDState), guaranteeing RFC 8785\nalignment.\n\nMCP ROUTING TRIGGERS: Causal Factorization, Epistemic Ledger Commit, Credit Assignment,\nMacroscopic Explanation, Deterministic Sorting",
       "properties": {
-        "agent_attributions": {
-          "description": "The array of individual causal contributions.",
-          "items": {
-            "$ref": "#/$defs/ShapleyAttributionReceipt"
-          },
-          "title": "Agent Attributions",
-          "type": "array"
-        },
-        "collective_intelligence": {
-          "$ref": "#/$defs/CollectiveIntelligenceProfile",
-          "description": "The system-level emergence metrics."
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -2057,14 +2045,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "target_outcome_event_id": {
-          "description": "The globally unique decentralized identifier (DID) anchoring the collective outcome being explained.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Outcome Event Id",
-          "type": "string"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -2078,6 +2058,26 @@
           "description": "Discriminator type for a causal explanation event.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "target_outcome_event_id": {
+          "description": "The globally unique decentralized identifier (DID) anchoring the collective outcome being explained.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Outcome Event Id",
+          "type": "string"
+        },
+        "collective_intelligence": {
+          "$ref": "#/$defs/CollectiveIntelligenceProfile",
+          "description": "The system-level emergence metrics."
+        },
+        "agent_attributions": {
+          "description": "The array of individual causal contributions.",
+          "items": {
+            "$ref": "#/$defs/ShapleyAttributionReceipt"
+          },
+          "title": "Agent Attributions",
+          "type": "array"
         }
       },
       "required": [
@@ -2112,6 +2112,10 @@
           "title": "Experiment Id",
           "type": "string"
         },
+        "hypothesis": {
+          "$ref": "#/$defs/SteadyStateHypothesisState",
+          "description": "The baseline steady state hypothesis being tested."
+        },
         "faults": {
           "description": "The strict array of fault injection profiles defining the chaotic elements.",
           "items": {
@@ -2119,10 +2123,6 @@
           },
           "title": "Faults",
           "type": "array"
-        },
-        "hypothesis": {
-          "$ref": "#/$defs/SteadyStateHypothesisState",
-          "description": "The baseline steady state hypothesis being tested."
         },
         "shocks": {
           "description": "The declarative array of exogenous Black Swan events injected into the topology.",
@@ -2145,21 +2145,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Lyapunov Stability and distributed Control Theory to guarantee that the neurosymbolic network returns to a deterministic equilibrium when facing catastrophic variance. As an ...Event suffix, this is a cryptographically frozen coordinate.\n\nCAUSAL AFFORDANCE: Physically severs the active execution thread for the targeted node, acting as a hardware guillotine that immediately halts out-of-memory cascades, runaway generative loops, or API rate-limit breaches.\n\nEPISTEMIC BOUNDS: The fault perimeter is mathematically restricted to a specific `target_node_cid` (`NodeCIDState`). To prevent log-poisoning and VRAM exhaustion during the crash, the `error_signature` is strictly clamped at `max_length=2000`.\n\nMCP ROUTING TRIGGERS: Lyapunov Stability, Control Theory, Circuit Breaker, Cascading Failure, State Equilibrium",
       "properties": {
-        "error_signature": {
-          "description": "Signature or summary of the error causing the trip.",
-          "maxLength": 2000,
-          "title": "Error Signature",
+        "topology_class": {
+          "const": "circuit_breaker_event",
+          "default": "circuit_breaker_event",
+          "description": "The type of the resilience payload.",
+          "title": "Topology Class",
           "type": "string"
         },
         "target_node_cid": {
           "$ref": "#/$defs/NodeCIDState",
           "description": "The deterministic capability pointer representing the node for which the circuit breaker was tripped."
         },
-        "topology_class": {
-          "const": "circuit_breaker_event",
-          "default": "circuit_breaker_event",
-          "description": "The type of the resilience payload.",
-          "title": "Topology Class",
+        "error_signature": {
+          "description": "Signature or summary of the error causing the trip.",
+          "maxLength": 2000,
+          "title": "Error Signature",
           "type": "string"
         }
       },
@@ -2194,6 +2194,21 @@
           "title": "Capabilities",
           "type": "object"
         },
+        "transition_matrix": {
+          "additionalProperties": {
+            "items": {
+              "$ref": "#/$defs/AnyTransitionEdge"
+            },
+            "type": "array"
+          },
+          "description": "The Stochastic Transition Matrix (P).",
+          "maxProperties": 500,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Transition Matrix",
+          "type": "object"
+        },
         "entry_point_cid": {
           "description": "Defines the initial state (S_0) of the MDP.",
           "title": "Entry Point Cid",
@@ -2210,21 +2225,6 @@
           ],
           "default": null,
           "description": "The bipartite graph constraint preventing toxic tool combinations."
-        },
-        "transition_matrix": {
-          "additionalProperties": {
-            "items": {
-              "$ref": "#/$defs/AnyTransitionEdge"
-            },
-            "type": "array"
-          },
-          "description": "The Stochastic Transition Matrix (P).",
-          "maxProperties": 500,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Transition Matrix",
-          "type": "object"
         }
       },
       "required": [
@@ -2240,82 +2240,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a stochastic actor traversing a Partially Observable Markov Decision Process (POMDP). It establishes the cognitive and physical constraints for autonomous swarm participants.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to instantiate an independent generative trajectory capable of active inference, Representation Engineering (RepE) steering via `baseline_cognitive_state`, and non-monotonic test-time compute escalation via `escalation_policy`.\n\nEPISTEMIC BOUNDS: The node's operational variance is physically bounded by its thermodynamic Spot-Market budget (`compute_frontier`). The `@model_validator` deterministically sorts `peft_adapters` by `adapter_id` for RFC 8785 canonical hashing. Type is strictly locked to `Literal[\"agent\"]`.\n\nMCP ROUTING TRIGGERS: POMDP, Stochastic Actor, Active Inference, Representation Engineering, Policy Gradient",
       "properties": {
-        "action_space_cid": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The globally unique decentralized identifier (DID) anchoring the specific CognitiveActionSpaceManifest (curated tool environment) bound to this agent.",
-          "title": "Action Space Cid"
-        },
-        "active_attention_ray": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EpistemicAttentionRay"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The continuous spatial vector representing the agent's localized cognitive focus prior to kinetic actuation."
-        },
-        "active_inference_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ActiveInferenceContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The formal contract demanding mathematical proof of Expected Information Gain before authorizing tool execution."
-        },
-        "agent_attestation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AgentAttestationReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic identity passport and AI-BOM for the agent."
-        },
-        "analogical_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AnalogicalMappingTask"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The formal contract forcing the agent to execute cross-domain lateral thinking."
-        },
-        "anchoring_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AnchoringPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The declarative contract mathematically binding this agent to a core altruistic objective."
-        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -2330,59 +2254,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "audit_policy": {
+        "justification": {
           "anyOf": [
             {
-              "$ref": "#/$defs/MechanisticAuditContract"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The adaptive trigger policy for executing deep mechanistic interpretability brain-scans on this agent."
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
         },
-        "baseline_cognitive_state": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CognitiveStateProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The default biochemical 'mood' simulated for this agent via Representation Engineering."
-        },
-        "compute_frontier": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RoutingFrontierPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic spot-market compute requirements for this agent."
-        },
-        "correction_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SelfCorrectionPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The policy governing self-correction loops."
-        },
-        "description": {
-          "description": "The semantic boundary defining the objective function of the execution node. [SITD-Gamma: Neurosymbolic Substrate Alignment]",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -2403,115 +2295,17 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
           "title": "Domain Extensions"
         },
-        "emulation_profile": {
+        "semantic_zoom": {
           "anyOf": [
             {
-              "$ref": "#/$defs/AdversarialEmulationProfile"
+              "$ref": "#/$defs/SemanticZoomProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The adversarial emulation geometry composing kinematic noise and environmental spoofing for anti-bot trajectory evasion."
-        },
-        "epistemic_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EpistemicScanningPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The policy governing epistemic scanning."
-        },
-        "escalation_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EscalationContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical boundary authorizing the agent to spin up Test-Time Compute."
-        },
-        "gflownet_balance_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CognitiveDetailedBalanceContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Authorizes trajectory balance optimization during non-monotonic reasoning."
-        },
-        "grpo_reward_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EpistemicRewardModelPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The RL post-training contract forcing the agent to evaluate traces against an implicit graph reward."
-        },
-        "hardware": {
-          "$ref": "#/$defs/SpatialHardwareProfile",
-          "description": "The physical constraints binding this agent to a specific thermodynamic deployment topology."
-        },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "interventional_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InterventionalCausalTask"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The formal contract authorizing the agent to mutate variables to prove Pearlian causation."
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
-        },
-        "logit_steganography": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LogitSteganographyContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic contract forcing this agent to embed an undeniable provenance signature into its generative token stream."
+          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
         },
         "markov_blanket": {
           "anyOf": [
@@ -2525,18 +2319,6 @@
           "default": null,
           "description": "The epistemic isolation boundary guarding this agent's internal generative states."
         },
-        "neural_optics": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/GaussianSplattingProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
-        },
         "optical_physics": {
           "anyOf": [
             {
@@ -2549,6 +2331,75 @@
           "default": null,
           "description": "The strict microfacet BRDF physics governing the visual representation of this node."
         },
+        "neural_optics": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GaussianSplattingProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
+        },
+        "description": {
+          "description": "The semantic boundary defining the objective function of the execution node. [SITD-Gamma: Neurosymbolic Substrate Alignment]",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
+        "topology_class": {
+          "const": "agent",
+          "default": "agent",
+          "description": "Discriminator for an Agent node.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "hardware": {
+          "$ref": "#/$defs/SpatialHardwareProfile",
+          "description": "The physical constraints binding this agent to a specific thermodynamic deployment topology."
+        },
+        "security": {
+          "$ref": "#/$defs/EpistemicSecurityProfile",
+          "description": "The rigid cryptographic rules dictating the agent's isolation boundaries."
+        },
+        "logit_steganography": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LogitSteganographyContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic contract forcing this agent to embed an undeniable provenance signature into its generative token stream."
+        },
+        "active_attention_ray": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpistemicAttentionRay"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The continuous spatial vector representing the agent's localized cognitive focus prior to kinetic actuation."
+        },
+        "compute_frontier": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RoutingFrontierPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic spot-market compute requirements for this agent."
+        },
         "peft_adapters": {
           "description": "The declarative array of ephemeral PEFT/LoRA weights required to be hot-swapped during this agent's execution.",
           "items": {
@@ -2557,29 +2408,33 @@
           "title": "Peft Adapters",
           "type": "array"
         },
-        "prm_policy": {
+        "agent_attestation": {
           "anyOf": [
             {
-              "$ref": "#/$defs/ProcessRewardContract"
+              "$ref": "#/$defs/AgentAttestationReceipt"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The ruleset governing how intermediate thoughts are scored and pruned."
+          "description": "The cryptographic identity passport and AI-BOM for the agent."
         },
-        "reflex_policy": {
+        "action_space_cid": {
           "anyOf": [
             {
-              "$ref": "#/$defs/System1ReflexPolicy"
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The policy governing System 1 reflex actions."
+          "description": "The globally unique decentralized identifier (DID) anchoring the specific CognitiveActionSpaceManifest (curated tool environment) bound to this agent.",
+          "title": "Action Space Cid"
         },
         "secure_sub_session": {
           "anyOf": [
@@ -2593,21 +2448,113 @@
           "default": null,
           "description": "Declarative boundary for handling unredacted secrets within a temporarily isolated state partition."
         },
-        "security": {
-          "$ref": "#/$defs/EpistemicSecurityProfile",
-          "description": "The rigid cryptographic rules dictating the agent's isolation boundaries."
-        },
-        "semantic_zoom": {
+        "baseline_cognitive_state": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SemanticZoomProfile"
+              "$ref": "#/$defs/CognitiveStateProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
+          "description": "The default biochemical 'mood' simulated for this agent via Representation Engineering."
+        },
+        "reflex_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/System1ReflexPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The policy governing System 1 reflex actions."
+        },
+        "epistemic_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpistemicScanningPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The policy governing epistemic scanning."
+        },
+        "correction_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SelfCorrectionPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The policy governing self-correction loops."
+        },
+        "escalation_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EscalationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical boundary authorizing the agent to spin up Test-Time Compute."
+        },
+        "prm_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ProcessRewardContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The ruleset governing how intermediate thoughts are scored and pruned."
+        },
+        "active_inference_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActiveInferenceContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal contract demanding mathematical proof of Expected Information Gain before authorizing tool execution."
+        },
+        "analogical_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnalogicalMappingTask"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal contract forcing the agent to execute cross-domain lateral thinking."
+        },
+        "interventional_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InterventionalCausalTask"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal contract authorizing the agent to mutate variables to prove Pearlian causation."
         },
         "symbolic_handoff_policy": {
           "anyOf": [
@@ -2621,12 +2568,65 @@
           "default": null,
           "description": "The API-like contract allowing the agent to offload rigid logic to deterministic CPU solvers."
         },
-        "topology_class": {
-          "const": "agent",
-          "default": "agent",
-          "description": "Discriminator for an Agent node.",
-          "title": "Topology Class",
-          "type": "string"
+        "audit_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MechanisticAuditContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The adaptive trigger policy for executing deep mechanistic interpretability brain-scans on this agent."
+        },
+        "anchoring_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnchoringPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The declarative contract mathematically binding this agent to a core altruistic objective."
+        },
+        "grpo_reward_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpistemicRewardModelPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The RL post-training contract forcing the agent to evaluate traces against an implicit graph reward."
+        },
+        "emulation_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AdversarialEmulationProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The adversarial emulation geometry composing kinematic noise and environmental spoofing for anti-bot trajectory evasion."
+        },
+        "gflownet_balance_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CognitiveDetailedBalanceContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Authorizes trajectory balance optimization during non-monotonic reasoning."
         }
       },
       "required": [
@@ -2639,12 +2639,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Step-Level Verification via Process Reward Models (PRMs) to evaluate and critique intermediate steps in non-monotonic reasoning trees.\n\nCAUSAL AFFORDANCE: Injects a dense latent supervision vector (`logical_flaw_embedding`) to mathematically repel the generative trajectory away from hallucinated or logically flawed probability manifolds during test-time compute.\n\nEPISTEMIC BOUNDS: Penalization magnitude strictly clamped by `epistemic_penalty_scalar` (`ge=0.0, le=1.0`) to prevent gradient explosion. Target is cryptographically locked via `reasoning_trace_hash` (SHA-256 pattern `^[a-f0-9]{64}$`).\n\nMCP ROUTING TRIGGERS: Process Reward Model, Step-Level Verification, Representation Engineering, Latent Repulsion, Test-Time Supervision",
       "properties": {
-        "epistemic_penalty_scalar": {
-          "description": "A continuous penalty applied to the branch's probability mass if normative drift or hallucination is detected.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Epistemic Penalty Scalar",
-          "type": "number"
+        "reasoning_trace_hash": {
+          "description": "The cryptographic Merkle root of the specific ThoughtBranch being evaluated.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Reasoning Trace Hash",
+          "type": "string"
         },
         "logical_flaw_embedding": {
           "anyOf": [
@@ -2658,13 +2659,12 @@
           "default": null,
           "description": "A dense latent space representation of the specific logical fallacy identified, used to mathematically repel future generation trajectories."
         },
-        "reasoning_trace_hash": {
-          "description": "The cryptographic Merkle root of the specific ThoughtBranch being evaluated.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Reasoning Trace Hash",
-          "type": "string"
+        "epistemic_penalty_scalar": {
+          "description": "A continuous penalty applied to the branch's probability mass if normative drift or hallucination is detected.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Epistemic Penalty Scalar",
+          "type": "number"
         }
       },
       "required": [
@@ -2678,6 +2678,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Generative Flow Network (GFlowNet) trajectory balance conditions to ensure that the probability of generating a non-monotonic reasoning path is strictly proportional to its terminal reward.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's sampling mechanism to continuously optimize for the detailed balance equations using the specified `flow_estimation_matrix`, ensuring proportional flow allocation across MDP branches.\n\nEPISTEMIC BOUNDS: Mathematical variance is strictly bounded by `target_balance_epsilon` (`ge=0.0, le=1.0`), preventing probability flow divergence. `local_exploration_k` (`gt=0, le=1`) physically caps exploratory branching.\n\nMCP ROUTING TRIGGERS: Generative Flow Networks, Detailed Balance, Markov Chain Monte Carlo, Trajectory Flow, Credit Assignment Problem",
       "properties": {
+        "target_balance_epsilon": {
+          "description": "The mathematical tolerance for the detailed balance constraint.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Target Balance Epsilon",
+          "type": "number"
+        },
         "flow_estimation_matrix": {
           "description": "The specific neural architecture used to estimate flow.",
           "maxLength": 2000,
@@ -2690,13 +2697,6 @@
           "maximum": 1.0,
           "title": "Local Exploration K",
           "type": "integer"
-        },
-        "target_balance_epsilon": {
-          "description": "The mathematical tolerance for the detailed balance constraint.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Target Balance Epsilon",
-          "type": "number"
         }
       },
       "required": [
@@ -2737,9 +2737,11 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Finite State Machine (FSM) Logit Masking and Constrained Decoding to deterministically herd LLM stochasticity into rigorous syntactic structures.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's inference engine to physically suffocate invalid token probabilities to negative infinity, mechanically ensuring the output conforms to downstream parser requirements.\n\nEPISTEMIC BOUNDS: Execution constraints are rigidly defined by `require_think_tags` and `final_answer_regex` (`max_length=2000`) to prevent ReDoS CPU exhaustion. The `@model_validator` `resolve_contract_conflicts` prevents unresolvable compilation conflicts in the DFA.\n\nMCP ROUTING TRIGGERS: FSM Logit Masking, Constrained Decoding, Regular Expression Automaton, Syntactic Boundary, Token Suffocation",
       "properties": {
-        "decoding_policy": {
-          "$ref": "#/$defs/ConstrainedDecodingPolicy",
-          "description": "The mandatory hardware-level execution limits for token masking."
+        "require_think_tags": {
+          "default": true,
+          "description": "Forces the inclusion of structural XML tags to isolate the reasoning trace.",
+          "title": "Require Think Tags",
+          "type": "boolean"
         },
         "final_answer_regex": {
           "anyOf": [
@@ -2755,11 +2757,9 @@
           "description": "The strict regular expression the model must satisfy to yield a valid discrete classification. Optional because LMQL/Guidance do not use standard regex.",
           "title": "Final Answer Regex"
         },
-        "require_think_tags": {
-          "default": true,
-          "description": "Forces the inclusion of structural XML tags to isolate the reasoning trace.",
-          "title": "Require Think Tags",
-          "type": "boolean"
+        "decoding_policy": {
+          "$ref": "#/$defs/ConstrainedDecodingPolicy",
+          "description": "The mandatory hardware-level execution limits for token masking."
         }
       },
       "required": [
@@ -2772,17 +2772,11 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Supervisory Control Theory within the causal DAG, instantiating an out-of-band Oracle node for Mixed-Initiative truth resolution.\n\nCAUSAL AFFORDANCE: Physically halts the continuous multi-agent generation loop, forcing the probability wave to suspend until external wetware (human) entropy is safely injected into the topological state.\n\nEPISTEMIC BOUNDS: To mathematically satisfy Byzantine Fault Tolerance (BFT), the `required_attestation` is mandatory. The orchestrator MUST NOT resolve this node without a cryptographically matching `WetwareAttestationContract`, verifying the human operator and preventing Sybil attacks.\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, Oracle Node, Mixed-Initiative, Proof of Humanity, Out-of-Band Entropy",
       "properties": {
-        "active_attention_ray": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EpistemicAttentionRay"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The continuous spatial vector representing the human operator's localized cognitive focus."
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
         },
         "architectural_intent": {
           "anyOf": [
@@ -2798,11 +2792,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -2823,27 +2833,17 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
           "title": "Domain Extensions"
         },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
+        "semantic_zoom": {
           "anyOf": [
             {
-              "maxLength": 2000,
-              "type": "string"
+              "$ref": "#/$defs/SemanticZoomProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
+          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
         },
         "markov_blanket": {
           "anyOf": [
@@ -2857,18 +2857,6 @@
           "default": null,
           "description": "The epistemic isolation boundary guarding this agent's internal generative states."
         },
-        "neural_optics": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/GaussianSplattingProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
-        },
         "optical_physics": {
           "anyOf": [
             {
@@ -2881,21 +2869,17 @@
           "default": null,
           "description": "The strict microfacet BRDF physics governing the visual representation of this node."
         },
-        "required_attestation": {
-          "$ref": "#/$defs/AttestationMechanismProfile",
-          "description": "The mandatory cryptographic attestation required to verify the human operator's identity."
-        },
-        "semantic_zoom": {
+        "neural_optics": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SemanticZoomProfile"
+              "$ref": "#/$defs/GaussianSplattingProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
+          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
         },
         "topology_class": {
           "const": "human",
@@ -2903,6 +2887,22 @@
           "description": "Discriminator for a Human node.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "required_attestation": {
+          "$ref": "#/$defs/AttestationMechanismProfile",
+          "description": "The mandatory cryptographic attestation required to verify the human operator's identity."
+        },
+        "active_attention_ray": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EpistemicAttentionRay"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The continuous spatial vector representing the human operator's localized cognitive focus."
         }
       },
       "required": [
@@ -2924,15 +2924,6 @@
           "title": "Event Cid",
           "type": "string"
         },
-        "predicted_top_k_tokens": {
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Predicted Top K Tokens",
-          "type": "array"
-        },
         "prior_event_hash": {
           "anyOf": [
             {
@@ -2949,18 +2940,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "source_chain_id": {
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Chain Id",
-          "type": "string"
-        },
-        "target_source_concept": {
-          "maxLength": 2000,
-          "title": "Target Source Concept",
-          "type": "string"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -2973,6 +2952,27 @@
           "default": "cognitive_prediction",
           "title": "Topology Class",
           "type": "string"
+        },
+        "source_chain_id": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Chain Id",
+          "type": "string"
+        },
+        "target_source_concept": {
+          "maxLength": 2000,
+          "title": "Target Source Concept",
+          "type": "string"
+        },
+        "predicted_top_k_tokens": {
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Predicted Top K Tokens",
+          "type": "array"
         }
       },
       "required": [
@@ -2989,6 +2989,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of a continuous proof trace resulting\nfrom a successfully resolved non-monotonic search, projecting internal System 2 thinking\ninto the observable graph. As a ...State suffix, this is a frozen N-dimensional\ncoordinate.\n\nCAUSAL AFFORDANCE: Binds the raw, unstructured Chain-of-Thought (trace_payload) to a\nformal EpistemicTopologicalProofManifest (source_proof_cid), injecting the internal\nmonologue into the verifiable DAG for downstream reward shaping (GRPO).\n\nEPISTEMIC BOUNDS: The token_length is restricted (ge=0, le=1000000000). The textual\nreasoning is physically bounded to max_length=100000 to prevent context window\nexplosion. The trace_cid is locked to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Chain of Thought, Non-Monotonic Trace, Proof Crystallization,\nLatent Monologue, Verifiable Reasoning",
       "properties": {
+        "trace_cid": {
+          "description": "The globally unique decentralized identifier (DID) anchoring this specific non-monotonic reasoning trace.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Trace Cid",
+          "type": "string"
+        },
         "source_proof_cid": {
           "description": "The EpistemicTopologicalProofManifest CID this trace is mathematically anchored to.",
           "maxLength": 128,
@@ -3003,14 +3011,6 @@
           "minimum": 0,
           "title": "Token Length",
           "type": "integer"
-        },
-        "trace_cid": {
-          "description": "The globally unique decentralized identifier (DID) anchoring this specific non-monotonic reasoning trace.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Trace Cid",
-          "type": "string"
         },
         "trace_payload": {
           "description": "The natural language reasoning steps bounded by structural tags.",
@@ -3032,13 +3032,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The immutable cryptographic receipt of a GRPO Advantage Actor-Critic\nevaluation step, permanently logging the mathematically verified advantage score of a\nspecific generation trajectory. As a ...Receipt suffix, this is an append-only coordinate\non the Merkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Unlocks policy gradient updates by providing the deterministic advantage\nsignal derived from the extracted_axioms of the source_generation_cid.\n\nEPISTEMIC BOUNDS: The calculated_r_path is strictly clamped between [ge=0.0, le=1.0], and\nthe total_advantage_score is capped at le=100.0. The @model_validator physically guarantees\nthat the extracted_axioms array is deterministically sorted by the composite key\n(source_concept_cid, directed_edge_class, target_concept_cid) to preserve RFC 8785 canonical\nhashing across the distributed swarm.\n\nMCP ROUTING TRIGGERS: Advantage Actor-Critic, Policy Gradient Update, Epistemic Reward,\nBaseline Normalization, Reinforcement Learning",
       "properties": {
-        "calculated_r_path": {
-          "description": "The dense reasoning reward signal derived from the verified axioms.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Calculated R Path",
-          "type": "number"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -3046,14 +3039,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "extracted_axioms": {
-          "description": "The specific axiomatic claims extracted exclusively from the bounded reasoning block.",
-          "items": {
-            "$ref": "#/$defs/EpistemicAxiomState"
-          },
-          "title": "Extracted Axioms",
-          "type": "array"
         },
         "prior_event_hash": {
           "anyOf": [
@@ -3071,14 +3056,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "source_generation_cid": {
-          "description": "The globally unique decentralized identifier (DID) anchoring the LLM's raw generated text trajectory.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Generation Cid",
-          "type": "string"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -3091,6 +3068,29 @@
           "default": "cognitive_reward_evaluation",
           "title": "Topology Class",
           "type": "string"
+        },
+        "source_generation_cid": {
+          "description": "The globally unique decentralized identifier (DID) anchoring the LLM's raw generated text trajectory.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Generation Cid",
+          "type": "string"
+        },
+        "extracted_axioms": {
+          "description": "The specific axiomatic claims extracted exclusively from the bounded reasoning block.",
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "title": "Extracted Axioms",
+          "type": "array"
+        },
+        "calculated_r_path": {
+          "description": "The dense reasoning reward signal derived from the verified axioms.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Calculated R Path",
+          "type": "number"
         },
         "total_advantage_score": {
           "description": "The final computed GRPO advantage signal used to update the policy gradients.",
@@ -3120,11 +3120,12 @@
           "title": "Dynamic Top K",
           "type": "integer"
         },
-        "enforce_functional_isolation": {
-          "default": false,
-          "description": "If True, the orchestrator applies a hard mask (-inf) to any expert not explicitly boosted in expert_logit_biases.",
-          "title": "Enforce Functional Isolation",
-          "type": "boolean"
+        "routing_temperature": {
+          "description": "The temperature applied to the router's softmax gate, controlling how deterministically it picks experts.",
+          "maximum": 1000000000.0,
+          "minimum": 0.0,
+          "title": "Routing Temperature",
+          "type": "number"
         },
         "expert_logit_biases": {
           "additionalProperties": {
@@ -3140,12 +3141,11 @@
           "title": "Expert Logit Biases",
           "type": "object"
         },
-        "routing_temperature": {
-          "description": "The temperature applied to the router's softmax gate, controlling how deterministically it picks experts.",
-          "maximum": 1000000000.0,
-          "minimum": 0.0,
-          "title": "Routing Temperature",
-          "type": "number"
+        "enforce_functional_isolation": {
+          "default": false,
+          "description": "If True, the orchestrator applies a hard mask (-inf) to any expert not explicitly boosted in expert_logit_biases.",
+          "title": "Enforce Functional Isolation",
+          "type": "boolean"
         }
       },
       "required": [
@@ -3159,19 +3159,19 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the Upper Confidence Bound (UCB) algorithm and Inverse Frequency Smoothing to regulate the exploration-exploitation geometry of Monte Carlo Tree Search (MCTS).\n\nCAUSAL AFFORDANCE: Physically regulates the search tree depth and dynamically prioritizes unexplored nodes, forcing the orchestrator to expand its epistemic search space before converging.\n\nEPISTEMIC BOUNDS: Graph traversal depth is rigidly cut off by max_complexity_hops (ge=1, le=1000000000). The mathematical exploration bonus is constrained by inverse_frequency_smoothing_epsilon (le=1.0), preventing exponential divergence in node prioritization.\n\nMCP ROUTING TRIGGERS: Monte Carlo Tree Search, Upper Confidence Bound, Inverse Frequency Smoothing, Heuristic Exploration, Graph Traversal",
       "properties": {
-        "inverse_frequency_smoothing_epsilon": {
-          "default": 1.0,
-          "description": "The epsilon constant ensuring unsampled nodes are mathematically prioritized.",
-          "maximum": 1.0,
-          "title": "Inverse Frequency Smoothing Epsilon",
-          "type": "number"
-        },
         "max_complexity_hops": {
           "description": "The absolute physical limit on path length N.",
           "maximum": 1000000000,
           "minimum": 1,
           "title": "Max Complexity Hops",
           "type": "integer"
+        },
+        "inverse_frequency_smoothing_epsilon": {
+          "default": 1.0,
+          "description": "The epsilon constant ensuring unsampled nodes are mathematically prioritized.",
+          "maximum": 1.0,
+          "title": "Inverse Frequency Smoothing Epsilon",
+          "type": "number"
         }
       },
       "required": [
@@ -3184,17 +3184,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Tracks the continuous Partially Observable Markov Decision Process (POMDP) belief distribution and dictates the active cognitive heuristic.\n\nCAUSAL AFFORDANCE: Orchestrates multi-dimensional state progression, determining if the agent explores via high `divergence_tolerance` or exploits via constrained caution vectors. Embeds steering and routing contracts for mechanistic control.\n\nEPISTEMIC BOUNDS: Relies on strict Pydantic bounding of internal indices (`urgency_index`, `caution_index`, `divergence_tolerance`) to continuous probability distributions mathematically locked between `[ge=0.0, le=1.0]`.\n\nMCP ROUTING TRIGGERS: POMDP, Continuous Belief Distribution, Heuristic Routing, State Progression, Cognitive Constraining",
       "properties": {
-        "activation_steering": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ActivationSteeringContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The precise mathematical contract for altering the residual stream to enforce this constraint."
+        "urgency_index": {
+          "description": "Drives structural constraints; high urgency forces fast heuristic routing.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Urgency Index",
+          "type": "number"
         },
         "caution_index": {
           "description": "Drives precision; high caution injects analytical/falsification steering vectors.",
@@ -3209,6 +3204,18 @@
           "minimum": 0.0,
           "title": "Divergence Tolerance",
           "type": "number"
+        },
+        "activation_steering": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ActivationSteeringContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The precise mathematical contract for altering the residual stream to enforce this constraint."
         },
         "moe_routing_directive": {
           "anyOf": [
@@ -3233,13 +3240,6 @@
           ],
           "default": null,
           "description": "The mathematical data starvation mechanism bounding the working memory context."
-        },
-        "urgency_index": {
-          "description": "Drives structural constraints; high urgency forces fast heuristic routing.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Urgency Index",
-          "type": "number"
         }
       },
       "required": [
@@ -3254,6 +3254,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encapsulates pure functional logic (Lambda Calculus) and Finite State Machine (FSM) mechanics to represent a completely deterministic, side-effect-free system capability.\n\nCAUSAL AFFORDANCE: Executes rigid, zero-variance procedural logic without invoking the expensive stochastic policy gradients required by foundational LLM models.\n\nEPISTEMIC BOUNDS: This node defines NO additional fields beyond inherited `CoreasonBaseState` constraints, including the rigorous `domain_extensions` volumetric depth limits. The type discriminator is locked to `Literal[\"system\"]`.\n\nMCP ROUTING TRIGGERS: Lambda Calculus, Finite State Machine, Referential Transparency, Deterministic Execution, Zero Variance",
       "properties": {
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -3268,11 +3274,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -3293,27 +3315,17 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
           "title": "Domain Extensions"
         },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
+        "semantic_zoom": {
           "anyOf": [
             {
-              "maxLength": 2000,
-              "type": "string"
+              "$ref": "#/$defs/SemanticZoomProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
+          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
         },
         "markov_blanket": {
           "anyOf": [
@@ -3327,18 +3339,6 @@
           "default": null,
           "description": "The epistemic isolation boundary guarding this agent's internal generative states."
         },
-        "neural_optics": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/GaussianSplattingProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
-        },
         "optical_physics": {
           "anyOf": [
             {
@@ -3351,17 +3351,17 @@
           "default": null,
           "description": "The strict microfacet BRDF physics governing the visual representation of this node."
         },
-        "semantic_zoom": {
+        "neural_optics": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SemanticZoomProfile"
+              "$ref": "#/$defs/GaussianSplattingProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
+          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
         },
         "topology_class": {
           "const": "system",
@@ -3403,17 +3403,17 @@
           "title": "Epistemic Knowledge Gap",
           "type": "number"
         },
-        "requires_abductive_escalation": {
-          "description": "True if epistemic_uncertainty breaches the safety threshold, requiring structural mandate escalation.",
-          "title": "Requires Abductive Escalation",
-          "type": "boolean"
-        },
         "semantic_consistency_score": {
           "description": "Counterfactual Geometries representing alternative timeline vectors.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Semantic Consistency Score",
           "type": "number"
+        },
+        "requires_abductive_escalation": {
+          "description": "True if epistemic_uncertainty breaches the safety threshold, requiring structural mandate escalation.",
+          "title": "Requires Abductive Escalation",
+          "type": "boolean"
         }
       },
       "required": [
@@ -3429,6 +3429,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Integrated Information Theory (IIT) and synergy metrics\nto quantify system-level emergence in the neurosymbolic swarm. As a ...Profile suffix,\nthis is a declarative property descriptor.\n\nCAUSAL AFFORDANCE: Provides the orchestrator with macroscopic topological variables to\nevaluate whether the multi-agent ensemble is producing non-linear, synergistic output\nversus independent parallel processing.\n\nEPISTEMIC BOUNDS: coordination_score and information_integration are upper-clamped at\nle=1.0 to represent normalized mutual information. synergy_index is capped at\nle=1000000000.0 to prevent scalar explosion. Note: no lower ge bounds are enforced on\nthese fields.\n\nMCP ROUTING TRIGGERS: Integrated Information Theory, Systemic Emergence, Conditional\nMutual Information, Synergy Index, Multi-Agent Coupling",
       "properties": {
+        "synergy_index": {
+          "description": "The mathematical measure of the degree of emergence. A high SI indicates strong positive emergence.",
+          "maximum": 1000000000.0,
+          "title": "Synergy Index",
+          "type": "number"
+        },
         "coordination_score": {
           "description": "The temporal alignment measuring the extent to which agents coordinate their actions over time.",
           "maximum": 1.0,
@@ -3439,12 +3445,6 @@
           "description": "The conditional mutual information quantifying the information flow and tight coupling between agents.",
           "maximum": 1.0,
           "title": "Information Integration",
-          "type": "number"
-        },
-        "synergy_index": {
-          "description": "The mathematical measure of the degree of emergence. A high SI indicates strong positive emergence.",
-          "maximum": 1000000000.0,
-          "title": "Synergy Index",
           "type": "number"
         }
       },
@@ -3460,6 +3460,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a Fractal Graph Abstraction, allowing the recursive encapsulation of entire workflow sub-topologies within a single, unified macroscopic vertex.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to suspend the parent graph, injecting state variables into the isolated topology (`AnyTopologyManifest`) via `input_mappings`, and extracting terminal output via `output_mappings`.\n\nEPISTEMIC BOUNDS: The `@model_validator` `_enforce_canonical_sort_mappings` deterministically sorts `input_mappings` by `parent_key` and `output_mappings` by `child_key`, guaranteeing zero-variance RFC 8785 canonical Merkle-DAG hashes across distributed nodes.\n\nMCP ROUTING TRIGGERS: Fractal Graph Abstraction, Recursive Encapsulation, State Projection, Bijective Mapping, Sub-Topology",
       "properties": {
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -3474,11 +3480,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -3499,35 +3521,17 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
           "title": "Domain Extensions"
         },
-        "input_mappings": {
-          "description": "Explicit state projection inputs.",
-          "items": {
-            "$ref": "#/$defs/InputMappingContract"
-          },
-          "title": "Input Mappings",
-          "type": "array"
-        },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
+        "semantic_zoom": {
           "anyOf": [
             {
-              "maxLength": 2000,
-              "type": "string"
+              "$ref": "#/$defs/SemanticZoomProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
+          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
         },
         "markov_blanket": {
           "anyOf": [
@@ -3541,18 +3545,6 @@
           "default": null,
           "description": "The epistemic isolation boundary guarding this agent's internal generative states."
         },
-        "neural_optics": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/GaussianSplattingProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
-        },
         "optical_physics": {
           "anyOf": [
             {
@@ -3565,29 +3557,17 @@
           "default": null,
           "description": "The strict microfacet BRDF physics governing the visual representation of this node."
         },
-        "output_mappings": {
-          "description": "Explicit state projection outputs.",
-          "items": {
-            "$ref": "#/$defs/OutputMappingContract"
-          },
-          "title": "Output Mappings",
-          "type": "array"
-        },
-        "semantic_zoom": {
+        "neural_optics": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SemanticZoomProfile"
+              "$ref": "#/$defs/GaussianSplattingProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
-        },
-        "topology": {
-          "$ref": "#/$defs/AnyTopologyManifest",
-          "description": "The encapsulated subgraph to execute."
+          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
         },
         "topology_class": {
           "const": "composite",
@@ -3595,6 +3575,26 @@
           "description": "Discriminator for a Composite node.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "topology": {
+          "$ref": "#/$defs/AnyTopologyManifest",
+          "description": "The encapsulated subgraph to execute."
+        },
+        "input_mappings": {
+          "description": "Explicit state projection inputs.",
+          "items": {
+            "$ref": "#/$defs/InputMappingContract"
+          },
+          "title": "Input Mappings",
+          "type": "array"
+        },
+        "output_mappings": {
+          "description": "Explicit state projection outputs.",
+          "items": {
+            "$ref": "#/$defs/OutputMappingContract"
+          },
+          "title": "Output Mappings",
+          "type": "array"
         }
       },
       "required": [
@@ -3608,22 +3608,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as the liquid compute substrate abstraction, defining the\nfoundational LLM matrix available on the Spot Market for dynamic routing. As a ...Profile\nsuffix, this is a declarative, frozen snapshot of a compute geometry.\n\nCAUSAL AFFORDANCE: Projects the physical LLM capabilities, contextual memory constraints,\nand thermodynamic rate cards (ComputeRateContract) into the orchestrator's active routing\nmanifold, allowing cost-aware topological planning.\n\nEPISTEMIC BOUNDS: The token working memory is mathematically bounded by\ncontext_window_size (le=1000000000). To guarantee RFC 8785 canonical hashing across\ndisparate nodes, the capabilities and supported_functional_experts arrays are strictly\nsorted at instantiation via @model_validator.\n\nMCP ROUTING TRIGGERS: Liquid Compute, Spot Market Routing, Foundation Model Matrix,\nThermodynamic Rate Card, Substrate Abstraction",
       "properties": {
-        "capabilities": {
-          "description": "The explicit, structurally bounded array of capabilities authorized for this model.",
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "maxItems": 1000,
-          "title": "Capabilities",
-          "type": "array"
-        },
-        "context_window_size": {
-          "description": "The maximum context window size in tokens.",
-          "maximum": 1000000000,
-          "title": "Context Window Size",
-          "type": "integer"
-        },
         "foundation_matrix_name": {
           "description": "The identifier of the underlying model.",
           "maxLength": 2000,
@@ -3635,6 +3619,22 @@
           "maxLength": 2000,
           "title": "Provider",
           "type": "string"
+        },
+        "context_window_size": {
+          "description": "The maximum context window size in tokens.",
+          "maximum": 1000000000,
+          "title": "Context Window Size",
+          "type": "integer"
+        },
+        "capabilities": {
+          "description": "The explicit, structurally bounded array of capabilities authorized for this model.",
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "maxItems": 1000,
+          "title": "Capabilities",
+          "type": "array"
         },
         "rate_card": {
           "$ref": "#/$defs/ComputeRateContract",
@@ -3670,11 +3670,6 @@
           "title": "Max Budget",
           "type": "integer"
         },
-        "qos_class": {
-          "$ref": "#/$defs/QoSClassificationProfile",
-          "default": "interactive",
-          "description": "The Quality of Service priority, used by the compute spot market for semantic load shedding."
-        },
         "required_capabilities": {
           "description": "The minimal functional capabilities required by the requested compute.",
           "items": {
@@ -3684,6 +3679,11 @@
           "maxItems": 1000,
           "title": "Required Capabilities",
           "type": "array"
+        },
+        "qos_class": {
+          "$ref": "#/$defs/QoSClassificationProfile",
+          "default": "interactive",
+          "description": "The Quality of Service priority, used by the compute spot market for semantic load shedding."
         }
       },
       "required": [
@@ -3724,22 +3724,25 @@
       "title": "ComputeRateContract",
       "type": "object"
     },
-    "ComputeTier": {
+    "ComputeTierProfile": {
       "description": "AGENT INSTRUCTION: Categorizes the latency and reasoning depth of a given logical node, physically segregating cheap syntactic execution from heavy semantic computation.\n\nCAUSAL AFFORDANCE: Instructs the scheduling orchestrator to route this node's computation to the appropriately tiered hardware cluster (e.g. fast cheap APIs vs heavy GPU inference).\n\nEPISTEMIC BOUNDS: Bounded to strict enumeration values.\n\nMCP ROUTING TRIGGERS: Hardware Scheduling, Tiered Compute, Orchestration Cost, Resource Allocation",
       "enum": [
         "KINETIC",
         "ORACLE"
       ],
-      "title": "ComputeTier",
+      "title": "ComputeTierProfile",
       "type": "string"
     },
     "ConsensusFederationTopologyManifest": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Zero-Cost Macro abstraction that deterministically projects a Practical Byzantine Fault Tolerance (pBFT) consensus ring into a multi-agent workflow. As a ...Manifest suffix, this defines a frozen coordinate of a topological structure.\n\nCAUSAL AFFORDANCE: Unrolls into a base CouncilTopologyManifest, enforcing strict quorum rules and sequential adjudication to guarantee ledger alignment and truth maintenance across a decentralized, zero-trust swarm.\n\nEPISTEMIC BOUNDS: Mathematically ensures Byzantine security by requiring a minimum of 3 participant_cids. The adjudicator_cid is physically isolated from the voting pool via the verify_adjudicator_isolation hook. The participant_cids array is deterministically sorted for invariant hashing.\n\nMCP ROUTING TRIGGERS: Practical Byzantine Fault Tolerance, pBFT, Distributed Consensus, Sybil Resistance, Macro Abstraction",
       "properties": {
-        "adjudicator_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The orchestrating sequencer for the PBFT consensus."
+        "topology_class": {
+          "const": "macro_federation",
+          "default": "macro_federation",
+          "description": "Discriminator for federation macro.",
+          "title": "Topology Class",
+          "type": "string"
         },
         "participant_cids": {
           "description": "The nodes forming the PBFT ring.",
@@ -3750,16 +3753,13 @@
           "title": "Participant Cids",
           "type": "array"
         },
+        "adjudicator_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The orchestrating sequencer for the PBFT consensus."
+        },
         "quorum_rules": {
           "$ref": "#/$defs/QuorumPolicy",
           "description": "The strict BFT tolerance bounds."
-        },
-        "topology_class": {
-          "const": "macro_federation",
-          "default": "macro_federation",
-          "description": "Discriminator for federation macro.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -3774,6 +3774,30 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Social Choice Theory and Distributed Consensus mechanisms\nto systematically synthesize a singular, crystallized truth from a multi-agent council.\nAs a ...Policy suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Triggers deterministic tie-breaking (via optional\ntie_breaker_node_cid: NodeCIDState) or algorithmic market resolution (via\noptional prediction_market_rules: PredictionMarketPolicy) when agents deadlock,\nforcefully collapsing the debate probability wave to maintain systemic liveness.\n\nEPISTEMIC BOUNDS: The max_debate_rounds (optional int) is clamped to le=1000000000 to\ncomputationally solve the Halting Problem for runaway arguments. The strategy Literal\n[\"unanimous\", \"majority\", \"debate_rounds\", \"prediction_market\", \"pbft\"] constrains\nthe combinatorial space. The @model_validator requires quorum_rules if strategy is\n\"pbft\".\n\nMCP ROUTING TRIGGERS: Social Choice Theory, Mechanism Design, Condorcet's Jury Theorem,\nAlgorithmic Consensus, Deadlock Resolution",
       "properties": {
+        "strategy": {
+          "description": "The mathematical rule for reaching agreement.",
+          "enum": [
+            "unanimous",
+            "majority",
+            "debate_rounds",
+            "prediction_market",
+            "pbft"
+          ],
+          "title": "Strategy",
+          "type": "string"
+        },
+        "tie_breaker_node_cid": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeCIDState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The node authorized to break deadlocks if unanimity or majority fails."
+        },
         "max_debate_rounds": {
           "anyOf": [
             {
@@ -3811,30 +3835,6 @@
           ],
           "default": null,
           "description": "The strict Byzantine fault tolerance limits required if the strategy is 'pbft'."
-        },
-        "strategy": {
-          "description": "The mathematical rule for reaching agreement.",
-          "enum": [
-            "unanimous",
-            "majority",
-            "debate_rounds",
-            "prediction_market",
-            "pbft"
-          ],
-          "title": "Strategy",
-          "type": "string"
-        },
-        "tie_breaker_node_cid": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeCIDState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The node authorized to break deadlocks if unanimity or majority fails."
         }
       },
       "required": [
@@ -3847,18 +3847,19 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a non-monotonic structural revision trigger within a Defeasible Logic framework, engineered to adapt the GovernancePolicy to out-of-distribution environments.\n\nCAUSAL AFFORDANCE: Triggers an active topological mutation (Pearlian intervention) to resolve logical friction, applying a strict RFC 6902 JSON Patch (`proposed_patch`) to the underlying alignment manifold.\n\nEPISTEMIC BOUNDS: Cryptographically anchored to the specific `drift_event_id` (regex bounded CID `^[a-zA-Z0-9_.:-]+$`) that mathematically justified the revision. The payload is constrained to a JSON Schema object (`proposed_patch`).\n\nMCP ROUTING TRIGGERS: Defeasible Logic, Non-Monotonic Revision, Out-of-Distribution Adaptation, Normative Drift Resolution, Pearlian Intervention",
       "properties": {
+        "topology_class": {
+          "const": "constitutional_amendment",
+          "default": "constitutional_amendment",
+          "description": "The strict discriminator for this intervention payload.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "drift_event_id": {
           "description": "The globally unique decentralized identifier (DID) anchoring the NormativeDriftEvent that justified triggering this proposal.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Drift Event Id",
-          "type": "string"
-        },
-        "justification": {
-          "description": "The AI's natural language structural/logical argument for why this patch resolves the contradiction without violating the root AnchoringPolicy.",
-          "maxLength": 2000,
-          "title": "Justification",
           "type": "string"
         },
         "proposed_patch": {
@@ -3870,11 +3871,10 @@
           "title": "Proposed Patch",
           "type": "object"
         },
-        "topology_class": {
-          "const": "constitutional_amendment",
-          "default": "constitutional_amendment",
-          "description": "The strict discriminator for this intervention payload.",
-          "title": "Topology Class",
+        "justification": {
+          "description": "The AI's natural language structural/logical argument for why this patch resolves the contradiction without violating the root AnchoringPolicy.",
+          "maxLength": 2000,
+          "title": "Justification",
           "type": "string"
         }
       },
@@ -3890,28 +3890,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a discrete normative axiom within a Constitutional AI\nframework to prevent instrumental convergence. As a ...Policy suffix, this object defines\nrigid mathematical boundaries that the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Establishes a hard structural boundary that mathematically repels the\nswarm's generative trajectory away from forbidden semantic manifolds. Violation severity\nis classified via a strict Literal[\"low\", \"medium\", \"high\", \"critical\"] tier.\n\nEPISTEMIC BOUNDS: Geometrically restricts the state space by blacklisting specific\nexecution branches via the forbidden_intents array (max_length=1000),\ndeterministically sorted by @model_validator to preserve RFC 8785 canonical hashing.\nThe rule_cid is bounded to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Constitutional AI, Value Alignment, Normative Axiom, Instrumental\nConvergence, Semantic Boundary",
       "properties": {
-        "description": {
-          "description": "The definitive causal constraint or heuristic boundary enforced by this rule.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
-        },
-        "forbidden_intents": {
-          "description": "The explicit, structurally bounded set of forbidden semantic intents.",
-          "items": {
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 1000,
-          "title": "Forbidden Intents",
-          "type": "array"
-        },
         "rule_cid": {
           "description": "Unique identifier for the constitutional rule.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Rule Cid",
+          "type": "string"
+        },
+        "description": {
+          "description": "The definitive causal constraint or heuristic boundary enforced by this rule.",
+          "maxLength": 2000,
+          "title": "Description",
           "type": "string"
         },
         "severity": {
@@ -3924,6 +3914,16 @@
           ],
           "title": "Severity",
           "type": "string"
+        },
+        "forbidden_intents": {
+          "description": "The explicit, structurally bounded set of forbidden semantic intents.",
+          "items": {
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 1000,
+          "title": "Forbidden Intents",
+          "type": "array"
         }
       },
       "required": [
@@ -3939,6 +3939,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A rigid mathematical boundary enforcing systemic constraints globally. Dictates the hardware-level execution limits for the token sampling phase by converting structural formatting from a probabilistic neural suggestion into a deterministic physics problem.\n\nCAUSAL AFFORDANCE: Enforces rigid isolation perimeters and limits subgraph generation by physically suffocating invalid token probabilities. Instructs the inference engine (e.g., Outlines, XGrammar) to compile a DFA/PDA and mechanically overwrite illegal token logits to negative infinity.\n\nEPISTEMIC BOUNDS: Strict categorical literals on `enforcement_strategy` and `compiler_backend`. The `validate_grammar_requirements` `@model_validator` mandates `formal_grammar_string` is non-null if the strategy expects a Context-Free Grammar (CFG).\n\nMCP ROUTING TRIGGERS: FSM Logit Masking, Constrained Decoding, Tokenizer Interception, Hardware Execution Boundary, Pushdown Automaton",
       "properties": {
+        "enforcement_strategy": {
+          "default": "fsm_logit_mask",
+          "description": "The mechanistic strategy for intercepting the LLM forward pass.",
+          "enum": [
+            "fsm_logit_mask",
+            "lmql_query",
+            "guidance_program",
+            "ebnf_grammar"
+          ],
+          "title": "Enforcement Strategy",
+          "type": "string"
+        },
         "compiler_backend": {
           "description": "The C++/CUDA backend used to compile the CFG or Regex into a DFA/PDA.",
           "enum": [
@@ -3951,18 +3963,6 @@
             "agnostic"
           ],
           "title": "Compiler Backend",
-          "type": "string"
-        },
-        "enforcement_strategy": {
-          "default": "fsm_logit_mask",
-          "description": "The mechanistic strategy for intercepting the LLM forward pass.",
-          "enum": [
-            "fsm_logit_mask",
-            "lmql_query",
-            "guidance_program",
-            "ebnf_grammar"
-          ],
-          "title": "Enforcement Strategy",
           "type": "string"
         },
         "formal_grammar_string": {
@@ -4013,21 +4013,6 @@
           "title": "Max Token Budget",
           "type": "integer"
         },
-        "parent_merge_threshold": {
-          "anyOf": [
-            {
-              "maximum": 1.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The geometric cosine similarity threshold required to merge parent nodes.",
-          "title": "Parent Merge Threshold"
-        },
         "surrounding_sentences_k": {
           "anyOf": [
             {
@@ -4042,6 +4027,21 @@
           "default": null,
           "description": "The strict temporal window of surrounding sentences.",
           "title": "Surrounding Sentences K"
+        },
+        "parent_merge_threshold": {
+          "anyOf": [
+            {
+              "maximum": 1.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The geometric cosine similarity threshold required to merge parent nodes.",
+          "title": "Parent Merge Threshold"
         }
       },
       "required": [
@@ -4055,6 +4055,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Projects a semantically unified spatial token footprint representing the strictly bounded source projection.\n\n    CAUSAL AFFORDANCE: Authorizes downstream parsing tasks to isolate exact dimensional target strings while strictly maintaining chronological relationships via the topological envelope.\n\n    EPISTEMIC BOUNDS: Limits structural explosion by constraining target sequences and contextual items mathematically to max_length=100000. Contains a strict topological exemption preventing array sorting.\n\n    MCP ROUTING TRIGGERS: Semantic Envelope, Contextual Projection, Spatial Token Footprint, Source Entity, Topos Sorting",
       "properties": {
+        "target_string": {
+          "description": "The strictly bounded, un-redacted 1D string projection of the semantic artifact undergoing evaluation.",
+          "maxLength": 100000,
+          "title": "Target String",
+          "type": "string"
+        },
         "contextual_envelope": {
           "description": "The strictly bounded array of adjacent token clusters forming the semantic proximity matrix. AGENT INSTRUCTION: Topological Exemption applied. Do NOT sort this array, as its chronological/spatial sequence is its mathematical state.",
           "items": {
@@ -4069,12 +4075,6 @@
           "description": "The mathematical boolean boundary indicating strict physical provenance to an external host.",
           "title": "Source System Provenance Flag",
           "type": "boolean"
-        },
-        "target_string": {
-          "description": "The strictly bounded, un-redacted 1D string projection of the semantic artifact undergoing evaluation.",
-          "maxLength": 100000,
-          "title": "Target String",
-          "type": "string"
         }
       },
       "required": [
@@ -4089,6 +4089,15 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Queueing Theory and Micro-Batching Stream Processing\nheuristics for continuous, high-velocity graph updates without violating Eventual\nConsistency. As a ...Policy suffix, this defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Dictates the thermodynamic flow of the orchestrator, determining\nexactly when to buffer and when to force-commit volatile StateMutationIntent\nmatrices to the EpistemicLedgerState via the mutation_paradigm\nLiteral [\"append_only\", \"merge_on_resolve\"].\n\nEPISTEMIC BOUNDS: Physically prevents Out-Of-Memory (OOM) VRAM crashes by\nmathematically enforcing max_uncommitted_edges (gt=0, le=1000000000). The\n@model_validator enforce_append_only_vram_bound further crushes this limit to\n<= 10000 for append_only operations. The commit cycle is temporally guillotined\nby micro_batch_interval_ms (gt=0, le=86400000).\n\nMCP ROUTING TRIGGERS: Queueing Theory, Stream Processing, Micro-Batching,\nBackpressure, Buffer Memory Bounding",
       "properties": {
+        "mutation_paradigm": {
+          "description": "Forces non-destructive graph mutations.",
+          "enum": [
+            "append_only",
+            "merge_on_resolve"
+          ],
+          "title": "Mutation Paradigm",
+          "type": "string"
+        },
         "max_uncommitted_edges": {
           "description": "Backpressure threshold before forcing a commit.",
           "exclusiveMinimum": 0,
@@ -4102,15 +4111,6 @@
           "maximum": 86400000,
           "title": "Micro Batch Interval Ms",
           "type": "integer"
-        },
-        "mutation_paradigm": {
-          "description": "Forces non-destructive graph mutations.",
-          "enum": [
-            "append_only",
-            "merge_on_resolve"
-          ],
-          "title": "Mutation Paradigm",
-          "type": "string"
         }
       },
       "required": [
@@ -4125,13 +4125,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the geometric snapshot of a continuous stream and its \"forget gate\" disfluency rules, acting as a declarative snapshot of continuous token flows.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to continuously process and retain token buffers governed by a temporal decay matrix.\n\nEPISTEMIC BOUNDS: The `token_buffer` is mathematically capped at `max_length=1000000` (Topological Exemption: DO NOT SORT). Each token restricted to `max_length=10000`. `temporal_decay_matrix` forces bounded temporal scaling (`ge=0.0, le=1.0`).\n\nMCP ROUTING TRIGGERS: Continuous Observation, State Space Models, Temporal Decay, Forget Gate, Streaming Disfluency",
       "properties": {
-        "latest_confidence_score": {
-          "description": "The certainty score of the latest token prediction.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Latest Confidence Score",
-          "type": "number"
-        },
         "stream_cid": {
           "description": "A Content Identifier (CID) for the continuous observation stream.",
           "maxLength": 128,
@@ -4139,6 +4132,16 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Stream Cid",
           "type": "string"
+        },
+        "token_buffer": {
+          "description": "The array of ingested tokens representing the continuous stream. AGENT INSTRUCTION: Topological Exemption applied. Do NOT sort this array, as its chronological sequence is its mathematical state.",
+          "items": {
+            "maxLength": 10000,
+            "type": "string"
+          },
+          "maxItems": 1000000,
+          "title": "Token Buffer",
+          "type": "array"
         },
         "temporal_decay_matrix": {
           "additionalProperties": {
@@ -4150,15 +4153,12 @@
           "title": "Temporal Decay Matrix",
           "type": "object"
         },
-        "token_buffer": {
-          "description": "The array of ingested tokens representing the continuous stream. AGENT INSTRUCTION: Topological Exemption applied. Do NOT sort this array, as its chronological sequence is its mathematical state.",
-          "items": {
-            "maxLength": 10000,
-            "type": "string"
-          },
-          "maxItems": 1000000,
-          "title": "Token Buffer",
-          "type": "array"
+        "latest_confidence_score": {
+          "description": "The certainty score of the latest token prediction.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Latest Confidence Score",
+          "type": "number"
         }
       },
       "required": [
@@ -4174,20 +4174,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes an Affine Conflict-free Replicated Data Type (CRDT) to execute Optimistic Concurrency Control across geometric manipulations.\n\nCAUSAL AFFORDANCE: Authorizes a participant to kinetically drag, rotate, or scale a topological node. The orchestrator uses the provided Lamport clock to mathematically resolve Spherical Linear Interpolation (SLERP) and translation collisions between concurrent actors.\n\nEPISTEMIC BOUNDS: The mutation strictly targets a verified `NodeCIDState`. The `lamport_clock` (`ge=0, le=1000000000`) prevents temporal overflow during logical state reconciliation.\n\nMCP ROUTING TRIGGERS: Optimistic Locking, Affine CRDT, Spherical Linear Interpolation, Continuous Reconciliation, Kinematic Drag",
       "properties": {
+        "target_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The specific topology vertex undergoing spatial mutation."
+        },
+        "proposed_transform": {
+          "$ref": "#/$defs/SE3TransformProfile",
+          "description": "The requested absolute SE(3) spatial terminus."
+        },
         "lamport_clock": {
           "description": "The logical clock scalar dictating Last-Writer-Wins consensus for the geometric shift.",
           "maximum": 1000000000,
           "minimum": 0,
           "title": "Lamport Clock",
           "type": "integer"
-        },
-        "proposed_transform": {
-          "$ref": "#/$defs/SE3TransformProfile",
-          "description": "The requested absolute SE(3) spatial terminus."
-        },
-        "target_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The specific topology vertex undergoing spatial mutation."
         }
       },
       "required": [
@@ -4202,9 +4202,27 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Social Choice Theory, Condorcet's Jury Theorem, and Practical Byzantine Fault Tolerance (pBFT) to synthesize an authoritative truth from a multi-agent network.\n\nCAUSAL AFFORDANCE: Unlocks decentralized truth-synthesis by routing conflicting proposals through a strict `consensus_policy`, ultimately collapsing the epistemic probability wave via the designated `adjudicator_cid`. Cognitive heterogeneity is enforced by `diversity_policy`.\n\nEPISTEMIC BOUNDS: The `@model_validator` `enforce_funded_byzantine_slashing` enforces a strict economic interlock: if the `consensus_policy` demands `slash_escrow` via pBFT, it halts instantiation unless a funded `council_escrow` is present. `check_adjudicator_id` verifies the adjudicator exists in the nodes registry.\n\nMCP ROUTING TRIGGERS: Social Choice Theory, PBFT Consensus, Multi-Agent Debate, Byzantine Fault Tolerance, Slashing Condition",
       "properties": {
-        "adjudicator_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The NodeCIDState of the adjudicator that synthesizes the council's output."
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
         },
         "architectural_intent": {
           "anyOf": [
@@ -4220,54 +4238,6 @@
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
         },
-        "consensus_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ConsensusPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The explicit ruleset governing how the council resolves disagreements."
-        },
-        "council_escrow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EscrowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The strictly typed mathematical surface area to lock funds specifically for PBFT council execution and slashing."
-        },
-        "diversity_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DiversityPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Constraints enforcing cognitive heterogeneity across the council."
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
         "justification": {
           "anyOf": [
             {
@@ -4282,16 +4252,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -4302,42 +4262,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "ontological_alignment": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/OntologicalAlignmentPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -4351,12 +4275,88 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
         "topology_class": {
           "const": "council",
           "default": "council",
           "description": "Discriminator for a Council topology.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "adjudicator_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The NodeCIDState of the adjudicator that synthesizes the council's output."
+        },
+        "diversity_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DiversityPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Constraints enforcing cognitive heterogeneity across the council."
+        },
+        "consensus_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConsensusPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The explicit ruleset governing how the council resolves disagreements."
+        },
+        "ontological_alignment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologicalAlignmentPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
+        },
+        "council_escrow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EscrowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strictly typed mathematical surface area to lock funds specifically for PBFT council execution and slashing."
         }
       },
       "required": [
@@ -4370,18 +4370,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Counterfactual Regret Minimization (CFR) and Pearlian Do-Calculus to execute simulated alternative timelines for policy refinement.\n\nCAUSAL AFFORDANCE: Commits a simulated causal divergence (intervention) into the ledger, mathematically quantifying the opportunity cost (regret) to backpropagate stateless adjustments to the routing policy.\n\nEPISTEMIC BOUNDS: Anchored to `historical_event_id` (128-char CID). Expected utilities and `epistemic_regret` are physically capped at `le=1000000000.0`. `policy_mutation_gradients` restrict tensor adjustments.\n\nMCP ROUTING TRIGGERS: Counterfactual Regret Minimization, Pearlian Do-Calculus, Opportunity Cost, Alternative Timeline, Policy Gradient Update",
       "properties": {
-        "counterfactual_intervention": {
-          "description": "The specific alternative action or do-calculus intervention applied in the simulation.",
-          "maxLength": 2000,
-          "title": "Counterfactual Intervention",
-          "type": "string"
-        },
-        "epistemic_regret": {
-          "description": "The mathematical variance (simulated - actual) representing the opportunity cost of the historical decision.",
-          "maximum": 1000000000.0,
-          "title": "Epistemic Regret",
-          "type": "number"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -4389,40 +4377,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "expected_utility_actual": {
-          "description": "The calculated utility of the trajectory that was actually executed.",
-          "maximum": 1000000000.0,
-          "title": "Expected Utility Actual",
-          "type": "number"
-        },
-        "expected_utility_simulated": {
-          "description": "The calculated utility of the simulated counterfactual trajectory.",
-          "maximum": 1000000000.0,
-          "title": "Expected Utility Simulated",
-          "type": "number"
-        },
-        "historical_event_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the specific historical state node where the agent mathematically diverged to simulate an alternative path.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Historical Event Id",
-          "type": "string"
-        },
-        "policy_mutation_gradients": {
-          "additionalProperties": {
-            "maximum": 1000.0,
-            "minimum": -1000.0,
-            "type": "number"
-          },
-          "description": "The stateless routing gradient adjustments derived from the calculated regret, used to self-correct future routing.",
-          "maxProperties": 1000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Policy Mutation Gradients",
-          "type": "object"
         },
         "prior_event_hash": {
           "anyOf": [
@@ -4453,6 +4407,52 @@
           "description": "Discriminator type for a counterfactual regret event.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "historical_event_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the specific historical state node where the agent mathematically diverged to simulate an alternative path.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Historical Event Id",
+          "type": "string"
+        },
+        "counterfactual_intervention": {
+          "description": "The specific alternative action or do-calculus intervention applied in the simulation.",
+          "maxLength": 2000,
+          "title": "Counterfactual Intervention",
+          "type": "string"
+        },
+        "expected_utility_actual": {
+          "description": "The calculated utility of the trajectory that was actually executed.",
+          "maximum": 1000000000.0,
+          "title": "Expected Utility Actual",
+          "type": "number"
+        },
+        "expected_utility_simulated": {
+          "description": "The calculated utility of the simulated counterfactual trajectory.",
+          "maximum": 1000000000.0,
+          "title": "Expected Utility Simulated",
+          "type": "number"
+        },
+        "epistemic_regret": {
+          "description": "The mathematical variance (simulated - actual) representing the opportunity cost of the historical decision.",
+          "maximum": 1000000000.0,
+          "title": "Epistemic Regret",
+          "type": "number"
+        },
+        "policy_mutation_gradients": {
+          "additionalProperties": {
+            "maximum": 1000.0,
+            "minimum": -1000.0,
+            "type": "number"
+          },
+          "description": "The stateless routing gradient adjustments derived from the calculated regret, used to self-correct future routing.",
+          "maxProperties": 1000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Policy Mutation Gradients",
+          "type": "object"
         }
       },
       "required": [
@@ -4487,10 +4487,6 @@
           "title": "Initiating Tenant Id",
           "type": "string"
         },
-        "offered_sla": {
-          "$ref": "#/$defs/FederatedBilateralSLA",
-          "description": "The initial structural/data boundary proposed."
-        },
         "receiving_tenant_id": {
           "description": "The enterprise DID receiving the connection.",
           "maxLength": 128,
@@ -4498,6 +4494,10 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Receiving Tenant Id",
           "type": "string"
+        },
+        "offered_sla": {
+          "$ref": "#/$defs/FederatedBilateralSLA",
+          "description": "The initial structural/data boundary proposed."
         },
         "status": {
           "default": "proposed",
@@ -4533,16 +4533,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the chromosomal crossover and genetic recombination\nheuristics for blending latent feature vectors of elite parent agents. As a ...Policy\nsuffix, this object defines rigid mathematical boundaries that the orchestrator must\nenforce globally.\n\nCAUSAL AFFORDANCE: Executes the deterministic interpolation of N-dimensional properties\nfrom successful agents using a specific geometric strategy (CrossoverMechanismProfile)\nto breed the next generation's starting state.\n\nEPISTEMIC BOUNDS: The blending_factor is strictly constrained to a fractional\ninterpolation ratio (ge=0.0, le=1.0) to mathematically prevent extrapolated state drift\nbeyond the parents' bounding box. Relies on optional verifiable_entropy\n(VerifiableEntropyReceipt) to ensure unbiased recombination.\n\nMCP ROUTING TRIGGERS: Genetic Recombination, Chromosomal Crossover, Vector\nInterpolation, Elitism, Reproduction Heuristic",
       "properties": {
+        "strategy_type": {
+          "$ref": "#/$defs/CrossoverMechanismProfile",
+          "description": "The heuristic method for blending successful parent agents."
+        },
         "blending_factor": {
           "description": "The proportional mix ratio when merging vector properties.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Blending Factor",
           "type": "number"
-        },
-        "strategy_type": {
-          "$ref": "#/$defs/CrossoverMechanismProfile",
-          "description": "The heuristic method for blending successful parent agents."
         },
         "verifiable_entropy": {
           "anyOf": [
@@ -4568,18 +4568,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: CrystallizationPolicy governs Systemic Memory Consolidation (analogous\nto Hebbian Learning). It is a mathematical threshold that determines exactly when noisy,\nhigh-entropy episodic logs are statistically proven enough to be promoted into permanent semantic axioms.\n\nCAUSAL AFFORDANCE: Instructs the swarm to execute Inductive Logic Programming. It authorizes the\norchestrator to collapse a massive subgraph of repetitive ObservationEvent nodes into a single,\ndense SemanticNodeState, drastically reducing future inference costs.\n\nEPISTEMIC BOUNDS: The aleatoric_entropy_threshold float (le=0.1) dictates the maximum statistical\nvariance allowed before compression is physically authorized. It mathematically mandates a sample\nsize of min_observations_required (ge=10) to prevent premature epistemic convergence.\n\nMCP ROUTING TRIGGERS: Hebbian Learning, Memory Consolidation, Inductive Logic Programming, Aleatoric Entropy, Knowledge Distillation",
       "properties": {
-        "aleatoric_entropy_threshold": {
-          "description": "The entropy variance must fall below this mathematical threshold to prove absolute certainty before compression is authorized.",
-          "maximum": 0.1,
-          "title": "Aleatoric Entropy Threshold",
-          "type": "number"
-        },
         "min_observations_required": {
           "description": "The minimum number of episodic logs needed to statistically prove a crystallized rule.",
           "maximum": 1000000000,
           "minimum": 10,
           "title": "Min Observations Required",
           "type": "integer"
+        },
+        "aleatoric_entropy_threshold": {
+          "description": "The entropy variance must fall below this mathematical threshold to prove absolute certainty before compression is authorized.",
+          "maximum": 0.1,
+          "title": "Aleatoric Entropy Threshold",
+          "type": "number"
         },
         "target_cognitive_tier": {
           "description": "The destination tier where the compressed rule will be stored.",
@@ -4603,20 +4603,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the successful execution of an InformationFlowPolicy redaction on the Merkle-DAG. Enforced as fully immutable via `ConfigDict(frozen=True)`.\n\nCAUSAL AFFORDANCE: Unlocks strict audit compliance by mathematically mapping the optional toxic `pre_redaction_hash` to the mandatory safe `post_redaction_hash`, proving non-repudiation via the `applied_policy_id`.\n\nEPISTEMIC BOUNDS: Temporal geometry strictly clamped to `redaction_timestamp_unix_nano` (`ge=0, le=253402300799000000000`). Both hashes are locked to immutable SHA-256 hexadecimal bounds (`^[a-f0-9]{64}$`). `pre_redaction_hash` is optional (`default=None`) for isolated audit vaults.\n\nMCP ROUTING TRIGGERS: Chain of Custody, Cryptographic Provenance, Merkle-DAG Audit, Non-Repudiation, Data Isomorphism",
       "properties": {
+        "record_cid": {
+          "description": "Unique identifier for this chain-of-custody entry.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Record Cid",
+          "type": "string"
+        },
+        "source_node_cid": {
+          "description": "The execution node that emitted the original payload.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Node Cid",
+          "type": "string"
+        },
         "applied_policy_id": {
           "description": "The deterministic capability pointer representing the InformationFlowPolicy successfully applied.",
           "maxLength": 255,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Applied Policy Id",
-          "type": "string"
-        },
-        "post_redaction_hash": {
-          "description": "The definitive SHA-256 hash of the sanitized, mathematically clean payload.",
-          "maxLength": 255,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Post Redaction Hash",
           "type": "string"
         },
         "pre_redaction_hash": {
@@ -4635,12 +4643,12 @@
           "description": "Optional SHA-256 hash of the raw toxic data for isolated audit vaults.",
           "title": "Pre Redaction Hash"
         },
-        "record_cid": {
-          "description": "Unique identifier for this chain-of-custody entry.",
+        "post_redaction_hash": {
+          "description": "The definitive SHA-256 hash of the sanitized, mathematically clean payload.",
           "maxLength": 255,
           "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Record Cid",
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Post Redaction Hash",
           "type": "string"
         },
         "redaction_timestamp_unix_nano": {
@@ -4649,14 +4657,6 @@
           "minimum": 0,
           "title": "Redaction Timestamp Unix Nano",
           "type": "integer"
-        },
-        "source_node_cid": {
-          "description": "The execution node that emitted the original payload.",
-          "maxLength": 255,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Node Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -4673,55 +4673,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a self-referential or cyclic Markov edge for deep recursive execution, utilizing Thermodynamic Discounting to prevent infinite loops. As a ...Profile suffix, this is a declarative, frozen snapshot of a routing geometry.\n\nCAUSAL AFFORDANCE: Authorizes recursive tool calls or non-monotonic backward execution. The orchestrator must apply the Bellman `discount_factor` to the compute budget during each traversal loop.\n\nEPISTEMIC BOUNDS: Structural repetition is checked by applying a geometric decay factor (`discount_factor` ge=0.0, le=1.0). An `@model_validator` mathematically prevents un-haltable infinite recursion if the `discount_factor` equals 1.0 without a strict `max_causal_depth` explicitly defined in the `terminal_condition`.\n\nMCP ROUTING TRIGGERS: Markov Decision Process, Cyclic Edge, Bellman Equation, Thermodynamic Discounting, Recursive Traversal",
       "properties": {
-        "compute_weight_magnitude": {
-          "description": "The thermodynamic cost to traverse this edge.",
-          "minimum": 0,
-          "title": "Compute Weight Magnitude",
-          "type": "integer"
-        },
-        "discount_factor": {
-          "description": "The Bellman Equation gamma applied to the budget on each cyclic loop.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Discount Factor",
-          "type": "number"
-        },
-        "eval_strategy": {
-          "default": "strict",
-          "description": "The evaluation strategy: 'strict' pre-fetches schemas, 'lazy' uses Coalgebraic Thunking to prevent State-Space Explosion.",
-          "enum": [
-            "strict",
-            "lazy"
-          ],
-          "title": "Eval Strategy",
+        "topology_class": {
+          "const": "cyclic",
+          "default": "cyclic",
+          "description": "Discriminator type for a cyclic edge.",
+          "title": "Topology Class",
           "type": "string"
-        },
-        "payload_mappings": {
-          "description": "The algebraic translation matrix mapping the source's Covariant output to the Contravariant input.",
-          "items": {
-            "$ref": "#/$defs/EdgeMappingContract"
-          },
-          "title": "Payload Mappings",
-          "type": "array"
-        },
-        "probability_weight": {
-          "description": "The stochastic heuristic preference of this path.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Probability Weight",
-          "type": "number"
-        },
-        "target_intent": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SemanticDiscoveryIntent"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Dynamic discovery intent for bridging nodes."
         },
         "target_node_cid": {
           "anyOf": [
@@ -4737,16 +4694,59 @@
           "description": "The coinductive pointer to the destination capability.",
           "title": "Target Node Cid"
         },
+        "target_intent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SemanticDiscoveryIntent"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Dynamic discovery intent for bridging nodes."
+        },
+        "payload_mappings": {
+          "description": "The algebraic translation matrix mapping the source's Covariant output to the Contravariant input.",
+          "items": {
+            "$ref": "#/$defs/EdgeMappingContract"
+          },
+          "title": "Payload Mappings",
+          "type": "array"
+        },
+        "eval_strategy": {
+          "default": "strict",
+          "description": "The evaluation strategy: 'strict' pre-fetches schemas, 'lazy' uses Coalgebraic Thunking to prevent State-Space Explosion.",
+          "enum": [
+            "strict",
+            "lazy"
+          ],
+          "title": "Eval Strategy",
+          "type": "string"
+        },
+        "probability_weight": {
+          "description": "The stochastic heuristic preference of this path.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Probability Weight",
+          "type": "number"
+        },
+        "compute_weight_magnitude": {
+          "description": "The thermodynamic cost to traverse this edge.",
+          "minimum": 0,
+          "title": "Compute Weight Magnitude",
+          "type": "integer"
+        },
+        "discount_factor": {
+          "description": "The Bellman Equation gamma applied to the budget on each cyclic loop.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Discount Factor",
+          "type": "number"
+        },
         "terminal_condition": {
           "$ref": "#/$defs/TerminalConditionContract",
           "description": "The mandatory structural conditions guaranteed to eventually halt traversal."
-        },
-        "topology_class": {
-          "const": "cyclic",
-          "default": "cyclic",
-          "description": "Discriminator type for a cyclic edge.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -4793,11 +4793,27 @@
         }
       ],
       "properties": {
-        "allow_cycles": {
-          "default": false,
-          "description": "Configuration indicating if cycles are allowed during validation.",
-          "title": "Allow Cycles",
-          "type": "boolean"
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
         },
         "architectural_intent": {
           "anyOf": [
@@ -4813,17 +4829,73 @@
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
         },
-        "backpressure": {
+        "justification": {
           "anyOf": [
             {
-              "$ref": "#/$defs/BackpressurePolicy"
+              "maxLength": 2000,
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Declarative backpressure constraints for the graph edges."
+          "description": "Cryptographic/audit justification for this topology's configuration.",
+          "title": "Justification"
+        },
+        "nodes": {
+          "additionalProperties": {
+            "$ref": "#/$defs/AnyNodeProfile"
+          },
+          "description": "Flat registry of all nodes in this topology.",
+          "propertyNames": {
+            "$ref": "#/$defs/NodeCIDState"
+          },
+          "title": "Nodes",
+          "type": "object"
+        },
+        "shared_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The schema-on-write contract governing the internal state of this topology."
+        },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
+        "topology_class": {
+          "const": "dag",
+          "default": "dag",
+          "description": "Discriminator for a DAG topology.",
+          "title": "Topology Class",
+          "type": "string"
         },
         "edges": {
           "description": "The strict, topologically bounded matrix of directed causal edges.",
@@ -4843,41 +4915,23 @@
           "title": "Edges",
           "type": "array"
         },
-        "epistemic_enforcement": {
+        "allow_cycles": {
+          "default": false,
+          "description": "Configuration indicating if cycles are allowed during validation.",
+          "title": "Allow Cycles",
+          "type": "boolean"
+        },
+        "backpressure": {
           "anyOf": [
             {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
+              "$ref": "#/$defs/BackpressurePolicy"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "justification": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Cryptographic/audit justification for this topology's configuration.",
-          "title": "Justification"
-        },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
+          "description": "Declarative backpressure constraints for the graph edges."
         },
         "max_depth": {
           "description": "The maximum recursive depth of the routing DAG.",
@@ -4893,53 +4947,6 @@
           "title": "Max Fan Out",
           "type": "integer"
         },
-        "nodes": {
-          "additionalProperties": {
-            "$ref": "#/$defs/AnyNodeProfile"
-          },
-          "description": "Flat registry of all nodes in this topology.",
-          "propertyNames": {
-            "$ref": "#/$defs/NodeCIDState"
-          },
-          "title": "Nodes",
-          "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
-        },
-        "shared_state_contract": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StateContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The schema-on-write contract governing the internal state of this topology."
-        },
         "speculative_boundaries": {
           "description": "The deterministic speculative boundaries executing within the DAG.",
           "items": {
@@ -4947,13 +4954,6 @@
           },
           "title": "Speculative Boundaries",
           "type": "array"
-        },
-        "topology_class": {
-          "const": "dag",
-          "default": "dag",
-          "description": "Discriminator for a DAG topology.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -4976,10 +4976,6 @@
           "title": "Attack Id",
           "type": "string"
         },
-        "attack_vector": {
-          "$ref": "#/$defs/AttackVectorProfile",
-          "description": "Geometric matrices of undercutting defeaters."
-        },
         "source_claim_id": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the claim mounting the attack.",
           "maxLength": 128,
@@ -4995,6 +4991,10 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Target Claim Id",
           "type": "string"
+        },
+        "attack_vector": {
+          "$ref": "#/$defs/AttackVectorProfile",
+          "description": "Geometric matrices of undercutting defeaters."
         }
       },
       "required": [
@@ -5018,11 +5018,13 @@
           "title": "Cascade Id",
           "type": "string"
         },
-        "cross_boundary_quarantine_issued": {
-          "default": false,
-          "description": "Cryptographic proof that this cascade was broadcast to the Swarm to halt epistemic contagion.",
-          "title": "Cross Boundary Quarantine Issued",
-          "type": "boolean"
+        "root_falsified_event_cid": {
+          "description": "The source BeliefMutationEvent or HypothesisGenerationEvent Content Identifier (CID) that collapsed and triggered this cascade.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Root Falsified Event Cid",
+          "type": "string"
         },
         "propagated_decay_factor": {
           "description": "The calculated Entropy Penalty applied to this specific subgraph.",
@@ -5042,13 +5044,11 @@
           "title": "Quarantined Event Cids",
           "type": "array"
         },
-        "root_falsified_event_cid": {
-          "description": "The source BeliefMutationEvent or HypothesisGenerationEvent Content Identifier (CID) that collapsed and triggered this cascade.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Root Falsified Event Cid",
-          "type": "string"
+        "cross_boundary_quarantine_issued": {
+          "default": false,
+          "description": "Cryptographic proof that this cascade was broadcast to the Swarm to halt epistemic contagion.",
+          "title": "Cross Boundary Quarantine Issued",
+          "type": "boolean"
         }
       },
       "required": [
@@ -5064,14 +5064,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Macaroons and Decentralized Identifiers (DIDs) to construct a verifiable delegation chain of authority from a human principal to an autonomous agent.\n\nCAUSAL AFFORDANCE: Empowers the `delegate_agent_did` to invoke the explicitly whitelisted `allowed_tool_cids`, acting as a cryptographic proxy for the `principal_did`. The `cryptographic_signature` proves the delegation chain.\n\nEPISTEMIC BOUNDS: The delegation's temporal geometry is physically bounded by `expiration_timestamp` (`ge=0.0, le=253402300799.0`). The `capability_id` is a 128-char CID anchor. The `allowed_tool_cids` array is deterministically sorted by `@model_validator` for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Macaroons, Delegation Chain, Public Key Infrastructure, Object Capability Model, Decentralized Identifiers",
       "properties": {
-        "allowed_tool_cids": {
-          "description": "The strictly bounded set of ToolIdentifiers this delegation permits.",
-          "items": {
-            "$ref": "#/$defs/CapabilityPointerState"
-          },
-          "title": "Allowed Tool Cids",
-          "type": "array"
-        },
         "capability_id": {
           "description": "A string CID for the delegated capability.",
           "maxLength": 128,
@@ -5080,15 +5072,21 @@
           "title": "Capability Id",
           "type": "string"
         },
-        "cryptographic_signature": {
-          "description": "A base64 string proving the cryptographic delegation.",
-          "maxLength": 10000,
-          "title": "Cryptographic Signature",
-          "type": "string"
+        "principal_did": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The DID representing the human or parent delegating authority."
         },
         "delegate_agent_did": {
           "$ref": "#/$defs/NodeCIDState",
           "description": "The DID representing the autonomous actor receiving authority."
+        },
+        "allowed_tool_cids": {
+          "description": "The strictly bounded set of ToolIdentifiers this delegation permits.",
+          "items": {
+            "$ref": "#/$defs/CapabilityPointerState"
+          },
+          "title": "Allowed Tool Cids",
+          "type": "array"
         },
         "expiration_timestamp": {
           "description": "A float bounding the temporal lifecycle.",
@@ -5097,9 +5095,11 @@
           "title": "Expiration Timestamp",
           "type": "number"
         },
-        "principal_did": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The DID representing the human or parent delegating authority."
+        "cryptographic_signature": {
+          "description": "A base64 string proving the cryptographic delegation.",
+          "maxLength": 10000,
+          "title": "Cryptographic Signature",
+          "type": "string"
         }
       },
       "required": [
@@ -5159,6 +5159,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of a Cyber-Physical Systems (CPS) Digital Twin, establishing an epistemically isolated shadow graph that mirrors a real-world topology without risking kinetic bleed.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to execute unbounded sandbox simulations against the mirrored `target_topology_cid` (128-char CID), mathematically severing all external write access if `enforce_no_side_effects` is True.\n\nEPISTEMIC BOUNDS: The simulation physics are structurally clamped by the `convergence_sla`, which physically bounds the maximum Monte Carlo rollouts and variance tolerance. External kinetic permutations are mechanically trapped.\n\nMCP ROUTING TRIGGERS: Digital Twin, Cyber-Physical Systems, Sandbox Simulation, Markov Blanket, Shadow Graph",
       "properties": {
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -5172,28 +5194,6 @@
           "default": null,
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
-        },
-        "convergence_sla": {
-          "$ref": "#/$defs/SimulationConvergenceSLA",
-          "description": "The strict mathematical boundaries for the simulation."
-        },
-        "enforce_no_side_effects": {
-          "default": true,
-          "description": "A declarative flag that instructs the runtime to mathematically sever all external write access.",
-          "title": "Enforce No Side Effects",
-          "type": "boolean"
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
         },
         "justification": {
           "anyOf": [
@@ -5209,16 +5209,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -5229,30 +5219,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -5266,6 +5232,37 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
+        "topology_class": {
+          "const": "digital_twin",
+          "default": "digital_twin",
+          "description": "Discriminator for a Digital Twin topology.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "target_topology_cid": {
           "description": "The identifier (expected to be a W3C DID) pointing to the real-world topology it is cloning.",
           "maxLength": 128,
@@ -5274,12 +5271,15 @@
           "title": "Target Topology Cid",
           "type": "string"
         },
-        "topology_class": {
-          "const": "digital_twin",
-          "default": "digital_twin",
-          "description": "Discriminator for a Digital Twin topology.",
-          "title": "Topology Class",
-          "type": "string"
+        "convergence_sla": {
+          "$ref": "#/$defs/SimulationConvergenceSLA",
+          "description": "The strict mathematical boundaries for the simulation."
+        },
+        "enforce_no_side_effects": {
+          "default": true,
+          "description": "A declarative flag that instructs the runtime to mathematically sever all external write access.",
+          "title": "Enforce No Side Effects",
+          "type": "boolean"
         }
       },
       "required": [
@@ -5294,21 +5294,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a linear algebraic transformation (e.g.,\nSingular Value Decomposition) mapping one embedding manifold to another,\ngrounded in the Johnson-Lindenstrauss Lemma. As a ...Contract suffix, this\nenforces rigid mathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to translate latent vectors\nacross zero-trust network boundaries, bridging incompatible LLM spaces. The\nsource_matrix_name and target_matrix_name (both max_length=2000) identify the\norigin and destination geometries.\n\nEPISTEMIC BOUNDS: Translation fidelity is physically proven by the\nisometry_preservation_score (ge=0.0, le=1.0), ensuring Earth Mover's Distance\npreservation. Cryptographic integrity is locked via projection_matrix_hash\n(SHA-256 regex ^[a-f0-9]{64}$).\n\nMCP ROUTING TRIGGERS: Singular Value Decomposition, Johnson-Lindenstrauss\nLemma, Tensor Projection, Earth Mover's Distance, Latent Translation",
       "properties": {
-        "isometry_preservation_score": {
-          "description": "Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Isometry Preservation Score",
-          "type": "number"
-        },
-        "projection_matrix_hash": {
-          "description": "The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Projection Matrix Hash",
-          "type": "string"
-        },
         "source_matrix_name": {
           "description": "The native embedding model of the origin agent.",
           "maxLength": 2000,
@@ -5320,6 +5305,21 @@
           "maxLength": 2000,
           "title": "Target Matrix Name",
           "type": "string"
+        },
+        "projection_matrix_hash": {
+          "description": "The SHA-256 hash of the exact mathematical matrix used to compress or translate the latent dimensions.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Projection Matrix Hash",
+          "type": "string"
+        },
+        "isometry_preservation_score": {
+          "description": "Mathematical proof (e.g., Earth Mover's Distance preservation) of how accurately relative semantic distances were maintained during projection.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Isometry Preservation Score",
+          "type": "number"
         }
       },
       "required": [
@@ -5335,29 +5335,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Bayesian Inference and Parametric Probability Density\nFunctions (PDFs) to mathematically define the stochastic shape of latent variables.\nAs a ...Profile suffix, this is a declarative, frozen snapshot of an evaluation geometry.\n\nCAUSAL AFFORDANCE: Projects a continuous statistical geometry (Gaussian, Uniform,\nor Beta) onto a stochastic process, dictating the generative bounds of entropy or\nreward distributions during reinforcement learning.\n\nEPISTEMIC BOUNDS: The Euclidean limits are physically clamped by mean and variance\n(le=1000000000.0). The @model_validator validate_confidence_interval mathematically\nenforces the invariant that the 95% confidence lower bound must be strictly less than\nthe upper bound.\n\nMCP ROUTING TRIGGERS: Probability Density Function, Bayesian Inference, Stochastic Geometry, Parametric Distribution, Variance Bounding",
       "properties": {
-        "confidence_interval_95": {
-          "anyOf": [
-            {
-              "maxItems": 1000,
-              "minItems": 2,
-              "prefixItems": [
-                {
-                  "type": "number"
-                },
-                {
-                  "type": "number"
-                }
-              ],
-              "type": "array"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The 95% probability bounds.",
-          "title": "Confidence Interval 95"
-        },
         "distribution_type": {
           "$ref": "#/$defs/DistributionShapeProfile",
           "description": "The mathematical shape of the probability density function."
@@ -5389,6 +5366,29 @@
           "default": null,
           "description": "The mathematical variance (sigma squared).",
           "title": "Variance"
+        },
+        "confidence_interval_95": {
+          "anyOf": [
+            {
+              "maxItems": 1000,
+              "minItems": 2,
+              "prefixItems": [
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "number"
+                }
+              ],
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The 95% probability bounds.",
+          "title": "Confidence Interval 95"
         }
       },
       "required": [
@@ -5487,9 +5487,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A discrete topological bounding box within a formalized\nDocument Object Model (DOM) taxonomy, acting as a spatial vertex in a\nmultimodal graph. As a ...State suffix, this is a frozen N-dimensional\ncoordinate.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's spatial extraction engine to\nclassify, extract, and isolate explicit sub-regions for localized processing\nusing the anchor (MultimodalTokenAnchorState).\n\nEPISTEMIC BOUNDS: The block_id is cryptographically anchored by a 128-char\nCID regex (^[a-zA-Z0-9_.:-]+$). The block_class structurally limits extraction\ngeometry to a finite Literal automaton [\"header\", \"paragraph\", \"figure\",\n\"table\", \"footnote\", \"caption\", \"equation\"].\n\nMCP ROUTING TRIGGERS: DOM Taxonomy, Topological Vertex, Spatial\nClassification, Bounding Box Geometry, Semantic Region Isolation",
       "properties": {
-        "anchor": {
-          "$ref": "#/$defs/MultimodalTokenAnchorState",
-          "description": "The strict visual and token coordinate bindings for this block."
+        "block_id": {
+          "description": "Unique structural identifier for this geometric region.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Block Id",
+          "type": "string"
         },
         "block_class": {
           "description": "The taxonomic classification of the layout region.",
@@ -5505,13 +5509,9 @@
           "title": "Block Class",
           "type": "string"
         },
-        "block_id": {
-          "description": "Unique structural identifier for this geometric region.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Block Id",
-          "type": "string"
+        "anchor": {
+          "$ref": "#/$defs/MultimodalTokenAnchorState",
+          "description": "The strict visual and token coordinate bindings for this block."
         }
       },
       "required": [
@@ -5526,6 +5526,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Fristonian Active Inference to minimize Expected Free Energy. Triggered when the swarm detects a catastrophic Epistemic Gap and lacks the structural parameters necessary to reduce Shannon Entropy autonomously.\n\nCAUSAL AFFORDANCE: Emits a structural query to an external human oracle to explicitly solicit data. It suspends autonomous trajectory generation until the missing semantic dimensions are actively projected back into the working memory partition.\n\nEPISTEMIC BOUNDS: The human's unstructured cognitive entropy is aggressively forced through a mathematical funnel via the `resolution_schema`. This schema is volumetrically clamped by the `enforce_payload_topology` hook to prevent AST explosion during input parsing.\n\nMCP ROUTING TRIGGERS: Active Inference, Expected Free Energy, Shannon Entropy Reduction, Zero-Shot Elicitation, Epistemic Gap",
       "properties": {
+        "topology_class": {
+          "const": "drafting",
+          "default": "drafting",
+          "description": "Discriminator for requesting specific missing context from a human.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "context_prompt": {
           "description": "The prompt explaining what information the swarm is missing.",
           "maxLength": 2000,
@@ -5552,13 +5559,6 @@
             "terminate"
           ],
           "title": "Timeout Action",
-          "type": "string"
-        },
-        "topology_class": {
-          "const": "drafting",
-          "default": "drafting",
-          "description": "Discriminator for requesting specific missing context from a human.",
-          "title": "Topology Class",
           "type": "string"
         }
       },
@@ -5633,6 +5633,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Provides the rendering matrix that translates the swarm's physics into human retinal variables using the Grammar of Graphics and Semantic Zooming.\n\nCAUSAL AFFORDANCE: Maps N-dimensional capabilities onto the UI plane without breaking semantic causal edges.\n\nEPISTEMIC BOUNDS: Binds an AST gradient and thermodynamic burn metric, governed by a physical zoom profile limit. Discriminator locked to `Literal[\"dynamic_manifold\"]`.\n\nMCP ROUTING TRIGGERS: Grammar of Graphics, Retinal Variables, UI Rendering, Semantic Zooming, Dynamic Manifold",
       "properties": {
+        "topology_class": {
+          "const": "dynamic_manifold",
+          "default": "dynamic_manifold",
+          "description": "Discriminator for the dynamic manifold projection.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "manifest_id": {
+          "description": "Unique identifier for this projection.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Manifest Id",
+          "type": "string"
+        },
         "active_forge_id": {
           "description": "A pointer to the CapabilityForgeTopologyManifest currently executing.",
           "maxLength": 128,
@@ -5645,24 +5660,9 @@
           "$ref": "#/$defs/GrammarPanelProfile",
           "description": "Algebraically maps the ASTGradientReceipt loss vectors into a 2D plot."
         },
-        "manifest_id": {
-          "description": "Unique identifier for this projection.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Manifest Id",
-          "type": "string"
-        },
         "thermodynamic_burn_mapping": {
           "$ref": "#/$defs/AnyPanelProfile",
           "description": "Tracks the KinematicDeltaManifest against the human's allocated_budget_magnitude."
-        },
-        "topology_class": {
-          "const": "dynamic_manifold",
-          "default": "dynamic_manifold",
-          "description": "Discriminator for the dynamic manifold projection.",
-          "title": "Topology Class",
-          "type": "string"
         },
         "viewport_zoom_profile": {
           "$ref": "#/$defs/SemanticZoomProfile",
@@ -5683,6 +5683,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a deterministic Softmax Router Gate to dictate the exact active execution topology, mapping multi-agent subgraphs to specific data modalities.\n\nCAUSAL AFFORDANCE: Physically directs the thermodynamic compute flow, unlocking specific worker nodes (active_subgraphs) and explicitly bypassing others (bypassed_steps), while locking economic allocations via branch_budgets_magnitude.\n\nEPISTEMIC BOUNDS: The @model_validator hooks mathematically verify topological soundness: validate_modality_alignment proves no routes to hallucinated modalities exist, and validate_conservation_of_custody ensures bypassed_steps perfectly align with the artifact_event_id.\n\nMCP ROUTING TRIGGERS: Softmax Router Gate, Sparse Mixture of Experts, Conservation of Custody, Topos Theory, Spot Compute Allocation",
       "properties": {
+        "manifest_id": {
+          "description": "The unique Content Identifier (CID) for this routing plan.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Manifest Id",
+          "type": "string"
+        },
+        "artifact_profile": {
+          "$ref": "#/$defs/GlobalSemanticProfile",
+          "description": "The semantic profile governing this route."
+        },
         "active_subgraphs": {
           "additionalProperties": {
             "items": {
@@ -5697,9 +5709,13 @@
           "title": "Active Subgraphs",
           "type": "object"
         },
-        "artifact_profile": {
-          "$ref": "#/$defs/GlobalSemanticProfile",
-          "description": "The semantic profile governing this route."
+        "bypassed_steps": {
+          "description": "The declarative array of steps the orchestrator is mandated to skip.",
+          "items": {
+            "$ref": "#/$defs/BypassReceipt"
+          },
+          "title": "Bypassed Steps",
+          "type": "array"
         },
         "branch_budgets_magnitude": {
           "additionalProperties": {
@@ -5712,22 +5728,6 @@
           },
           "title": "Branch Budgets Magnitude",
           "type": "object"
-        },
-        "bypassed_steps": {
-          "description": "The declarative array of steps the orchestrator is mandated to skip.",
-          "items": {
-            "$ref": "#/$defs/BypassReceipt"
-          },
-          "title": "Bypassed Steps",
-          "type": "array"
-        },
-        "manifest_id": {
-          "description": "The unique Content Identifier (CID) for this routing plan.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Manifest Id",
-          "type": "string"
         }
       },
       "required": [
@@ -5767,19 +5767,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Multimodal Sensor Fusion by quantifying Bayesian Surprise (KL Divergence) against the agent's prior belief manifold.\n\nCAUSAL AFFORDANCE: Emits a quantified sensory vector to the orchestrator, determining whether an exogenous signal contains enough information-theoretic value to cross the continuous-to-discrete gap and trigger a topological observation.\n\nEPISTEMIC BOUNDS: The bayesian_surprise_score is strictly clamped to a continuous float space (le=1.0), and physical presence is bounded by temporal_duration_ms (le=86400000).\n\nMCP ROUTING TRIGGERS: Bayesian Surprise, Multimodal Sensor Fusion, Kullback-Leibler Divergence, Exteroceptive Vector, Proprioception",
       "properties": {
-        "bayesian_surprise_score": {
-          "description": "The calculated KL divergence between the prior belief and the incoming structural evidence.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Bayesian Surprise Score",
-          "type": "number"
-        },
-        "salience_threshold_breached": {
-          "default": true,
-          "description": "Continuous-to-Discrete Crystallization threshold being crossed.",
-          "title": "Salience Threshold Breached",
-          "type": "boolean"
-        },
         "sensory_modality": {
           "description": "Multimodal Sensor Fusion and Spatial-Temporal Bindings representing Proprioceptive State and Exteroceptive Vectors.",
           "enum": [
@@ -5790,12 +5777,25 @@
           "title": "Sensory Modality",
           "type": "string"
         },
+        "bayesian_surprise_score": {
+          "description": "The calculated KL divergence between the prior belief and the incoming structural evidence.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Bayesian Surprise Score",
+          "type": "number"
+        },
         "temporal_duration_ms": {
           "description": "The exact length of the timeline encapsulated by this observation.",
           "exclusiveMinimum": 0,
           "maximum": 86400000,
           "title": "Temporal Duration Ms",
           "type": "integer"
+        },
+        "salience_threshold_breached": {
+          "default": true,
+          "description": "Continuous-to-Discrete Crystallization threshold being crossed.",
+          "title": "Salience Threshold Breached",
+          "type": "boolean"
         }
       },
       "required": [
@@ -5841,35 +5841,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the deterministic Browser Fingerprint Entropy geometry\nfor spoofing environmental telemetry vectors (WebGL canvas hashes, User-Agent\nstrings, timezone offsets, TLS Client Hello fingerprints, and display resolution).\nAs a ...Profile suffix, this is a declarative, frozen snapshot of a spoofed\nenvironmental coordinate.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's Spatial Kinematics engine to\nproject a synthetic browser identity, masking the true computational substrate\nfrom exogenous anti-bot fingerprinting oracles including JA3/JA4 TLS analysis.\n\nEPISTEMIC BOUNDS: The webgl_entropy_seed_hash is constrained to a 128-char CID\npattern. The user_agent_template is clamped to max_length=2000. The\ntimezone_offset_minutes is mathematically bounded to the valid UTC range\n(ge=-720, le=840). Screen resolution components are bounded (ge=1, le=15360).\nThe tls_cipher_permutation is locked to a Literal automaton. The\nhardware_concurrency_mask is bounded (gt=0, le=256).\n\nMCP ROUTING TRIGGERS: Browser Fingerprinting, WebGL Canvas Entropy, User-Agent\nSpoofing, JA3 TLS Fingerprint, Anti-Fingerprint Evasion",
       "properties": {
-        "hardware_concurrency_mask": {
-          "default": 8,
-          "description": "The spoofed CPU core count projected to the DOM via navigator.hardwareConcurrency.",
-          "exclusiveMinimum": 0,
-          "maximum": 256,
-          "title": "Hardware Concurrency Mask",
-          "type": "integer"
-        },
-        "screen_resolution_height": {
-          "description": "The spoofed vertical display resolution in pixels.",
-          "maximum": 15360,
-          "minimum": 1,
-          "title": "Screen Resolution Height",
-          "type": "integer"
-        },
-        "screen_resolution_width": {
-          "description": "The spoofed horizontal display resolution in pixels.",
-          "maximum": 15360,
-          "minimum": 1,
-          "title": "Screen Resolution Width",
-          "type": "integer"
-        },
-        "timezone_offset_minutes": {
-          "description": "The spoofed UTC timezone offset in minutes, bounded to the valid terrestrial range.",
-          "maximum": 840,
-          "minimum": -720,
-          "title": "Timezone Offset Minutes",
-          "type": "integer"
-        },
         "tls_cipher_permutation": {
           "default": "chrome_windows",
           "description": "The JA3/JA4 TLS Client Hello fingerprint to project during handshake emulation.",
@@ -5882,12 +5853,6 @@
           "title": "Tls Cipher Permutation",
           "type": "string"
         },
-        "user_agent_template": {
-          "description": "The User-Agent string template projected to exogenous web servers to mask the true computational substrate.",
-          "maxLength": 2000,
-          "title": "User Agent Template",
-          "type": "string"
-        },
         "webgl_entropy_seed_hash": {
           "description": "The Content Identifier (CID) of the WebGL canvas entropy seed used to generate a deterministic spoofed fingerprint.",
           "maxLength": 128,
@@ -5895,6 +5860,41 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Webgl Entropy Seed Hash",
           "type": "string"
+        },
+        "user_agent_template": {
+          "description": "The User-Agent string template projected to exogenous web servers to mask the true computational substrate.",
+          "maxLength": 2000,
+          "title": "User Agent Template",
+          "type": "string"
+        },
+        "hardware_concurrency_mask": {
+          "default": 8,
+          "description": "The spoofed CPU core count projected to the DOM via navigator.hardwareConcurrency.",
+          "exclusiveMinimum": 0,
+          "maximum": 256,
+          "title": "Hardware Concurrency Mask",
+          "type": "integer"
+        },
+        "timezone_offset_minutes": {
+          "description": "The spoofed UTC timezone offset in minutes, bounded to the valid terrestrial range.",
+          "maximum": 840,
+          "minimum": -720,
+          "title": "Timezone Offset Minutes",
+          "type": "integer"
+        },
+        "screen_resolution_width": {
+          "description": "The spoofed horizontal display resolution in pixels.",
+          "maximum": 15360,
+          "minimum": 1,
+          "title": "Screen Resolution Width",
+          "type": "integer"
+        },
+        "screen_resolution_height": {
+          "description": "The spoofed vertical display resolution in pixels.",
+          "maximum": 15360,
+          "minimum": 1,
+          "title": "Screen Resolution Height",
+          "type": "integer"
         }
       },
       "required": [
@@ -5911,17 +5911,30 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a hardware-level Sandboxing and Trusted Execution Environment (TEE) paradigm, utilizing WASI, eBPF, or zkVMs to safely execute exogenous bytecode.\n\nCAUSAL AFFORDANCE: Physically isolates kinetic execution from the host OS via `execution_runtime` Literal `[\"wasm32-wasi\", \"riscv32-zkvm\", \"bpf\"]`, authorizing the orchestrator to instantiate a temporary virtual machine strictly conforming to bounded network egress and subprocess rules.\n\nEPISTEMIC BOUNDS: The Halting Problem is managed via `max_ttl_seconds` (`le=86400, gt=0`), and memory exhaustion is prevented via `max_vram_mb` (`le=1000000000, gt=0`). The `@model_validator` enforces SHA-256 regex on `authorized_bytecode_hashes` and sorts them deterministically.\n\nMCP ROUTING TRIGGERS: WebAssembly System Interface, Zero-Knowledge Virtual Machine, eBPF, Execution Sandbox, Arbitrary Code Execution Mitigation",
       "properties": {
-        "allow_network_egress": {
-          "default": false,
-          "description": "Capability-based flag to allow or mathematically deny network sockets.",
-          "title": "Allow Network Egress",
-          "type": "boolean"
+        "topology_class": {
+          "const": "ephemeral_partition",
+          "default": "ephemeral_partition",
+          "description": "Discriminator type for an ephemeral namespace partition.",
+          "title": "Topology Class",
+          "type": "string"
         },
-        "allow_subprocess_spawning": {
-          "default": false,
-          "description": "Capability-based flag to allow or deny OS-level process spawning.",
-          "title": "Allow Subprocess Spawning",
-          "type": "boolean"
+        "partition_id": {
+          "description": "Unique identifier for this ephemeral partition.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Partition Id",
+          "type": "string"
+        },
+        "execution_runtime": {
+          "description": "The strict virtual machine target mandated for dynamic execution.",
+          "enum": [
+            "wasm32-wasi",
+            "riscv32-zkvm",
+            "bpf"
+          ],
+          "title": "Execution Runtime",
+          "type": "string"
         },
         "authorized_bytecode_hashes": {
           "description": "The explicit whitelist of SHA-256 hashes allowed to execute within this partition.",
@@ -5933,16 +5946,6 @@
           "minItems": 1,
           "title": "Authorized Bytecode Hashes",
           "type": "array"
-        },
-        "execution_runtime": {
-          "description": "The strict virtual machine target mandated for dynamic execution.",
-          "enum": [
-            "wasm32-wasi",
-            "riscv32-zkvm",
-            "bpf"
-          ],
-          "title": "Execution Runtime",
-          "type": "string"
         },
         "max_ttl_seconds": {
           "description": "The absolute temporal guillotine before the orchestrator drops the context.",
@@ -5958,20 +5961,17 @@
           "title": "Max Vram Mb",
           "type": "integer"
         },
-        "partition_id": {
-          "description": "Unique identifier for this ephemeral partition.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Partition Id",
-          "type": "string"
+        "allow_network_egress": {
+          "default": false,
+          "description": "Capability-based flag to allow or mathematically deny network sockets.",
+          "title": "Allow Network Egress",
+          "type": "boolean"
         },
-        "topology_class": {
-          "const": "ephemeral_partition",
-          "default": "ephemeral_partition",
-          "description": "Discriminator type for an ephemeral namespace partition.",
-          "title": "Topology Class",
-          "type": "string"
+        "allow_subprocess_spawning": {
+          "default": false,
+          "description": "Capability-based flag to allow or deny OS-level process spawning.",
+          "title": "Allow Subprocess Spawning",
+          "type": "boolean"
         }
       },
       "required": [
@@ -6031,18 +6031,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Constructs the macroscopic adjacency matrix for the complete $AF = \\langle AR, \\rightarrow \\rangle$ topology. As a ...State suffix, this is a declarative, frozen snapshot of the dialectical geometry.\n\nCAUSAL AFFORDANCE: Exposes the holistic bipartite mapping of claims and their defeasible attacks to the orchestrator, allowing graph traversal algorithms to deterministically compute the conflict-free Grounded Extension of surviving truths.\n\nEPISTEMIC BOUNDS: Physically limits state-space explosion by capping the `claims` and `attacks` dictionaries at `max_length=10000` keys each. Key geometries are strictly bounded to 255 characters to prevent Dictionary Bombing during canonicalization.\n\nMCP ROUTING TRIGGERS: Dung's AAF, Adjacency Matrix, Grounded Extension, State-Space Bounding, Dialectical Justification",
       "properties": {
-        "attacks": {
-          "additionalProperties": {
-            "$ref": "#/$defs/DefeasibleAttackEvent"
-          },
-          "description": "Geometric matrices of undercutting defeaters.",
-          "maxProperties": 10000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Attacks",
-          "type": "object"
-        },
         "claims": {
           "additionalProperties": {
             "$ref": "#/$defs/EpistemicArgumentClaimState"
@@ -6053,6 +6041,18 @@
             "maxLength": 255
           },
           "title": "Claims",
+          "type": "object"
+        },
+        "attacks": {
+          "additionalProperties": {
+            "$ref": "#/$defs/DefeasibleAttackEvent"
+          },
+          "description": "Geometric matrices of undercutting defeaters.",
+          "maxProperties": 10000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Attacks",
           "type": "object"
         }
       },
@@ -6066,6 +6066,10 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Joint Attention and Gaze Raycasting across the distributed topology. Projects a continuous vector from an observer's optical center to indicate cognitive focus prior to physical mutation.\n\nCAUSAL AFFORDANCE: Broadcasts a non-kinetic 'cursor presence' to the swarm. The orchestrator calculates the dot product between this vector and surrounding nodes, identifying the exact topological vertices the observer is currently evaluating.\n\nEPISTEMIC BOUNDS: The `direction_unit_vector` is mathematically normalized to exactly 1.0 via `@model_validator` to prevent raycast scalar explosions. To mitigate $O(N^2)$ intersection complexity, the `intersected_node_cids` array is strictly capped at `max_length=100` and deterministically sorted.\n\nMCP ROUTING TRIGGERS: Spatial Raycasting, Joint Attention, Cognitive Frustum Intersection, Vector Math, Gaze Tracking",
       "properties": {
+        "origin": {
+          "$ref": "#/$defs/SE3TransformProfile",
+          "description": "The absolute SE(3) spatial coordinate representing the observer's optical center."
+        },
         "direction_unit_vector": {
           "description": "The strictly normalized 3D directional vector representing the angle of gaze.",
           "maxItems": 3,
@@ -6084,6 +6088,15 @@
           "title": "Direction Unit Vector",
           "type": "array"
         },
+        "intersected_node_cids": {
+          "description": "The array of topological vertices mathematically pierced by this attention ray.",
+          "items": {
+            "$ref": "#/$defs/NodeCIDState"
+          },
+          "maxItems": 100,
+          "title": "Intersected Node Cids",
+          "type": "array"
+        },
         "hardware_gaze_signature": {
           "anyOf": [
             {
@@ -6097,19 +6110,6 @@
           "default": null,
           "description": "Hardware-backed cryptographic proof of human eye-tracking from a Trusted Execution Environment (TEE), preventing bot-driven attention spoofing.",
           "title": "Hardware Gaze Signature"
-        },
-        "intersected_node_cids": {
-          "description": "The array of topological vertices mathematically pierced by this attention ray.",
-          "items": {
-            "$ref": "#/$defs/NodeCIDState"
-          },
-          "maxItems": 100,
-          "title": "Intersected Node Cids",
-          "type": "array"
-        },
-        "origin": {
-          "$ref": "#/$defs/SE3TransformProfile",
-          "description": "The absolute SE(3) spatial coordinate representing the observer's optical center."
         }
       },
       "required": [
@@ -6123,18 +6123,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements First-Order Logic and Resource Description Framework (RDF) triples to mathematically formalize knowledge. As a ...State suffix, this is a declarative, frozen snapshot of a specific causal connection.\n\nCAUSAL AFFORDANCE: Distills high-entropy natural language token streams into rigid, hashable causal edges (Subject, Predicate, Object), unlocking deterministic querying and Truth Maintenance System (TMS) traversals.\n\nEPISTEMIC BOUNDS: Source and target concept physical boundaries are strictly locked to 128-char CIDs matching the regex `^[a-zA-Z0-9_.:-]+$`. The `directed_edge_class` is clamped to a `max_length=2000` to prevent dictionary bombing during semantic evaluation.\n\nMCP ROUTING TRIGGERS: First-Order Logic, RDF Triple, Semantic Distillation, Causal Edge, Directed Graph",
       "properties": {
-        "directed_edge_class": {
-          "description": "The topological relationship.",
-          "maxLength": 2000,
-          "title": "Directed Edge Class",
-          "type": "string"
-        },
         "source_concept_cid": {
           "description": "The globally unique decentralized identifier (DID) anchoring the origin node.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Source Concept Cid",
+          "type": "string"
+        },
+        "directed_edge_class": {
+          "description": "The topological relationship.",
+          "maxLength": 2000,
+          "title": "Directed Edge Class",
           "type": "string"
         },
         "target_concept_cid": {
@@ -6166,10 +6166,6 @@
           "title": "Event Cid",
           "type": "string"
         },
-        "fact_score_passed": {
-          "title": "Fact Score Passed",
-          "type": "boolean"
-        },
         "prior_event_hash": {
           "anyOf": [
             {
@@ -6186,19 +6182,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "sequence_similarity_score": {
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Sequence Similarity Score",
-          "type": "number"
-        },
-        "source_prediction_cid": {
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Prediction Cid",
-          "type": "string"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -6211,6 +6194,23 @@
           "default": "epistemic_axiom_verification",
           "title": "Topology Class",
           "type": "string"
+        },
+        "source_prediction_cid": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Prediction Cid",
+          "type": "string"
+        },
+        "sequence_similarity_score": {
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Sequence Similarity Score",
+          "type": "number"
+        },
+        "fact_score_passed": {
+          "title": "Fact Score Passed",
+          "type": "boolean"
         }
       },
       "required": [
@@ -6234,13 +6234,6 @@
           "title": "Chain Cid",
           "type": "string"
         },
-        "semantic_leaves": {
-          "items": {
-            "$ref": "#/$defs/EpistemicAxiomState"
-          },
-          "title": "Semantic Leaves",
-          "type": "array"
-        },
         "syntactic_roots": {
           "items": {
             "maxLength": 2000,
@@ -6248,6 +6241,13 @@
           },
           "minItems": 1,
           "title": "Syntactic Roots",
+          "type": "array"
+        },
+        "semantic_leaves": {
+          "items": {
+            "$ref": "#/$defs/EpistemicAxiomState"
+          },
+          "title": "Semantic Leaves",
           "type": "array"
         }
       },
@@ -6263,18 +6263,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the Information Bottleneck Method to govern the\nlossy compression of episodic or multimodal payloads into structured semantic\ngeometry. As an ...SLA suffix, this enforces rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Instructs the extraction and transmutation engines to discard\naleatoric noise while mathematically preserving the mutual information of the\nsource artifact. The strict_probability_retention (bool, default=True) forces\nthe resulting SemanticNodeState to populate its uncertainty_profile.\n\nEPISTEMIC BOUNDS: The informational loss is strictly bounded by\nmax_allowed_entropy_loss (ge=0.0, le=1.0), mathematically preventing the\nover-compression of truth. The required_grounding_density is locked to the\nLiteral automaton [\"sparse\", \"dense\", \"exhaustive\"].\n\nMCP ROUTING TRIGGERS: Information Bottleneck Method, Shannon Entropy Loss,\nSemantic Compression, Multimodal Grounding, Autoencoder Distillation",
       "properties": {
+        "strict_probability_retention": {
+          "default": true,
+          "description": "If True, forces the resulting SemanticNodeState to populate its uncertainty_profile.",
+          "title": "Strict Probability Retention",
+          "type": "boolean"
+        },
         "max_allowed_entropy_loss": {
           "description": "The maximum allowed statistical flattening of the source data. Bounded between [0.0, 1.0].",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Max Allowed Entropy Loss",
-          "type": "number"
-        },
-        "minimum_fidelity_threshold": {
-          "description": "Mathematical boundary condition (epsilon_max).",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Minimum Fidelity Threshold",
           "type": "number"
         },
         "required_grounding_density": {
@@ -6287,11 +6286,12 @@
           "title": "Required Grounding Density",
           "type": "string"
         },
-        "strict_probability_retention": {
-          "default": true,
-          "description": "If True, forces the resulting SemanticNodeState to populate its uncertainty_profile.",
-          "title": "Strict Probability Retention",
-          "type": "boolean"
+        "minimum_fidelity_threshold": {
+          "description": "Mathematical boundary condition (epsilon_max).",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Minimum Fidelity Threshold",
+          "type": "number"
         }
       },
       "required": [
@@ -6369,19 +6369,19 @@
           "title": "Baseline Entropy Threshold",
           "type": "number"
         },
-        "max_escalation_tiers": {
-          "description": "The absolute integer limit on how many times the orchestrator can recursively multiply the compute budget before forcing a SystemFaultEvent.",
-          "maximum": 10,
-          "minimum": 1,
-          "title": "Max Escalation Tiers",
-          "type": "integer"
-        },
         "test_time_multiplier": {
           "description": "The continuous scalar applied to the agent's baseline max_latent_tokens_budget when the entropy threshold is breached.",
           "exclusiveMinimum": 1.0,
           "maximum": 1000000000.0,
           "title": "Test Time Multiplier",
           "type": "number"
+        },
+        "max_escalation_tiers": {
+          "description": "The absolute integer limit on how many times the orchestrator can recursively multiply the compute budget before forcing a SystemFaultEvent.",
+          "maximum": 10,
+          "minimum": 1,
+          "title": "Max Escalation Tiers",
+          "type": "integer"
         }
       },
       "required": [
@@ -6396,13 +6396,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An immutable cryptographic coordinate recording the successful\nfactorization of a terminal reward into a fractional flow value across a continuous\nCognitiveReasoningTraceState trajectory. As a ...Receipt suffix, this is an append-only\ncoordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Physically anchors the scalar backpropagation of a factored reward\nto a specific source_trajectory_cid, unlocking global flow consistency calculations\nacross the distributed swarm. The terminal_reward_factorized boolean confirms\nsuccessful reward decomposition.\n\nEPISTEMIC BOUNDS: Flow magnitude is geometrically bounded by estimated_flow_value\n(ge=0.0, le=1000000000.0) to prevent exploding gradients during policy updates.\nCryptographically mapped to a rigid 128-char source_trajectory_cid CID.\n\nMCP ROUTING TRIGGERS: Trajectory Balance, Reward Factorization, Flow Network Receipt,\nScalar Backpropagation, Acyclic Path",
       "properties": {
-        "estimated_flow_value": {
-          "description": "The non-negative flow value scalar representing the factorized outcome reward.",
-          "maximum": 1000000000.0,
-          "minimum": 0.0,
-          "title": "Estimated Flow Value",
-          "type": "number"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -6427,19 +6420,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "source_trajectory_cid": {
-          "description": "The globally unique decentralized identifier (DID) anchoring the partial CognitiveReasoningTraceState.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Trajectory Cid",
-          "type": "string"
-        },
-        "terminal_reward_factorized": {
-          "description": "True if this flow successfully factorized a terminal outcome reward.",
-          "title": "Terminal Reward Factorized",
-          "type": "boolean"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -6452,6 +6432,26 @@
           "default": "epistemic_flow_state",
           "title": "Topology Class",
           "type": "string"
+        },
+        "source_trajectory_cid": {
+          "description": "The globally unique decentralized identifier (DID) anchoring the partial CognitiveReasoningTraceState.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Trajectory Cid",
+          "type": "string"
+        },
+        "estimated_flow_value": {
+          "description": "The non-negative flow value scalar representing the factorized outcome reward.",
+          "maximum": 1000000000.0,
+          "minimum": 0.0,
+          "title": "Estimated Flow Value",
+          "type": "number"
+        },
+        "terminal_reward_factorized": {
+          "description": "True if this flow successfully factorized a terminal outcome reward.",
+          "title": "Terminal Reward Factorized",
+          "type": "boolean"
         }
       },
       "required": [
@@ -6476,23 +6476,23 @@
           "title": "Task Cid",
           "type": "string"
         },
-        "thinking_trace": {
-          "$ref": "#/$defs/CognitiveReasoningTraceState",
-          "description": "The verified reasoning path."
-        },
         "topological_proof": {
           "$ref": "#/$defs/EpistemicTopologicalProofManifest",
           "description": "The underlying latent path."
-        },
-        "verification_lock": {
-          "$ref": "#/$defs/CognitiveDualVerificationReceipt",
-          "description": "The cryptographic proof of dual-agent approval."
         },
         "vignette_payload": {
           "description": "The generated natural language scenario.",
           "maxLength": 100000,
           "title": "Vignette Payload",
           "type": "string"
+        },
+        "thinking_trace": {
+          "$ref": "#/$defs/CognitiveReasoningTraceState",
+          "description": "The verified reasoning path."
+        },
+        "verification_lock": {
+          "$ref": "#/$defs/CognitiveDualVerificationReceipt",
+          "description": "The cryptographic proof of dual-agent approval."
         }
       },
       "required": [
@@ -6509,18 +6509,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the limits of infinite graph unfolding to protect UI VRAM when pulling from the EpistemicLedgerState.\nCAUSAL AFFORDANCE: Instructs the orchestrator's deserialization engine to halt graph traversal at a specific recursion depth, replacing raw objects with cryptographic pointers.\nEPISTEMIC BOUNDS: The `max_unfold_depth` strictly bounds the DAG traversal depth (`ge=1, le=100`). `lazy_fetch_timeout_ms` prevents infinite halting (`ge=1, le=60000`). `truncation_strategy` is constrained to a Literal.\nMCP ROUTING TRIGGERS: Coalgebraic Unfolding, Lazy Evaluation, State-Space Bounding, VRAM Exhaustion Prevention",
       "properties": {
-        "lazy_fetch_timeout_ms": {
-          "description": "Temporal guillotine for resolving cryptographic pointers.",
-          "maximum": 60000,
-          "minimum": 1,
-          "title": "Lazy Fetch Timeout Ms",
-          "type": "integer"
-        },
         "max_unfold_depth": {
           "description": "Absolute recursive depth limit for DAG deserialization.",
           "maximum": 100,
           "minimum": 1,
           "title": "Max Unfold Depth",
+          "type": "integer"
+        },
+        "lazy_fetch_timeout_ms": {
+          "description": "Temporal guillotine for resolving cryptographic pointers.",
+          "maximum": 60000,
+          "minimum": 1,
+          "title": "Lazy Fetch Timeout Ms",
           "type": "integer"
         },
         "truncation_strategy": {
@@ -6544,44 +6544,16 @@
     },
     "EpistemicLedgerState": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Event Sourcing and the Merkle-DAG structure as the absolute, immutable source of truth for the swarm, fully partitioned from volatile memory.\n\nCAUSAL AFFORDANCE: Permanently crystallizes validated events into the `history` log. Applies Truth Maintenance, context eviction, and tracks active `DefeasibleCascadeEvents` and `RollbackIntents`.\n\nEPISTEMIC BOUNDS: The `@model_validator` `_enforce_canonical_sort` deterministically sorts history by timestamp, checkpoints by ID, and active cascades\u2014guaranteeing invariant RFC 8785 canonical hashing. Validation prevents epistemic paradoxes (child before parent).\n\nMCP ROUTING TRIGGERS: Event Sourcing, Merkle-DAG, Immutable Ledger, Truth Crystallization, Chronological Sort",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Event Sourcing and the Merkle-DAG structure as the absolute, immutable source of truth for the swarm, fully partitioned from volatile memory.\n\nCAUSAL AFFORDANCE: Permanently crystallizes validated events into the `history` log. Applies Truth Maintenance, context eviction, and tracks active `DefeasibleCascadeEvents` and `RollbackIntents`.\n\nEPISTEMIC BOUNDS: The `@model_validator` `_enforce_canonical_sort` deterministically sorts history by timestamp, checkpoints by ID, and active cascades—guaranteeing invariant RFC 8785 canonical hashing. Validation prevents epistemic paradoxes (child before parent).\n\nMCP ROUTING TRIGGERS: Event Sourcing, Merkle-DAG, Immutable Ledger, Truth Crystallization, Chronological Sort",
       "properties": {
-        "active_cascades": {
-          "description": "The active state-differential payload muting specific causal subgraphs due to falsification.",
+        "history": {
+          "description": "An append-only, cryptographic ledger of state events. [SITD-Alpha: Non-Monotonic Epistemic Quarantine Isometry]",
           "items": {
-            "$ref": "#/$defs/DefeasibleCascadeEvent"
+            "$ref": "#/$defs/AnyStateEvent"
           },
-          "title": "Active Cascades",
+          "maxItems": 10000,
+          "title": "History",
           "type": "array"
-        },
-        "active_rollbacks": {
-          "description": "Causal invalidations actively enforced on the execution tree.",
-          "items": {
-            "$ref": "#/$defs/RollbackIntent"
-          },
-          "title": "Active Rollbacks",
-          "type": "array"
-        },
-        "checkpoints": {
-          "description": "Hard temporal anchors allowing state restoration.",
-          "items": {
-            "$ref": "#/$defs/TemporalCheckpointState"
-          },
-          "maxItems": 1000,
-          "title": "Checkpoints",
-          "type": "array"
-        },
-        "crystallization_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CrystallizationPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical threshold required to compress episodic observations into semantic rules."
         },
         "defeasible_claims": {
           "description": "The set of non-monotonic claims residing in the epistemic ledger that are structurally liable to falsification.",
@@ -6596,6 +6568,34 @@
           "title": "Defeasible Claims",
           "type": "object"
         },
+        "retracted_nodes": {
+          "description": "A strict sequence of CIDs representing historical nodes that have been severed from the causal graph via defeasible logic.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_.:-]+$",
+            "type": "string"
+          },
+          "title": "Retracted Nodes",
+          "type": "array"
+        },
+        "checkpoints": {
+          "description": "Hard temporal anchors allowing state restoration.",
+          "items": {
+            "$ref": "#/$defs/TemporalCheckpointState"
+          },
+          "maxItems": 1000,
+          "title": "Checkpoints",
+          "type": "array"
+        },
+        "active_rollbacks": {
+          "description": "Causal invalidations actively enforced on the execution tree.",
+          "items": {
+            "$ref": "#/$defs/RollbackIntent"
+          },
+          "title": "Active Rollbacks",
+          "type": "array"
+        },
         "eviction_policy": {
           "anyOf": [
             {
@@ -6607,26 +6607,6 @@
           ],
           "default": null,
           "description": "The strict mathematical boundary governing context window compression."
-        },
-        "history": {
-          "description": "An append-only, cryptographic ledger of state events. [SITD-Alpha: Non-Monotonic Epistemic Quarantine Isometry]",
-          "items": {
-            "$ref": "#/$defs/AnyStateEvent"
-          },
-          "maxItems": 10000,
-          "title": "History",
-          "type": "array"
-        },
-        "retracted_nodes": {
-          "description": "A strict sequence of CIDs representing historical nodes that have been severed from the causal graph via defeasible logic.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "pattern": "^[a-zA-Z0-9_.:-]+$",
-            "type": "string"
-          },
-          "title": "Retracted Nodes",
-          "type": "array"
         },
         "truth_maintenance_policy": {
           "anyOf": [
@@ -6640,6 +6620,26 @@
           ],
           "default": null,
           "description": "The mathematical contract governing automated causal graph ablations and probabilistic decay."
+        },
+        "active_cascades": {
+          "description": "The active state-differential payload muting specific causal subgraphs due to falsification.",
+          "items": {
+            "$ref": "#/$defs/DefeasibleCascadeEvent"
+          },
+          "title": "Active Cascades",
+          "type": "array"
+        },
+        "crystallization_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CrystallizationPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical threshold required to compress episodic observations into semantic rules."
         }
       },
       "required": [
@@ -6652,9 +6652,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a purely out-of-band semantic logging vector, structurally isolated from the rigorous causal constraints of the Dapper trace tree.\n\nCAUSAL AFFORDANCE: Emits asynchronous telemetry for human-in-the-loop debugging or peripheral auditing without mutating the active Epistemic Ledger's topological state.\n\nEPISTEMIC BOUNDS: Temporal reality clamped by `timestamp`. Severity strictly masked by a Literal automaton `[\"DEBUG\", \"INFO\", \"WARNING\", \"ERROR\", \"CRITICAL\"]`. Message bounded to `max_length=2000`.\n\nMCP ROUTING TRIGGERS: Out-of-Band Telemetry, Asynchronous Logging, Severity Masking, Peripheral Audit, Ephemeral Context",
       "properties": {
-        "context_profile": {
-          "$ref": "#/$defs/TelemetryContextProfile",
-          "description": "Contextual key-value metadata associated with the event."
+        "timestamp": {
+          "description": "The UNIX timestamp of the log event.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
         },
         "level": {
           "description": "The severity level of the log event.",
@@ -6674,12 +6677,9 @@
           "title": "Message",
           "type": "string"
         },
-        "timestamp": {
-          "description": "The UNIX timestamp of the log event.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
+        "context_profile": {
+          "$ref": "#/$defs/TelemetryContextProfile",
+          "description": "Contextual key-value metadata associated with the event."
         }
       },
       "required": [
@@ -6694,20 +6694,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents Hippocampal-Neocortical Consolidation, proving the successful extraction and transfer of generalized knowledge from short-term episodic traces into the permanent semantic graph.\n\nCAUSAL AFFORDANCE: Emits a permanent Merkle-DAG coordinate (`crystallized_semantic_node_id`) that downstream agents can zero-shot reference, severing the need to reload raw source logs into active context.\n\nEPISTEMIC BOUNDS: Mathematical chain of custody bound to the strictly sorted array of `source_episodic_event_cids`. Token efficiency proven by `compression_ratio` float (`le=1.0`) guaranteeing Shannon Entropy reduction.\n\nMCP ROUTING TRIGGERS: Hippocampal Consolidation, Knowledge Distillation, Semantic Memory, Shannon Entropy Compression, Epistemic Promotion",
       "properties": {
-        "compression_ratio": {
-          "description": "A mathematical proof of the token savings achieved (e.g., old_token_count / new_token_count).",
-          "maximum": 1.0,
-          "title": "Compression Ratio",
-          "type": "number"
-        },
-        "crystallized_semantic_node_id": {
-          "description": "The resulting permanent W3C DID / The globally unique decentralized identifier (DID) anchoring the newly minted knowledge node.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Crystallized Semantic Node Id",
-          "type": "string"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -6732,16 +6718,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "source_episodic_event_cids": {
-          "description": "The strict array of CIDs (Content Identifiers) representing the raw logs being compressed and archived.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Source Episodic Event Cids",
-          "type": "array"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -6755,6 +6731,30 @@
           "description": "Discriminator type for an epistemic promotion event.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "source_episodic_event_cids": {
+          "description": "The strict array of CIDs (Content Identifiers) representing the raw logs being compressed and archived.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Source Episodic Event Cids",
+          "type": "array"
+        },
+        "crystallized_semantic_node_id": {
+          "description": "The resulting permanent W3C DID / The globally unique decentralized identifier (DID) anchoring the newly minted knowledge node.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Crystallized Semantic Node Id",
+          "type": "string"
+        },
+        "compression_ratio": {
+          "description": "A mathematical proof of the token savings achieved (e.g., old_token_count / new_token_count).",
+          "maximum": 1.0,
+          "title": "Compression Ratio",
+          "type": "number"
         }
       },
       "required": [
@@ -6771,13 +6771,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a formal Data Provenance anchor, cryptographically locking a semantic state to its exact physical, temporal, or neural genesis block on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Unlocks deterministic causal tracing and auditability, granting the orchestrator the physical capability to walk the Knowledge Graph backward across multiple swarm hops to the raw multimodal source.\n\nEPISTEMIC BOUNDS: Geometric topology rigidly anchored by the `source_event_cid` (128-char CID regex `^[a-zA-Z0-9_.:-]+$`). Spatial and temporal origin physically clamped by the optional multimodal anchor (`MultimodalTokenAnchorState`).\n\nMCP ROUTING TRIGGERS: Data Provenance, Causal Tracing, Epistemic Anchoring, Bijective Mapping, Genesis Block",
       "properties": {
-        "derivation_mode": {
-          "$ref": "#/$defs/DerivationMode"
-        },
-        "extracted_by": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The Content Identifier (CID) of the agent node that extracted this payload."
-        },
         "fidelity_receipt_hash": {
           "anyOf": [
             {
@@ -6791,43 +6784,6 @@
           "default": null,
           "description": "Cryptographic pointer back to the TopologicalFidelityReceipt generated at the Input Gate.",
           "title": "Fidelity Receipt Hash"
-        },
-        "justification_hash": {
-          "anyOf": [
-            {
-              "maxLength": 64,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Justification Hash"
-        },
-        "lineage_watermark": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/LineageWatermarkReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic, tamper-evident chain of custody tracing this memory across multiple swarm hops."
-        },
-        "multimodal_anchor": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/MultimodalTokenAnchorState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The unified VLM spatial and temporal token matrix where this data was extracted."
         },
         "revision_loops_executed": {
           "anyOf": [
@@ -6843,6 +6799,18 @@
           "default": null,
           "description": "Records the exact cycle count the neural model required to pass the verifier.",
           "title": "Revision Loops Executed"
+        },
+        "extracted_by": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The Content Identifier (CID) of the agent node that extracted this payload."
+        },
+        "source_event_cid": {
+          "description": "The exact event Content Identifier (CID) in the EpistemicLedgerState that generated this fact.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Event Cid",
+          "type": "string"
         },
         "source_artifact_id": {
           "anyOf": [
@@ -6860,13 +6828,45 @@
           "description": "The globally unique decentralized identifier (DID) anchoring the Genesis MultimodalArtifactReceipt this semantic state was transmutated from.",
           "title": "Source Artifact Id"
         },
-        "source_event_cid": {
-          "description": "The exact event Content Identifier (CID) in the EpistemicLedgerState that generated this fact.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Event Cid",
-          "type": "string"
+        "multimodal_anchor": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/MultimodalTokenAnchorState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The unified VLM spatial and temporal token matrix where this data was extracted."
+        },
+        "lineage_watermark": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LineageWatermarkReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic, tamper-evident chain of custody tracing this memory across multiple swarm hops."
+        },
+        "derivation_mode": {
+          "$ref": "#/$defs/DerivationMode"
+        },
+        "justification_hash": {
+          "anyOf": [
+            {
+              "maxLength": 64,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Justification Hash"
         }
       },
       "required": [
@@ -6881,6 +6881,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a discrete Epistemic Quarantine and Working\nMemory partition, isolating volatile, non-monotonic probability waves from\nthe immutable ledger. As a ...Snapshot suffix, this is a frozen N-dimensional\ncoordinate of ephemeral context.\n\nCAUSAL AFFORDANCE: Provides a sandbox for the agent to simulate Theory of\nMind (theory_of_mind_matrices, list[TheoryOfMindSnapshot]) and compute\ndefeasible argumentation (argumentation, EpistemicArgumentGraphState | None).\nThe system_prompt (max_length=2000) defines the basal instruction set.\naffordance_projection and capability_attestations extend the discovery surface.\n\nEPISTEMIC BOUNDS: Physical memory is clamped by active_context (key\nmax_length=255, value max_length=100000, le=1000000000). The @model_validator\nsort_arrays deterministically sorts theory_of_mind_matrices by target_agent_cid\nand capability_attestations by attestation_cid for RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Working Memory Partition, Epistemic Quarantine, Theory\nof Mind, Volatile State Isolation, Semantic Sandbox",
       "properties": {
+        "system_prompt": {
+          "description": "The basal non-monotonic instruction set currently held in Epistemic Quarantine.",
+          "maxLength": 2000,
+          "title": "System Prompt",
+          "type": "string"
+        },
         "active_context": {
           "additionalProperties": {
             "maxLength": 100000,
@@ -6894,18 +6900,6 @@
           "title": "Active Context",
           "type": "object"
         },
-        "affordance_projection": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/OntologicalSurfaceProjectionManifest"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematically bounded subgraph of capabilities currently available to the agent."
-        },
         "argumentation": {
           "anyOf": [
             {
@@ -6918,26 +6912,32 @@
           "default": null,
           "description": "The formal graph of non-monotonic claims and defeasible attacks currently active in the swarm's working state."
         },
-        "capability_attestations": {
-          "description": "Immutable cryptographic receipts of dynamically discovered external enterprise connectors.",
-          "items": {
-            "$ref": "#/$defs/FederatedCapabilityAttestationReceipt"
-          },
-          "title": "Capability Attestations",
-          "type": "array"
-        },
-        "system_prompt": {
-          "description": "The basal non-monotonic instruction set currently held in Epistemic Quarantine.",
-          "maxLength": 2000,
-          "title": "System Prompt",
-          "type": "string"
-        },
         "theory_of_mind_matrices": {
           "description": "Empathetic models of other agents to compress and target outgoing communications.",
           "items": {
             "$ref": "#/$defs/TheoryOfMindSnapshot"
           },
           "title": "Theory Of Mind Matrices",
+          "type": "array"
+        },
+        "affordance_projection": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologicalSurfaceProjectionManifest"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematically bounded subgraph of capabilities currently available to the agent."
+        },
+        "capability_attestations": {
+          "description": "Immutable cryptographic receipts of dynamically discovered external enterprise connectors.",
+          "items": {
+            "$ref": "#/$defs/FederatedCapabilityAttestationReceipt"
+          },
+          "title": "Capability Attestations",
           "type": "array"
         }
       },
@@ -6952,17 +6952,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the Group Relative Policy Optimization (GRPO) reward shaping ruleset, mathematically immunizing the swarm against Goodhart's Law and reward hacking.\n\nCAUSAL AFFORDANCE: Projects a continuous penalty/reward gradient across extracted axiomatic paths, enforcing syntactic compliance through the format contract while simultaneously evaluating semantic/topological validity.\n\nEPISTEMIC BOUNDS: Prevents reward hacking by scaling the logical validity score (R_path) via the `beta_path_weight` scalar (`ge=0.0, le=1.0`). Gated by a cryptographic `reference_graph_cid` CID.\n\nMCP ROUTING TRIGGERS: GRPO, Reward Shaping, Goodhart's Law, Policy Gradient, Advantage Estimation",
       "properties": {
-        "beta_path_weight": {
-          "description": "The scalar weight applied to the logical path validity (R_path) to prevent reward hacking.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Beta Path Weight",
-          "type": "number"
-        },
-        "format_contract": {
-          "$ref": "#/$defs/CognitiveFormatContract",
-          "description": "The syntactic constraints the agent must follow to prevent reward zeroing."
-        },
         "policy_cid": {
           "description": "CID for this specific reward configuration.",
           "maxLength": 128,
@@ -6978,6 +6967,17 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Reference Graph Cid",
           "type": "string"
+        },
+        "format_contract": {
+          "$ref": "#/$defs/CognitiveFormatContract",
+          "description": "The syntactic constraints the agent must follow to prevent reward zeroing."
+        },
+        "beta_path_weight": {
+          "description": "The scalar weight applied to the logical path validity (R_path) to prevent reward hacking.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Beta Path Weight",
+          "type": "number"
         },
         "topological_scoring": {
           "anyOf": [
@@ -7005,6 +7005,41 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encodes a macroscopic Petri net or Directed Acyclic Graph (DAG)\nformalizing standard operating procedures into mathematically traversable state\ntransitions. As a ...Manifest suffix, this defines a frozen, N-dimensional coordinate\nstate.\n\nCAUSAL AFFORDANCE: Physically bounds the executing agent (target_persona:\nProfileCIDState) to a deterministic sequence of CognitiveStateProfiles, unlocking\nthe ability for the orchestrator to dynamically evaluate execution via Process Reward\nModels (prm_evaluations: list[ProcessRewardContract]) at each topological node.\n\nEPISTEMIC BOUNDS: The cognitive_steps dictionary is constrained to max_length=1000\nto cap memory footprint. The @model_validator reject_ghost_nodes mathematically enforces\nreferential integrity, guaranteeing that no chronological_flow_edges AND no\nstructural_grammar_hashes point to an undefined state.\n\nMCP ROUTING TRIGGERS: Petri Net, Directed Acyclic Graph, Process Reward Model,\nTopological Flow, Referential Integrity",
       "properties": {
+        "sop_id": {
+          "description": "A Content Identifier (CID) for the Standard Operating Procedure.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Sop Id",
+          "type": "string"
+        },
+        "target_persona": {
+          "$ref": "#/$defs/ProfileCIDState",
+          "description": "The deterministic cognitive routing boundary for the persona executing the SOP."
+        },
+        "cognitive_steps": {
+          "additionalProperties": {
+            "$ref": "#/$defs/CognitiveStateProfile"
+          },
+          "description": "Dictionary mapping step_ids to strict causal DAG constraints.",
+          "maxProperties": 1000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Cognitive Steps",
+          "type": "object"
+        },
+        "structural_grammar_hashes": {
+          "additionalProperties": {
+            "type": "string"
+          },
+          "description": "Dictionary mapping step_ids to SHA-256 hashes of strict Context-Free Grammars or JSON Schemas.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Structural Grammar Hashes",
+          "type": "object"
+        },
         "chronological_flow_edges": {
           "description": "The exact topological flow between step_ids.",
           "items": {
@@ -7023,18 +7058,6 @@
           "title": "Chronological Flow Edges",
           "type": "array"
         },
-        "cognitive_steps": {
-          "additionalProperties": {
-            "$ref": "#/$defs/CognitiveStateProfile"
-          },
-          "description": "Dictionary mapping step_ids to strict causal DAG constraints.",
-          "maxProperties": 1000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Cognitive Steps",
-          "type": "object"
-        },
         "prm_evaluations": {
           "description": "The strict array of Process Reward Contracts evaluating the logic.",
           "items": {
@@ -7042,29 +7065,6 @@
           },
           "title": "Prm Evaluations",
           "type": "array"
-        },
-        "sop_id": {
-          "description": "A Content Identifier (CID) for the Standard Operating Procedure.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Sop Id",
-          "type": "string"
-        },
-        "structural_grammar_hashes": {
-          "additionalProperties": {
-            "type": "string"
-          },
-          "description": "Dictionary mapping step_ids to SHA-256 hashes of strict Context-Free Grammars or JSON Schemas.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Structural Grammar Hashes",
-          "type": "object"
-        },
-        "target_persona": {
-          "$ref": "#/$defs/ProfileCIDState",
-          "description": "The deterministic cognitive routing boundary for the persona executing the SOP."
         }
       },
       "required": [
@@ -7082,16 +7082,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Metacognitive Monitoring and Fristonian Active Inference to continuously scan the agent's internal belief distribution and residual stream for epistemic gaps. As a ...Policy suffix, this object defines rigid mathematical boundaries that the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Triggers a structural interlock when the agent detects a spike in Shannon Entropy or cognitive dissonance, forcing the orchestrator to halt forward-pass generation and actively probe or clarify the uncertainty. Gated by the active boolean toggle.\n\nEPISTEMIC BOUNDS: The sensitivity of the metacognitive scanner is physically clamped by the dissonance_threshold (ge=0.0, le=1.0). Recovery mechanisms are deterministically restricted by the action_on_gap FSM literal automaton [\"fail\", \"probe\", \"clarify\"].\n\nMCP ROUTING TRIGGERS: Metacognitive Monitoring, Active Inference, Cognitive Dissonance, Epistemic Foraging, Shannon Entropy",
       "properties": {
-        "action_on_gap": {
-          "description": "The action to take when an epistemic gap is detected.",
-          "enum": [
-            "fail",
-            "probe",
-            "clarify"
-          ],
-          "title": "Action On Gap",
-          "type": "string"
-        },
         "active": {
           "description": "Whether the epistemic scanner is active.",
           "title": "Active",
@@ -7103,6 +7093,16 @@
           "minimum": 0.0,
           "title": "Dissonance Threshold",
           "type": "number"
+        },
+        "action_on_gap": {
+          "description": "The action to take when an epistemic gap is detected.",
+          "enum": [
+            "fail",
+            "probe",
+            "clarify"
+          ],
+          "title": "Action On Gap",
+          "type": "string"
         }
       },
       "required": [
@@ -7113,27 +7113,21 @@
       "title": "EpistemicScanningPolicy",
       "type": "object"
     },
-    "EpistemicSecurity": {
+    "EpistemicSecurityPolicy": {
       "description": "AGENT INSTRUCTION: Defines the minimum cryptographic isolation perimeter required for this node's thermodynamic execution.\n\nCAUSAL AFFORDANCE: Binds the execution graph to hardware Trusted Execution Environments (TEEs) if CONFIDENTIAL is set, physically guillotining unauthorized exfiltration.\n\nEPISTEMIC BOUNDS: Constrained strictly to the predefined enumeration values.\n\nMCP ROUTING TRIGGERS: TEE Enforcement, Hardware Isolation, Secure Enclave, Zero-Trust Execution",
       "enum": [
         "STANDARD",
         "CONFIDENTIAL"
       ],
-      "title": "EpistemicSecurity",
+      "title": "EpistemicSecurityPolicy",
       "type": "string"
     },
     "EpistemicSecurityProfile": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of the cryptographic isolation boundaries surrounding this node. As a ...Profile suffix, this defines a rigid mathematical boundary.\n\nCAUSAL AFFORDANCE: Instructs the zero-trust orchestrator to enforce hardware-level Trusted Execution Environments (TEEs) and Mixnet egress routing before authorizing the node to handle sensitive payloads.\n\nEPISTEMIC BOUNDS: The boolean gates (network_isolation, egress_obfuscation) rigidly confine the node's kinetic network reach. The epistemic_security enum mathematically dictates if the host hypervisor is trusted.\n\nMCP ROUTING TRIGGERS: Sovereign Execution, Trusted Execution Environment, Egress Obfuscation, Mixnet Routing, Network Isolation",
       "properties": {
-        "egress_obfuscation": {
-          "default": false,
-          "description": "The strict Boolean constraint mandating that all outgoing packets be routed through a Sphinx-packet Mixnet.",
-          "title": "Egress Obfuscation",
-          "type": "boolean"
-        },
         "epistemic_security": {
-          "$ref": "#/$defs/EpistemicSecurity",
+          "$ref": "#/$defs/EpistemicSecurityPolicy",
           "default": "STANDARD",
           "description": "The level of hardware-enforced cryptographic isolation required (STANDARD or CONFIDENTIAL)."
         },
@@ -7141,6 +7135,12 @@
           "default": false,
           "description": "The strict Boolean constraint mandating a fully isolated subnet or eBPF mesh.",
           "title": "Network Isolation",
+          "type": "boolean"
+        },
+        "egress_obfuscation": {
+          "default": false,
+          "description": "The strict Boolean constraint mandating that all outgoing packets be routed through a Sphinx-packet Mixnet.",
+          "title": "Egress Obfuscation",
           "type": "boolean"
         }
       },
@@ -7151,17 +7151,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Subgraph Injection and Graph Neural Network (GNN)\nneighborhood sampling heuristics. As a ...Policy suffix, this defines rigid\nmathematical boundaries the orchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Authorizes the algorithmic injection of high-density semantic\nseeds or priors into an existing Knowledge Graph, ensuring topological diversity\nby clustering relationships into strictly bounded neighborhood buckets.\n\nEPISTEMIC BOUNDS: The semantic proximity for neighborhood sampling is\nmathematically clamped by similarity_threshold_alpha (ge=0.0, le=1.0). To\nprevent topological density explosions (hub nodes), the\nrelation_diversity_bucket_size is bounded (gt=0, le=1000000000).\n\nMCP ROUTING TRIGGERS: Subgraph Injection, Graph Neural Networks, Neighborhood\nSampling, Topological Diversity, Semantic Seeding",
       "properties": {
-        "relation_diversity_bucket_size": {
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Relation Diversity Bucket Size",
-          "type": "integer"
-        },
         "similarity_threshold_alpha": {
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Similarity Threshold Alpha",
           "type": "number"
+        },
+        "relation_diversity_bucket_size": {
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Relation Diversity Bucket Size",
+          "type": "integer"
         }
       },
       "required": [
@@ -7175,38 +7175,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Human-in-the-Loop (HITL) Supervisory Control Theory and Epistemic Regret tracking to measure out-of-band human physical attention kinematics.\n\nCAUSAL AFFORDANCE: Emits passive structural telemetry to update retrieval gradients and Bayesian priors based on human spatial interaction, without halting the underlying execution DAG.\n\nEPISTEMIC BOUNDS: The human interaction is rigidly confined to the `interaction_modality` Literal automaton. Temporal liveness of attention is bounded by `dwell_duration_ms` (`ge=0, le=86400000`). Target is locked to `target_node_cid` CID.\n\nMCP ROUTING TRIGGERS: Epistemic Regret, Supervisory Control Theory, Human-in-the-Loop, Dwell Time, Spatial Telemetry",
       "properties": {
-        "dwell_duration_ms": {
-          "anyOf": [
-            {
-              "maximum": 86400000,
-              "minimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The strictly typed temporal bound measuring human attention focus.",
-          "title": "Dwell Duration Ms"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
-          "type": "string"
-        },
-        "interaction_modality": {
-          "description": "The exact topological action the human operator performed on the projected manifold.",
-          "enum": [
-            "expansion",
-            "collapse",
-            "dwell_focus",
-            "heuristic_rejection"
-          ],
-          "title": "Interaction Modality",
           "type": "string"
         },
         "prior_event_hash": {
@@ -7225,26 +7199,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "spatial_coordinates": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SE3TransformProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional 3D trajectory of the human pointer event mapped to the spatial grid."
-        },
-        "target_node_cid": {
-          "description": "The specific TaxonomicNodeState CID that was manipulated.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Node Cid",
-          "type": "string"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -7258,6 +7212,52 @@
           "description": "Discriminator type for telemetry events.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "interaction_modality": {
+          "description": "The exact topological action the human operator performed on the projected manifold.",
+          "enum": [
+            "expansion",
+            "collapse",
+            "dwell_focus",
+            "heuristic_rejection"
+          ],
+          "title": "Interaction Modality",
+          "type": "string"
+        },
+        "target_node_cid": {
+          "description": "The specific TaxonomicNodeState CID that was manipulated.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Node Cid",
+          "type": "string"
+        },
+        "dwell_duration_ms": {
+          "anyOf": [
+            {
+              "maximum": 86400000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strictly typed temporal bound measuring human attention focus.",
+          "title": "Dwell Duration Ms"
+        },
+        "spatial_coordinates": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SE3TransformProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional 3D trajectory of the human pointer event mapped to the spatial grid."
         }
       },
       "required": [
@@ -7273,6 +7273,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Curry-Howard Correspondence, mapping pure logic to computational types to form an unassailable deductive chain. As a ...Manifest suffix, this defines a frozen, N-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Unlocks verifiable automated theorem proving. By presenting a strictly ordered, acyclic sequence of axioms (`axiomatic_chain`), it allows an independent auditor or secondary LLM to mechanically verify the logical deduction step-by-step.\n\nEPISTEMIC BOUNDS: The `axiomatic_chain` array is structurally declared with `min_length=1`. Crucially, it invokes the Topological Exemption from array sorting; the sequence order MUST mathematically preserve the chronological deduction steps.\n\nMCP ROUTING TRIGGERS: Curry-Howard Correspondence, Constructive Proof, Topological Sort, Deductive Reasoning, Automated Theorem Proving",
       "properties": {
+        "proof_cid": {
+          "description": "A Content Identifier (CID) for this specific topological proof.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Proof Cid",
+          "type": "string"
+        },
         "axiomatic_chain": {
           "description": "The strictly ordered sequence of axioms forming the reasoning path.",
           "items": {
@@ -7281,14 +7289,6 @@
           "minItems": 1,
           "title": "Axiomatic Chain",
           "type": "array"
-        },
-        "proof_cid": {
-          "description": "A Content Identifier (CID) for this specific topological proof.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Proof Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -7302,6 +7302,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates Cross-Modal Representation Alignment,\ndeterministically transmuting unstructured artifacts into machine-readable\nN-dimensional tensors or discrete graphs. As a ...Task suffix, this represents\nan authorized kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Forces the orchestrator's VLM or extraction engine to process\nthe artifact_event_id (128-char CID) and project it into target_modalities\n(5-value Literal, min_length=1) while strictly adhering to the attached\ncompression_sla (EpistemicCompressionSLA).\n\nEPISTEMIC BOUNDS: The @model_validator validate_grounding_density_for_visuals\nrejects sparse grounding for visual/tabular modalities. The @model_validator\nsort_arrays deterministically sorts target_modalities for RFC 8785 canonical\nhashing. The optional execution_cost_budget_magnitude (int | None,\nle=1000000000, ge=0, default=None) caps thermodynamic cost.\n\nMCP ROUTING TRIGGERS: Cross-Modal Alignment, Representation Engineering,\nMultimodal Extraction, VLM Transmutation, Deterministic Projection",
       "properties": {
+        "task_cid": {
+          "description": "Unique identifier for this specific multimodal extraction intervention.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Cid",
+          "type": "string"
+        },
         "artifact_event_id": {
           "description": "The globally unique decentralized identifier (DID) anchoring the MultimodalArtifactReceipt being processed.",
           "maxLength": 128,
@@ -7309,6 +7317,22 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Artifact Event Id",
           "type": "string"
+        },
+        "target_modalities": {
+          "description": "The specific SOTA modality resolutions required for this extraction pass.",
+          "items": {
+            "enum": [
+              "text",
+              "raster_image",
+              "vector_graphics",
+              "tabular_grid",
+              "n_dimensional_tensor"
+            ],
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Target Modalities",
+          "type": "array"
         },
         "compression_sla": {
           "$ref": "#/$defs/EpistemicCompressionSLA",
@@ -7328,30 +7352,6 @@
           "default": null,
           "description": "Optional maximum economic expenditure authorized to run this VLM transmutation.",
           "title": "Execution Cost Budget Magnitude"
-        },
-        "target_modalities": {
-          "description": "The specific SOTA modality resolutions required for this extraction pass.",
-          "items": {
-            "enum": [
-              "text",
-              "raster_image",
-              "vector_graphics",
-              "tabular_grid",
-              "n_dimensional_tensor"
-            ],
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Target Modalities",
-          "type": "array"
-        },
-        "task_cid": {
-          "description": "Unique identifier for this specific multimodal extraction intervention.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -7367,17 +7367,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Authorizes a connectionist agent to execute an abductive leap, reversing lossy compression via context.\n\n    CAUSAL AFFORDANCE: Unlocks generative projection mapping by allowing an agent to expand a generalized node into highly specific ontology dimensions based on contextual vectors.\n\n    EPISTEMIC BOUNDS: The confidence of the upsampling projection is clamped tightly between 0.0 and 1.0. Justification arrays enforce maximum structural lengths and explicitly declare Topological Exemptions against array sort.\n\n    MCP ROUTING TRIGGERS: Abductive Leap, Epistemic Upsampling, Lossy Compression Reversal, Vector Expansion, Connectionist Grounding",
       "properties": {
-        "justification_vectors": {
-          "description": "The strictly ordered matrix of reasoning paths mathematically justifying the topological expansion. AGENT INSTRUCTION: Topological Exemption applied. Do NOT sort this array, as the chronological sequence of extraction acts as mathematical state.",
-          "items": {
-            "maxLength": 2000,
-            "type": "string"
-          },
-          "maxItems": 1000,
-          "minItems": 1,
-          "title": "Justification Vectors",
-          "type": "array"
-        },
         "source_entity": {
           "$ref": "#/$defs/ContextualizedSourceEntity",
           "description": "The specific source contextualized entity subject to topological upsampling."
@@ -7394,6 +7383,17 @@
           "minimum": 0.0,
           "title": "Upsampling Confidence Threshold",
           "type": "number"
+        },
+        "justification_vectors": {
+          "description": "The strictly ordered matrix of reasoning paths mathematically justifying the topological expansion. AGENT INSTRUCTION: Topological Exemption applied. Do NOT sort this array, as the chronological sequence of extraction acts as mathematical state.",
+          "items": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "maxItems": 1000,
+          "minItems": 1,
+          "title": "Justification Vectors",
+          "type": "array"
         }
       },
       "required": [
@@ -7409,6 +7409,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A rigid mathematical agreement governing when an agent is authorized\nto expand its test-time compute allocation (System 2 thinking) based on measured doubt.\nAs a ...Contract suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Physically unlocks the LatentScratchpadReceipt, granting the agent\na budget of hidden tokens to execute a non-monotonic search tree (MCTS or Beam Search).\n\nEPISTEMIC BOUNDS: Mathematically bounded by uncertainty_escalation_threshold (ge=0.0,\nle=1.0). The computation is physically capped by max_latent_tokens_budget (gt=0,\nle=1000000000) and max_test_time_compute_ms (gt=0, le=86400000) to prevent infinite\nloops and VRAM exhaustion.\n\nMCP ROUTING TRIGGERS: Test-Time Compute, System 2 Thinking, Epistemic Uncertainty,\nNon-Monotonic Escalation, Token Budgeting",
       "properties": {
+        "uncertainty_escalation_threshold": {
+          "description": "The exact Epistemic Uncertainty score that triggers the opening of the Latent Scratchpad.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Uncertainty Escalation Threshold",
+          "type": "number"
+        },
         "max_latent_tokens_budget": {
           "description": "The maximum number of hidden tokens the orchestrator is authorized to buy for the internal monologue.",
           "exclusiveMinimum": 0,
@@ -7422,13 +7429,6 @@
           "maximum": 86400000,
           "title": "Max Test Time Compute Ms",
           "type": "integer"
-        },
-        "uncertainty_escalation_threshold": {
-          "description": "The exact Epistemic Uncertainty score that triggers the opening of the Latent Scratchpad.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Uncertainty Escalation Threshold",
-          "type": "number"
         }
       },
       "required": [
@@ -7443,6 +7443,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Anchors in the Biba Integrity Model to orchestrate a Dictatorial Override mechanism within a Zero-Trust Architecture. Emitted when a rigid mathematical safety boundary is breached during inference.\n\nCAUSAL AFFORDANCE: Severs the active kinetic thread when a rule is tripped, violently halting generation to force the presentation of a `resolution_schema`. Demands explicit, structurally verified cryptographic sign-off from a higher-clearance entity to bypass the breaker.\n\nEPISTEMIC BOUNDS: The `resolution_schema` is mathematically bounded against recursive JSON-bombing by the `enforce_payload_topology` hook. The `tripped_rule_id` is strictly anchored to a 128-char CID regex (`^[a-zA-Z0-9_.:-]+$`).\n\nMCP ROUTING TRIGGERS: Biba Integrity Model, Dictatorial Override, Privilege Escalation, Payload Loss Prevention, Cryptographic Sign-Off",
       "properties": {
+        "topology_class": {
+          "const": "escalation",
+          "default": "escalation",
+          "description": "Discriminator for security or economic boundary overrides.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "tripped_rule_id": {
+          "description": "The deterministic capability pointer representing the Payload Loss Prevention (PLP) or Governance rule that blocked execution.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Tripped Rule Id",
+          "type": "string"
+        },
         "resolution_schema": {
           "additionalProperties": {
             "$ref": "#/$defs/JsonPrimitiveState"
@@ -7462,21 +7477,6 @@
             "terminate"
           ],
           "title": "Timeout Action",
-          "type": "string"
-        },
-        "topology_class": {
-          "const": "escalation",
-          "default": "escalation",
-          "description": "Discriminator for security or economic boundary overrides.",
-          "title": "Topology Class",
-          "type": "string"
-        },
-        "tripped_rule_id": {
-          "description": "The deterministic capability pointer representing the Payload Loss Prevention (PLP) or Governance rule that blocked execution.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Tripped Rule Id",
           "type": "string"
         }
       },
@@ -7499,18 +7499,18 @@
           "title": "Escrow Locked Magnitude",
           "type": "integer"
         },
+        "release_condition_metric": {
+          "description": "A declarative pointer to the SLA or QA rubric required to release the funds.",
+          "maxLength": 2000,
+          "title": "Release Condition Metric",
+          "type": "string"
+        },
         "refund_target_node_cid": {
           "description": "The exact NodeCIDState to return funds to if the release condition fails.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Refund Target Node Cid",
-          "type": "string"
-        },
-        "release_condition_metric": {
-          "description": "A declarative pointer to the SLA or QA rubric required to release the funds.",
-          "maxLength": 2000,
-          "title": "Release Condition Metric",
           "type": "string"
         }
       },
@@ -7526,6 +7526,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of an Actor-Critic (Generator-Discriminator) micro-topology, establishing a zero-sum minimax game between two discrete node identities.\n\nCAUSAL AFFORDANCE: Executes a finite, adversarial generation-evaluation-revision loop, forcing the `generator_node_cid` to propose states and the `evaluator_node_cid` to strictly critique them.\n\nEPISTEMIC BOUNDS: State-Space Explosion is mathematically prevented by capping `max_revision_loops` (`ge=1, le=1000000000`). The `@model_validator` structurally guarantees both nodes exist in the topology's nodes registry AND are disjoint identities.\n\nMCP ROUTING TRIGGERS: Actor-Critic Architecture, Minimax Optimization, Adversarial Critique, Dual-Process Revision, Generative Adversarial Loop",
       "properties": {
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -7539,26 +7561,6 @@
           "default": null,
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "evaluator_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The deterministic capability pointer representing the critic scoring the payload."
-        },
-        "generator_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The deterministic capability pointer representing the actor generating the payload."
         },
         "justification": {
           "anyOf": [
@@ -7574,23 +7576,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
-        "max_revision_loops": {
-          "description": "The absolute limit on Actor-Critic cycles to prevent infinite compute burn.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Max Revision Loops",
-          "type": "integer"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -7601,36 +7586,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "require_multimodal_grounding": {
-          "default": false,
-          "description": "If True, the evaluator_node_cid MUST mathematically mask all tokens outside the MultimodalTokenAnchorState during its forward pass to execute pure adversarial Proposer-Critique validation.",
-          "title": "Require Multimodal Grounding",
-          "type": "boolean"
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -7644,12 +7599,57 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
         "topology_class": {
           "const": "evaluator_optimizer",
           "default": "evaluator_optimizer",
           "description": "Discriminator for an Evaluator-Optimizer loop.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "generator_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The deterministic capability pointer representing the actor generating the payload."
+        },
+        "evaluator_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The deterministic capability pointer representing the critic scoring the payload."
+        },
+        "max_revision_loops": {
+          "description": "The absolute limit on Actor-Critic cycles to prevent infinite compute burn.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Max Revision Loops",
+          "type": "integer"
+        },
+        "require_multimodal_grounding": {
+          "default": false,
+          "description": "If True, the evaluator_node_cid MUST mathematically mask all tokens outside the MultimodalTokenAnchorState during its forward pass to execute pure adversarial Proposer-Critique validation.",
+          "title": "Require Multimodal Grounding",
+          "type": "boolean"
         }
       },
       "required": [
@@ -7665,6 +7665,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: EvictionPolicy implements Information Bottleneck Theory and the\nEbbinghaus Forgetting Curve. It is a rigid mathematical boundary dictating how the\nactive context partition sheds low-salience episodic memories to prevent attention dilution.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator's tensor-pruning heuristic to physically purge,\nsummarize, or decay historical nodes from the GPU VRAM, while mathematically guaranteeing that\nthe protected_event_ids array remains perfectly invariant in the context window.\n\nEPISTEMIC BOUNDS: The absolute physical boundary is enforced by the max_retained_tokens\ninteger limit (gt=0). The eviction behavior is deterministically restricted to the string\nliterals 'fifo', 'salience_decay', or 'summarize' to prevent hallucinated memory management.\n\nMCP ROUTING TRIGGERS: Information Bottleneck, Ebbinghaus Forgetting Curve, Salience Decay, LRU Cache Eviction, Attention Dilution",
       "properties": {
+        "strategy": {
+          "description": "The mathematical heuristic used to select which semantic memories are retracted or compressed.",
+          "enum": [
+            "fifo",
+            "salience_decay",
+            "summarize"
+          ],
+          "title": "Strategy",
+          "type": "string"
+        },
         "max_retained_tokens": {
           "description": "The strict geometric upper bound of the Epistemic Quarantine's token capacity.",
           "exclusiveMinimum": 0,
@@ -7681,16 +7691,6 @@
           },
           "title": "Protected Event Ids",
           "type": "array"
-        },
-        "strategy": {
-          "description": "The mathematical heuristic used to select which semantic memories are retracted or compressed.",
-          "enum": [
-            "fifo",
-            "salience_decay",
-            "summarize"
-          ],
-          "title": "Strategy",
-          "type": "string"
         }
       },
       "required": [
@@ -7704,12 +7704,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Toulmin Model of Argumentation by creating a structural bridge between a localized EpistemicArgumentClaimState and a globally verifiable Merkle-DAG coordinate.\n\nCAUSAL AFFORDANCE: Physically anchors a non-monotonic proposition to an immutable historical fact, unlocking the ability for downstream evaluators to mathematically trace the justification logic back to its evidentiary origin.\n\nEPISTEMIC BOUNDS: Requires either a `source_event_cid` or `source_semantic_node_id` (both optional, bounded to 128-char CIDs via strict regex `^[a-zA-Z0-9_.:-]+$`). The inferential leap is constrained by `justification`, capped at `max_length=2000` characters to prevent context-window exhaustion.\n\nMCP ROUTING TRIGGERS: Toulmin Model, Evidentiary Warrant, Inferential Bridge, Grounding Coordinate, Argumentation Theory",
       "properties": {
-        "justification": {
-          "description": "The logical premise explaining why this evidence supports the claim.",
-          "maxLength": 2000,
-          "title": "Justification",
-          "type": "string"
-        },
         "source_event_cid": {
           "anyOf": [
             {
@@ -7741,6 +7735,12 @@
           "default": null,
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for a specific concept in the Semantic Knowledge Graph.",
           "title": "Source Semantic Node Id"
+        },
+        "justification": {
+          "description": "The logical premise explaining why this evidence supports the claim.",
+          "maxLength": 2000,
+          "title": "Justification",
+          "type": "string"
         }
       },
       "required": [
@@ -7753,6 +7753,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a Genetic Algorithm (GA) or Evolutionary Strategy (ES) topology for the gradient-free optimization of agent populations over discrete temporal generations.\n\nCAUSAL AFFORDANCE: Orchestrates the iterative instantiation, evaluation, and culling of autonomous agents, actively applying stochastic perturbations (`MutationPolicy`) and chromosomal combinations (`CrossoverPolicy`) to maximize fitness.\n\nEPISTEMIC BOUNDS: The state space explosion is physically restricted by integer limits on `population_size` (`le=1000000000`) and `generations` (`le=1.0`). The `@model_validator` mathematically guarantees that `fitness_objectives` are deterministically sorted by `target_metric`.\n\nMCP ROUTING TRIGGERS: Genetic Algorithm, Evolutionary Strategy, Gradient-Free Optimization, Population Dynamics, Multi-Objective Optimization",
       "properties": {
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -7766,36 +7788,6 @@
           "default": null,
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
-        },
-        "crossover": {
-          "$ref": "#/$defs/CrossoverPolicy",
-          "description": "The mathematical rules for combining elite agents."
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "fitness_objectives": {
-          "description": "The multi-dimensional criteria used to score and cull the population.",
-          "items": {
-            "$ref": "#/$defs/FitnessObjectiveProfile"
-          },
-          "title": "Fitness Objectives",
-          "type": "array"
-        },
-        "generations": {
-          "description": "The absolute limit on evolutionary breeding cycles.",
-          "maximum": 1.0,
-          "title": "Generations",
-          "type": "integer"
         },
         "justification": {
           "anyOf": [
@@ -7811,20 +7803,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
-        "mutation": {
-          "$ref": "#/$defs/MutationPolicy",
-          "description": "The constraints governing random heuristic mutations."
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -7835,36 +7813,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "population_size": {
-          "description": "The number of concurrent agents instantiated per generation.",
-          "maximum": 1000000000,
-          "title": "Population Size",
-          "type": "integer"
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -7878,12 +7826,64 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
         "topology_class": {
           "const": "evolutionary",
           "default": "evolutionary",
           "description": "Discriminator for an Evolutionary topology.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "generations": {
+          "description": "The absolute limit on evolutionary breeding cycles.",
+          "maximum": 1.0,
+          "title": "Generations",
+          "type": "integer"
+        },
+        "population_size": {
+          "description": "The number of concurrent agents instantiated per generation.",
+          "maximum": 1000000000,
+          "title": "Population Size",
+          "type": "integer"
+        },
+        "mutation": {
+          "$ref": "#/$defs/MutationPolicy",
+          "description": "The constraints governing random heuristic mutations."
+        },
+        "crossover": {
+          "$ref": "#/$defs/CrossoverPolicy",
+          "description": "The mathematical rules for combining elite agents."
+        },
+        "fitness_objectives": {
+          "description": "The multi-dimensional criteria used to score and cull the population.",
+          "items": {
+            "$ref": "#/$defs/FitnessObjectiveProfile"
+          },
+          "title": "Fitness Objectives",
+          "type": "array"
         }
       },
       "required": [
@@ -7901,17 +7901,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the mathematical Reader/Writer/State (RWS) Monad, completely enveloping execution inside pure functions.\n\n    CAUSAL AFFORDANCE: Acts as the envelope functor that strictly maps a pure value into a bounded computational context.\n\n    EPISTEMIC BOUNDS: The execution configuration absolutely forbids external keys via extra=forbid and isolates strictly to trace, state, and payload variables.\n\n    MCP ROUTING TRIGGERS: Reader Writer State Monad, Pure Functions, Envelope Functor, Execution Context, Algebraic Structures",
       "properties": {
-        "payload": {
-          "description": "Represents the pure value payload data structure, domain-specific.",
-          "title": "Payload"
+        "trace_context": {
+          "$ref": "#/$defs/TraceContextState",
+          "description": "Represents the Reader/Writer monad for causality and recursion."
         },
         "state_vector": {
           "$ref": "#/$defs/StateVectorProfile",
           "description": "Represents the State monad of Labeled Transition Systems."
         },
-        "trace_context": {
-          "$ref": "#/$defs/TraceContextState",
-          "description": "Represents the Reader/Writer monad for causality and recursion."
+        "payload": {
+          "description": "Represents the pure value payload data structure, domain-specific.",
+          "title": "Payload"
         }
       },
       "required": [
@@ -7926,39 +7926,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a discrete computational vertex within a Merkle-DAG execution trace, binding raw data inputs to deterministic outputs. As an append-only coordinate, it guarantees algorithmic reproducibility.\n\nCAUSAL AFFORDANCE: Permits the orchestrator to cryptographically re-evaluate, replay, or slash execution branches by guaranteeing all computational inputs, outputs, and parent pointers are deterministically serialized.\n\nEPISTEMIC BOUNDS: The `@model_validator` mathematically guarantees the `node_hash` via RFC 8785 canonical JSON serialization, trapping any non-deterministic dictionary properties. Orphaned lineages are structurally blocked.\n\nMCP ROUTING TRIGGERS: Merkle-DAG, RFC 8785 Canonicalization, Execution Trace, Cryptographic Determinism, Directed Acyclic Graph",
       "properties": {
-        "inputs": {
-          "$ref": "#/$defs/JsonPrimitiveState",
-          "description": "The inputs provided to the execution node. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion."
-        },
-        "node_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic SHA-256 hash of this node.",
-          "title": "Node Hash"
-        },
-        "outputs": {
-          "$ref": "#/$defs/JsonPrimitiveState",
-          "description": "The outputs generated by the execution node. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion."
-        },
-        "parent_hashes": {
-          "description": "The strict array of cryptographic hashes of parent execution nodes.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Parent Hashes",
-          "type": "array"
+        "request_cid": {
+          "description": "The unique ID for this specific execution.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Request Cid",
+          "type": "string"
         },
         "parent_request_id": {
           "anyOf": [
@@ -7976,14 +7950,6 @@
           "description": "The deterministic capability pointer anchoring the parent request manifold.",
           "title": "Parent Request Id"
         },
-        "request_cid": {
-          "description": "The unique ID for this specific execution.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Request Cid",
-          "type": "string"
-        },
         "root_request_id": {
           "anyOf": [
             {
@@ -7999,6 +7965,40 @@
           "default": null,
           "description": "The deterministic capability pointer anchoring the trace root manifold.",
           "title": "Root Request Id"
+        },
+        "inputs": {
+          "$ref": "#/$defs/JsonPrimitiveState",
+          "description": "The inputs provided to the execution node. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion."
+        },
+        "outputs": {
+          "$ref": "#/$defs/JsonPrimitiveState",
+          "description": "The outputs generated by the execution node. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion."
+        },
+        "parent_hashes": {
+          "description": "The strict array of cryptographic hashes of parent execution nodes.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Parent Hashes",
+          "type": "array"
+        },
+        "node_hash": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic SHA-256 hash of this node.",
+          "title": "Node Hash"
         }
       },
       "required": [
@@ -8013,6 +8013,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The rigid physical boundary dictating the absolute time and memory limits for kinetic execution, practically bounding the Halting Problem within the swarm.\n\nCAUSAL AFFORDANCE: Acts as the hardware guillotine. Instructs the orchestrator's C++/Rust runtime to physically sever the thread, drop the VRAM context, or kill the WASM container if an agent exceeds its footprint, preventing Denial of Service (DoS).\n\nEPISTEMIC BOUNDS: Absolute physical limits are clamped via intrinsic Pydantic limits: `max_execution_time_ms` (`le=86400000`, `gt=0`) and `max_compute_footprint_mb` (`le=1000000000`, `gt=0`).\n\nMCP ROUTING TRIGGERS: Hardware Guillotine, Halting Problem Bounding, VRAM Allocation, Process Termination, Resource Exhaustion",
       "properties": {
+        "max_execution_time_ms": {
+          "description": "The maximum allowed execution time in milliseconds before the orchestrator kills the process.",
+          "exclusiveMinimum": 0,
+          "maximum": 86400000,
+          "title": "Max Execution Time Ms",
+          "type": "integer"
+        },
         "max_compute_footprint_mb": {
           "anyOf": [
             {
@@ -8027,13 +8034,6 @@
           "default": null,
           "description": "The maximum physical compute footprint allowed for the tool's execution sandbox.",
           "title": "Max Compute Footprint Mb"
-        },
-        "max_execution_time_ms": {
-          "description": "The maximum allowed execution time in milliseconds before the orchestrator kills the process.",
-          "exclusiveMinimum": 0,
-          "maximum": 86400000,
-          "title": "Max Execution Time Ms",
-          "type": "integer"
         }
       },
       "required": [
@@ -8046,39 +8046,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the Dapper distributed tracing model to deterministically map the causal execution DAG of the swarm. As an append-only coordinate on the Merkle-DAG, it mathematically binds parent-child RPC calls.\n\nCAUSAL AFFORDANCE: Unlocks global observability by mapping causal edges across the zero-trust network, enabling exact bottleneck detection and graph reconstruction.\n\nEPISTEMIC BOUNDS: Temporal boundaries are rigidly constrained by `start_time_unix_nano` (`ge=0`). The `@model_validator` enforces Allen's Interval Algebra to physically guarantee `end_time` cannot precede `start_time`. `events` array sorted by time.\n\nMCP ROUTING TRIGGERS: Dapper Tracing Model, Distributed Causal DAG, Allen's Interval Algebra, OpenTelemetry, Execution Provenance",
       "properties": {
-        "end_time_unix_nano": {
-          "anyOf": [
-            {
-              "maximum": 253402300799000000000,
-              "minimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Temporal end bound, if completed.",
-          "title": "End Time Unix Nano"
+        "trace_cid": {
+          "description": "The global identifier for the entire execution causal tree.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Trace Cid",
+          "type": "string"
         },
-        "events": {
-          "description": "Structured log records emitted during the span.",
-          "items": {
-            "$ref": "#/$defs/SpanEvent"
-          },
-          "maxItems": 10000,
-          "title": "Events",
-          "type": "array"
-        },
-        "kind": {
-          "$ref": "#/$defs/SpanKindProfile",
-          "default": "internal",
-          "description": "The role of the span."
-        },
-        "name": {
-          "description": "The semantic identifier for the operation.",
-          "maxLength": 2000,
-          "title": "Name",
+        "span_cid": {
+          "description": "The unique identifier for this specific operation.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Span Cid",
           "type": "string"
         },
         "parent_span_cid": {
@@ -8097,13 +8078,16 @@
           "description": "The causal edge to the invoking node.",
           "title": "Parent Span Cid"
         },
-        "span_cid": {
-          "description": "The unique identifier for this specific operation.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Span Cid",
+        "name": {
+          "description": "The semantic identifier for the operation.",
+          "maxLength": 2000,
+          "title": "Name",
           "type": "string"
+        },
+        "kind": {
+          "$ref": "#/$defs/SpanKindProfile",
+          "default": "internal",
+          "description": "The role of the span."
         },
         "start_time_unix_nano": {
           "description": "Temporal start bound.",
@@ -8112,18 +8096,34 @@
           "title": "Start Time Unix Nano",
           "type": "integer"
         },
+        "end_time_unix_nano": {
+          "anyOf": [
+            {
+              "maximum": 253402300799000000000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Temporal end bound, if completed.",
+          "title": "End Time Unix Nano"
+        },
         "status": {
           "$ref": "#/$defs/SpanStatusCodeProfile",
           "default": "unset",
           "description": "The execution health flag."
         },
-        "trace_cid": {
-          "description": "The global identifier for the entire execution causal tree.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Trace Cid",
-          "type": "string"
+        "events": {
+          "description": "Structured log records emitted during the span.",
+          "items": {
+            "$ref": "#/$defs/SpanEvent"
+          },
+          "maxItems": 10000,
+          "title": "Events",
+          "type": "array"
         }
       },
       "required": [
@@ -8139,17 +8139,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Nassim Taleb's Black Swan Theory by injecting\nOut-of-Distribution (OOD) epistemic shocks into the causal graph. As an ...Event suffix,\nthis is an append-only coordinate on the Merkle-DAG that the LLM must never hallucinate\na mutation to.\n\nCAUSAL AFFORDANCE: Forces the active reasoning topology to process a high-entropy\nsynthetic_payload, actively testing the swarm's non-monotonic truth maintenance,\ndefeasible reasoning, and overall topological resilience.\n\nEPISTEMIC BOUNDS: Cryptographically targets a specific Merkle root via target_node_hash\n(strict SHA-256 pattern ^[a-f0-9]{64}$) and bounds the Variational Free Energy via\nbayesian_surprise_score [ge=0.0, le=1.0, allow_inf_nan=False]. The @model_validator\nphysically guarantees execution is halted if the attached escrow is not strictly positive.\n\nMCP ROUTING TRIGGERS: Black Swan Theory, Out-of-Distribution Shock, Variational Free\nEnergy, Exogenous Perturbation, Epistemic Stress Test",
       "properties": {
-        "bayesian_surprise_score": {
-          "description": "Strictly bounded mathematical quantification of the epistemic decay or Variational Free Energy.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Bayesian Surprise Score",
-          "type": "number"
-        },
-        "escrow": {
-          "$ref": "#/$defs/SimulationEscrowContract",
-          "description": "The cryptographic Proof-of-Stake funding the shock."
-        },
         "shock_id": {
           "description": "Cryptographic identifier for the Black Swan event.",
           "maxLength": 128,
@@ -8157,6 +8146,21 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Shock Id",
           "type": "string"
+        },
+        "target_node_hash": {
+          "description": "Regex-bound SHA-256 string targeting a specific Merkle root in the epistemic graph.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Target Node Hash",
+          "type": "string"
+        },
+        "bayesian_surprise_score": {
+          "description": "Strictly bounded mathematical quantification of the epistemic decay or Variational Free Energy.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Bayesian Surprise Score",
+          "type": "number"
         },
         "synthetic_payload": {
           "additionalProperties": {
@@ -8170,13 +8174,9 @@
           "title": "Synthetic Payload",
           "type": "object"
         },
-        "target_node_hash": {
-          "description": "Regex-bound SHA-256 string targeting a specific Merkle root in the epistemic graph.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Target Node Hash",
-          "type": "string"
+        "escrow": {
+          "$ref": "#/$defs/SimulationEscrowContract",
+          "description": "The cryptographic Proof-of-Stake funding the shock."
         }
       },
       "required": [
@@ -8208,20 +8208,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Edward Tufte's principles of Small Multiples (Trellis displays) by establishing a categorical partitioning matrix for high-dimensional data projections.\n\nCAUSAL AFFORDANCE: Authorizes the rendering engine to recursively split and project a singular visual grammar into a grid of structurally isomorphic sub-manifolds based on distinct categorical fields.\n\nEPISTEMIC BOUNDS: The partitioning constraints (`row_field`, `column_field`) are both optional (`default=None`) and physically bounded by `max_length=2000` to mathematically prevent Dictionary Bombing and OOM crashes during matrix generation.\n\nMCP ROUTING TRIGGERS: Small Multiples, Trellis Display, Isomorphic Sub-Manifold, High-Dimensional Projection, Categorical Partitioning",
       "properties": {
-        "column_field": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dataset field used to split the chart into columns.",
-          "title": "Column Field"
-        },
         "row_field": {
           "anyOf": [
             {
@@ -8235,6 +8221,20 @@
           "default": null,
           "description": "The dataset field used to split the chart into rows.",
           "title": "Row Field"
+        },
+        "column_field": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dataset field used to split the chart into columns.",
+          "title": "Column Field"
         }
       },
       "title": "FacetMatrixProfile",
@@ -8244,14 +8244,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Graceful Degradation within a Markov Decision Process (MDP), executing a deterministic policy intervention to escape an absorbing state (terminal failure) upon node collapse. As an ...Intent suffix, this is a kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Re-routes the probabilistic execution wave from a failing primary node (`target_node_cid`) to a pre-verified, lower-variance backup node (`fallback_node_id`), actively bypassing structural collapse and maintaining systemic liveness.\n\nEPISTEMIC BOUNDS: Enforces strict structural referential integrity by requiring both `target_node_cid` and `fallback_node_id` to resolve to mathematically valid `NodeCIDState` DIDs, severing hallucinated graph traversals.\n\nMCP ROUTING TRIGGERS: Markov Decision Process, Absorbing State, Graceful Degradation, Control-Flow Override, Policy Intervention",
       "properties": {
-        "fallback_node_id": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The deterministic capability pointer representing the node to use as a fallback."
-        },
-        "target_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The deterministic capability pointer representing the failing node."
-        },
         "topology_class": {
           "const": "fallback_intent",
           "default": "fallback_intent",
@@ -8259,6 +8251,14 @@
           "le": 1000000000,
           "title": "Topology Class",
           "type": "string"
+        },
+        "target_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The deterministic capability pointer representing the failing node."
+        },
+        "fallback_node_id": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The deterministic capability pointer representing the node to use as a fallback."
         }
       },
       "required": [
@@ -8270,19 +8270,14 @@
     },
     "FallbackSLA": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a Hard Real-Time Systems deadline for Supervisory Control\nTheory interactions, mathematically bounding the Halting Problem during human-in-the-loop\npauses. As an ...SLA suffix, this object enforces rigid mathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Dictates the deterministic timeout_action\n(Literal[\"fail_safe\", \"proceed_with_defaults\", \"escalate\"]) the orchestrator must execute\nwhen the temporal limit expires, structurally preventing execution deadlocks. If\nescalation is selected, traffic routes to the optional escalation_target_node_cid.\n\nEPISTEMIC BOUNDS: The temporal envelope is physically capped by timeout_seconds (gt=0,\nle=86400 \u2014 a strict 24-hour absolute maximum TTL). Escalation routing targets a valid\nNodeCIDState (escalation_target_node_cid, default=None).\n\nMCP ROUTING TRIGGERS: Hard Real-Time Systems, Supervisory Control Theory, Execution\nDeadlock Prevention, Bounded Delay, Liveness Guarantee",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a Hard Real-Time Systems deadline for Supervisory Control\nTheory interactions, mathematically bounding the Halting Problem during human-in-the-loop\npauses. As an ...SLA suffix, this object enforces rigid mathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Dictates the deterministic timeout_action\n(Literal[\"fail_safe\", \"proceed_with_defaults\", \"escalate\"]) the orchestrator must execute\nwhen the temporal limit expires, structurally preventing execution deadlocks. If\nescalation is selected, traffic routes to the optional escalation_target_node_cid.\n\nEPISTEMIC BOUNDS: The temporal envelope is physically capped by timeout_seconds (gt=0,\nle=86400 — a strict 24-hour absolute maximum TTL). Escalation routing targets a valid\nNodeCIDState (escalation_target_node_cid, default=None).\n\nMCP ROUTING TRIGGERS: Hard Real-Time Systems, Supervisory Control Theory, Execution\nDeadlock Prevention, Bounded Delay, Liveness Guarantee",
       "properties": {
-        "escalation_target_node_cid": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeCIDState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The specific NodeCIDState to route the execution to if the escalate action is triggered."
+        "timeout_seconds": {
+          "description": "The maximum allowed delay for a human intervention.",
+          "exclusiveMinimum": 0,
+          "maximum": 86400,
+          "title": "Timeout Seconds",
+          "type": "integer"
         },
         "timeout_action": {
           "description": "The action to take when the timeout expires.",
@@ -8294,12 +8289,17 @@
           "title": "Timeout Action",
           "type": "string"
         },
-        "timeout_seconds": {
-          "description": "The maximum allowed delay for a human intervention.",
-          "exclusiveMinimum": 0,
-          "maximum": 86400,
-          "title": "Timeout Seconds",
-          "type": "integer"
+        "escalation_target_node_cid": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeCIDState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific NodeCIDState to route the execution to if the escalate action is triggered."
         }
       },
       "required": [
@@ -8327,12 +8327,6 @@
           "title": "Description",
           "type": "string"
         },
-        "falsifying_observation_signature": {
-          "description": "The expected data schema or regex pattern that, if returned by the tool, kills the hypothesis.",
-          "maxLength": 2000,
-          "title": "Falsifying Observation Signature",
-          "type": "string"
-        },
         "required_tool_name": {
           "anyOf": [
             {
@@ -8346,6 +8340,12 @@
           "default": null,
           "description": "The specific CognitiveActionSpaceManifest tool required to test this condition (e.g., 'sql_query_db').",
           "title": "Required Tool Name"
+        },
+        "falsifying_observation_signature": {
+          "description": "The expected data schema or regex pattern that, if returned by the tool, kills the hypothesis.",
+          "maxLength": 2000,
+          "title": "Falsifying Observation Signature",
+          "type": "string"
         }
       },
       "required": [
@@ -8377,12 +8377,6 @@
           "$ref": "#/$defs/FaultCategoryProfile",
           "description": "The specific type of fault to inject."
         },
-        "intensity": {
-          "description": "The severity of the fault, represented from 0.0 to 1.0.",
-          "maximum": 1000000000.0,
-          "title": "Intensity",
-          "type": "number"
-        },
         "target_node_cid": {
           "anyOf": [
             {
@@ -8398,6 +8392,12 @@
           "default": null,
           "description": "The specific node to attack, or None for swarm-wide.",
           "title": "Target Node Cid"
+        },
+        "intensity": {
+          "description": "The severity of the fault, represented from 0.0 to 1.0.",
+          "maximum": 1000000000.0,
+          "title": "Intensity",
+          "type": "number"
         }
       },
       "required": [
@@ -8411,6 +8411,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the zero-trust structural boundary for multi-tenant federation,\nsecuring cross-boundary graph traversal against Shor's algorithm via an optional\nPostQuantumSignatureReceipt. As an ...SLA suffix, this object enforces rigid mathematical\nboundaries that the orchestrator must respect globally.\n\nCAUSAL AFFORDANCE: Unlocks cross-swarm graph bridging by enforcing strict liability,\nphysical location routing, semantic data classification constraints via\nmax_permitted_classification, and ESG carbon intensity limits.\n\nEPISTEMIC BOUNDS: Economically constrained by liability_limit_magnitude (ge=0,\nle=1000000000). ESG limits physically bind the node grid to the optional\nmax_permitted_grid_carbon_intensity (ge=0.0, le=10000.0). The permitted_geographic_regions\narray is deterministically sorted via @model_validator for RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Post-Quantum Cryptography, Federated\nLearning, Bilateral SLA, Data Residency",
       "properties": {
+        "receiving_tenant_id": {
+          "description": "The strict enterprise identifier of the foreign B2B tenant receiving this payload.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Receiving Tenant Id",
+          "type": "string"
+        },
+        "max_permitted_classification": {
+          "$ref": "#/$defs/SemanticClassificationProfile",
+          "description": "The absolute highest semantic sensitivity allowed to cross this federated boundary."
+        },
         "liability_limit_magnitude": {
           "description": "The strict magnitude cap on cross-tenant economic liability.",
           "maximum": 1000000000,
@@ -8418,9 +8430,14 @@
           "title": "Liability Limit Magnitude",
           "type": "integer"
         },
-        "max_permitted_classification": {
-          "$ref": "#/$defs/SemanticClassificationProfile",
-          "description": "The absolute highest semantic sensitivity allowed to cross this federated boundary."
+        "permitted_geographic_regions": {
+          "description": "Explicit whitelist of geographic regions or cloud enclaves where execution is structurally permitted (Payload Residency Pinning).",
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "title": "Permitted Geographic Regions",
+          "type": "array"
         },
         "max_permitted_grid_carbon_intensity": {
           "anyOf": [
@@ -8437,15 +8454,6 @@
           "description": "Absolute structural ESG mandate. The execution graph will quarantine any federated node operating on a grid exceeding this gCO2eq/kWh threshold.",
           "title": "Max Permitted Grid Carbon Intensity"
         },
-        "permitted_geographic_regions": {
-          "description": "Explicit whitelist of geographic regions or cloud enclaves where execution is structurally permitted (Payload Residency Pinning).",
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "title": "Permitted Geographic Regions",
-          "type": "array"
-        },
         "pq_signature": {
           "anyOf": [
             {
@@ -8457,14 +8465,6 @@
           ],
           "default": null,
           "description": "The quantum-resistant signature securing the multi-tenant structural boundary."
-        },
-        "receiving_tenant_id": {
-          "description": "The strict enterprise identifier of the foreign B2B tenant receiving this payload.",
-          "maxLength": 255,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Receiving Tenant Id",
-          "type": "string"
         }
       },
       "required": [
@@ -8487,6 +8487,10 @@
           "title": "Attestation Cid",
           "type": "string"
         },
+        "target_topology_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The globally unique decentralized identifier (DID) anchoring the discovered external state matrix/VPC."
+        },
         "authorized_session": {
           "$ref": "#/$defs/SecureSubSessionState",
           "description": "The isolated state partition granted to the agent for this connection."
@@ -8494,10 +8498,6 @@
         "governing_sla": {
           "$ref": "#/$defs/FederatedBilateralSLA",
           "description": "The structural and physical boundary constraints for querying this target."
-        },
-        "target_topology_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The globally unique decentralized identifier (DID) anchoring the discovered external state matrix/VPC."
         }
       },
       "required": [
@@ -8553,12 +8553,12 @@
           "title": "Adapter Merkle Root",
           "type": "string"
         },
-        "cache_priority_weight": {
-          "description": "The relative importance scalar used by the orchestrator's LRU eviction algorithm when VRAM limits are saturated.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Cache Priority Weight",
-          "type": "number"
+        "vram_footprint_bytes": {
+          "description": "The exact spatial geometry required in VRAM to mount this adapter.",
+          "exclusiveMinimum": 0,
+          "maximum": 100000000000,
+          "title": "Vram Footprint Bytes",
+          "type": "integer"
         },
         "ephemeral_ttl_ms": {
           "description": "The absolute Time-To-Live for the adapter to exist in the kinetic execution plane before forced eviction.",
@@ -8567,12 +8567,12 @@
           "title": "Ephemeral Ttl Ms",
           "type": "integer"
         },
-        "vram_footprint_bytes": {
-          "description": "The exact spatial geometry required in VRAM to mount this adapter.",
-          "exclusiveMinimum": 0,
-          "maximum": 100000000000,
-          "title": "Vram Footprint Bytes",
-          "type": "integer"
+        "cache_priority_weight": {
+          "description": "The relative importance scalar used by the orchestrator's LRU eviction algorithm when VRAM limits are saturated.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Cache Priority Weight",
+          "type": "number"
         }
       },
       "required": [
@@ -8612,15 +8612,15 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a specific mathematical objective function (fitness dimension)\nwithin a multi-objective optimization landscape for evaluating agent phenotypes. As a\n...Profile suffix, this is a declarative, frozen snapshot of an evaluation geometry.\n\nCAUSAL AFFORDANCE: Provides the mathematical vector (OptimizationDirectionProfile:\nminimize/maximize) and scalar weight required by the orchestrator to score an agent's\nexecution telemetry, ultimately determining its survival on the Pareto Efficiency\nfrontier.\n\nEPISTEMIC BOUNDS: The relative influence of this objective is mathematically clamped by\nthe weight field (le=1.0, default=1.0) to prevent gradient or reward explosion during\nfitness aggregation. The target_metric is bounded to max_length=2000.\n\nMCP ROUTING TRIGGERS: Fitness Landscape, Objective Function, Multi-Objective\nOptimization, Phenotype Scoring, Pareto Efficiency",
       "properties": {
-        "direction": {
-          "$ref": "#/$defs/OptimizationDirectionProfile",
-          "description": "Whether the algorithm should maximize or minimize this metric."
-        },
         "target_metric": {
           "description": "The specific telemetry or execution metric to evaluate (e.g., 'latency', 'accuracy').",
           "maxLength": 2000,
           "title": "Target Metric",
           "type": "string"
+        },
+        "direction": {
+          "$ref": "#/$defs/OptimizationDirectionProfile",
+          "description": "Whether the algorithm should maximize or minimize this metric."
         },
         "weight": {
           "default": 1.0,
@@ -8641,20 +8641,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Leverages Automated Theorem Proving and the Curry-Howard\nCorrespondence to bind the causal graph to a mathematically verified safety\ninvariant. As a ...Contract suffix, this enforces rigid mathematical\nboundaries globally.\n\nCAUSAL AFFORDANCE: Authorizes the Rust/C++ orchestrator to ingest a compiled\nproof artifact and mechanically verify that the topology cannot transition into\na catastrophic or forbidden geometric state. The invariant_theorem\n(max_length=2000) specifies the exact safety assertion.\n\nEPISTEMIC BOUNDS: The theorem prover dialect is strictly locked to the\nproof_system Literal [\"tla_plus\", \"lean4\", \"coq\", \"z3\"]. Cryptographic\nintegrity is guaranteed by the compiled_proof_hash (SHA-256 regex\n^[a-f0-9]{64}$).\n\nMCP ROUTING TRIGGERS: Automated Theorem Proving, Curry-Howard Correspondence,\nSafety Invariant, TLA+, Formal Methods",
       "properties": {
-        "compiled_proof_hash": {
-          "description": "The SHA-256 fingerprint of the verified proof object that the Rust/C++ orchestrator must load and check.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Compiled Proof Hash",
-          "type": "string"
-        },
-        "invariant_theorem": {
-          "description": "The exact mathematical assertion or safety invariant being proven (e.g., 'No data classified as CONFIDENTIAL routes externally').",
-          "maxLength": 2000,
-          "title": "Invariant Theorem",
-          "type": "string"
-        },
         "proof_system": {
           "description": "The mathematical dialect and theorem prover used to compile the proof.",
           "enum": [
@@ -8664,6 +8650,20 @@
             "z3"
           ],
           "title": "Proof System",
+          "type": "string"
+        },
+        "invariant_theorem": {
+          "description": "The exact mathematical assertion or safety invariant being proven (e.g., 'No data classified as CONFIDENTIAL routes externally').",
+          "maxLength": 2000,
+          "title": "Invariant Theorem",
+          "type": "string"
+        },
+        "compiled_proof_hash": {
+          "description": "The SHA-256 fingerprint of the verified proof object that the Rust/C++ orchestrator must load and check.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Compiled Proof Hash",
           "type": "string"
         }
       },
@@ -8679,6 +8679,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Neural Radiance Fields, 3D Gaussian Splatting, Spherical Harmonics, Volumetric Rendering, Covariance Matrix\nCAUSAL AFFORDANCE: Neural Radiance Fields, 3D Gaussian Splatting, Spherical Harmonics, Volumetric Rendering, Covariance Matrix\nEPISTEMIC BOUNDS: Neural Radiance Fields, 3D Gaussian Splatting, Spherical Harmonics, Volumetric Rendering, Covariance Matrix\nMCP ROUTING TRIGGERS: Neural Radiance Fields, 3D Gaussian Splatting, Spherical Harmonics, Volumetric Rendering, Covariance Matrix",
       "properties": {
+        "spherical_harmonics_degree": {
+          "description": "Capped at 3 to physically prevent VRAM explosion during WebGL rasterization.",
+          "maximum": 3,
+          "minimum": 0,
+          "title": "Spherical Harmonics Degree",
+          "type": "integer"
+        },
         "covariance_scale": {
           "description": "The 3D anisotropic scaling vector of the Gaussian ellipsoid.",
           "maxItems": 3,
@@ -8703,13 +8710,6 @@
           "minimum": 0.0,
           "title": "Opacity Alpha",
           "type": "number"
-        },
-        "spherical_harmonics_degree": {
-          "description": "Capped at 3 to physically prevent VRAM explosion during WebGL rasterization.",
-          "maximum": 3,
-          "minimum": 0,
-          "title": "Spherical Harmonics Degree",
-          "type": "integer"
         }
       },
       "required": [
@@ -8724,6 +8724,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Ergodic Theory and Branching Factor Analysis to\nrigorously bound the topological expansion of synthetic or fractal graphs. As\nan ...SLA suffix, this enforces rigid mathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Acts as a physical gas limit on generative expansion,\nauthorizing the orchestrator to cull recursive encapsulation before it induces\nstate-space explosion or GPU VRAM exhaustion.\n\nEPISTEMIC BOUNDS: Mathematically clamps geometric explosion via the\n@model_validator enforce_geometric_bounds, guaranteeing\nmax_node_fanout ** max_topological_depth <= 1000. Both max_topological_depth\nand max_node_fanout are strictly positive (ge=1, le=1000000000). Synthetic\ntoken economy is capped by max_synthetic_tokens (ge=1, le=1000000000).\n\nMCP ROUTING TRIGGERS: Ergodic Theory, Branching Factor Analysis, State-Space\nExplosion, Fractal Graph Bounding, Gas Limit",
       "properties": {
+        "max_topological_depth": {
+          "description": "The absolute physical depth limit for recursive encapsulation.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Max Topological Depth",
+          "type": "integer"
+        },
         "max_node_fanout": {
           "description": "The maximum number of horizontally connected nodes per topology tier.",
           "maximum": 1000000000,
@@ -8736,13 +8743,6 @@
           "maximum": 1000000000,
           "minimum": 1,
           "title": "Max Synthetic Tokens",
-          "type": "integer"
-        },
-        "max_topological_depth": {
-          "description": "The absolute physical depth limit for recursive encapsulation.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Max Topological Depth",
           "type": "integer"
         }
       },
@@ -8766,6 +8766,14 @@
           "title": "Manifest Id",
           "type": "string"
         },
+        "root_node_id": {
+          "description": "The globally unique decentralized identifier (DID) anchoring the top-level TaxonomicNodeState initiating the tree.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Root Node Id",
+          "type": "string"
+        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/TaxonomicNodeState"
@@ -8777,14 +8785,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "root_node_id": {
-          "description": "The globally unique decentralized identifier (DID) anchoring the top-level TaxonomicNodeState initiating the tree.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Root Node Id",
-          "type": "string"
         }
       },
       "required": [
@@ -8797,27 +8797,8 @@
     },
     "GlobalGovernancePolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Superimposes macro-economic and thermodynamic constraints over the\nswarm's execution graph to prevent unbounded compute exhaustion. As a ...Policy suffix,\nthis object defines rigid mathematical boundaries that the orchestrator must enforce\nglobally.\n\nCAUSAL AFFORDANCE: Acts as the ultimate hardware guillotine, authorizing the orchestrator\nto physically sever the execution thread if thermodynamic, economic, or temporal budgets\nare breached. Includes a mandatory zero-trust @model_validator enforcing the Prosperity\nPublic License 3.0 via mandatory_license_rule (rule_cid=\"PPL_3_0_COMPLIANCE\",\nseverity=\"critical\").\n\nEPISTEMIC BOUNDS: Enforces absolute physical ceilings: max_budget_magnitude\n(le=1000000000), max_global_tokens (le=1000000000), global_timeout_seconds (ge=0,\nle=86400 \u2014 a strict 24-hour TTL), and optional max_carbon_budget_gco2eq (ge=0.0,\nle=10000.0). An optional FormalVerificationContract provides mathematical proofs of\nstructural correctness.\n\nMCP ROUTING TRIGGERS: Thermodynamic Compute Limits, Hardware Guillotine, Halting Problem\nBounding, ESG Constraint, Execution Envelope",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Superimposes macro-economic and thermodynamic constraints over the\nswarm's execution graph to prevent unbounded compute exhaustion. As a ...Policy suffix,\nthis object defines rigid mathematical boundaries that the orchestrator must enforce\nglobally.\n\nCAUSAL AFFORDANCE: Acts as the ultimate hardware guillotine, authorizing the orchestrator\nto physically sever the execution thread if thermodynamic, economic, or temporal budgets\nare breached. Includes a mandatory zero-trust @model_validator enforcing the Prosperity\nPublic License 3.0 via mandatory_license_rule (rule_cid=\"PPL_3_0_COMPLIANCE\",\nseverity=\"critical\").\n\nEPISTEMIC BOUNDS: Enforces absolute physical ceilings: max_budget_magnitude\n(le=1000000000), max_global_tokens (le=1000000000), global_timeout_seconds (ge=0,\nle=86400 — a strict 24-hour TTL), and optional max_carbon_budget_gco2eq (ge=0.0,\nle=10000.0). An optional FormalVerificationContract provides mathematical proofs of\nstructural correctness.\n\nMCP ROUTING TRIGGERS: Thermodynamic Compute Limits, Hardware Guillotine, Halting Problem\nBounding, ESG Constraint, Execution Envelope",
       "properties": {
-        "formal_verification": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/FormalVerificationContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical proof of structural correctness mandated for this execution graph."
-        },
-        "global_timeout_seconds": {
-          "description": "The absolute Time-To-Live (TTL) for the execution envelope before graceful termination.",
-          "maximum": 86400,
-          "minimum": 0,
-          "title": "Global Timeout Seconds",
-          "type": "integer"
-        },
         "mandatory_license_rule": {
           "$ref": "#/$defs/ConstitutionalPolicy"
         },
@@ -8825,6 +8806,12 @@
           "description": "The absolute maximum economic cost allowed for the entire swarm lifecycle.",
           "maximum": 1000000000,
           "title": "Max Budget Magnitude",
+          "type": "integer"
+        },
+        "max_global_tokens": {
+          "description": "The maximum aggregate token usage allowed across all nodes.",
+          "maximum": 1000000000,
+          "title": "Max Global Tokens",
           "type": "integer"
         },
         "max_carbon_budget_gco2eq": {
@@ -8842,11 +8829,24 @@
           "description": "The absolute physical energy footprint allowed for this execution graph. If exceeded, the orchestrator terminates the swarm.",
           "title": "Max Carbon Budget Gco2Eq"
         },
-        "max_global_tokens": {
-          "description": "The maximum aggregate token usage allowed across all nodes.",
-          "maximum": 1000000000,
-          "title": "Max Global Tokens",
+        "global_timeout_seconds": {
+          "description": "The absolute Time-To-Live (TTL) for the execution envelope before graceful termination.",
+          "maximum": 86400,
+          "minimum": 0,
+          "title": "Global Timeout Seconds",
           "type": "integer"
+        },
+        "formal_verification": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FormalVerificationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical proof of structural correctness mandated for this execution graph."
         }
       },
       "required": [
@@ -8911,6 +8911,10 @@
           "title": "Policy Name",
           "type": "string"
         },
+        "version": {
+          "$ref": "#/$defs/SemanticVersionState",
+          "description": "Semantic version of the governance policy."
+        },
         "rules": {
           "description": "The explicit array of constitutional rules included in this policy.",
           "items": {
@@ -8918,10 +8922,6 @@
           },
           "title": "Rules",
           "type": "array"
-        },
-        "version": {
-          "$ref": "#/$defs/SemanticVersionState",
-          "description": "Semantic version of the governance policy."
         }
       },
       "required": [
@@ -8970,6 +8970,35 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Leland Wilkinson's Grammar of Graphics to deterministically project N-dimensional Epistemic Ledger state into a 2D topological manifold.\n\nCAUSAL AFFORDANCE: Authorizes the frontend rendering engine to construct geometric marks (`Literal[\"point\", \"line\", \"area\", \"bar\", \"rect\", \"arc\"]`) driven strictly by the underlying `ledger_source_id`.\n\nEPISTEMIC BOUNDS: Bounded by a rigid `encodings` array sorted mathematically by `channel` via a `@model_validator` to preserve RFC 8785 canonical hashing. Prevents hallucinated visuals by strictly linking to a verified `ledger_source_id` CID.\n\nMCP ROUTING TRIGGERS: Grammar of Graphics, Data Visualization, Geometric Projection, Declarative UI, Retinal Variables",
       "properties": {
+        "panel_cid": {
+          "description": "The unique identifier for this UI panel.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Panel Cid",
+          "type": "string"
+        },
+        "topology_class": {
+          "const": "grammar",
+          "default": "grammar",
+          "description": "Discriminator for Grammar of Graphics charts.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "title": {
+          "description": "The declarative semantic anchor summarizing the underlying visual grammar.",
+          "maxLength": 2000,
+          "title": "Title",
+          "type": "string"
+        },
+        "ledger_source_id": {
+          "description": "The cryptographic pointer to the semantic series in the EpistemicLedgerState.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Ledger Source Id",
+          "type": "string"
+        },
         "billboard_physics": {
           "anyOf": [
             {
@@ -8981,6 +9010,19 @@
           ],
           "default": null,
           "description": "The kinematic constraint anchoring this 2D panel to the 3D topology."
+        },
+        "mark": {
+          "description": "The geometric shape used to represent the matrix.",
+          "enum": [
+            "point",
+            "line",
+            "area",
+            "bar",
+            "rect",
+            "arc"
+          ],
+          "title": "Mark",
+          "type": "string"
         },
         "encodings": {
           "description": "The mapping of structural fields to visual channels.",
@@ -9001,48 +9043,6 @@
           ],
           "default": null,
           "description": "Optional faceting matrix for small multiples."
-        },
-        "ledger_source_id": {
-          "description": "The cryptographic pointer to the semantic series in the EpistemicLedgerState.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Ledger Source Id",
-          "type": "string"
-        },
-        "mark": {
-          "description": "The geometric shape used to represent the matrix.",
-          "enum": [
-            "point",
-            "line",
-            "area",
-            "bar",
-            "rect",
-            "arc"
-          ],
-          "title": "Mark",
-          "type": "string"
-        },
-        "panel_cid": {
-          "description": "The unique identifier for this UI panel.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Panel Cid",
-          "type": "string"
-        },
-        "title": {
-          "description": "The declarative semantic anchor summarizing the underlying visual grammar.",
-          "maxLength": 2000,
-          "title": "Title",
-          "type": "string"
-        },
-        "topology_class": {
-          "const": "grammar",
-          "default": "grammar",
-          "description": "Discriminator for Grammar of Graphics charts.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -9059,15 +9059,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A rigid Graph Isomorphism and Dimensionality Reduction protocol\ndefining the deterministic translation of high-dimensional neurosymbolic Knowledge\nGraphs into flat, tabular matrices for standard OLAP processing. As a ...Policy\nsuffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Forces the structural projection engine to serialize complex\nsemantic nodes and edges into wide-columnar arrays or adjacency matrices. The\npreserve_cryptographic_lineage boolean (default=True) guarantees Merkle-DAG hashes\nsurvive the flattening transformation.\n\nEPISTEMIC BOUNDS: The reduction geometry is rigidly constrained by Literal enums for\nnode_projection_mode [\"wide_columnar\", \"struct_array\"] and edge_projection_mode\n[\"adjacency_matrix\", \"map_array\"], mathematically severing the capability for agents\nto hallucinate unsupported tabular schemas.\n\nMCP ROUTING TRIGGERS: Graph Isomorphism, Dimensionality Reduction, Adjacency Matrix,\nWide-Columnar Projection, Structural Serialization",
       "properties": {
-        "edge_projection_mode": {
-          "description": "How to flatten SemanticEdgeState.",
-          "enum": [
-            "adjacency_matrix",
-            "map_array"
-          ],
-          "title": "Edge Projection Mode",
-          "type": "string"
-        },
         "node_projection_mode": {
           "description": "How to flatten SemanticNodeState.",
           "enum": [
@@ -9075,6 +9066,15 @@
             "struct_array"
           ],
           "title": "Node Projection Mode",
+          "type": "string"
+        },
+        "edge_projection_mode": {
+          "description": "How to flatten SemanticEdgeState.",
+          "enum": [
+            "adjacency_matrix",
+            "map_array"
+          ],
+          "title": "Edge Projection Mode",
           "type": "string"
         },
         "preserve_cryptographic_lineage": {
@@ -9095,18 +9095,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a Stateless Client-Server Architecture for JSON-RPC 2.0 message passing, serving as the egress manifold for Zero-Trust Network Access (ZTNA).\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to open an out-of-band HTTP socket, transmitting structured semantic payloads while strictly confining custom headers to prevent protocol manipulation.\n\nEPISTEMIC BOUNDS: The `headers` dictionary is mathematically bounded (`max_length=2000`) and explicitly trapped by the `@field_validator` `_prevent_crlf_injection` to physically block HTTP Request Smuggling.\n\nMCP ROUTING TRIGGERS: Stateless Architecture, Zero-Trust Network Access, HTTP Request Smuggling Prevention, JSON-RPC Egress, Out-of-Band Socket",
       "properties": {
-        "headers": {
-          "additionalProperties": {
-            "maxLength": 2000,
-            "type": "string"
-          },
-          "description": "HTTP headers, strictly bounded for zero-trust credentials.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Headers",
-          "type": "object"
-        },
         "topology_class": {
           "const": "http",
           "default": "http",
@@ -9121,6 +9109,18 @@
           "minLength": 1,
           "title": "Uri",
           "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "description": "HTTP headers, strictly bounded for zero-trust credentials.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Headers",
+          "type": "object"
         }
       },
       "required": [
@@ -9145,18 +9145,18 @@
           "title": "Enclave Class",
           "type": "string"
         },
-        "hardware_signature_blob": {
-          "description": "The base64-encoded hardware quote signed by the silicon manufacturer's master private key.",
-          "maxLength": 8192,
-          "title": "Hardware Signature Blob",
-          "type": "string"
-        },
         "platform_measurement_hash": {
           "description": "The cryptographic hash of the Platform Configuration Registers (PCRs) proving the memory state was physically isolated.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-f0-9]{64}$",
           "title": "Platform Measurement Hash",
+          "type": "string"
+        },
+        "hardware_signature_blob": {
+          "description": "The base64-encoded hardware quote signed by the silicon manufacturer's master private key.",
+          "maxLength": 8192,
+          "title": "Hardware Signature Blob",
           "type": "string"
         }
       },
@@ -9179,15 +9179,6 @@
           "title": "Capability Id",
           "type": "string"
         },
-        "postconditions": {
-          "description": "The strictly bounded array of subsequent LiquidTypeContracts representing the Q state geometry.",
-          "items": {
-            "$ref": "#/$defs/LiquidTypeContract"
-          },
-          "minItems": 1,
-          "title": "Postconditions",
-          "type": "array"
-        },
         "preconditions": {
           "description": "The strictly bounded array of foundational LiquidTypeContracts representing the P state geometry.",
           "items": {
@@ -9195,6 +9186,15 @@
           },
           "minItems": 1,
           "title": "Preconditions",
+          "type": "array"
+        },
+        "postconditions": {
+          "description": "The strictly bounded array of subsequent LiquidTypeContracts representing the Q state geometry.",
+          "items": {
+            "$ref": "#/$defs/LiquidTypeContract"
+          },
+          "minItems": 1,
+          "title": "Postconditions",
           "type": "array"
         },
         "proof_system": {
@@ -9230,12 +9230,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Lattice-Based Cryptography to enable the evaluation of geometric and arithmetic operations directly on an encrypted tensor state.\n\nCAUSAL AFFORDANCE: Permits an external, untrusted orchestrator to calculate geometric distances or compute reward gradients on sensitive representations without exposing plaintext.\n\nEPISTEMIC BOUNDS: The encryption dialect is rigidly locked to the `fhe_scheme` Literal automaton `[\"ckks\", \"bgv\", \"bfv\", \"tfhe\"]`. Cryptographic memory explosion is prevented by capping `ciphertext_blob` at `max_length=5000000`. `public_key_cid` is a 128-char CID.\n\nMCP ROUTING TRIGGERS: Fully Homomorphic Encryption, Lattice-Based Cryptography, CKKS Scheme, Privacy-Preserving Computation, Encrypted Tensor",
       "properties": {
-        "ciphertext_blob": {
-          "description": "The base64-encoded homomorphic ciphertext.",
-          "maxLength": 5000000,
-          "title": "Ciphertext Blob",
-          "type": "string"
-        },
         "fhe_scheme": {
           "description": "The specific homomorphic encryption dialect used to encode the ciphertext.",
           "enum": [
@@ -9254,6 +9248,12 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Public Key Cid",
           "type": "string"
+        },
+        "ciphertext_blob": {
+          "description": "The base64-encoded homomorphic ciphertext.",
+          "maxLength": 5000000,
+          "title": "Ciphertext Blob",
+          "type": "string"
         }
       },
       "required": [
@@ -9268,12 +9268,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Translates unstructured human goals into the deterministic physics required to trigger the Agentic Forge.\n\nCAUSAL AFFORDANCE: Maps an unstructured human objective to a dense VectorEmbeddingState target, initiating capability generation.\n\nEPISTEMIC BOUNDS: `allocated_budget_magnitude` is strictly bounded between 1 and 1,000,000,000 to lock escrow. Discriminator locked to `Literal[\"human_directive\"]`.\n\nMCP ROUTING TRIGGERS: Human-in-the-Loop, Intent Translation, Agentic Forge, Objective Setting, Budget Allocation",
       "properties": {
-        "allocated_budget_magnitude": {
-          "description": "The absolute thermodynamic token budget the human is locking in escrow.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Allocated Budget Magnitude",
-          "type": "integer"
+        "topology_class": {
+          "const": "human_directive",
+          "default": "human_directive",
+          "description": "Discriminator type for a human directive.",
+          "title": "Topology Class",
+          "type": "string"
         },
         "natural_language_goal": {
           "description": "The raw, unstructured human objective.",
@@ -9281,16 +9281,16 @@
           "title": "Natural Language Goal",
           "type": "string"
         },
+        "allocated_budget_magnitude": {
+          "description": "The absolute thermodynamic token budget the human is locking in escrow.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Allocated Budget Magnitude",
+          "type": "integer"
+        },
         "target_qos": {
           "$ref": "#/$defs/QoSClassificationProfile",
           "description": "The priority classification for Spot Market compute routing."
-        },
-        "topology_class": {
-          "const": "human_directive",
-          "default": "human_directive",
-          "description": "Discriminator type for a human directive.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -9305,54 +9305,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Instantiates an abductive reasoning branch governed by Popperian Falsification and Bayesian updating on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Commits a formalized causal premise into the EpistemicLedgerState, unlocking the orchestration of empirical testing via active inference to falsify or verify the embedded causal model.\n\nEPISTEMIC BOUNDS: `bayesian_prior` is clamped `[ge=0.0, le=1.0]`. Identity is cryptographically locked via `hypothesis_id` (128-char CID). `falsification_conditions` deterministically sorted by `@model_validator`.\n\nMCP ROUTING TRIGGERS: Abductive Reasoning, Popperian Falsification, Bayesian Prior, Causal Hypothesis, Epistemic Commitment",
       "properties": {
-        "bayesian_prior": {
-          "description": "The agent's initial probabilistic belief in this hypothesis before testing.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Bayesian Prior",
-          "type": "number"
-        },
-        "causal_model": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StructuralCausalGraphProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The formal DAG representing the agent's structural assumptions about the environment."
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
-          "type": "string"
-        },
-        "falsification_conditions": {
-          "description": "The strict array of strict conditions that the orchestrator must test to attempt to disprove this premise.",
-          "items": {
-            "$ref": "#/$defs/FalsificationContract"
-          },
-          "minItems": 1,
-          "title": "Falsification Conditions",
-          "type": "array"
-        },
-        "hypothesis_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this abductive leap to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Hypothesis Id",
-          "type": "string"
-        },
-        "premise_text": {
-          "description": "The natural language explanation of the abductive theory.",
-          "maxLength": 2000,
-          "title": "Premise Text",
           "type": "string"
         },
         "prior_event_hash": {
@@ -9371,17 +9329,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "status": {
-          "default": "active",
-          "description": "The current validity state of this hypothesis in the EpistemicLedgerState.",
-          "enum": [
-            "active",
-            "falsified",
-            "verified"
-          ],
-          "title": "Status",
-          "type": "string"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -9395,6 +9342,59 @@
           "description": "Discriminator for a hypothesis generation event.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "hypothesis_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this abductive leap to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Hypothesis Id",
+          "type": "string"
+        },
+        "premise_text": {
+          "description": "The natural language explanation of the abductive theory.",
+          "maxLength": 2000,
+          "title": "Premise Text",
+          "type": "string"
+        },
+        "bayesian_prior": {
+          "description": "The agent's initial probabilistic belief in this hypothesis before testing.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Bayesian Prior",
+          "type": "number"
+        },
+        "falsification_conditions": {
+          "description": "The strict array of strict conditions that the orchestrator must test to attempt to disprove this premise.",
+          "items": {
+            "$ref": "#/$defs/FalsificationContract"
+          },
+          "minItems": 1,
+          "title": "Falsification Conditions",
+          "type": "array"
+        },
+        "status": {
+          "default": "active",
+          "description": "The current validity state of this hypothesis in the EpistemicLedgerState.",
+          "enum": [
+            "active",
+            "falsified",
+            "verified"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "causal_model": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StructuralCausalGraphProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The formal DAG representing the agent's structural assumptions about the environment."
         }
       },
       "required": [
@@ -9420,12 +9420,13 @@
           "title": "Agent Cid",
           "type": "string"
         },
-        "implied_probability": {
-          "description": "The agent's calculated internal confidence score.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Implied Probability",
-          "type": "number"
+        "target_hypothesis_id": {
+          "description": "The exact HypothesisGenerationEvent the agent is betting on.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Hypothesis Id",
+          "type": "string"
         },
         "staked_magnitude": {
           "description": "The volume of compute budget committed to this position.",
@@ -9434,13 +9435,12 @@
           "title": "Staked Magnitude",
           "type": "integer"
         },
-        "target_hypothesis_id": {
-          "description": "The exact HypothesisGenerationEvent the agent is betting on.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Hypothesis Id",
-          "type": "string"
+        "implied_probability": {
+          "description": "The agent's calculated internal confidence score.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Implied Probability",
+          "type": "number"
         }
       },
       "required": [
@@ -9456,20 +9456,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the macroscopic Payload Loss Prevention (PLP) and\nLattice-Based Information Flow Control (IFC) bounds across the entire execution graph.\nAs a ...Policy suffix, this object defines rigid mathematical boundaries that the\norchestrator must enforce globally.\n\nCAUSAL AFFORDANCE: Projects a unified defensive mesh that aggregates RedactionPolicy\nrules, an optional SemanticFirewallPolicy intercept, and tensor-level SaeLatentPolicy\nfirewalls to comprehensively sanitize all graph edges. The active toggle controls\nwhether enforcement is live.\n\nEPISTEMIC BOUNDS: Ensures absolute deterministic evaluation by utilizing a\n@model_validator to physically sort the rules array by rule_cid and the latent_firewalls\narray by target_feature_index, guaranteeing an invariant Merkle root.\n\nMCP ROUTING TRIGGERS: Information Flow Control, Payload Loss Prevention, Lattice-Based\nSecurity, Biba Integrity Model, Defense-in-Depth",
       "properties": {
-        "active": {
-          "default": true,
-          "description": "Whether this policy is currently enforcing data sanitization.",
-          "title": "Active",
-          "type": "boolean"
-        },
-        "latent_firewalls": {
-          "description": "The strict array of tensor-level mechanistic firewalls monitoring the forward pass for adversarial intent.",
-          "items": {
-            "$ref": "#/$defs/SaeLatentPolicy"
-          },
-          "title": "Latent Firewalls",
-          "type": "array"
-        },
         "policy_cid": {
           "description": "Unique identifier for this macroscopic flow control policy.",
           "maxLength": 128,
@@ -9477,6 +9463,12 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Policy Cid",
           "type": "string"
+        },
+        "active": {
+          "default": true,
+          "description": "Whether this policy is currently enforcing data sanitization.",
+          "title": "Active",
+          "type": "boolean"
         },
         "rules": {
           "description": "The array of sanitization rules to enforce.",
@@ -9497,6 +9489,14 @@
           ],
           "default": null,
           "description": "The active cognitive defense perimeter against adversarial control-flow overrides."
+        },
+        "latent_firewalls": {
+          "description": "The strict array of tensor-level mechanistic firewalls monitoring the forward pass for adversarial intent.",
+          "items": {
+            "$ref": "#/$defs/SaeLatentPolicy"
+          },
+          "title": "Latent Firewalls",
+          "type": "array"
         }
       },
       "required": [
@@ -9509,16 +9509,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a covariant Functor (Category Theory) mapping\nhigher-order topological state dimensions into an encapsulated subgraph's\nlocalized working memory. As a ...Contract suffix, this enforces rigid\nmathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's state projection engine to\nsafely inject parent variables into a CompositeNodeProfile without violating\nscope isolation or referential transparency.\n\nEPISTEMIC BOUNDS: The geometric projection vectors parent_key and child_key\nare strictly clamped to max_length=2000, mathematically severing the\ncapability for String Exhaustion Attacks and Path Traversal vulnerabilities\nduring AST resolution.\n\nMCP ROUTING TRIGGERS: Category Theory, Covariant Functor, Scope Isolation,\nState Projection, Bijective Mapping",
       "properties": {
-        "child_key": {
-          "description": "The mapped key in the nested topology's state contract.",
-          "maxLength": 2000,
-          "title": "Child Key",
-          "type": "string"
-        },
         "parent_key": {
           "description": "The key in the parent's shared state contract.",
           "maxLength": 2000,
           "title": "Parent Key",
+          "type": "string"
+        },
+        "child_key": {
+          "description": "The mapped key in the nested topology's state contract.",
+          "maxLength": 2000,
+          "title": "Child Key",
           "type": "string"
         }
       },
@@ -9533,6 +9533,33 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative bounding box for rendering condensed semantic summaries (Information Bottleneck compression) into human-readable 2D space.\n\nCAUSAL AFFORDANCE: Projects Markdown-formatted text onto the UI plane while serving as a structural honeypot against Polyglot XSS and Markdown execution injection attacks.\n\nEPISTEMIC BOUNDS: Physically restricts payload size to `max_length=100000` on `markdown_content`. Two distinct `@field_validator` hooks mathematically strip HTML event handlers and malicious URI schemes, ensuring zero-trust projection.\n\nMCP ROUTING TRIGGERS: Information Bottleneck, Semantic Compression, XSS Sanitization, Markdown Projection, Zero-Trust UI",
       "properties": {
+        "panel_cid": {
+          "description": "The unique identifier for this UI panel.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Panel Cid",
+          "type": "string"
+        },
+        "topology_class": {
+          "const": "insight_card",
+          "default": "insight_card",
+          "description": "Discriminator for markdown insight cards.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "title": {
+          "description": "The declarative semantic anchor summarizing the underlying matrix or markdown projection.",
+          "maxLength": 2000,
+          "title": "Title",
+          "type": "string"
+        },
+        "markdown_content": {
+          "description": "The markdown formatted text content.",
+          "maxLength": 100000,
+          "title": "Markdown Content",
+          "type": "string"
+        },
         "billboard_physics": {
           "anyOf": [
             {
@@ -9544,33 +9571,6 @@
           ],
           "default": null,
           "description": "The kinematic constraint anchoring this 2D card to the 3D topology."
-        },
-        "markdown_content": {
-          "description": "The markdown formatted text content.",
-          "maxLength": 100000,
-          "title": "Markdown Content",
-          "type": "string"
-        },
-        "panel_cid": {
-          "description": "The unique identifier for this UI panel.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Panel Cid",
-          "type": "string"
-        },
-        "title": {
-          "description": "The declarative semantic anchor summarizing the underlying matrix or markdown projection.",
-          "maxLength": 2000,
-          "title": "Title",
-          "type": "string"
-        },
-        "topology_class": {
-          "const": "insight_card",
-          "default": "insight_card",
-          "description": "Discriminator for markdown insight cards.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -9585,19 +9585,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the non-monotonic\ncollapse of a high-entropy human natural language string into a discrete, mathematically\nbounded routing heuristic. As a ...Receipt suffix, this is an append-only Merkle-DAG coordinate.\n\nCAUSAL AFFORDANCE: Commits the LLM's Softmax classification verdict to the Epistemic Ledger,\nauthorizing the TaxonomicRoutingPolicy or router gate to physically execute the targeted\ntopology or sub-agent.\n\nEPISTEMIC BOUNDS: The raw_input_string is physically clamped (max_length=100000) to prevent\ncontext window buffer overflows. The classification confidence is strictly bound to a\nnormalized float (ge=0.0, le=1.0).\n\nMCP ROUTING TRIGGERS: Intent Classification, Softmax Gating, High-Entropy Parsing,\nRouting Heuristic, Semantic Wave Collapse",
       "properties": {
-        "classified_intent": {
-          "description": "The discrete, structurally bounded capability or heuristic mapped by the LLM.",
-          "maxLength": 255,
-          "title": "Classified Intent",
-          "type": "string"
-        },
-        "confidence_score": {
-          "description": "The probabilistic certainty of the classification.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Confidence Score",
-          "type": "number"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -9622,11 +9609,38 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "topology_class": {
+          "const": "intent_classification",
+          "default": "intent_classification",
+          "description": "Discriminator type for an intent classification receipt.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "raw_input_string": {
           "description": "The raw, unparsed human natural language instruction.",
           "maxLength": 100000,
           "title": "Raw Input String",
           "type": "string"
+        },
+        "classified_intent": {
+          "description": "The discrete, structurally bounded capability or heuristic mapped by the LLM.",
+          "maxLength": 255,
+          "title": "Classified Intent",
+          "type": "string"
+        },
+        "confidence_score": {
+          "description": "The probabilistic certainty of the classification.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Score",
+          "type": "number"
         },
         "routing_policy_id": {
           "anyOf": [
@@ -9643,20 +9657,6 @@
           "default": null,
           "description": "The TaxonomicRoutingPolicy CID that governed this classification.",
           "title": "Routing Policy Id"
-        },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "topology_class": {
-          "const": "intent_classification",
-          "default": "intent_classification",
-          "description": "Discriminator type for an intent classification receipt.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -9673,6 +9673,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Zero-Cost Macro-Topology that translates unstructured, high-entropy human multimodal input into a mathematically verified, zero-entropy HumanDirectiveIntent.\n\nCAUSAL AFFORDANCE: Unrolls a cyclic Directed Graph that orchestrates Multimodal Transmutation, Metacognitive Scanning (Shannon Entropy measurement), and Schema-on-Write Drafting (Human Interrogation) before yielding to the Agentic Forge.\n\nEPISTEMIC BOUNDS: The max_clarification_loops physical Halting Problem guillotine is mathematically clamped between 1 and 50 to prevent infinite clarification loops.\n\nMCP ROUTING TRIGGERS: Intent Elicitation, Zero-Entropy Distillation, Cyclical Routing, Human Interrogation, Multimodal Transmutation",
       "properties": {
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -9686,22 +9708,6 @@
           "default": null,
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "human_oracle_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The human UI node receiving the DraftingIntent."
         },
         "justification": {
           "anyOf": [
@@ -9717,24 +9723,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
-        "max_clarification_loops": {
-          "default": 5,
-          "description": "A physical Halting Problem guillotine preventing infinite clarification loops.",
-          "maximum": 50,
-          "minimum": 1,
-          "title": "Max Clarification Loops",
-          "type": "integer"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -9745,42 +9733,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "raw_human_artifact_cid": {
-          "description": "The anchor to the initial, unstructured MultimodalArtifactReceipt uploaded by the human.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Raw Human Artifact Cid",
-          "type": "string"
-        },
-        "scanner_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The agent node actively running the EpistemicScanningPolicy."
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -9794,6 +9746,30 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
         "topology_class": {
           "const": "macro_elicitation",
           "default": "macro_elicitation",
@@ -9801,9 +9777,33 @@
           "title": "Topology Class",
           "type": "string"
         },
+        "raw_human_artifact_cid": {
+          "description": "The anchor to the initial, unstructured MultimodalArtifactReceipt uploaded by the human.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Raw Human Artifact Cid",
+          "type": "string"
+        },
         "transmuter_node_cid": {
           "$ref": "#/$defs/NodeCIDState",
           "description": "The system node responsible for executing the EpistemicTransmutationTask."
+        },
+        "scanner_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The agent node actively running the EpistemicScanningPolicy."
+        },
+        "human_oracle_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The human UI node receiving the DraftingIntent."
+        },
+        "max_clarification_loops": {
+          "default": 5,
+          "description": "A physical Halting Problem guillotine preventing infinite clarification loops.",
+          "maximum": 50,
+          "minimum": 1,
+          "title": "Max Clarification Loops",
+          "type": "integer"
         }
       },
       "required": [
@@ -9820,42 +9820,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Supervisory Control Theory (Ramadge & Wonham) for Discrete-Event Systems, acting as a formal Mixed-Initiative Control mechanism.\n\nCAUSAL AFFORDANCE: Physically halts the active Directed Acyclic Graph (DAG) traversal or Petri Net reachability loop, preventing the swarm from committing a state transition until an explicit, authorized Pearlian intervention is negotiated by the human supervisor.\n\nEPISTEMIC BOUNDS: Execution suspension is rigorously bounded by the temporal logic of the `adjudication_deadline` (a float representing a UNIX timestamp) and the attached FallbackSLA. The `proposed_action` schema is clamped against deep recursion constraints.\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, Mixed-Initiative System, Discrete-Event System, Bounded Delay, Pearlian Intervention",
       "properties": {
-        "adjudication_deadline": {
-          "description": "The deadline for adjudication, represented as a UNIX timestamp.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Adjudication Deadline",
-          "type": "number"
-        },
-        "context_summary": {
-          "description": "A summary of the context requiring intervention.",
-          "maxLength": 2000,
-          "title": "Context Summary",
+        "topology_class": {
+          "const": "request",
+          "default": "request",
+          "description": "The type of the intervention payload.",
+          "title": "Topology Class",
           "type": "string"
-        },
-        "failure_context": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TerminalCognitiveFailure"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Packages the exact contextual state at the moment of computational failure."
-        },
-        "fallback_sla": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/FallbackSLA"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SLA constraints on the intervention delay."
         },
         "intervention_scope": {
           "anyOf": [
@@ -9869,6 +9839,28 @@
           "default": null,
           "description": "The scope constraints bounding the intervention."
         },
+        "fallback_sla": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/FallbackSLA"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The SLA constraints on the intervention delay."
+        },
+        "target_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The deterministic capability pointer representing the target node."
+        },
+        "context_summary": {
+          "description": "A summary of the context requiring intervention.",
+          "maxLength": 2000,
+          "title": "Context Summary",
+          "type": "string"
+        },
         "proposed_action": {
           "additionalProperties": {
             "$ref": "#/$defs/JsonPrimitiveState"
@@ -9881,16 +9873,24 @@
           "title": "Proposed Action",
           "type": "object"
         },
-        "target_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The deterministic capability pointer representing the target node."
+        "adjudication_deadline": {
+          "description": "The deadline for adjudication, represented as a UNIX timestamp.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Adjudication Deadline",
+          "type": "number"
         },
-        "topology_class": {
-          "const": "request",
-          "default": "request",
-          "description": "The type of the intervention payload.",
-          "title": "Topology Class",
-          "type": "string"
+        "failure_context": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TerminalCognitiveFailure"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Packages the exact contextual state at the moment of computational failure."
         }
       },
       "required": [
@@ -9906,6 +9906,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Executes Supervisory Control Theory by embedding\ndeterministic execution hooks (transitions) into the swarm's Petri Net\nlifecycle graph. As a ...Policy suffix, this defines rigid mathematical\nboundaries.\n\nCAUSAL AFFORDANCE: Physically halts the autonomous execution loop (if blocking\nis True, default=True) at the exact topological trigger coordinate\n(LifecycleTriggerEvent), forcing the orchestrator to await an external\nInterventionReceipt before proceeding.\n\nEPISTEMIC BOUNDS: The interruption locus is rigidly confined to the\nLifecycleTriggerEvent literal automaton. The structural mutation permissions\nduring the pause are strictly governed by the optional scope\n(BoundedInterventionScopePolicy | None, default=None).\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, Petri Net Transition,\nLifecycle Hook, Execution Halting, Mixed-Initiative Interaction",
       "properties": {
+        "trigger": {
+          "$ref": "#/$defs/LifecycleTriggerEvent",
+          "description": "The exact topological lifecycle event that triggers this intervention."
+        },
+        "scope": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/BoundedInterventionScopePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The strictly typed boundaries for what the human/oversight system is allowed to mutate during this pause."
+        },
+        "blocking": {
+          "default": true,
+          "description": "If True, the graph execution halts until a verdict is rendered. If False, it is an async observation.",
+          "title": "Blocking",
+          "type": "boolean"
+        },
         "async_observation_port": {
           "anyOf": [
             {
@@ -9922,33 +9944,11 @@
           "description": "The endpoint for emitting non-blocking shadow telemetry.",
           "title": "Async Observation Port"
         },
-        "blocking": {
-          "default": true,
-          "description": "If True, the graph execution halts until a verdict is rendered. If False, it is an async observation.",
-          "title": "Blocking",
-          "type": "boolean"
-        },
         "emit_telemetry_on_revision": {
           "default": false,
           "description": "The toggle to enable shadow monitoring on revision loops.",
           "title": "Emit Telemetry On Revision",
           "type": "boolean"
-        },
-        "scope": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/BoundedInterventionScopePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The strictly typed boundaries for what the human/oversight system is allowed to mutate during this pause."
-        },
-        "trigger": {
-          "$ref": "#/$defs/LifecycleTriggerEvent",
-          "description": "The exact topological lifecycle event that triggers this intervention."
         }
       },
       "required": [
@@ -9961,22 +9961,29 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: InterventionReceipt is a cryptographically frozen historical fact representing\nthe resolution of a Mixed-Initiative pause. It acts as the mathematical key that unlocks a suspended\nstate partition.\n\nCAUSAL AFFORDANCE: Collapses the halted superposition of the DAG, physically re-activating the\nexecution thread and authorizing the orchestrator to commit the human-approved state mutation to\nthe Epistemic Ledger.\n\nEPISTEMIC BOUNDS: Mathematically locked against Replay Attacks via the intervention_request_cid\n(a UUID cryptographic nonce). The @model_validator physically guarantees that if a WetwareAttestationContract\nis present, its internal DAG node nonce must perfectly match the request ID, preventing signature laundering,\nand mathematically linking the human's signature to the liveness_challenge_hash challenge.\n\nMCP ROUTING TRIGGERS: Cryptographic Nonce, State Resumption, Replay Attack Prevention, Wetware Attestation, Liveness Resolution",
       "properties": {
+        "topology_class": {
+          "const": "verdict",
+          "default": "verdict",
+          "description": "The type of the intervention payload.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "intervention_request_cid": {
+          "description": "The cryptographic nonce uniquely identifying the intervention request.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Intervention Request Cid",
+          "type": "string"
+        },
+        "target_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The deterministic capability pointer representing the target node."
+        },
         "approved": {
           "description": "Indicates whether the proposed action was approved.",
           "title": "Approved",
           "type": "boolean"
-        },
-        "attestation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/WetwareAttestationContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic proof provided by the human operator, if required."
         },
         "feedback": {
           "anyOf": [
@@ -9991,24 +9998,17 @@
           "description": "Optional feedback provided along with the verdict.",
           "title": "Feedback"
         },
-        "intervention_request_cid": {
-          "description": "The cryptographic nonce uniquely identifying the intervention request.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Intervention Request Cid",
-          "type": "string"
-        },
-        "target_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The deterministic capability pointer representing the target node."
-        },
-        "topology_class": {
-          "const": "verdict",
-          "default": "verdict",
-          "description": "The type of the intervention payload.",
-          "title": "Topology Class",
-          "type": "string"
+        "attestation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/WetwareAttestationContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic proof provided by the human operator, if required."
         }
       },
       "required": [
@@ -10024,30 +10024,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a formal Pearlian Do-Operator (P(y|do(X=x))) intervention, forcefully severing a variable from its historical back-door causal mechanisms to prove direct causal influence.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to physically mutate the intervention_variable to the do_operator_state, breaking confounding structural edges in the directed acyclic graph.\n\nEPISTEMIC BOUNDS: The physical mutation is economically capped by execution_cost_budget_magnitude (le=1000000000), and its justification is strictly quantified by expected_causal_information_gain (bounded mathematically between 0.0 and 1.0).\n\nMCP ROUTING TRIGGERS: Pearlian Do-Calculus, Structural Causal Models, Causal Intervention, Confounder Ablation, Back-door Criterion",
       "properties": {
-        "do_operator_state": {
-          "description": "The exact value or condition forced upon the intervention_variable, isolating it from its historical causes.",
-          "maxLength": 2000,
-          "title": "Do Operator State",
-          "type": "string"
-        },
-        "execution_cost_budget_magnitude": {
-          "description": "The maximum economic expenditure authorized to run this specific causal intervention.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Execution Cost Budget Magnitude",
-          "type": "integer"
-        },
-        "expected_causal_information_gain": {
-          "description": "The mathematical proof of entropy reduction yielded specifically by breaking the confounding back-doors.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Expected Causal Information Gain",
-          "type": "number"
-        },
-        "intervention_variable": {
-          "description": "The specific node $X$ in the SCM the agent is forcing to a specific state.",
-          "maxLength": 2000,
-          "title": "Intervention Variable",
+        "task_cid": {
+          "description": "Unique identifier for this causal intervention.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Cid",
           "type": "string"
         },
         "target_hypothesis_id": {
@@ -10058,13 +10040,31 @@
           "title": "Target Hypothesis Id",
           "type": "string"
         },
-        "task_cid": {
-          "description": "Unique identifier for this causal intervention.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Cid",
+        "intervention_variable": {
+          "description": "The specific node $X$ in the SCM the agent is forcing to a specific state.",
+          "maxLength": 2000,
+          "title": "Intervention Variable",
           "type": "string"
+        },
+        "do_operator_state": {
+          "description": "The exact value or condition forced upon the intervention_variable, isolating it from its historical causes.",
+          "maxLength": 2000,
+          "title": "Do Operator State",
+          "type": "string"
+        },
+        "expected_causal_information_gain": {
+          "description": "The mathematical proof of entropy reduction yielded specifically by breaking the confounding back-doors.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Expected Causal Information Gain",
+          "type": "number"
+        },
+        "execution_cost_budget_magnitude": {
+          "description": "The maximum economic expenditure authorized to run this specific causal intervention.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Execution Cost Budget Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -10082,6 +10082,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The definitive top-level envelope for transmitting a\nJSONRPCErrorState across a Zero-Trust Architecture boundary. As a ...State suffix,\nthis is a frozen N-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Concludes a failed Distributed RPC call via the error\n(JSONRPCErrorState) typed reference, forcing the orchestrator to sever the current\nexecution tree and apply necessary truth maintenance.\n\nEPISTEMIC BOUNDS: The jsonrpc field is a rigid Literal[\"2.0\"] automaton. The id is\ntopologically locked to a 128-char CID regex or an integer (le=1000000000) or None.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Distributed RPC, Execution Severing,\nTruth Maintenance, Fault Envelope",
       "properties": {
+        "jsonrpc": {
+          "const": "2.0",
+          "description": "JSON-RPC version.",
+          "title": "Jsonrpc",
+          "type": "string"
+        },
         "error": {
           "$ref": "#/$defs/JSONRPCErrorState",
           "description": "The error object."
@@ -10109,12 +10115,6 @@
           "default": null,
           "description": "The request ID that this error corresponds to.",
           "title": "Id"
-        },
-        "jsonrpc": {
-          "const": "2.0",
-          "description": "JSON-RPC version.",
-          "title": "Jsonrpc",
-          "type": "string"
         }
       },
       "required": [
@@ -10134,6 +10134,12 @@
           "title": "Code",
           "type": "integer"
         },
+        "message": {
+          "description": "The strict semantic fault boundary explaining the structural or execution collapse.",
+          "maxLength": 2000,
+          "title": "Message",
+          "type": "string"
+        },
         "data": {
           "anyOf": [
             {
@@ -10145,12 +10151,6 @@
           ],
           "default": null,
           "description": "A Primitive or Structured value that contains additional information about the error. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion."
-        },
-        "message": {
-          "description": "The strict semantic fault boundary explaining the structural or execution collapse.",
-          "maxLength": 2000,
-          "title": "Message",
-          "type": "string"
         }
       },
       "required": [
@@ -10199,6 +10199,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a zero-allocation, high-velocity telemetry manifold designed exclusively for continuous thermodynamic state updates across the Markov Blanket.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to transmit continuous SE(3) coordinates and optic states as flattened contiguous memory blocks (Struct of Arrays), mechanically bypassing recursive Garbage Collection (GC) pauses in external clients.\n\nEPISTEMIC BOUNDS: The state differential is mathematically restricted to a strict 16-element tuple mapping (position, rotation, scale, opacity, velocity). The `deltas` array is deterministically sorted by `node_cid` to preserve RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Zero-Allocation Telemetry, Struct of Arrays, High-Velocity Buffer, SE3 Delta, Kinematic Stream",
       "properties": {
+        "stream_cid": {
+          "description": "A Content Identifier (CID) anchoring the continuous telemetry stream.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Stream Cid",
+          "type": "string"
+        },
         "deltas": {
           "description": "The strictly typed contiguous memory block of 16-element kinematic tuples, embedding first-order temporal derivatives for continuous Hermite Spline interpolation.",
           "items": {
@@ -10259,14 +10267,6 @@
           },
           "title": "Deltas",
           "type": "array"
-        },
-        "stream_cid": {
-          "description": "A Content Identifier (CID) anchoring the continuous telemetry stream.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Stream Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -10280,8 +10280,8 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics\nCAUSAL AFFORDANCE: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics\nEPISTEMIC BOUNDS: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics\nMCP ROUTING TRIGGERS: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics",
       "properties": {
-        "angular_acceleration": {
-          "description": "The 3D rotational acceleration vector.",
+        "linear_velocity": {
+          "description": "The 3D Euclidean velocity vector.",
           "maxItems": 3,
           "minItems": 3,
           "prefixItems": [
@@ -10295,7 +10295,7 @@
               "type": "number"
             }
           ],
-          "title": "Angular Acceleration",
+          "title": "Linear Velocity",
           "type": "array"
         },
         "angular_velocity": {
@@ -10334,8 +10334,8 @@
           "title": "Linear Acceleration",
           "type": "array"
         },
-        "linear_velocity": {
-          "description": "The 3D Euclidean velocity vector.",
+        "angular_acceleration": {
+          "description": "The 3D rotational acceleration vector.",
           "maxItems": 3,
           "minItems": 3,
           "prefixItems": [
@@ -10349,7 +10349,7 @@
               "type": "number"
             }
           ],
-          "title": "Linear Velocity",
+          "title": "Angular Acceleration",
           "type": "array"
         }
       },
@@ -10364,23 +10364,8 @@
     },
     "KinematicNoiseProfile": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Stochastic Process Theory (1/f^\u03b2 spectral noise)\nand Hick-Hyman Law cognitive delay modeling to inject human-like motor control\nperturbations into pointer trajectories, preventing deterministic bot-detection\nvia timing analysis. As a ...Profile suffix, this is a declarative, frozen\nsnapshot of a noise geometry.\n\nCAUSAL AFFORDANCE: Authorizes the Spatial Kinematics engine to perturb each\nSE3TransformProfile along the Bezier trajectory by sampling from the\nspecified noise distribution, achieving biomechanically plausible jitter with\ncognitive delay and corrective submovements.\n\nEPISTEMIC BOUNDS: The pink_noise_amplitude is strictly clamped to the\nnormalized range (ge=0.0, le=1.0), preventing trajectory corruption. The\nfrequency_exponent (1/f^\u03b2) is bounded (ge=0.0, le=5.0) to cover the full\nspectrum from white noise (\u03b2=0) to black noise (\u03b2\u22652). The noise_class Literal\nautomaton locks generation to [\"pink\", \"brownian\", \"gaussian\"]. The\nvelocity_profile is locked to [\"minimum_jerk\", \"constant\",\n\"fractional_brownian\"]. target_overshoot_radius_pixels is bounded (ge=0,\nle=5000) and hick_hyman_dwell_time_ms is bounded (ge=0, le=86400000).\n\nMCP ROUTING TRIGGERS: Stochastic Process, Pink Noise, Brownian Motion,\nMotor Control Perturbation, Hick-Hyman Law, Fitts's Law",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Stochastic Process Theory (1/f^β spectral noise)\nand Hick-Hyman Law cognitive delay modeling to inject human-like motor control\nperturbations into pointer trajectories, preventing deterministic bot-detection\nvia timing analysis. As a ...Profile suffix, this is a declarative, frozen\nsnapshot of a noise geometry.\n\nCAUSAL AFFORDANCE: Authorizes the Spatial Kinematics engine to perturb each\nSE3TransformProfile along the Bezier trajectory by sampling from the\nspecified noise distribution, achieving biomechanically plausible jitter with\ncognitive delay and corrective submovements.\n\nEPISTEMIC BOUNDS: The pink_noise_amplitude is strictly clamped to the\nnormalized range (ge=0.0, le=1.0), preventing trajectory corruption. The\nfrequency_exponent (1/f^β) is bounded (ge=0.0, le=5.0) to cover the full\nspectrum from white noise (β=0) to black noise (β≥2). The noise_class Literal\nautomaton locks generation to [\"pink\", \"brownian\", \"gaussian\"]. The\nvelocity_profile is locked to [\"minimum_jerk\", \"constant\",\n\"fractional_brownian\"]. target_overshoot_radius_pixels is bounded (ge=0,\nle=5000) and hick_hyman_dwell_time_ms is bounded (ge=0, le=86400000).\n\nMCP ROUTING TRIGGERS: Stochastic Process, Pink Noise, Brownian Motion,\nMotor Control Perturbation, Hick-Hyman Law, Fitts's Law",
       "properties": {
-        "frequency_exponent": {
-          "description": "The spectral exponent \u03b2 in the 1/f^\u03b2 power spectral density function governing noise color.",
-          "maximum": 5.0,
-          "minimum": 0.0,
-          "title": "Frequency Exponent",
-          "type": "number"
-        },
-        "hick_hyman_dwell_time_ms": {
-          "default": 0,
-          "description": "Cognitive choice reaction delay in milliseconds, modeled via Hick-Hyman Law.",
-          "maximum": 86400000,
-          "minimum": 0,
-          "title": "Hick Hyman Dwell Time Ms",
-          "type": "integer"
-        },
         "noise_class": {
           "description": "The stochastic process governing the noise generation for pointer trajectory perturbation.",
           "enum": [
@@ -10390,21 +10375,6 @@
           ],
           "title": "Noise Class",
           "type": "string"
-        },
-        "pink_noise_amplitude": {
-          "description": "The normalized amplitude of the 1/f noise injected into the pointer trajectory. Bounded [0.0, 1.0].",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Pink Noise Amplitude",
-          "type": "number"
-        },
-        "target_overshoot_radius_pixels": {
-          "default": 0,
-          "description": "The Euclidean radius in pixels for corrective submovements overshooting the target coordinate.",
-          "maximum": 5000,
-          "minimum": 0,
-          "title": "Target Overshoot Radius Pixels",
-          "type": "integer"
         },
         "velocity_profile": {
           "default": "minimum_jerk",
@@ -10416,6 +10386,36 @@
           ],
           "title": "Velocity Profile",
           "type": "string"
+        },
+        "pink_noise_amplitude": {
+          "description": "The normalized amplitude of the 1/f noise injected into the pointer trajectory. Bounded [0.0, 1.0].",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Pink Noise Amplitude",
+          "type": "number"
+        },
+        "frequency_exponent": {
+          "description": "The spectral exponent β in the 1/f^β power spectral density function governing noise color.",
+          "maximum": 5.0,
+          "minimum": 0.0,
+          "title": "Frequency Exponent",
+          "type": "number"
+        },
+        "target_overshoot_radius_pixels": {
+          "default": 0,
+          "description": "The Euclidean radius in pixels for corrective submovements overshooting the target coordinate.",
+          "maximum": 5000,
+          "minimum": 0,
+          "title": "Target Overshoot Radius Pixels",
+          "type": "integer"
+        },
+        "hick_hyman_dwell_time_ms": {
+          "default": 0,
+          "description": "Cognitive choice reaction delay in milliseconds, modeled via Hick-Hyman Law.",
+          "maximum": 86400000,
+          "minimum": 0,
+          "title": "Hick Hyman Dwell Time Ms",
+          "type": "integer"
         }
       },
       "required": [
@@ -10430,13 +10430,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Optimal Stopping Theory and Simulated Annealing to mechanistically manage the Exploration-Exploitation dilemma during Test-Time Compute.\n\nCAUSAL AFFORDANCE: Forces probability wave collapse by dynamically throttling the sampling temperature toward the `dynamic_temperature_asymptote` and physically halting lateral ThoughtBranch generation when the `forced_exploitation_threshold_ms` is breached.\n\nEPISTEMIC BOUNDS: The `dynamic_temperature_asymptote` is physically clamped to `le=2.0`. In Softmax thermodynamics, T -> 0 forces argmax exploitation; exceeding this boundary induces uniform noise, mathematically defeating exploitation. The decay geometry is strictly confined to the `exploration_decay_curve` Literal.\n\nMCP ROUTING TRIGGERS: Optimal Stopping Theory, Simulated Annealing, Probability Wave Collapse, Exploration-Exploitation Dilemma, Kinetic Thermodynamics",
       "properties": {
-        "dynamic_temperature_asymptote": {
-          "description": "The absolute minimum sampling temperature the system must converge to during the final exploitation phase.",
-          "maximum": 2.0,
-          "minimum": 0.0,
-          "title": "Dynamic Temperature Asymptote",
-          "type": "number"
-        },
         "exploration_decay_curve": {
           "description": "The mathematical function dictating how rapidly lateral ThoughtBranches are restricted over time.",
           "enum": [
@@ -10453,6 +10446,13 @@
           "maximum": 86400000,
           "title": "Forced Exploitation Threshold Ms",
           "type": "integer"
+        },
+        "dynamic_temperature_asymptote": {
+          "description": "The absolute minimum sampling temperature the system must converge to during the final exploitation phase.",
+          "maximum": 2.0,
+          "minimum": 0.0,
+          "title": "Dynamic Temperature Asymptote",
+          "type": "number"
         }
       },
       "required": [
@@ -10467,13 +10467,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements strict Bipartite Graph Separation (Conflict Graphs) to mathematically prevent toxic capability combinations from co-existing within the same causal execution chain.\n\nCAUSAL AFFORDANCE: Forces the orchestrator to perform an intersection check across `mutually_exclusive_clusters`; if an overlap occurs, it mechanically triggers the `enforcement_action` (e.g., `halt_and_quarantine`) to sever the chain.\n\nEPISTEMIC BOUNDS: The 2D matrix of string constraints (`max_length=2000`) is rigidly sorted both internally and externally by `@model_validator` `_enforce_canonical_sort_clusters`, ensuring deterministic RFC 8785 hashing. The `enforcement_action` is clamped to a strict Literal.\n\nMCP ROUTING TRIGGERS: Bipartite Graph Separation, Toxic Capability Quarantine, Finite State Machine, Structural Interlock, Conflict Graph",
       "properties": {
-        "enforcement_action": {
-          "description": "The deterministic action the orchestrator must take if a bipartite cycle is detected.",
-          "enum": [
-            "halt_and_quarantine",
-            "sever_causal_chain"
-          ],
-          "title": "Enforcement Action",
+        "policy_cid": {
+          "description": "Unique identifier for this specific separation boundary.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Policy Cid",
           "type": "string"
         },
         "mutually_exclusive_clusters": {
@@ -10488,12 +10487,13 @@
           "title": "Mutually Exclusive Clusters",
           "type": "array"
         },
-        "policy_cid": {
-          "description": "Unique identifier for this specific separation boundary.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Policy Cid",
+        "enforcement_action": {
+          "description": "The deterministic action the orchestrator must take if a bipartite cycle is detected.",
+          "enum": [
+            "halt_and_quarantine",
+            "sever_causal_chain"
+          ],
+          "title": "Enforcement Action",
           "type": "string"
         }
       },
@@ -10509,24 +10509,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as the kinetic trigger for Maximum Inner Product Search (MIPS) and k-Nearest Neighbors (k-NN) retrieval across high-dimensional semantic manifolds.\n\nCAUSAL AFFORDANCE: Forces the orchestrator's embedding engine to dynamically hydrate the working context by fetching the `top_k_candidates` nearest to the `synthetic_target_vector`.\n\nEPISTEMIC BOUNDS: Mathematically boundary-enforced by `min_isometry_score` (`ge=-1.0, le=1.0`) to automatically prune low-relevance hallucinations before they consume context window tokens. `top_k_candidates` is strictly positive (`gt=0`).\n\nMCP ROUTING TRIGGERS: Maximum Inner Product Search, k-Nearest Neighbors, Latent Manifold Projection, Retrieval-Augmented Generation",
       "properties": {
-        "context_expansion": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ContextExpansionPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural rules governing context hydration."
-        },
-        "min_isometry_score": {
-          "description": "The minimum cosine similarity bounds for accepting a vector match.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Min Isometry Score",
-          "type": "number"
+        "topology_class": {
+          "const": "latent_projection",
+          "default": "latent_projection",
+          "description": "Discriminator for RAG projection intent.",
+          "title": "Topology Class",
+          "type": "string"
         },
         "synthetic_target_vector": {
           "$ref": "#/$defs/VectorEmbeddingState",
@@ -10537,6 +10525,13 @@
           "exclusiveMinimum": 0,
           "title": "Top K Candidates",
           "type": "integer"
+        },
+        "min_isometry_score": {
+          "description": "The minimum cosine similarity bounds for accepting a vector match.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Min Isometry Score",
+          "type": "number"
         },
         "topological_bounds": {
           "anyOf": [
@@ -10550,12 +10545,17 @@
           "default": null,
           "description": "The explicit graph traversal contract."
         },
-        "topology_class": {
-          "const": "latent_projection",
-          "default": "latent_projection",
-          "description": "Discriminator for RAG projection intent.",
-          "title": "Topology Class",
-          "type": "string"
+        "context_expansion": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ContextExpansionPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural rules governing context hydration."
         }
       },
       "required": [
@@ -10570,25 +10570,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Authorizes Abductive Reasoning on intercepted unstructured byte streams or memory heaps to probabilistically derive a deterministic StateContract.\n\nCAUSAL AFFORDANCE: Triggers the LLM's representation engineering engine to process a chaotic `target_buffer_id` and output a rigid JSON schema, bridging the gap between exogenous data and the structural Hollow Data Plane.\n\nEPISTEMIC BOUNDS: State-Space explosion is prevented by bounding `max_schema_depth` (`le=10, ge=1`) and `max_properties` (`le=1000, ge=1`) to mathematically prevent recursive JSON-bombing during schema generation. The `target_buffer_id` is locked to a 128-char CID.\n\nMCP ROUTING TRIGGERS: Schema Inference, Memory Heap Parsing, Abductive Reasoning, XHR Interception, Unstructured Transmutation",
       "properties": {
-        "max_properties": {
-          "description": "The maximum allowed keys in the deduced JSON dictionary.",
-          "maximum": 1000,
-          "minimum": 1,
-          "title": "Max Properties",
-          "type": "integer"
-        },
-        "max_schema_depth": {
-          "description": "The maximum recursive depth of the probabilistically generated schema.",
-          "maximum": 10,
-          "minimum": 1,
-          "title": "Max Schema Depth",
-          "type": "integer"
-        },
-        "require_strict_validation": {
-          "default": true,
-          "description": "If True, forces the resulting schema to set additionalProperties=False.",
-          "title": "Require Strict Validation",
-          "type": "boolean"
+        "topology_class": {
+          "const": "latent_schema_inference",
+          "default": "latent_schema_inference",
+          "description": "Discriminator for unstructured payload schema deduction.",
+          "title": "Topology Class",
+          "type": "string"
         },
         "target_buffer_id": {
           "description": "The CID pointing to the TerminalBufferState or raw intercepted byte stream.",
@@ -10598,12 +10585,25 @@
           "title": "Target Buffer Id",
           "type": "string"
         },
-        "topology_class": {
-          "const": "latent_schema_inference",
-          "default": "latent_schema_inference",
-          "description": "Discriminator for unstructured payload schema deduction.",
-          "title": "Topology Class",
-          "type": "string"
+        "max_schema_depth": {
+          "description": "The maximum recursive depth of the probabilistically generated schema.",
+          "maximum": 10,
+          "minimum": 1,
+          "title": "Max Schema Depth",
+          "type": "integer"
+        },
+        "max_properties": {
+          "description": "The maximum allowed keys in the deduced JSON dictionary.",
+          "maximum": 1000,
+          "minimum": 1,
+          "title": "Max Properties",
+          "type": "integer"
+        },
+        "require_strict_validation": {
+          "default": true,
+          "description": "If True, forces the resulting schema to set additionalProperties=False.",
+          "title": "Require Strict Validation",
+          "type": "boolean"
         }
       },
       "required": [
@@ -10618,6 +10618,22 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An append-only, cryptographically frozen coordinate representing an\nEphemeral Epistemic Quarantine used for Monte Carlo Tree Search (MCTS) or Beam Search.\nAs a ...Receipt suffix, this is an append-only coordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Isolates exploratory trajectories (ThoughtBranchState) from the\nimmutable EpistemicLedgerState, allowing the orchestrator to collapse probability waves\n(via resolution_branch_id) and prune dead-ends without causal contamination.\n\nEPISTEMIC BOUNDS: Two @model_validators enforce integrity: (1) verify_referential_\nintegrity confirms resolution_branch_id and all discarded_branches exist within\nexplored_branches; (2) sort_arrays deterministically sorts both explored_branches\n(by branch_cid) and discarded_branches for RFC 8785 Canonical Hashing.\ntotal_latent_tokens is hard-capped (ge=0, le=1000000000).\n\nMCP ROUTING TRIGGERS: Monte Carlo Tree Search, Beam Search, Epistemic Quarantine,\nProbability Wave Collapse, State-Space Exploration",
       "properties": {
+        "trace_cid": {
+          "description": "A Content Identifier (CID) bounding this ephemeral test-time execution tree.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Trace Cid",
+          "type": "string"
+        },
+        "explored_branches": {
+          "description": "All logical paths the agent attempted within this Ephemeral Epistemic Quarantine—a volatile workspace where probability waves collapse before being committed to the immutable ledger.",
+          "items": {
+            "$ref": "#/$defs/ThoughtBranchState"
+          },
+          "title": "Explored Branches",
+          "type": "array"
+        },
         "discarded_branches": {
           "description": "The strict array of Content Identifiers (CIDs) that were explicitly pruned due to logical dead-ends.",
           "items": {
@@ -10626,14 +10642,6 @@
             "type": "string"
           },
           "title": "Discarded Branches",
-          "type": "array"
-        },
-        "explored_branches": {
-          "description": "All logical paths the agent attempted within this Ephemeral Epistemic Quarantine\u2014a volatile workspace where probability waves collapse before being committed to the immutable ledger.",
-          "items": {
-            "$ref": "#/$defs/ThoughtBranchState"
-          },
-          "title": "Explored Branches",
           "type": "array"
         },
         "resolution_branch_id": {
@@ -10658,14 +10666,6 @@
           "minimum": 0,
           "title": "Total Latent Tokens",
           "type": "integer"
-        },
-        "trace_cid": {
-          "description": "A Content Identifier (CID) bounding this ephemeral test-time execution tree.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Trace Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -10691,6 +10691,13 @@
           "title": "Decay Function",
           "type": "string"
         },
+        "transition_window_tokens": {
+          "description": "The exact number of forward-pass generation steps over which the decay is applied.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Transition Window Tokens",
+          "type": "integer"
+        },
         "decay_rate_param": {
           "anyOf": [
             {
@@ -10704,13 +10711,6 @@
           "default": null,
           "description": "The optional tuning parameter (e.g., half-life lambda for exponential decay).",
           "title": "Decay Rate Param"
-        },
-        "transition_window_tokens": {
-          "description": "The exact number of forward-pass generation steps over which the decay is applied.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Transition Window Tokens",
-          "type": "integer"
         }
       },
       "required": [
@@ -10735,6 +10735,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Cryptographic Watermarking and Homomorphic MAC frameworks to mathematically seal the chain of custody against laundering, obfuscation, or Byzantine tampering on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Enforces a zero-trust execution perimeter by forcing participating agents to append their deterministic execution signatures to the `hop_signatures` matrix, verifying non-repudiation before advancing the graph.\n\nEPISTEMIC BOUNDS: The mathematical sealing mechanism is strictly constrained by the `watermark_protocol` Literal automaton `[\"merkle_dag\", \"statistical_token\", \"homomorphic_mac\"]`. The `hop_signatures` dictionary keys/values are physically bounded by StringConstraints (`max_length=255/2000`, dict `le=1000000000`) to prevent memory exhaustion during serialization.\n\nMCP ROUTING TRIGGERS: Cryptographic Watermarking, Homomorphic MAC, Byzantine Fault Detection, Zero-Trust Lineage, Chain of Custody",
       "properties": {
+        "watermark_protocol": {
+          "description": "The mathematical methodology used to embed the chain of custody.",
+          "enum": [
+            "merkle_dag",
+            "statistical_token",
+            "homomorphic_mac"
+          ],
+          "title": "Watermark Protocol",
+          "type": "string"
+        },
         "hop_signatures": {
           "additionalProperties": {
             "maxLength": 2000,
@@ -10753,16 +10763,6 @@
           "maxLength": 2000,
           "title": "Tamper Evident Root",
           "type": "string"
-        },
-        "watermark_protocol": {
-          "description": "The mathematical methodology used to embed the chain of custody.",
-          "enum": [
-            "merkle_dag",
-            "statistical_token",
-            "homomorphic_mac"
-          ],
-          "title": "Watermark Protocol",
-          "type": "string"
         }
       },
       "required": [
@@ -10777,16 +10777,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Mathematically bounds a specific target property using strict Liquid Type (Refinement Type) declarations.\n\n    CAUSAL AFFORDANCE: Establishes a definitive algebraic constraint against an instantiated variable, forcing the formal verifier to evaluate conditions mathematically prior to downstream deployment.\n\n    EPISTEMIC BOUNDS: Bounding variables and mathematical predicates are rigidly clamped to a maximum string geometry of 2000 characters to prevent polynomial regex execution attacks.\n\n    MCP ROUTING TRIGGERS: Liquid Types, Refinement Types, Algebraic Constraint, Mathematical Predicate, Bounded Property",
       "properties": {
-        "mathematical_predicate": {
-          "description": "The formal algebraic representation vector utilized to define physical bounds (e.g., x > 0 and x < 100).",
-          "maxLength": 2000,
-          "title": "Mathematical Predicate",
-          "type": "string"
-        },
         "target_property": {
           "description": "The specific localized node schema key undergoing rigorous mathematical bounding.",
           "maxLength": 2000,
           "title": "Target Property",
+          "type": "string"
+        },
+        "mathematical_predicate": {
+          "description": "The formal algebraic representation vector utilized to define physical bounds (e.g., x > 0 and x < 100).",
+          "maxLength": 2000,
+          "title": "Mathematical Predicate",
           "type": "string"
         }
       },
@@ -10801,12 +10801,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographic mandate for neural watermarking. Uses a Pseudo-Random Function (PRF) seeded by previous token context to deterministically split the vocabulary during Gumbel-Softmax sampling.\n\nCAUSAL AFFORDANCE: Physically manipulates the LLM's residual stream logit distribution just before the final softmax activation, embedding an undeniable, high-entropy Shannon information signature directly into the generated text without degrading model perplexity.\n\nEPISTEMIC BOUNDS: Injection is mathematically clamped by `watermark_strength_delta` (`gt=0.0, le=1.0`). Resistance to cropping attacks is geometrically enforced by `context_history_window` (`ge=0, le=1000000000`). Information density is bounded by `target_bits_per_token` (`gt=0.0, le=1000000000.0`). Locked by `prf_seed_hash` (SHA-256).\n\nMCP ROUTING TRIGGERS: Logit Steganography, Gumbel-Softmax Watermarking, Pseudo-Random Function, Shannon Entropy, Provenance Tracking",
       "properties": {
-        "context_history_window": {
-          "description": "The k-gram rolling window size of preceding tokens hashed into the PRF state to ensure robustness against text cropping.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Context History Window",
-          "type": "integer"
+        "verification_public_key_id": {
+          "description": "The DID or public key identifier required by an auditor to reconstruct the PRF and verify the watermark.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Verification Public Key Id",
+          "type": "string"
         },
         "prf_seed_hash": {
           "description": "The SHA-256 hash of the cryptographic seed used to initialize the pseudo-random function (PRF).",
@@ -10816,6 +10817,13 @@
           "title": "Prf Seed Hash",
           "type": "string"
         },
+        "watermark_strength_delta": {
+          "description": "The exact logit scalar (bias) injected into the 'green list' vocabulary partition before Gumbel-Softmax sampling.",
+          "exclusiveMinimum": 0.0,
+          "maximum": 1.0,
+          "title": "Watermark Strength Delta",
+          "type": "number"
+        },
         "target_bits_per_token": {
           "description": "The information-theoretic density of the payload being embedded into the generative stream.",
           "exclusiveMinimum": 0.0,
@@ -10823,20 +10831,12 @@
           "title": "Target Bits Per Token",
           "type": "number"
         },
-        "verification_public_key_id": {
-          "description": "The DID or public key identifier required by an auditor to reconstruct the PRF and verify the watermark.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Verification Public Key Id",
-          "type": "string"
-        },
-        "watermark_strength_delta": {
-          "description": "The exact logit scalar (bias) injected into the 'green list' vocabulary partition before Gumbel-Softmax sampling.",
-          "exclusiveMinimum": 0.0,
-          "maximum": 1.0,
-          "title": "Watermark Strength Delta",
-          "type": "number"
+        "context_history_window": {
+          "description": "The k-gram rolling window size of preceding tokens hashed into the PRF state to ensure robustness against text cropping.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Context History Window",
+          "type": "integer"
         }
       },
       "required": [
@@ -10853,13 +10853,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a Lattice-Based Access Control (LBAC) and Zero-Trust Architecture perimeter, restricting JSON-RPC capability mounts from foreign subgraphs.\n\nCAUSAL AFFORDANCE: Acts as a structural firewall that physically prevents the orchestrator from binding unauthorized external tools, resources, or prompts into the active agent's CognitiveActionSpaceManifest.\n\nEPISTEMIC BOUNDS: The boundary is geometrically enforced via `StringConstraints` (`max_length=2000` for `authorized_capability_array`, `allowed_resources`, `allowed_prompts`). The `@model_validator` strictly sorts all arrays alphabetically to mathematically guarantee RFC 8785 Canonical Hashing.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Lattice-Based Access Control, Least Privilege, RPC Firewall, Bipartite Partitioning",
       "properties": {
-        "allowed_prompts": {
-          "description": "The explicit whitelist of workflow templates the node is allowed to trigger.",
+        "authorized_capability_array": {
+          "description": "The explicit whitelist of function names the node is allowed to call.",
           "items": {
             "maxLength": 2000,
             "type": "string"
           },
-          "title": "Allowed Prompts",
+          "title": "Authorized Capability Array",
           "type": "array"
         },
         "allowed_resources": {
@@ -10871,13 +10871,13 @@
           "title": "Allowed Resources",
           "type": "array"
         },
-        "authorized_capability_array": {
-          "description": "The explicit whitelist of function names the node is allowed to call.",
+        "allowed_prompts": {
+          "description": "The explicit whitelist of workflow templates the node is allowed to trigger.",
           "items": {
             "maxLength": 2000,
             "type": "string"
           },
-          "title": "Authorized Capability Array",
+          "title": "Allowed Prompts",
           "type": "array"
         },
         "required_licenses": {
@@ -10897,38 +10897,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An inherited JSON-RPC 2.0 substrate specifically binding Model Context Protocol (MCP) client intent emissions to the frontend UI. As an ...Intent suffix, this represents an authorized kinetic execution trigger.\nCAUSAL AFFORDANCE: Executes an exact semantic signal (Literal[\"mcp.ui.emit_intent\"]) to bubble internal agent states (like drafting or adjudication) to the human operator.\nEPISTEMIC BOUNDS: Inherits all recursive depth bounds from BoundedJSONRPCIntent and mathematically clamps the method space to a singular Literal[\"mcp.ui.emit_intent\"] to prevent execution drift.\nMCP ROUTING TRIGGERS: Model Context Protocol, Intent Bubbling, Human-in-the-Loop, Semantic Signaling, Method Clamping",
       "properties": {
-        "holographic_projection": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/DynamicManifoldProjectionManifest"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematically pre-calculated view manifold tailored to the observer's frustum."
-        },
-        "id": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "maximum": 1000000000,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Unique request identifier.",
-          "title": "Id"
-        },
         "jsonrpc": {
           "const": "2.0",
           "description": "JSON-RPC version.",
@@ -10960,6 +10928,38 @@
           "default": null,
           "description": "Payload parameters. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
           "title": "Params"
+        },
+        "id": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
+            },
+            {
+              "maximum": 1000000000,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Unique request identifier.",
+          "title": "Id"
+        },
+        "holographic_projection": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/DynamicManifoldProjectionManifest"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematically pre-calculated view manifold tailored to the observer's frustum."
         }
       },
       "required": [
@@ -10973,6 +10973,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a Higher-Order Function within the Model Context Protocol, mapping a dynamic Latent Prompt Manifold into the agent's execution context.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to fetch and interpolate an exogenous prompt template from a remote server, using the `arguments` dictionary to inject localized state into the template.\n\nEPISTEMIC BOUNDS: The `arguments` matrix is aggressively routed through the volumetric hardware guillotine (`enforce_payload_topology`) to mathematically prevent Manifold Interpolation Complexity crashes from poisoned external servers. Supply-chain attacks are mitigated by the optional `prompt_hash`.\n\nMCP ROUTING TRIGGERS: Higher-Order Function, Latent Prompt Manifold, Template Interpolation, Supply-Chain Verification, Stateless RPC",
       "properties": {
+        "server_cid": {
+          "description": "The deterministic capability pointer representing the MCP server providing this prompt.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Server Cid",
+          "type": "string"
+        },
+        "prompt_name": {
+          "description": "The name of the prompt template.",
+          "maxLength": 2000,
+          "title": "Prompt Name",
+          "type": "string"
+        },
         "arguments": {
           "additionalProperties": {
             "$ref": "#/$defs/JsonPrimitiveState"
@@ -11014,20 +11028,6 @@
           "default": null,
           "description": "Cryptographic hash for prompt integrity verification.",
           "title": "Prompt Hash"
-        },
-        "prompt_name": {
-          "description": "The name of the prompt template.",
-          "maxLength": 2000,
-          "title": "Prompt Name",
-          "type": "string"
-        },
-        "server_cid": {
-          "description": "The deterministic capability pointer representing the MCP server providing this prompt.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Server Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -11069,9 +11069,37 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a cryptographically verifiable Distributed RPC substrate mapping within the Actor Model, binding an external Model Context Protocol (MCP) manifold into the swarm's local topology under strict Object-Capability (OCap) rules.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to physically bridge a zero-trust network boundary, establishing a polymorphic communication channel (stdio, sse, or http) to perceive external resources and actuate remote functions.\n\nEPISTEMIC BOUNDS: The `server_cid` is locked to a 128-char CID regex (`^[a-zA-Z0-9_.:-]+$`). The `@model_validator` `enforce_stdio_supply_chain_lock` strictly mandates a `binary_hash` (SHA-256) for local process generation, sealing the execution envelope against supply-chain poisoning.\n\nMCP ROUTING TRIGGERS: Actor Model, Object Capability Model, Zero-Trust Architecture, Distributed RPC, Supply-Chain Isolation",
       "properties": {
-        "attestation_receipt": {
-          "$ref": "#/$defs/VerifiableCredentialPresentationReceipt",
-          "description": "Cryptographic proof of identity and authorization for the external server."
+        "topology_class": {
+          "const": "mcp_server",
+          "default": "mcp_server",
+          "description": "Discriminator type for an MCP server.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "server_cid": {
+          "description": "A unique cryptographic identifier (CID) for this server instance.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Server Cid",
+          "type": "string"
+        },
+        "transport": {
+          "description": "Polymorphic transport configuration (stdio, sse, or http) including env_vars, args, and headers.",
+          "discriminator": {
+            "mapping": {
+              "http": "#/$defs/MCPTransportProfile",
+              "sse": "#/$defs/MCPTransportProfile",
+              "stdio": "#/$defs/MCPTransportProfile"
+            },
+            "propertyName": "topology_class"
+          },
+          "oneOf": [
+            {
+              "$ref": "#/$defs/MCPTransportProfile"
+            }
+          ],
+          "title": "Transport"
         },
         "binary_hash": {
           "anyOf": [
@@ -11093,13 +11121,9 @@
           "$ref": "#/$defs/MCPCapabilityWhitelistPolicy",
           "description": "The strict capability bounds (tools, resources, prompts) enforced by the orchestrator prior to connection."
         },
-        "server_cid": {
-          "description": "A unique cryptographic identifier (CID) for this server instance.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Server Cid",
-          "type": "string"
+        "attestation_receipt": {
+          "$ref": "#/$defs/VerifiableCredentialPresentationReceipt",
+          "description": "Cryptographic proof of identity and authorization for the external server."
         },
         "state_synchronization_optics": {
           "description": "Profunctor mappings for side-effect-free state synchronization.",
@@ -11108,30 +11132,6 @@
           },
           "title": "State Synchronization Optics",
           "type": "array"
-        },
-        "topology_class": {
-          "const": "mcp_server",
-          "default": "mcp_server",
-          "description": "Discriminator type for an MCP server.",
-          "title": "Topology Class",
-          "type": "string"
-        },
-        "transport": {
-          "description": "Polymorphic transport configuration (stdio, sse, or http) including env_vars, args, and headers.",
-          "discriminator": {
-            "mapping": {
-              "http": "#/$defs/MCPTransportProfile",
-              "sse": "#/$defs/MCPTransportProfile",
-              "stdio": "#/$defs/MCPTransportProfile"
-            },
-            "propertyName": "topology_class"
-          },
-          "oneOf": [
-            {
-              "$ref": "#/$defs/MCPTransportProfile"
-            }
-          ],
-          "title": "Transport"
         }
       },
       "required": [
@@ -11160,14 +11160,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a Cartesian topological coordinator based on Edward Tufte's Small Multiples, organizing multiple discrete visual artifacts into a unified grid configuration.\n\nCAUSAL AFFORDANCE: Translates abstract UI panels into fixed 2D matrices (`layout_matrix`), forcing spatial determinism on the frontend rendering engine.\n\nEPISTEMIC BOUNDS: A strictly bounded `@model_validator` executes a referential integrity sweep, mathematically guaranteeing that every panel ID referenced in the `layout_matrix` (`max_length=1000`) corresponds to a verified object in the `panels` array, physically severing Ghost Panel hallucinations. The `@model_validator` `verify_matrix_dimensions` mathematically forces `column_fractional_weights` and `row_fractional_weights` to perfectly match the Cartesian topology.\n\nMCP ROUTING TRIGGERS: Cartesian Coordinate System, Small Multiples, Spatial Topology, Referential Integrity, Layout Matrix",
       "properties": {
-        "column_fractional_weights": {
-          "description": "Euclidean fractional weights for column partitioning.",
-          "items": {
-            "type": "number"
-          },
-          "title": "Column Fractional Weights",
-          "type": "array"
-        },
         "layout_matrix": {
           "description": "A matrix defining the layout structure, using panel IDs.",
           "items": {
@@ -11181,12 +11173,12 @@
           "title": "Layout Matrix",
           "type": "array"
         },
-        "panels": {
-          "description": "The ordered array of topological UI panels physically rendered in the grid.",
+        "column_fractional_weights": {
+          "description": "Euclidean fractional weights for column partitioning.",
           "items": {
-            "$ref": "#/$defs/AnyPanelProfile"
+            "type": "number"
           },
-          "title": "Panels",
+          "title": "Column Fractional Weights",
           "type": "array"
         },
         "row_fractional_weights": {
@@ -11195,6 +11187,14 @@
             "type": "number"
           },
           "title": "Row Fractional Weights",
+          "type": "array"
+        },
+        "panels": {
+          "description": "The ordered array of topological UI panels physically rendered in the grid.",
+          "items": {
+            "$ref": "#/$defs/AnyPanelProfile"
+          },
+          "title": "Panels",
           "type": "array"
         }
       },
@@ -11209,12 +11209,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A machine-readable, deterministic JSON receipt of an exact topological failure, replacing unstructured stack traces.\n\nCAUSAL AFFORDANCE: Enables the agent to execute $O(1)$ surgical patches via StateMutationIntent rather than hallucinating fixes.\n\nEPISTEMIC BOUNDS: `failing_pointer` mathematically maps exactly to RFC 6902 JSON Pointers (`max_length=2000`). `violation_type` capped at `255`.\n\nMCP ROUTING TRIGGERS: Fault Receipt, RFC 6902, Epistemic Loss Prevention, Surgical Patching, Traceback Serialization",
       "properties": {
-        "diagnostic_message": {
-          "description": "The specific constraint breached.",
-          "maxLength": 2000,
-          "title": "Diagnostic Message",
-          "type": "string"
-        },
         "failing_pointer": {
           "description": "The exact RFC 6902 JSON pointer isolating the topological failure.",
           "maxLength": 2000,
@@ -11225,6 +11219,12 @@
           "description": "Categorical descriptor of the failure, e.g., missing, type_error.",
           "maxLength": 255,
           "title": "Violation Type",
+          "type": "string"
+        },
+        "diagnostic_message": {
+          "description": "The specific constraint breached.",
+          "maxLength": 2000,
+          "title": "Diagnostic Message",
           "type": "string"
         }
       },
@@ -11265,6 +11265,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents the definitive collapse of the LMSR market superposition into a crystallized `payout_distribution` using Strictly Proper Scoring Rules (e.g., Brier scores).\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to definitively allocate compute magnitudes to the `winning_hypothesis_id` and flush `falsified_hypothesis_cids` from the active context via a Defeasible Cascade.\n\nEPISTEMIC BOUNDS: Enforces a strictly bounded `payout_distribution` dictionary mapping W3C DIDs to non-negative integers (`ge=0`), with deterministic RFC 8785 array sorting applied to the falsified hypotheses.\n\nMCP ROUTING TRIGGERS: Brier Scoring, Market Settlement, Probability Wave Collapse, Truth Crystallization",
       "properties": {
+        "market_cid": {
+          "description": "The deterministic capability pointer representing the prediction market.",
+          "le": 1000000000,
+          "minLength": 1,
+          "title": "Market Cid",
+          "type": "string"
+        },
+        "winning_hypothesis_id": {
+          "description": "The hypothesis ID that was verified.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Winning Hypothesis Id",
+          "type": "string"
+        },
         "falsified_hypothesis_cids": {
           "description": "The hypothesis IDs that were falsified.",
           "items": {
@@ -11275,13 +11290,6 @@
           "maxItems": 1000,
           "title": "Falsified Hypothesis Cids",
           "type": "array"
-        },
-        "market_cid": {
-          "description": "The deterministic capability pointer representing the prediction market.",
-          "le": 1000000000,
-          "minLength": 1,
-          "title": "Market Cid",
-          "type": "string"
         },
         "payout_distribution": {
           "additionalProperties": {
@@ -11294,14 +11302,6 @@
           },
           "title": "Payout Distribution",
           "type": "object"
-        },
-        "winning_hypothesis_id": {
-          "description": "The hypothesis ID that was verified.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Winning Hypothesis Id",
-          "type": "string"
         }
       },
       "required": [
@@ -11317,6 +11317,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Translates Fristonian Active Inference boundaries into rigid physical optics.\nIt defines the exact geometric perimeter where an agent's internal generative states become\nconditionally independent of (and thus occluded from) the external macroscopic swarm topology.\n\nCAUSAL AFFORDANCE: Mathematically forces the opacity of internal mechanistics (e.g., SAE\nactivations, scratchpad trees) to absolute zero, until the observer's SE(3) coordinate\nphysically pierces the agent's volumetric bounding cage.\n\nEPISTEMIC BOUNDS: The physical penetration depth is strictly bounded by pierce_distance_meters\n(ge=0.0). Exogenous interfaces (sensory and active states) are governed by strict boolean gates.\n\nMCP ROUTING TRIGGERS: Fristonian Active Inference, Markov Blanket, Epistemic Isolation, Volumetric Penetration, Conditional Independence",
       "properties": {
+        "pierce_distance_meters": {
+          "description": "The precise Euclidean distance at which an observer's coordinate successfully breaches the agent's internal state partition.",
+          "minimum": 0.0,
+          "title": "Pierce Distance Meters",
+          "type": "number"
+        },
         "expose_sensory_active_states": {
           "default": true,
           "description": "Authorizes the continuous projection of the agent's exogenous API interactions and structural tool commitments to the macroscopic layer.",
@@ -11328,12 +11334,6 @@
           "description": "Forces absolute rendering occlusion of internal non-monotonic reasoning loops unless the pierce distance is breached.",
           "title": "Occlude Internal Mechanistics",
           "type": "boolean"
-        },
-        "pierce_distance_meters": {
-          "description": "The precise Euclidean distance at which an observer's coordinate successfully breaches the agent's internal state partition.",
-          "minimum": 0.0,
-          "title": "Pierce Distance Meters",
-          "type": "number"
         }
       },
       "required": [
@@ -11346,29 +11346,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a rigorous Mechanistic Interpretability brain-scan protocol, executing real-time latent state extraction across targeted neural circuits.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to halt token generation upon specific `trigger_conditions` to physically slice, quantify, and export the top-k SAE features from the designated `target_layers`.\n\nEPISTEMIC BOUNDS: GPU VRAM exhaustion is mathematically prevented by capping `max_features_per_layer` (`gt=0, le=1000000000`). The `@model_validator` deterministically sorts conditions and layers for RFC 8785 hashing. System integrity enforced via `require_zk_commitments`.\n\nMCP ROUTING TRIGGERS: Latent State Extraction, Mechanistic Interpretability, Sparse Autoencoder, Zero-Knowledge Commitments, VRAM Optimization",
       "properties": {
-        "max_features_per_layer": {
-          "description": "The top-k features to extract, preventing VRAM exhaustion.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Max Features Per Layer",
-          "type": "integer"
-        },
-        "require_zk_commitments": {
-          "default": true,
-          "description": "If True, the orchestrator MUST generate cryptographic latent state proofs alongside the activation extractions.",
-          "title": "Require Zk Commitments",
-          "type": "boolean"
-        },
-        "target_layers": {
-          "description": "The specific transformer block indices the execution engine must extract from.",
-          "items": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "minItems": 1,
-          "title": "Target Layers",
-          "type": "array"
-        },
         "trigger_conditions": {
           "description": "The specific architectural events that authorize the orchestrator to halt generation and extract internal activations.",
           "items": {
@@ -11383,6 +11360,29 @@
           "minItems": 1,
           "title": "Trigger Conditions",
           "type": "array"
+        },
+        "target_layers": {
+          "description": "The specific transformer block indices the execution engine must extract from.",
+          "items": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "minItems": 1,
+          "title": "Target Layers",
+          "type": "array"
+        },
+        "max_features_per_layer": {
+          "description": "The top-k features to extract, preventing VRAM exhaustion.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Max Features Per Layer",
+          "type": "integer"
+        },
+        "require_zk_commitments": {
+          "default": true,
+          "description": "If True, the orchestrator MUST generate cryptographic latent state proofs alongside the activation extractions.",
+          "title": "Require Zk Commitments",
+          "type": "boolean"
         }
       },
       "required": [
@@ -11397,6 +11397,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Dynamic Programming principles to create a passive, cryptographic structural interlock pointing to a historically executed and verified graph branch.\n\nCAUSAL AFFORDANCE: Bypasses redundant thermodynamic compute expenditure by collapsing an entire sub-DAG execution into a single, O(1) state retrieval keyed by the `target_topology_hash`.\n\nEPISTEMIC BOUNDS: The cache-hit is mathematically locked to the exact `target_topology_hash` (`TopologyHashReceipt`), guaranteeing perfect graph isomorphism. The retrieved payload is physically constrained by `expected_output_schema` (`max_length=1000`). The type discriminator is locked to `Literal[\"memoized\"]`.\n\nMCP ROUTING TRIGGERS: Dynamic Programming, O(1) Retrieval, Cryptographic Cache, Graph Isomorphism, Compute Conservation",
       "properties": {
+        "description": {
+          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -11411,11 +11417,27 @@
           "description": "The AI's declarative rationale for selecting this node.",
           "title": "Architectural Intent"
         },
-        "description": {
-          "description": "The semantic boundary defining the objective function or computational perimeter of the execution node.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
+        "justification": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic/audit justification for this node's existence in the graph.",
+          "title": "Justification"
+        },
+        "intervention_policies": {
+          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+          "items": {
+            "$ref": "#/$defs/InterventionPolicy"
+          },
+          "title": "Intervention Policies",
+          "type": "array"
         },
         "domain_extensions": {
           "anyOf": [
@@ -11436,39 +11458,17 @@
           "description": "Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
           "title": "Domain Extensions"
         },
-        "expected_output_schema": {
-          "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitiveState"
-          },
-          "description": "The strictly typed JSON Schema expected from the cached payload.",
-          "maxProperties": 1000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Expected Output Schema",
-          "type": "object"
-        },
-        "intervention_policies": {
-          "description": "The declarative array of proactive oversight hooks bound to this node's lifecycle.",
-          "items": {
-            "$ref": "#/$defs/InterventionPolicy"
-          },
-          "title": "Intervention Policies",
-          "type": "array"
-        },
-        "justification": {
+        "semantic_zoom": {
           "anyOf": [
             {
-              "maxLength": 2000,
-              "type": "string"
+              "$ref": "#/$defs/SemanticZoomProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "Cryptographic/audit justification for this node's existence in the graph.",
-          "title": "Justification"
+          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
         },
         "markov_blanket": {
           "anyOf": [
@@ -11482,18 +11482,6 @@
           "default": null,
           "description": "The epistemic isolation boundary guarding this agent's internal generative states."
         },
-        "neural_optics": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/GaussianSplattingProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
-        },
         "optical_physics": {
           "anyOf": [
             {
@@ -11506,21 +11494,17 @@
           "default": null,
           "description": "The strict microfacet BRDF physics governing the visual representation of this node."
         },
-        "semantic_zoom": {
+        "neural_optics": {
           "anyOf": [
             {
-              "$ref": "#/$defs/SemanticZoomProfile"
+              "$ref": "#/$defs/GaussianSplattingProfile"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The mathematical Information Bottleneck thresholds dictating the semantic degradation of this specific node."
-        },
-        "target_topology_hash": {
-          "$ref": "#/$defs/TopologyHashReceipt",
-          "description": "The exact SHA-256 fingerprint of the executed topology."
+          "description": "The volumetric Gaussian Splatting configuration for non-polygonal rendering."
         },
         "topology_class": {
           "const": "memoized",
@@ -11528,6 +11512,22 @@
           "description": "Discriminator for a Memoized node.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "target_topology_hash": {
+          "$ref": "#/$defs/TopologyHashReceipt",
+          "description": "The exact SHA-256 fingerprint of the executed topology."
+        },
+        "expected_output_schema": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonPrimitiveState"
+          },
+          "description": "The strictly typed JSON Schema expected from the cached payload.",
+          "maxProperties": 1000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Expected Output Schema",
+          "type": "object"
         }
       },
       "required": [
@@ -11550,18 +11550,18 @@
           "title": "Artifact Id",
           "type": "string"
         },
+        "mime_type": {
+          "description": "Strict MIME typing of the source artifact (e.g., 'application/pdf').",
+          "maxLength": 2000,
+          "title": "Mime Type",
+          "type": "string"
+        },
         "byte_stream_hash": {
           "description": "The undeniable SHA-256 hash of the pre-transmutation byte stream.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-f0-9]{64}$",
           "title": "Byte Stream Hash",
-          "type": "string"
-        },
-        "mime_type": {
-          "description": "Strict MIME typing of the source artifact (e.g., 'application/pdf').",
-          "maxLength": 2000,
-          "title": "Mime Type",
           "type": "string"
         },
         "temporal_ingest_timestamp": {
@@ -11585,26 +11585,45 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates cross-modal coordinate geometry by mapping 1D\nsequential token spaces (LLMs) to 2D continuous spatial patches\n(Vision-Language Models). As a ...State suffix, this is a declarative, frozen\nsnapshot.\n\nCAUSAL AFFORDANCE: Physically anchors extracted neurosymbolic concepts directly\nto verifiable visual and textual evidence, locking them via block_class\nclassification and visual_patch_hashes arrays.\n\nEPISTEMIC BOUNDS: Token sequences (token_span_start, token_span_end) are\nmathematically bounded 1D limits (ge=0, le=1000000000) constrained by\n@model_validator validate_token_spans to be monotonically increasing. Spatial\ngeometries (bounding_box) enforce normalized Cartesian invariants via\nvalidate_spatial_geometry. Arrays are sorted via sort_arrays.\n\nMCP ROUTING TRIGGERS: Vision-Language Alignment, 1D-2D Projection, VQ-VAE\nSpatial Tracking, Geometric Affine Transforms, Coordinate Bounding",
       "properties": {
-        "block_class": {
+        "token_span_start": {
           "anyOf": [
             {
-              "enum": [
-                "paragraph",
-                "table",
-                "figure",
-                "footnote",
-                "header",
-                "equation"
-              ],
-              "type": "string"
+              "maximum": 1000000000,
+              "minimum": 0,
+              "type": "integer"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The structural classification of the source region.",
-          "title": "Block Class"
+          "description": "The starting index in the discrete VLM context window.",
+          "title": "Token Span Start"
+        },
+        "token_span_end": {
+          "anyOf": [
+            {
+              "maximum": 1000000000,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The ending index in the discrete VLM context window.",
+          "title": "Token Span End"
+        },
+        "visual_patch_hashes": {
+          "description": "The explicit array of SHA-256 hashes corresponding to specific VQ-VAE visual patches attended to.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Visual Patch Hashes",
+          "type": "array"
         },
         "bounding_box": {
           "anyOf": [
@@ -11635,45 +11654,26 @@
           "description": "The strictly typed [x_min, y_min, x_max, y_max] normalized coordinate matrix.",
           "title": "Bounding Box"
         },
-        "token_span_end": {
+        "block_class": {
           "anyOf": [
             {
-              "maximum": 1000000000,
-              "minimum": 0,
-              "type": "integer"
+              "enum": [
+                "paragraph",
+                "table",
+                "figure",
+                "footnote",
+                "header",
+                "equation"
+              ],
+              "type": "string"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The ending index in the discrete VLM context window.",
-          "title": "Token Span End"
-        },
-        "token_span_start": {
-          "anyOf": [
-            {
-              "maximum": 1000000000,
-              "minimum": 0,
-              "type": "integer"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The starting index in the discrete VLM context window.",
-          "title": "Token Span Start"
-        },
-        "visual_patch_hashes": {
-          "description": "The explicit array of SHA-256 hashes corresponding to specific VQ-VAE visual patches attended to.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Visual Patch Hashes",
-          "type": "array"
+          "description": "The structural classification of the source region.",
+          "title": "Block Class"
         }
       },
       "title": "MultimodalTokenAnchorState",
@@ -11720,13 +11720,9 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Tensor Calculus and Differential Geometry representations\nto safely proxy high-dimensional latent structures across zero-trust network boundaries\nwithout transmitting raw, uncompressed bytes. As a ...Manifest suffix, this defines a\nfrozen, declarative coordinate.\n\nCAUSAL AFFORDANCE: Allows the orchestrator to route traffic and reserve exact physical\nGPU memory for massive tensors prior to downloading them via the storage_uri,\npreventing runtime out-of-memory (OOM) execution faults.\n\nEPISTEMIC BOUNDS: The @model_validator _enforce_physics_engine mathematically proves\nthat the topological shape exactly matches the declared vram_footprint_bytes limit\n(le=100000000000) based on the scalar structural_type byte density. Supply-chain\ntampering is physically prevented via the merkle_root SHA-256 requirement.\n\nMCP ROUTING TRIGGERS: Tensor Calculus, Differential Geometry, Merkle Tree Verification, Zero-Trust Computing, Memory Allocation",
       "properties": {
-        "merkle_root": {
-          "description": "SHA-256 Merkle root of the payload chunks.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-fA-F0-9]{64}$",
-          "title": "Merkle Root",
-          "type": "string"
+        "structural_type": {
+          "$ref": "#/$defs/TensorStructuralFormatProfile",
+          "description": "Structural type of the tensor elements."
         },
         "shape": {
           "description": "N-Dimensional shape tuple.",
@@ -11737,22 +11733,26 @@
           "title": "Shape",
           "type": "array"
         },
+        "vram_footprint_bytes": {
+          "description": "Exact byte size of the uncompressed tensor.",
+          "maximum": 100000000000,
+          "title": "Vram Footprint Bytes",
+          "type": "integer"
+        },
+        "merkle_root": {
+          "description": "SHA-256 Merkle root of the payload chunks.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-fA-F0-9]{64}$",
+          "title": "Merkle Root",
+          "type": "string"
+        },
         "storage_uri": {
           "description": "Strict URI pointer to the physical bytes.",
           "maxLength": 128,
           "minLength": 1,
           "title": "Storage Uri",
           "type": "string"
-        },
-        "structural_type": {
-          "$ref": "#/$defs/TensorStructuralFormatProfile",
-          "description": "Structural type of the tensor elements."
-        },
-        "vram_footprint_bytes": {
-          "description": "Exact byte size of the uncompressed tensor.",
-          "maximum": 100000000000,
-          "title": "Vram Footprint Bytes",
-          "type": "integer"
         }
       },
       "required": [
@@ -11777,12 +11777,6 @@
           "title": "Audit Id",
           "type": "string"
         },
-        "causal_scrubbing_applied": {
-          "default": false,
-          "description": "Cryptographic proof that the orchestrator actively resampled or ablated this circuit to verify its causal responsibility for the output.",
-          "title": "Causal Scrubbing Applied",
-          "type": "boolean"
-        },
         "layer_activations": {
           "additionalProperties": {
             "items": {
@@ -11793,6 +11787,12 @@
           "description": "A mapping of specific transformer layer indices to their top-k activated SAE features.",
           "title": "Layer Activations",
           "type": "object"
+        },
+        "causal_scrubbing_applied": {
+          "default": false,
+          "description": "Cryptographic proof that the orchestrator actively resampled or ablated this circuit to verify its causal responsibility for the output.",
+          "title": "Causal Scrubbing Applied",
+          "type": "boolean"
         }
       },
       "required": [
@@ -11806,23 +11806,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Bridges the stochastic-deterministic divide by invoking Satisfiability Modulo Theories (SMT) and formal theorem provers (Z3, Lean4, Coq) to execute mathematically unassailable logic.\n\nCAUSAL AFFORDANCE: Offloads non-monotonic probabilistic reasoning into a rigid, verifiable algebraic solver, returning the mathematically proven result to the swarm via the `expected_proof_schema`.\n\nEPISTEMIC BOUNDS: The solver target is restricted to the strict `solver_protocol` Literal automaton (`[\"z3\", \"lean4\", \"coq\", \"tla_plus\", \"sympy\"]`). The Halting Problem is explicitly mitigated by clamping `timeout_ms` (`gt=0, le=86400000`), preventing infinite computational loops.\n\nMCP ROUTING TRIGGERS: Satisfiability Modulo Theories, Curry-Howard Correspondence, Theorem Proving, Symbolic Handoff, Halting Problem Mitigation",
       "properties": {
-        "expected_proof_schema": {
-          "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitiveState"
-          },
-          "description": "The strict JSON Schema the deterministic solver must use to return the verified answer to the agent.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Expected Proof Schema",
-          "type": "object"
-        },
-        "formal_grammar_payload": {
-          "description": "The raw code or formal proof syntax generated by the LLM to be evaluated.",
-          "maxLength": 100000,
-          "title": "Formal Grammar Payload",
-          "type": "string"
-        },
         "handoff_id": {
           "description": "Unique identifier for this symbolic delegation.",
           "maxLength": 128,
@@ -11842,6 +11825,23 @@
           ],
           "title": "Solver Protocol",
           "type": "string"
+        },
+        "formal_grammar_payload": {
+          "description": "The raw code or formal proof syntax generated by the LLM to be evaluated.",
+          "maxLength": 100000,
+          "title": "Formal Grammar Payload",
+          "type": "string"
+        },
+        "expected_proof_schema": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonPrimitiveState"
+          },
+          "description": "The strict JSON Schema the deterministic solver must use to return the verified answer to the agent.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Expected Proof Schema",
+          "type": "object"
         },
         "timeout_ms": {
           "description": "The maximum compute time allocated to the symbolic solver before aborting.",
@@ -11865,21 +11865,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates the core execution payload boundary, acting as the structural pre-inference gate for neurosymbolic probability.\n\n    CAUSAL AFFORDANCE: Empowers the routing engine to sever execution prior to LLM generation if the structural certainty SLA evaluates beyond acceptable mathematical variance boundaries.\n\n    EPISTEMIC BOUNDS: Mandates exact nesting of deterministic fidelity and uncertainty profiles. The pre-flight validator mathematically terminates evaluation if epistemic degradation breaches the SLA limit.\n\n    MCP ROUTING TRIGGERS: Pre-Inference Gate, Neurosymbolic Request, Probability Envelope, SLA Enforcement, Inference Termination",
       "properties": {
-        "fidelity_receipt": {
-          "$ref": "#/$defs/TopologicalFidelityReceipt",
-          "description": "The immutable scalar matrix capturing pre-inference mathematical contextual completeness."
-        },
-        "sla": {
-          "$ref": "#/$defs/EpistemicCompressionSLA",
-          "description": "The mathematical structural boundaries defining acceptable epistemic loss perimeters."
-        },
         "source_entity": {
           "$ref": "#/$defs/ContextualizedSourceEntity",
           "description": "The structurally isolated 1D boundary representing the semantic payload injected into the context window."
         },
+        "fidelity_receipt": {
+          "$ref": "#/$defs/TopologicalFidelityReceipt",
+          "description": "The immutable scalar matrix capturing pre-inference mathematical contextual completeness."
+        },
         "uncertainty_profile": {
           "$ref": "#/$defs/CognitiveUncertaintyProfile",
           "description": "The rigid matrix evaluating probabilistic uncertainty vectors bounding the initial request state."
+        },
+        "sla": {
+          "$ref": "#/$defs/EpistemicCompressionSLA",
+          "description": "The mathematical structural boundaries defining acceptable epistemic loss perimeters."
         }
       },
       "required": [
@@ -11895,6 +11895,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nA Zero-Cost Macro abstraction enforcing a strict Bipartite Graph for Proposer-Verifier loops. Isolates connectionist generation from symbolic validation and bounds cyclic computation.",
       "properties": {
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -11908,32 +11930,6 @@
           "default": null,
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
-        },
-        "critique_schema_cid": {
-          "anyOf": [
-            {
-              "maxLength": 255,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "A pointer to the penalty gradient structure.",
-          "title": "Critique Schema Cid"
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
         },
         "justification": {
           "anyOf": [
@@ -11949,23 +11945,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
-        "max_revision_loops": {
-          "description": "The physical execution ceiling to solve the Halting Problem.",
-          "maximum": 100,
-          "minimum": 1,
-          "title": "Max Revision Loops",
-          "type": "integer"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -11976,36 +11955,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "proposer_node_cid": {
-          "description": "The connectionist agent generating hypotheses.",
-          "maxLength": 255,
-          "title": "Proposer Node Cid",
-          "type": "string"
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -12019,6 +11968,30 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
         "topology_class": {
           "const": "macro_neurosymbolic",
           "default": "macro_neurosymbolic",
@@ -12026,11 +11999,38 @@
           "title": "Topology Class",
           "type": "string"
         },
+        "proposer_node_cid": {
+          "description": "The connectionist agent generating hypotheses.",
+          "maxLength": 255,
+          "title": "Proposer Node Cid",
+          "type": "string"
+        },
         "verifier_node_cid": {
           "description": "The deterministic solver evaluating the hypotheses.",
           "maxLength": 255,
           "title": "Verifier Node Cid",
           "type": "string"
+        },
+        "max_revision_loops": {
+          "description": "The physical execution ceiling to solve the Halting Problem.",
+          "maximum": 100,
+          "minimum": 1,
+          "title": "Max Revision Loops",
+          "type": "integer"
+        },
+        "critique_schema_cid": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "A pointer to the penalty gradient structure.",
+          "title": "Critique Schema Cid"
         }
       },
       "required": [
@@ -12052,14 +12052,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact tracking the Kullback-Leibler (KL) divergence between the swarm's active behavioral manifold and its foundational ConstitutionalPolicy.\n\nCAUSAL AFFORDANCE: Emits a deterministic topological signal that the causal graph is experiencing logical friction against the `tripped_rule_id`, unlocking the injection of a System2RemediationIntent constraint.\n\nEPISTEMIC BOUNDS: Mathematically bounded by `measured_semantic_drift` (`le=1000000000.0`) and cryptographically tied to `contradiction_proof_hash` (SHA-256 pattern `^[a-f0-9]{64}$`) proving the anomaly.\n\nMCP ROUTING TRIGGERS: Kullback-Leibler Divergence, Normative Drift, Distributional Shift, Semantic Friction, Constitutional Alignment",
       "properties": {
-        "contradiction_proof_hash": {
-          "description": "A cryptographic pointer to the internal scratchpad trace (ThoughtBranchState) definitively proving the rule is obsolete or causing a loop.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Contradiction Proof Hash",
-          "type": "string"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -12067,12 +12059,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "measured_semantic_drift": {
-          "description": "The calculated probabilistic delta showing how far the swarm's observed reality is diverging from the static rule.",
-          "maximum": 1000000000.0,
-          "title": "Measured Semantic Drift",
-          "type": "number"
         },
         "prior_event_hash": {
           "anyOf": [
@@ -12111,6 +12097,20 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Tripped Rule Id",
           "type": "string"
+        },
+        "measured_semantic_drift": {
+          "description": "The calculated probabilistic delta showing how far the swarm's observed reality is diverging from the static rule.",
+          "maximum": 1000000000.0,
+          "title": "Measured Semantic Drift",
+          "type": "number"
+        },
+        "contradiction_proof_hash": {
+          "description": "A cryptographic pointer to the internal scratchpad trace (ThoughtBranchState) definitively proving the rule is obsolete or causing a loop.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Contradiction Proof Hash",
+          "type": "string"
         }
       },
       "required": [
@@ -12127,6 +12127,23 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the macroscopic Graph Coarsening Engine, replacing binary\nlogging with structural Dimensionality Reduction for massive topologies.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to execute Spectral Graph Partitioning when\nthe topology exceeds the hardware rendering limit. It dynamically collapses dense subgraphs\ninto singular Hierarchical Level of Detail (HLOD) proxy meshes.\n\nEPISTEMIC BOUNDS: The vertex ceiling is rigidly bounded by max_rendered_vertices (gt=0,\nle=1000000000) to physically prevent GPU VRAM exhaustion on the observer client. Binds the\nTelemetryBackpressureContract to link graph scaling with network flow.\n\nMCP ROUTING TRIGGERS: Spectral Graph Coarsening, Hierarchical Level of Detail, HLOD, Topology Collapse, VRAM Optimization",
       "properties": {
+        "max_rendered_vertices": {
+          "description": "The absolute physical ceiling of simultaneous causal nodes authorized to exist in the spatial projection pipeline.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Max Rendered Vertices",
+          "type": "integer"
+        },
+        "spectral_coarsening_active": {
+          "default": true,
+          "description": "Authorizes the dynamic algebraic collapse of dense node communities into single macroscopic proxy vertices when the vertex ceiling is threatened.",
+          "title": "Spectral Coarsening Active",
+          "type": "boolean"
+        },
+        "telemetry_backpressure": {
+          "$ref": "#/$defs/TelemetryBackpressureContract",
+          "description": "The network flow constraints mathematically bound to the observer's kinematics."
+        },
         "active_spatial_subscriptions": {
           "description": "The array of Area of Interest perimeters dictating spatial telemetry isolation.",
           "items": {
@@ -12148,23 +12165,6 @@
           "default": null,
           "description": "The Laplacian noise parameter ($\\epsilon$) injected into the spatial telemetry for nodes residing in the meso and macro distance thresholds, preventing reverse-engineering of exact swarm weights.",
           "title": "Foveated Privacy Epsilon"
-        },
-        "max_rendered_vertices": {
-          "description": "The absolute physical ceiling of simultaneous causal nodes authorized to exist in the spatial projection pipeline.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Max Rendered Vertices",
-          "type": "integer"
-        },
-        "spectral_coarsening_active": {
-          "default": true,
-          "description": "Authorizes the dynamic algebraic collapse of dense node communities into single macroscopic proxy vertices when the vertex ceiling is threatened.",
-          "title": "Spectral Coarsening Active",
-          "type": "boolean"
-        },
-        "telemetry_backpressure": {
-          "$ref": "#/$defs/TelemetryBackpressureContract",
-          "description": "The network flow constraints mathematically bound to the observer's kinematics."
         }
       },
       "required": [
@@ -12178,6 +12178,143 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the ingestion of Bayesian Evidence ($E$) by capturing the raw, lossless semantic output from a ToolInvocationEvent or environmental shift.\n\nCAUSAL AFFORDANCE: Injects verified exogenous truth into the EpistemicLedgerState. The payload is linked to its source via `triggering_invocation_cid`.\n\nEPISTEMIC BOUNDS: The `payload` dictionary is physically constrained against OOM exhaustion via the `@field_validator` `enforce_payload_topology`. Hardware attestation and zero-knowledge proofs provide cryptographic integrity.\n\nMCP ROUTING TRIGGERS: Bayesian Evidence, Neurosymbolic Binding, Exogenous Truth, Epistemic Grounding, Payload Topological Bounding",
       "properties": {
+        "event_cid": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Event Cid",
+          "type": "string"
+        },
+        "prior_event_hash": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+          "title": "Prior Event Hash"
+        },
+        "timestamp": {
+          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "topology_class": {
+          "const": "observation",
+          "default": "observation",
+          "description": "Discriminator type for an observation event.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "payload": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonPrimitiveState"
+          },
+          "description": "Neurosymbolic Bindings of the raw, lossless semantic output appended from the environment or tool execution that anchor statistical probability to a definitive causal event hash. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Payload",
+          "type": "object"
+        },
+        "source_node_cid": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeCIDState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific topological node that appended this observation."
+        },
+        "hardware_attestation": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HardwareEnclaveReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The physical hardware root-of-trust proving this observation was appended in a secure enclave."
+        },
+        "zk_proof": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ZeroKnowledgeReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical attestation proving this observation was appended securely."
+        },
+        "toolchain_snapshot": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AnyToolchainState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The immutable cryptographic snapshot of the external environment at the moment of observation."
+        },
+        "sensory_trigger": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EmbodiedSensoryVectorProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The continuous multimodal trigger that forced this discrete observation."
+        },
+        "neural_audit": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NeuralAuditAttestationReceipt"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical brain-scan proving exactly which neural circuits fired to append this event."
+        },
+        "triggering_invocation_cid": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The deterministic capability pointer representing the specific ToolInvocationEvent that spawned this observation, forming a strict bipartite directed edge.",
+          "title": "Triggering Invocation Cid"
+        },
         "continuous_stream": {
           "anyOf": [
             {
@@ -12201,143 +12338,6 @@
           ],
           "default": null,
           "description": "Rules for the forget gate to slice out stutters or ambient noise."
-        },
-        "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Event Cid",
-          "type": "string"
-        },
-        "hardware_attestation": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HardwareEnclaveReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The physical hardware root-of-trust proving this observation was appended in a secure enclave."
-        },
-        "neural_audit": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NeuralAuditAttestationReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical brain-scan proving exactly which neural circuits fired to append this event."
-        },
-        "payload": {
-          "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitiveState"
-          },
-          "description": "Neurosymbolic Bindings of the raw, lossless semantic output appended from the environment or tool execution that anchor statistical probability to a definitive causal event hash. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Payload",
-          "type": "object"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
-        },
-        "sensory_trigger": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EmbodiedSensoryVectorProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The continuous multimodal trigger that forced this discrete observation."
-        },
-        "source_node_cid": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/NodeCIDState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The specific topological node that appended this observation."
-        },
-        "timestamp": {
-          "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
-          "maximum": 253402300799.0,
-          "minimum": 0.0,
-          "title": "Timestamp",
-          "type": "number"
-        },
-        "toolchain_snapshot": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AnyToolchainState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The immutable cryptographic snapshot of the external environment at the moment of observation."
-        },
-        "topology_class": {
-          "const": "observation",
-          "default": "observation",
-          "description": "Discriminator type for an observation event.",
-          "title": "Topology Class",
-          "type": "string"
-        },
-        "triggering_invocation_cid": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The deterministic capability pointer representing the specific ToolInvocationEvent that spawned this observation, forming a strict bipartite directed edge.",
-          "title": "Triggering Invocation Cid"
-        },
-        "zk_proof": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ZeroKnowledgeReceipt"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical attestation proving this observation was appended securely."
         }
       },
       "required": [
@@ -12352,18 +12352,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Vector Space Isometry and Earth Mover's Distance\nbounds to mathematically verify semantic compatibility across disjoint neural\nmodels before allowing multi-agent graph coupling. As a ...Policy suffix, this\ndefines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Mechanically severs federated discovery attempts if the\nparticipating agents' internal embedding distances fall below the required\nthreshold. A fallback_state_contract (StateContract | None, default=None)\nforces agents to use canonical JSON Schemas when geometries are\nincommensurable.\n\nEPISTEMIC BOUNDS: The min_cosine_similarity is strictly clamped\n(ge=-1.0, le=1.0). The require_isometry_proof boolean (no default) enforces\nrigid projection validation prior to semantic mapping.\n\nMCP ROUTING TRIGGERS: Vector Space Isometry, Earth Mover's Distance, Latent\nSemantic Alignment, Zero-Trust Federation, Geometric Projection",
       "properties": {
-        "fallback_state_contract": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/StateContract"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The rigid external JSON schema to force agents to use if their latent vector geometries are hopelessly incommensurable."
-        },
         "min_cosine_similarity": {
           "description": "The absolute minimum latent vector similarity required to allow swarm communication.",
           "maximum": 1.0,
@@ -12375,6 +12363,18 @@
           "description": "If True, the orchestrator must reject dimensional projections that fall below a safe isometry preservation score.",
           "title": "Require Isometry Proof",
           "type": "boolean"
+        },
+        "fallback_state_contract": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StateContract"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The rigid external JSON schema to force agents to use if their latent vector geometries are hopelessly incommensurable."
         }
       },
       "required": [
@@ -12388,6 +12388,33 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the absolute\nmathematical alignment of two swarms' latent vector spaces prior to establishing a shared\nepistemic blackboard. As a ...Receipt suffix, this is an append-only coordinate on the\nMerkle-DAG that the LLM must never hallucinate a mutation to.\n\nCAUSAL AFFORDANCE: Authorizes the physical bridging of two independent N-dimensional\nsemantic spaces. If native geometries are incommensurable, it structurally demands the\napplication of a DimensionalProjectionContract (applied_projection). The alignment_status\nLiteral [\"aligned\", \"projected\", \"fallback_triggered\", \"incommensurable\"] records the\nfinal verdict.\n\nEPISTEMIC BOUNDS: Semantic isometry is quantified via measured_cosine_similarity, strictly\nclamped between [ge=-1.0, le=1.0]. The participant_node_cids array (min_length=2) is\ndeterministically sorted via @model_validator to prevent Byzantine replay anomalies\nduring cross-swarm Merkle hashing.\n\nMCP ROUTING TRIGGERS: Earth Mover's Distance, Cosine Similarity, Vector Space Isometry,\nLatent Alignment, Holographic Graph Projection",
       "properties": {
+        "handshake_cid": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this protocol handshake to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Handshake Cid",
+          "type": "string"
+        },
+        "participant_node_cids": {
+          "description": "The agents establishing semantic alignment.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "maxItems": 250,
+          "minItems": 2,
+          "title": "Participant Node Cids",
+          "type": "array"
+        },
+        "measured_cosine_similarity": {
+          "description": "The calculated geometric alignment of the agents' core definitions.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Measured Cosine Similarity",
+          "type": "number"
+        },
         "alignment_status": {
           "description": "The final verdict of the handshake protocol.",
           "enum": [
@@ -12410,33 +12437,6 @@
           ],
           "default": null,
           "description": "The projection applied if the agents natively used different embedding dimensionalities."
-        },
-        "handshake_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this protocol handshake to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Handshake Cid",
-          "type": "string"
-        },
-        "measured_cosine_similarity": {
-          "description": "The calculated geometric alignment of the agents' core definitions.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Measured Cosine Similarity",
-          "type": "number"
-        },
-        "participant_node_cids": {
-          "description": "The agents establishing semantic alignment.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "maxItems": 250,
-          "minItems": 2,
-          "title": "Participant Node Cids",
-          "type": "array"
         },
         "remote_state_snapshot": {
           "anyOf": [
@@ -12464,22 +12464,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a Bipartite Graph Projection of Gibsonian Affordances, establishing the mathematically bounded subgraph of all capabilities currently valid for the agent.\n\nCAUSAL AFFORDANCE: Injects a dynamic Action Space manifold into the agent's working memory, authorizing the invocation of strictly defined toolsets and procedural manifolds.\n\nEPISTEMIC BOUNDS: Structural integrity is mathematically guaranteed by the `@model_validator`, which enforces unique `action_space_ids` and deterministically sorts `action_spaces`, `supported_personas`, and `available_procedural_manifolds` by their CIDs, ensuring invariant RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Gibsonian Affordances, Bipartite Graph Projection, Action Space Manifold, RFC 8785 Canonicalization, Holographic Subgraph",
       "properties": {
-        "action_spaces": {
-          "description": "The full, machine-readable declaration of accessible tools and MCP servers.",
-          "items": {
-            "$ref": "#/$defs/CognitiveActionSpaceManifest"
-          },
-          "title": "Action Spaces",
-          "type": "array"
-        },
-        "available_procedural_manifolds": {
-          "description": "The lightweight progressive disclosure tier for procedural skills.",
-          "items": {
-            "$ref": "#/$defs/ProceduralMetadataManifest"
-          },
-          "title": "Available Procedural Manifolds",
-          "type": "array"
-        },
         "projection_cid": {
           "description": "A cryptographic Lineage Watermark bounding this specific capability set.",
           "maxLength": 128,
@@ -12488,12 +12472,28 @@
           "title": "Projection Cid",
           "type": "string"
         },
+        "action_spaces": {
+          "description": "The full, machine-readable declaration of accessible tools and MCP servers.",
+          "items": {
+            "$ref": "#/$defs/CognitiveActionSpaceManifest"
+          },
+          "title": "Action Spaces",
+          "type": "array"
+        },
         "supported_personas": {
           "description": "The strict array of foundational model personas available.",
           "items": {
             "$ref": "#/$defs/ProfileCIDState"
           },
           "title": "Supported Personas",
+          "type": "array"
+        },
+        "available_procedural_manifolds": {
+          "description": "The lightweight progressive disclosure tier for procedural skills.",
+          "items": {
+            "$ref": "#/$defs/ProceduralMetadataManifest"
+          },
+          "title": "Available Procedural Manifolds",
           "type": "array"
         }
       },
@@ -12568,15 +12568,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A Dictatorial Byzantine Fault Resolution mechanism. It is an absolute, zero-trust kinetic override that violently preempts autonomous algorithmic consensus or prediction market resolution.\n\nCAUSAL AFFORDANCE: Forces an absolute Pearlian do-operator intervention ($do(X=x)$). Physically shatters the active causal chain of the `target_node_cid` and forcibly injects the `override_action` payload into the state vector, bypassing decentralized voting.\n\nEPISTEMIC BOUNDS: The blast radius is strictly confined to the `target_node_cid`. The orchestrator must mathematically verify the `authorized_node_id` against the highest-tier W3C DID enterprise clearance before allowing the payload to overwrite the Epistemic Blackboard (`override_action` bounded `max_length=1000`).\n\nMCP ROUTING TRIGGERS: Dictatorial Override, Byzantine Fault Resolution, Pearlian Intervention, Causal Shattering, Zero-Trust Override",
       "properties": {
+        "topology_class": {
+          "const": "override",
+          "default": "override",
+          "description": "The type of the intervention payload.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "authorized_node_id": {
           "$ref": "#/$defs/NodeCIDState",
           "description": "The NodeCIDState of the human or agent executing the override."
         },
-        "justification": {
-          "description": "Cryptographic audit justification for bypassing algorithmic consensus.",
-          "maxLength": 2000,
-          "title": "Justification",
-          "type": "string"
+        "target_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The NodeCIDState being forcefully overridden."
         },
         "override_action": {
           "additionalProperties": {
@@ -12590,15 +12595,10 @@
           "title": "Override Action",
           "type": "object"
         },
-        "target_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The NodeCIDState being forcefully overridden."
-        },
-        "topology_class": {
-          "const": "override",
-          "default": "override",
-          "description": "The type of the intervention payload.",
-          "title": "Topology Class",
+        "justification": {
+          "description": "Cryptographic audit justification for bypassing algorithmic consensus.",
+          "maxLength": 2000,
+          "title": "Justification",
           "type": "string"
         }
       },
@@ -12634,12 +12634,13 @@
           "title": "Adapter Id",
           "type": "string"
         },
-        "adapter_rank": {
-          "description": "The low-rank intrinsic dimension (r) of the update matrices, used by the orchestrator to calculate VRAM cost.",
-          "exclusiveMinimum": 0,
-          "maximum": 65536,
-          "title": "Adapter Rank",
-          "type": "integer"
+        "safetensors_hash": {
+          "description": "The SHA-256 hash of the cold-storage adapter weights file ensuring supply-chain zero-trust.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Safetensors Hash",
+          "type": "string"
         },
         "base_model_hash": {
           "description": "The SHA-256 hash of the exact foundational model this adapter was mathematically trained against.",
@@ -12648,6 +12649,23 @@
           "pattern": "^[a-f0-9]{64}$",
           "title": "Base Model Hash",
           "type": "string"
+        },
+        "adapter_rank": {
+          "description": "The low-rank intrinsic dimension (r) of the update matrices, used by the orchestrator to calculate VRAM cost.",
+          "exclusiveMinimum": 0,
+          "maximum": 65536,
+          "title": "Adapter Rank",
+          "type": "integer"
+        },
+        "target_modules": {
+          "description": "The explicit array of attention head modules to inject (e.g., ['q_proj', 'v_proj']).",
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Target Modules",
+          "type": "array"
         },
         "eviction_ttl_seconds": {
           "anyOf": [
@@ -12663,24 +12681,6 @@
           "default": null,
           "description": "The time-to-live before the inference engine forcefully evicts this adapter from the LRU cache.",
           "title": "Eviction Ttl Seconds"
-        },
-        "safetensors_hash": {
-          "description": "The SHA-256 hash of the cold-storage adapter weights file ensuring supply-chain zero-trust.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Safetensors Hash",
-          "type": "string"
-        },
-        "target_modules": {
-          "description": "The explicit array of attention head modules to inject (e.g., ['q_proj', 'v_proj']).",
-          "items": {
-            "maxLength": 255,
-            "type": "string"
-          },
-          "minItems": 1,
-          "title": "Target Modules",
-          "type": "array"
         }
       },
       "required": [
@@ -12697,6 +12697,11 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The strict Zero-Trust Architecture security perimeter defining exactly what external physical systems or networks an agent node is authorized to touch.\n\nCAUSAL AFFORDANCE: Mechanically limits kinetic reach. Forces the orchestrator to drop network egress packets, block disk I/O, or mandate cryptographic handshakes (e.g., mTLS) before allocating compute.\n\nEPISTEMIC BOUNDS: Bounded by deterministic string arrays (`allowed_domains`, `auth_requirements` constrained to `max_length=2000`) that are alphabetically sorted at instantiation via `@model_validator` to prevent Hash Poisoning attacks.\n\nMCP ROUTING TRIGGERS: Zero-Trust Architecture, Network Egress Filtering, Capability-Based Security, mTLS Handshake, Hash Poisoning Prevention",
       "properties": {
+        "network_access": {
+          "description": "The absolute Boolean gate authorizing or severing exogenous network egress.",
+          "title": "Network Access",
+          "type": "boolean"
+        },
         "allowed_domains": {
           "anyOf": [
             {
@@ -12714,6 +12719,11 @@
           "description": "The explicit whitelist of allowed network domains if network access is true.",
           "title": "Allowed Domains"
         },
+        "file_system_mutation_forbidden": {
+          "description": "The strict Boolean constraint severing local disk I/O capabilities.",
+          "title": "File System Mutation Forbidden",
+          "type": "boolean"
+        },
         "auth_requirements": {
           "anyOf": [
             {
@@ -12730,16 +12740,6 @@
           "default": null,
           "description": "An explicit array of authentication protocol identifiers (e.g., 'oauth2:github', 'mtls:internal') the orchestrator must negotiate before allocating compute.",
           "title": "Auth Requirements"
-        },
-        "file_system_mutation_forbidden": {
-          "description": "The strict Boolean constraint severing local disk I/O capabilities.",
-          "title": "File System Mutation Forbidden",
-          "type": "boolean"
-        },
-        "network_access": {
-          "description": "The absolute Boolean gate authorizing or severing exogenous network egress.",
-          "title": "Network Access",
-          "type": "boolean"
         }
       },
       "required": [
@@ -12753,28 +12753,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the absolute Write-Ahead Logging (WAL) serialization of an ephemeral state differential to durable cold-storage.\n\nCAUSAL AFFORDANCE: Commits the internal `committed_state_diff_id` into the macroscopic Apache Iceberg or Delta Lake backing store, yielding a verifiable `lakehouse_snapshot_id` to guarantee Eventual Consistency.\n\nEPISTEMIC BOUNDS: `lakehouse_snapshot_id` and `committed_state_diff_id` are rigorously clamped by `max_length=128` and a strict CID regex (`^[a-zA-Z0-9_.:-]+$`), mathematically preventing path traversal injections.\n\nMCP ROUTING TRIGGERS: Event Sourcing, Write-Ahead Logging, Two-Phase Commit, Lakehouse Serialization, State Differential Flush",
       "properties": {
-        "committed_state_diff_id": {
-          "description": "The internal StateDifferentialManifest CID that was flushed.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Committed State Diff Id",
-          "type": "string"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
-          "type": "string"
-        },
-        "lakehouse_snapshot_id": {
-          "description": "The external cryptographic receipt generated by Iceberg/Delta.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Lakehouse Snapshot Id",
           "type": "string"
         },
         "prior_event_hash": {
@@ -12793,13 +12777,6 @@
           "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
           "title": "Prior Event Hash"
         },
-        "target_table_uri": {
-          "description": "The specific table mutated.",
-          "maxLength": 2048,
-          "minLength": 1,
-          "title": "Target Table Uri",
-          "type": "string"
-        },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
           "maximum": 253402300799.0,
@@ -12812,6 +12789,29 @@
           "default": "persistence_commit",
           "description": "Discriminator type for a persistence commit receipt.",
           "title": "Topology Class",
+          "type": "string"
+        },
+        "lakehouse_snapshot_id": {
+          "description": "The external cryptographic receipt generated by Iceberg/Delta.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Lakehouse Snapshot Id",
+          "type": "string"
+        },
+        "committed_state_diff_id": {
+          "description": "The internal StateDifferentialManifest CID that was flushed.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Committed State Diff Id",
+          "type": "string"
+        },
+        "target_table_uri": {
+          "description": "The specific table mutated.",
+          "maxLength": 2048,
+          "minLength": 1,
+          "title": "Target Table Uri",
           "type": "string"
         }
       },
@@ -12829,20 +12829,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Cook-Torrance Microfacet BRDF (Bidirectional Reflectance Distribution Function) to establish the exact physical optic properties of a topological vertex.\n\nCAUSAL AFFORDANCE: Authorizes the spatial computing renderer to deterministically compute light scattering, reflection, and refraction for the node's geometry, translating logical state into physical optic variables (e.g., pulsing emission during active compute).\n\nEPISTEMIC BOUNDS: Diffuse and specular physics are rigidly clamped to normalized probability spaces (`ge=0.0, le=1.0`) for `metalness`, `roughness`, and `transmission`. The Index of Refraction (`ior`) is bounded to valid physical materials `[1.0, 3.0]`. `emissive_intensity` is clamped to `[0.0, 100.0]`.\n\nMCP ROUTING TRIGGERS: Physically Based Rendering, Microfacet BRDF, Index of Refraction, Spatial Optics, Material Thermodynamics",
       "properties": {
-        "emissive_intensity": {
-          "description": "The thermodynamic glow indicating active kinetic compute.",
-          "maximum": 100.0,
-          "minimum": 0.0,
-          "title": "Emissive Intensity",
-          "type": "number"
-        },
-        "ior": {
-          "description": "The Index of Refraction dictating photon trajectory.",
-          "maximum": 3.0,
-          "minimum": 1.0,
-          "title": "Ior",
-          "type": "number"
-        },
         "mesh_geometry": {
           "description": "The rigid 3D primitive geometry bounding the topological vertex.",
           "enum": [
@@ -12875,6 +12861,20 @@
           "minimum": 0.0,
           "title": "Transmission",
           "type": "number"
+        },
+        "ior": {
+          "description": "The Index of Refraction dictating photon trajectory.",
+          "maximum": 3.0,
+          "minimum": 1.0,
+          "title": "Ior",
+          "type": "number"
+        },
+        "emissive_intensity": {
+          "description": "The thermodynamic glow indicating active kinetic compute.",
+          "maximum": 100.0,
+          "minimum": 0.0,
+          "title": "Emissive Intensity",
+          "type": "number"
         }
       },
       "required": [
@@ -12902,18 +12902,18 @@
           "title": "Pq Algorithm",
           "type": "string"
         },
-        "pq_signature_blob": {
-          "description": "The base64-encoded post-quantum signature. Bounded to 100KB to safely accommodate massive SPHINCS+ hash trees without OOM crashes.",
-          "maxLength": 100000,
-          "title": "Pq Signature Blob",
-          "type": "string"
-        },
         "public_key_cid": {
           "description": "The identifier of the post-quantum public evaluation key.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Public Key Cid",
+          "type": "string"
+        },
+        "pq_signature_blob": {
+          "description": "The base64-encoded post-quantum signature. Bounded to 100KB to safely accommodate massive SPHINCS+ hash trees without OOM crashes.",
+          "maxLength": 100000,
+          "title": "Pq Signature Blob",
           "type": "string"
         }
       },
@@ -12929,20 +12929,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the mathematical Automated Market Maker (AMM) using Robin Hanson's Logarithmic Market Scoring Rule (LMSR) parameters to guarantee infinite liquidity.\n\nCAUSAL AFFORDANCE: Triggers quadratic staking functions to mathematically prevent Sybil attacks and dictates the exact `convergence_delta_threshold` required to halt trading and collapse the probability wave.\n\nEPISTEMIC BOUNDS: `min_liquidity_magnitude` is capped at an integer `le=1000000000, ge=0`, and `convergence_delta_threshold` is strictly clamped to a probability distribution `[ge=0.0, le=1.0]`. `staking_function` is a Literal.\n\nMCP ROUTING TRIGGERS: LMSR, Automated Market Maker, Quadratic Staking, Sybil Resistance, Convergence Delta",
       "properties": {
-        "convergence_delta_threshold": {
-          "description": "The threshold indicating the market price has stabilized enough to trigger the resolution oracle.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Convergence Delta Threshold",
-          "type": "number"
-        },
-        "min_liquidity_magnitude": {
-          "description": "Minimum liquidity required.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Min Liquidity Magnitude",
-          "type": "integer"
-        },
         "staking_function": {
           "description": "The mathematical curve applied to stakes. Quadratic enforces Sybil resistance.",
           "enum": [
@@ -12951,6 +12937,20 @@
           ],
           "title": "Staking Function",
           "type": "string"
+        },
+        "min_liquidity_magnitude": {
+          "description": "Minimum liquidity required.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Min Liquidity Magnitude",
+          "type": "integer"
+        },
+        "convergence_delta_threshold": {
+          "description": "The threshold indicating the market price has stabilized enough to trigger the resolution oracle.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Convergence Delta Threshold",
+          "type": "number"
         }
       },
       "required": [
@@ -12965,6 +12965,37 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of an Automated Market Maker (AMM) utilizing Robin Hanson's Logarithmic Market Scoring Rule (LMSR) to guarantee infinite liquidity.\n\nCAUSAL AFFORDANCE: Aggregates `HypothesisStakeReceipt` vectors, allowing the orchestrator to track the shifting probability manifold and trigger market resolution when the AMM reaches the required convergence threshold.\n\nEPISTEMIC BOUNDS: `current_market_probabilities` is geometrically bounded by `max_length=1000`. `market_cid` is restricted to a 128-char CID. `order_book` array is deterministically sorted by `agent_cid` via `@model_validator`.\n\nMCP ROUTING TRIGGERS: Logarithmic Market Scoring Rule, Automated Market Maker, Prediction Market, Infinite Liquidity, Brier Score",
       "properties": {
+        "market_cid": {
+          "description": "The deterministic capability pointer representing the prediction market.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Market Cid",
+          "type": "string"
+        },
+        "resolution_oracle_condition_id": {
+          "description": "The specific FalsificationContract ID whose execution will trigger the market payout.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Resolution Oracle Condition Id",
+          "type": "string"
+        },
+        "lmsr_b_parameter": {
+          "description": "The stringified decimal representing the liquidity parameter defining the market depth and max loss for the AMM.",
+          "maxLength": 255,
+          "pattern": "^\\d+\\.\\d+$",
+          "title": "Lmsr B Parameter",
+          "type": "string"
+        },
+        "order_book": {
+          "description": "The immutable ledger of all stakes placed by the swarm.",
+          "items": {
+            "$ref": "#/$defs/HypothesisStakeReceipt"
+          },
+          "title": "Order Book",
+          "type": "array"
+        },
         "current_market_probabilities": {
           "additionalProperties": {
             "maxLength": 255,
@@ -12977,37 +13008,6 @@
           },
           "title": "Current Market Probabilities",
           "type": "object"
-        },
-        "lmsr_b_parameter": {
-          "description": "The stringified decimal representing the liquidity parameter defining the market depth and max loss for the AMM.",
-          "maxLength": 255,
-          "pattern": "^\\d+\\.\\d+$",
-          "title": "Lmsr B Parameter",
-          "type": "string"
-        },
-        "market_cid": {
-          "description": "The deterministic capability pointer representing the prediction market.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Market Cid",
-          "type": "string"
-        },
-        "order_book": {
-          "description": "The immutable ledger of all stakes placed by the swarm.",
-          "items": {
-            "$ref": "#/$defs/HypothesisStakeReceipt"
-          },
-          "title": "Order Book",
-          "type": "array"
-        },
-        "resolution_oracle_condition_id": {
-          "description": "The specific FalsificationContract ID whose execution will trigger the market payout.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Resolution Oracle Condition Id",
-          "type": "string"
         }
       },
       "required": [
@@ -13024,6 +13024,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The macroscopic orchestrator envelope binding a deterministic visual\nmanifold (grid: MacroGridProfile) to a specific Supervisory Control Theory cognitive\nstate (intent: AnyPresentationIntent). As a ...Manifest suffix, this defines a frozen,\nN-dimensional coordinate state.\n\nCAUSAL AFFORDANCE: Forces the active orchestration loop to suspend or pivot by projecting\na human-in-the-loop interaction surface (e.g., Drafting, Adjudication) alongside its\nvisual evidentiary warrants.\n\nEPISTEMIC BOUNDS: Mathematically binds exactly one AnyPresentationIntent to one\nMacroGridProfile, preventing asynchronous UI state drift and ensuring the generated grid\nis causally justified by a verified intent. The focal_depth_meters is strictly clamped\n(ge=0.1, le=100.0) to physically intercept the observer's optical plane at a safe depth.\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, Mixed-Initiative UI, Cognitive State\nBinding, Structural Manifold Envelope, Human-in-the-Loop",
       "properties": {
+        "intent": {
+          "$ref": "#/$defs/AnyPresentationIntent",
+          "description": "The reason an agent is presenting this data to a human."
+        },
+        "grid": {
+          "$ref": "#/$defs/MacroGridProfile",
+          "description": "The grid of panels being presented."
+        },
         "ambient_telemetry": {
           "anyOf": [
             {
@@ -13043,14 +13051,6 @@
           "minimum": 0.1,
           "title": "Focal Depth Meters",
           "type": "number"
-        },
-        "grid": {
-          "$ref": "#/$defs/MacroGridProfile",
-          "description": "The grid of panels being presented."
-        },
-        "intent": {
-          "$ref": "#/$defs/AnyPresentationIntent",
-          "description": "The reason an agent is presenting this data to a human."
         }
       },
       "required": [
@@ -13064,18 +13064,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a Level-1 Epistemic Discovery Surface utilizing Lazy Evaluation and Information Bottleneck Theory to act as a progressive disclosure pointer to a massive EpistemicSOPManifest.\n\nCAUSAL AFFORDANCE: Prevents context window token exhaustion by keeping the full Standard Operating Procedure in cold storage until the agent's generative trajectory actively mathematically intersects with the `trigger_description`.\n\nEPISTEMIC BOUNDS: The `metadata_cid` and `target_sop_id` are physically locked to 128-char CIDs. The semantic geometry of the `trigger_description` is clamped at `max_length=2000` to prevent dictionary bombing during routing evaluation.\n\nMCP ROUTING TRIGGERS: Lazy Evaluation, Progressive Disclosure, Information Bottleneck, Discovery Surface, Epistemic Pointer",
       "properties": {
-        "latent_vector_coordinate": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/VectorEmbeddingState"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Optional dense-vector geometry for zero-shot semantic routing without LLM forward-pass evaluation."
-        },
         "metadata_cid": {
           "description": "A strict cryptographic string identifier for this L1 procedural pointer.",
           "maxLength": 128,
@@ -13097,6 +13085,18 @@
           "maxLength": 2000,
           "title": "Trigger Description",
           "type": "string"
+        },
+        "latent_vector_coordinate": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/VectorEmbeddingState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional dense-vector geometry for zero-shot semantic routing without LLM forward-pass evaluation."
         }
       },
       "required": [
@@ -13123,6 +13123,20 @@
           "default": null,
           "description": "The dynamic circuit breaker that halts the search when PRM variance converges, preventing VRAM waste."
         },
+        "pruning_threshold": {
+          "description": "If a ThoughtBranchState's prm_score falls below this threshold, the orchestrator MUST halt its generation.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Pruning Threshold",
+          "type": "number"
+        },
+        "max_backtracks_allowed": {
+          "description": "The absolute limit on how many times the agent can start a new branch before throwing a SystemFaultEvent.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Max Backtracks Allowed",
+          "type": "integer"
+        },
         "evaluator_matrix_name": {
           "anyOf": [
             {
@@ -13136,20 +13150,6 @@
           "default": null,
           "description": "The specific PRM model used to score the logic (e.g., 'math-prm-v2').",
           "title": "Evaluator Matrix Name"
-        },
-        "max_backtracks_allowed": {
-          "description": "The absolute limit on how many times the agent can start a new branch before throwing a SystemFaultEvent.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Max Backtracks Allowed",
-          "type": "integer"
-        },
-        "pruning_threshold": {
-          "description": "If a ThoughtBranchState's prm_score falls below this threshold, the orchestrator MUST halt its generation.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Pruning Threshold",
-          "type": "number"
         }
       },
       "required": [
@@ -13183,21 +13183,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Triggers an Epistemic Quarantine utilizing rigid Spectral Graph Partitioning to mathematically isolate a hallucinating, degraded, or Byzantine node from the active working context.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to sever all outgoing causal edges from the `target_node_cid`, reducing its algebraic connectivity to zero. Neutralizes probability mass in the routing manifold and prevents entropy contamination.\n\nEPISTEMIC BOUNDS: The execution discriminator is locked to a strict Literal string. Topological isolation is strictly targeted via `target_node_cid`. The causal justification for the graph cut is physically constrained to `reason` (`max_length=2000`).\n\nMCP ROUTING TRIGGERS: Spectral Graph Partitioning, Byzantine Fault Isolation, Epistemic Contagion, Defeasible Logic, Algebraic Connectivity",
       "properties": {
-        "reason": {
-          "description": "The deterministic causal justification for the structural quarantine.",
-          "maxLength": 2000,
-          "title": "Reason",
+        "topology_class": {
+          "const": "quarantine_intent",
+          "default": "quarantine_intent",
+          "description": "The type of the resilience payload.",
+          "title": "Topology Class",
           "type": "string"
         },
         "target_node_cid": {
           "$ref": "#/$defs/NodeCIDState",
           "description": "The deterministic capability pointer representing the node to be quarantined."
         },
-        "topology_class": {
-          "const": "quarantine_intent",
-          "default": "quarantine_intent",
-          "description": "The type of the resilience payload.",
-          "title": "Topology Class",
+        "reason": {
+          "description": "The deterministic causal justification for the structural quarantine.",
+          "maxLength": 2000,
+          "title": "Reason",
           "type": "string"
         }
       },
@@ -13212,16 +13212,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the Practical Byzantine Fault Tolerance (pBFT)\nmathematical boundaries for a decentralized swarm to survive malicious or hallucinating\nactors. As a ...Policy suffix, this object defines rigid mathematical boundaries.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to validate the state_validation_metric\n(Literal [\"ledger_hash\", \"zk_proof\", \"semantic_embedding\"]) across $N$ nodes, physically\nexecuting the byzantine_action (Literal [\"quarantine\", \"slash_escrow\", \"ignore\"])\nagainst nodes that violate the consensus.\n\nEPISTEMIC BOUNDS: Physically bounds max_tolerable_faults (ge=0, le=1000000000) and\nmin_quorum_size (gt=0, le=1000000000). The @model_validator enforce_bft_math enforces\nthe strict invariant $N \\ge 3f + 1$, guaranteeing Byzantine agreement.\n\nMCP ROUTING TRIGGERS: Byzantine Fault Tolerance, pBFT, Quorum Sensing, Sybil\nResistance, Distributed Consensus",
       "properties": {
-        "byzantine_action": {
-          "description": "The deterministic punishment executed by the orchestrator against nodes that violate the consensus quorum.",
-          "enum": [
-            "quarantine",
-            "slash_escrow",
-            "ignore"
-          ],
-          "title": "Byzantine Action",
-          "type": "string"
-        },
         "max_tolerable_faults": {
           "description": "The maximum number of actively malicious, hallucinating, or degraded nodes (f) the swarm must survive.",
           "maximum": 1000000000,
@@ -13245,6 +13235,16 @@
           ],
           "title": "State Validation Metric",
           "type": "string"
+        },
+        "byzantine_action": {
+          "description": "The deterministic punishment executed by the orchestrator against nodes that violate the consensus quorum.",
+          "enum": [
+            "quarantine",
+            "slash_escrow",
+            "ignore"
+          ],
+          "title": "Byzantine Action",
+          "type": "string"
         }
       },
       "required": [
@@ -13260,19 +13260,19 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Governs how human rejections translate into penalty scalars to bend the agent's Monte Carlo Tree Search.\n\nCAUSAL AFFORDANCE: Permits human observation and penalty insertion into internal LatentScratchpadReceipt traces without halting the execution tree.\n\nEPISTEMIC BOUNDS: Bounds `telemetry_export_frequency_hz` between 1 and 60. Bounds `human_override_gradient` between `0.0` and `1.0`.\n\nMCP ROUTING TRIGGERS: Supervisory Control Theory, MCTS Bending, Penalty Scalar, Trace Evaluation, Cognitive Engineering",
       "properties": {
-        "human_override_gradient": {
-          "description": "The absolute penalty applied to a prm_score if a human rejects the branch.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Human Override Gradient",
-          "type": "number"
-        },
         "telemetry_export_frequency_hz": {
           "description": "The continuous stream rate of the thought branch expansion.",
           "maximum": 60,
           "minimum": 1,
           "title": "Telemetry Export Frequency Hz",
           "type": "integer"
+        },
+        "human_override_gradient": {
+          "description": "The absolute penalty applied to a prm_score if a human rejects the branch.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Human Override Gradient",
+          "type": "number"
         }
       },
       "required": [
@@ -13286,13 +13286,29 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a deterministic Data Sanitization heuristic mapped to a\nspecific SemanticClassificationProfile (e.g., Bell-LaPadula clearance levels). As a\n...Policy suffix, this object defines rigid mathematical boundaries that the orchestrator\nmust enforce globally.\n\nCAUSAL AFFORDANCE: Executes a rigid regex-bounded search-and-replace algorithm via\ntarget_regex_pattern to mutate or mask toxic data payloads, substituting matches with a\nsafe replacement_token. The action (SanitizationActionIntent) dictates the exact\nsanitization method.\n\nEPISTEMIC BOUNDS: The target_regex_pattern is strictly capped at max_length=200 to\nmathematically prevent ReDoS (Regular Expression Denial of Service) CPU exhaustion. A\nsecondary target_pattern (max_length=2000) provides a broader semantic entity match. The\noptional context_exclusion_zones array (max_length=100) is deterministically sorted by\nthe @model_validator.\n\nMCP ROUTING TRIGGERS: Data Sanitization, Regular Expression DoS Prevention,\nBell-LaPadula Model, Masking Heuristic, Algorithmic Redaction",
       "properties": {
-        "action": {
-          "$ref": "#/$defs/SanitizationActionIntent",
-          "description": "The required algorithmic response when this pattern is detected."
+        "rule_cid": {
+          "description": "Unique identifier for the sanitization rule.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Rule Cid",
+          "type": "string"
         },
         "classification": {
           "$ref": "#/$defs/SemanticClassificationProfile",
           "description": "The category of sensitive payload this rule targets."
+        },
+        "target_pattern": {
+          "description": "The semantic entity type or declarative regex pattern to identify.",
+          "maxLength": 2000,
+          "title": "Target Pattern",
+          "type": "string"
+        },
+        "target_regex_pattern": {
+          "description": "The dynamic regex pattern to target.",
+          "maxLength": 200,
+          "title": "Target Regex Pattern",
+          "type": "string"
         },
         "context_exclusion_zones": {
           "anyOf": [
@@ -13312,6 +13328,10 @@
           "description": "Specific JSON paths where this rule should NOT apply.",
           "title": "Context Exclusion Zones"
         },
+        "action": {
+          "$ref": "#/$defs/SanitizationActionIntent",
+          "description": "The required algorithmic response when this pattern is detected."
+        },
         "replacement_token": {
           "anyOf": [
             {
@@ -13325,26 +13345,6 @@
           "default": null,
           "description": "The strictly typed string to insert if the action is 'redact'.",
           "title": "Replacement Token"
-        },
-        "rule_cid": {
-          "description": "Unique identifier for the sanitization rule.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Rule Cid",
-          "type": "string"
-        },
-        "target_pattern": {
-          "description": "The semantic entity type or declarative regex pattern to identify.",
-          "maxLength": 2000,
-          "title": "Target Pattern",
-          "type": "string"
-        },
-        "target_regex_pattern": {
-          "description": "The dynamic regex pattern to target.",
-          "maxLength": 200,
-          "title": "Target Regex Pattern",
-          "type": "string"
         }
       },
       "required": [
@@ -13371,16 +13371,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A kinetic execution trigger initiating a macroscopic Pearlian\ncounterfactual reversal, mathematically rewinding the state vector to a pristine historical\nMerkle root. As an ...Intent suffix, the LLM may execute non-monotonic reasoning here.\n\nCAUSAL AFFORDANCE: Forces the orchestrator to execute a Pearlian do-operator intervention\n($do(X=x)$), flushing all invalidated_node_cids from the active context and restoring the\ntopology to the target_event_cid coordinate.\n\nEPISTEMIC BOUNDS: Deterministic execution is mathematically guaranteed by the\n@model_validator which strictly alphabetizes invalidated_node_cids via sorted() prior to\nRFC 8785 canonical hashing, preventing Byzantine replay divergence.\n\nMCP ROUTING TRIGGERS: Pearlian Counterfactual, Causal Reversal, State Vector Rollback,\nTemporal Negation, Topological Falsification",
       "properties": {
-        "invalidated_node_cids": {
-          "description": "The strict array of nodes whose operational histories are causally tainted and must be flushed.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "title": "Invalidated Node Cids",
-          "type": "array"
-        },
         "request_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for the causal rollback operation.",
           "maxLength": 128,
@@ -13396,6 +13386,16 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Target Event Cid",
           "type": "string"
+        },
+        "invalidated_node_cids": {
+          "description": "The strict array of nodes whose operational histories are causally tainted and must be flushed.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "title": "Invalidated Node Cids",
+          "type": "array"
         }
       },
       "required": [
@@ -13409,33 +13409,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The Multi-Objective Optimization matrix used to navigate the Spot-Market compute layer, calculating the Pareto Efficiency frontier between speed, cost, and intelligence.\n\nCAUSAL AFFORDANCE: Instructs the Spot-Market router on how to mechanically weigh competing inference engines. If a query requires extreme logic, it authorizes high cost; if it requires a UI reflex, it enforces strict latency bounds.\n\nEPISTEMIC BOUNDS: Strict physical, economic, and thermodynamic ceilings are mathematically enforced: `max_latency_ms` (`le=86400000`), `max_cost_magnitude_per_token` (`le=1000000000`), and an absolute ESG bound via `max_carbon_intensity_gco2eq_kwh` (`le=10000.0`).\n\nMCP ROUTING TRIGGERS: Pareto Efficiency, Multi-Objective Optimization, Spot-Market Routing, Carbon Budget, Compute Allocation",
       "properties": {
-        "max_carbon_intensity_gco2eq_kwh": {
-          "anyOf": [
-            {
-              "maximum": 10000.0,
-              "minimum": 0.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The maximum operational carbon intensity of the physical data center grid allowed for this agent's routing.",
-          "title": "Max Carbon Intensity Gco2Eq Kwh"
+        "max_latency_ms": {
+          "description": "The absolute physical speed limit acceptable for time-to-first-token or total generation.",
+          "exclusiveMinimum": 0,
+          "maximum": 86400000,
+          "title": "Max Latency Ms",
+          "type": "integer"
         },
         "max_cost_magnitude_per_token": {
           "description": "The strict magnitude ceiling. MUST be an integer to maintain cryptographic determinism.",
           "exclusiveMinimum": 0,
           "maximum": 1000000000,
           "title": "Max Cost Magnitude Per Token",
-          "type": "integer"
-        },
-        "max_latency_ms": {
-          "description": "The absolute physical speed limit acceptable for time-to-first-token or total generation.",
-          "exclusiveMinimum": 0,
-          "maximum": 86400000,
-          "title": "Max Latency Ms",
           "type": "integer"
         },
         "min_capability_score": {
@@ -13456,6 +13441,21 @@
           ],
           "title": "Tradeoff Preference",
           "type": "string"
+        },
+        "max_carbon_intensity_gco2eq_kwh": {
+          "anyOf": [
+            {
+              "maximum": 10000.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The maximum operational carbon intensity of the physical data center grid allowed for this agent's routing.",
+          "title": "Max Carbon Intensity Gco2Eq Kwh"
         }
       },
       "required": [
@@ -13471,6 +13471,81 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a strict rigid-body transformation within the Special Euclidean group SE(3). Projects an absolute mathematical coordinate encompassing both translation ($\\mathbb{R}^3$) and rotation ($S^3$).\n\nCAUSAL AFFORDANCE: Provides the absolute spatial terminus for UI matrices, multi-agent topologies, and multimodal tokens, dictating the exact kinematic positioning of a node relative to a verified SpatialReferenceFrameManifest.\n\nEPISTEMIC BOUNDS: Translation vectors are unbounded floats. Rotational geometry is rigidly constrained to a 4D unit quaternion bounded `[-1.0, 1.0]`. The `@model_validator` `enforce_quaternion_normalization` physically guarantees singularity-free rotation by enforcing an absolute quaternion magnitude of 1.0, eliminating Gimbal Lock. `scale` is bounded `[0.0001, 10000.0]`.\n\nMCP ROUTING TRIGGERS: Special Euclidean Group, SE(3) Manifold, Rigid Body Transformation, Hamiltonian Unit Quaternion, Kinematic Topology",
       "properties": {
+        "reference_frame_cid": {
+          "description": "The SpatialReferenceFrameManifest CID this coordinate is relative to, anchoring it to a physical or virtual room.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Reference Frame Cid",
+          "type": "string"
+        },
+        "x": {
+          "description": "Translation along the X-axis relative to the reference frame.",
+          "title": "X",
+          "type": "number"
+        },
+        "y": {
+          "description": "Translation along the Y-axis relative to the reference frame.",
+          "title": "Y",
+          "type": "number"
+        },
+        "z": {
+          "description": "Translation along the Z-axis relative to the reference frame.",
+          "title": "Z",
+          "type": "number"
+        },
+        "qx": {
+          "default": 0.0,
+          "description": "The i component of the rotation quaternion.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Qx",
+          "type": "number"
+        },
+        "qy": {
+          "default": 0.0,
+          "description": "The j component of the rotation quaternion.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Qy",
+          "type": "number"
+        },
+        "qz": {
+          "default": 0.0,
+          "description": "The k component of the rotation quaternion.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Qz",
+          "type": "number"
+        },
+        "qw": {
+          "default": 1.0,
+          "description": "The real (scalar) part of the rotation quaternion.",
+          "maximum": 1.0,
+          "minimum": -1.0,
+          "title": "Qw",
+          "type": "number"
+        },
+        "scale": {
+          "default": 1.0,
+          "description": "Strictly positive uniform volumetric scaling factor.",
+          "maximum": 10000.0,
+          "minimum": 0.0001,
+          "title": "Scale",
+          "type": "number"
+        },
+        "kinematic_derivatives": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/KinematicDerivativeTensor"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Tensors governing continuous momentum and velocity."
+        },
         "dual_quaternion_motor": {
           "anyOf": [
             {
@@ -13511,81 +13586,6 @@
           "default": null,
           "description": "The 8-dimensional Clifford Algebra motor for mathematically flawless ScLERP interpolation.",
           "title": "Dual Quaternion Motor"
-        },
-        "kinematic_derivatives": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/KinematicDerivativeTensor"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Tensors governing continuous momentum and velocity."
-        },
-        "qw": {
-          "default": 1.0,
-          "description": "The real (scalar) part of the rotation quaternion.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Qw",
-          "type": "number"
-        },
-        "qx": {
-          "default": 0.0,
-          "description": "The i component of the rotation quaternion.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Qx",
-          "type": "number"
-        },
-        "qy": {
-          "default": 0.0,
-          "description": "The j component of the rotation quaternion.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Qy",
-          "type": "number"
-        },
-        "qz": {
-          "default": 0.0,
-          "description": "The k component of the rotation quaternion.",
-          "maximum": 1.0,
-          "minimum": -1.0,
-          "title": "Qz",
-          "type": "number"
-        },
-        "reference_frame_cid": {
-          "description": "The SpatialReferenceFrameManifest CID this coordinate is relative to, anchoring it to a physical or virtual room.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Reference Frame Cid",
-          "type": "string"
-        },
-        "scale": {
-          "default": 1.0,
-          "description": "Strictly positive uniform volumetric scaling factor.",
-          "maximum": 10000.0,
-          "minimum": 0.0001,
-          "title": "Scale",
-          "type": "number"
-        },
-        "x": {
-          "description": "Translation along the X-axis relative to the reference frame.",
-          "title": "X",
-          "type": "number"
-        },
-        "y": {
-          "description": "Translation along the Y-axis relative to the reference frame.",
-          "title": "Y",
-          "type": "number"
-        },
-        "z": {
-          "description": "Translation along the Z-axis relative to the reference frame.",
-          "title": "Z",
-          "type": "number"
         }
       },
       "required": [
@@ -13601,6 +13601,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot establishing a Secure Multi-Party Computation (SMPC) ring, leveraging cryptographic privacy-preserving protocols to evaluate a joint function over decentralized inputs.\n\nCAUSAL AFFORDANCE: Authorizes the decentralized orchestrator to route zero-trust traffic via specific mathematical logic (`garbled_circuits`, `secret_sharing`, `oblivious_transfer`), allowing mutually distrustful agents to synthesize a shared output.\n\nEPISTEMIC BOUNDS: The topology physically mandates a minimum of two participants (`participant_node_cids` `min_length=2`) to satisfy the multi-party invariant. The `joint_function_uri` is bounded to `max_length=2000`. Nodes are deterministically sorted.\n\nMCP ROUTING TRIGGERS: Secure Multi-Party Computation, Garbled Circuits, Secret Sharing, Oblivious Transfer, Zero-Trust Cryptography",
       "properties": {
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
+        },
         "architectural_intent": {
           "anyOf": [
             {
@@ -13614,24 +13636,6 @@
           "default": null,
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
-        "joint_function_uri": {
-          "description": "The URI or hash pointing to the exact math circuit or polynomial function the ring will collaboratively compute.",
-          "maxLength": 2000,
-          "title": "Joint Function Uri",
-          "type": "string"
         },
         "justification": {
           "anyOf": [
@@ -13647,16 +13651,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -13667,53 +13661,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "ontological_alignment": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/OntologicalAlignmentPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
-        },
-        "participant_node_cids": {
-          "description": "The strict ordered array of NodeIdentifierStates participating in the Secure Multi-Party Computation ring.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "type": "string"
-          },
-          "minItems": 2,
-          "title": "Participant Node Cids",
-          "type": "array"
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -13727,6 +13674,37 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
+        "topology_class": {
+          "const": "smpc",
+          "default": "smpc",
+          "description": "Discriminator for SMPC Topology.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "smpc_protocol": {
           "description": "The exact cryptographic P2P protocol the nodes must use to evaluate the function.",
           "enum": [
@@ -13737,12 +13715,34 @@
           "title": "Smpc Protocol",
           "type": "string"
         },
-        "topology_class": {
-          "const": "smpc",
-          "default": "smpc",
-          "description": "Discriminator for SMPC Topology.",
-          "title": "Topology Class",
+        "joint_function_uri": {
+          "description": "The URI or hash pointing to the exact math circuit or polynomial function the ring will collaboratively compute.",
+          "maxLength": 2000,
+          "title": "Joint Function Uri",
           "type": "string"
+        },
+        "participant_node_cids": {
+          "description": "The strict ordered array of NodeIdentifierStates participating in the Secure Multi-Party Computation ring.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "type": "string"
+          },
+          "minItems": 2,
+          "title": "Participant Node Cids",
+          "type": "array"
+        },
+        "ontological_alignment": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/OntologicalAlignmentPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The pre-flight execution gate forcing agents to mathematically align their latent semantics before participating in the topology."
         }
       },
       "required": [
@@ -13758,18 +13758,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements an Asynchronous Event-Driven Architecture leveraging Server-Sent Events (SSE) to map a unidirectional, continuous topology of Server-to-Client state transitions.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to maintain a persistent, long-lived TCP connection, processing incoming JSON-RPC streams without the thermodynamic overhead of continuous polling.\n\nEPISTEMIC BOUNDS: The `headers` are strictly limited via `StringConstraints` (`max_length=255/2000`) and mathematically sanitized against CRLF injection via `@field_validator` `_prevent_crlf_injection` to preserve protocol boundary integrity.\n\nMCP ROUTING TRIGGERS: Event-Driven Architecture, Server-Sent Events, Unidirectional Stream, Asynchronous Message Passing, TCP Persistence",
       "properties": {
-        "headers": {
-          "additionalProperties": {
-            "maxLength": 2000,
-            "type": "string"
-          },
-          "description": "HTTP headers, e.g., for authentication.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Headers",
-          "type": "object"
-        },
         "topology_class": {
           "const": "sse",
           "default": "sse",
@@ -13784,6 +13772,18 @@
           "minLength": 1,
           "title": "Uri",
           "type": "string"
+        },
+        "headers": {
+          "additionalProperties": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "description": "HTTP headers, e.g., for authentication.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Headers",
+          "type": "object"
         }
       },
       "required": [
@@ -13796,18 +13796,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Isolates a discrete, monosemantic feature from the foundational model's polysemantic residual stream using a Sparse Autoencoder (SAE) projection matrix.\n\nCAUSAL AFFORDANCE: Surfaces hidden geometric concept vectors (e.g., 'sycophancy' or 'truth_retrieval') to the orchestrator, enabling real-time circuit-level inspection, feature clamping, and causal tracing.\n\nEPISTEMIC BOUNDS: The semantic abstraction is rigidly bounded to a specific `feature_index` (`ge=0, le=1000000000`). `activation_magnitude` physically measures Euclidean strength (`le=1000000000`). Optional `interpretability_label` restricts semantic descriptions (`max_length=2000`).\n\nMCP ROUTING TRIGGERS: Sparse Autoencoder, Monosemantic Feature, Concept Vector, Mechanistic Interpretability, Euclidean Magnitude",
       "properties": {
-        "activation_magnitude": {
-          "description": "The mathematical strength of this feature's activation during the forward pass.",
-          "maximum": 1000000000,
-          "title": "Activation Magnitude",
-          "type": "number"
-        },
         "feature_index": {
           "description": "The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
           "maximum": 1000000000,
           "minimum": 0,
           "title": "Feature Index",
           "type": "integer"
+        },
+        "activation_magnitude": {
+          "description": "The mathematical strength of this feature's activation during the forward pass.",
+          "maximum": 1000000000,
+          "title": "Activation Magnitude",
+          "type": "number"
         },
         "interpretability_label": {
           "anyOf": [
@@ -13833,8 +13833,43 @@
     },
     "SaeLatentPolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability to actively monitor and steer monosemantic neural circuits during the model's forward pass.\n\nCAUSAL AFFORDANCE: Executes real-time tensor remediation\u2014clamping, halting, quarantining, or smoothly decaying residual stream activations\u2014when specific features diverge toward adversarial or hallucinated geometries.\n\nEPISTEMIC BOUNDS: The `max_activation_threshold` (`ge=0.0, le=1000000000.0`) physically bounds the continuous Euclidean magnitude of the `target_feature_index`. Topologically locked to SAE matrix via `sae_dictionary_hash` (SHA-256). The `@model_validator` `validate_smooth_decay` mathematically enforces asymptotic bounds.\n\nMCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream Steering, Tensor Remediation, Monosemantic Features",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability to actively monitor and steer monosemantic neural circuits during the model's forward pass.\n\nCAUSAL AFFORDANCE: Executes real-time tensor remediation—clamping, halting, quarantining, or smoothly decaying residual stream activations—when specific features diverge toward adversarial or hallucinated geometries.\n\nEPISTEMIC BOUNDS: The `max_activation_threshold` (`ge=0.0, le=1000000000.0`) physically bounds the continuous Euclidean magnitude of the `target_feature_index`. Topologically locked to SAE matrix via `sae_dictionary_hash` (SHA-256). The `@model_validator` `validate_smooth_decay` mathematically enforces asymptotic bounds.\n\nMCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream Steering, Tensor Remediation, Monosemantic Features",
       "properties": {
+        "target_feature_index": {
+          "description": "The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Target Feature Index",
+          "type": "integer"
+        },
+        "monitored_layers": {
+          "description": "The specific transformer layer indices where this feature activation must be monitored.",
+          "items": {
+            "minimum": 0,
+            "type": "integer"
+          },
+          "minItems": 1,
+          "title": "Monitored Layers",
+          "type": "array"
+        },
+        "max_activation_threshold": {
+          "description": "The mathematical magnitude limit. If the feature activates beyond this, the firewall trips.",
+          "maximum": 1000000000.0,
+          "minimum": 0.0,
+          "title": "Max Activation Threshold",
+          "type": "number"
+        },
+        "violation_action": {
+          "description": "The tensor-level remediation applied when the threshold is breached.",
+          "enum": [
+            "clamp",
+            "halt",
+            "quarantine",
+            "smooth_decay"
+          ],
+          "title": "Violation Action",
+          "type": "string"
+        },
         "clamp_value": {
           "anyOf": [
             {
@@ -13848,23 +13883,6 @@
           "default": null,
           "description": "If violation_action is 'clamp', the physical value to which the activation tensor is forced.",
           "title": "Clamp Value"
-        },
-        "max_activation_threshold": {
-          "description": "The mathematical magnitude limit. If the feature activates beyond this, the firewall trips.",
-          "maximum": 1000000000.0,
-          "minimum": 0.0,
-          "title": "Max Activation Threshold",
-          "type": "number"
-        },
-        "monitored_layers": {
-          "description": "The specific transformer layer indices where this feature activation must be monitored.",
-          "items": {
-            "minimum": 0,
-            "type": "integer"
-          },
-          "minItems": 1,
-          "title": "Monitored Layers",
-          "type": "array"
         },
         "sae_dictionary_hash": {
           "description": "The SHA-256 hash of the exact SAE projection matrix required to decode this feature.",
@@ -13885,24 +13903,6 @@
           ],
           "default": null,
           "description": "The geometric parameters for continuous attenuation if violation_action is 'smooth_decay'."
-        },
-        "target_feature_index": {
-          "description": "The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Target Feature Index",
-          "type": "integer"
-        },
-        "violation_action": {
-          "description": "The tensor-level remediation applied when the threshold is breached.",
-          "enum": [
-            "clamp",
-            "halt",
-            "quarantine",
-            "smooth_decay"
-          ],
-          "title": "Violation Action",
-          "type": "string"
         }
       },
       "required": [
@@ -13954,19 +13954,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Stevens's levels of measurement and Wilkinson's Grammar of Graphics to mathematically project abstract data domains into visual geometric ranges.\n\nCAUSAL AFFORDANCE: Physically distorts or linearly maps the input metric tensor into rendering space, dictating how the orchestrator processes logarithmic, temporal, or ordinal data vectors for UI projection.\n\nEPISTEMIC BOUNDS: The transformation algorithm is strictly constrained to a Literal automaton `[\"linear\", \"log\", \"time\", \"ordinal\", \"nominal\"]`. Physical data boundaries (`domain_min`, `domain_max`) are upper-bounded by `le=1000000000.0` to prevent geometric projection overflow.\n\nMCP ROUTING TRIGGERS: Grammar of Graphics, Metric Tensor Distortion, Levels of Measurement, Scale Projection, FSM Literal",
       "properties": {
-        "domain_max": {
-          "anyOf": [
-            {
-              "maximum": 1000000000.0,
-              "type": "number"
-            },
-            {
-              "type": "null"
-            }
+        "topology_class": {
+          "description": "The strictly typed mathematical mapping function distorting metrics into Euclidean pixel space.",
+          "enum": [
+            "linear",
+            "log",
+            "time",
+            "ordinal",
+            "nominal"
           ],
-          "default": null,
-          "description": "The optional maximum bound of the scale domain.",
-          "title": "Domain Max"
+          "title": "Topology Class",
+          "type": "string"
         },
         "domain_min": {
           "anyOf": [
@@ -13982,17 +13980,19 @@
           "description": "The optional minimum bound of the scale domain.",
           "title": "Domain Min"
         },
-        "topology_class": {
-          "description": "The strictly typed mathematical mapping function distorting metrics into Euclidean pixel space.",
-          "enum": [
-            "linear",
-            "log",
-            "time",
-            "ordinal",
-            "nominal"
+        "domain_max": {
+          "anyOf": [
+            {
+              "maximum": 1000000000.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
           ],
-          "title": "Topology Class",
-          "type": "string"
+          "default": null,
+          "description": "The optional maximum bound of the scale domain.",
+          "title": "Domain Max"
         }
       },
       "required": [
@@ -14005,6 +14005,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Principle of Least Privilege (PoLP) and Time-Based Access Control (TBAC) for handling high-entropy cryptographic secrets within a declarative N-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Authorizes a temporary, mathematically bounded partition where the agent can access unredacted enterprise vault keys without permanently leaking them into the global EpistemicLedgerState.\n\nEPISTEMIC BOUNDS: The temporal exposure window is physically clamped by `max_ttl_seconds` (`ge=1, le=3600`), enforcing an absolute maximum 1-hour session. Spatial access is geometrically restricted to `allowed_vault_keys` (`max_length=100`), deterministically sorted by `@model_validator` for RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Principle of Least Privilege, Time-Based Access Control, Secret Vaulting, Ephemeral Partition, Cryptographic Isolation",
       "properties": {
+        "session_cid": {
+          "description": "Unique identifier for the secure session.",
+          "maxLength": 255,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Session Cid",
+          "type": "string"
+        },
         "allowed_vault_keys": {
           "description": "The explicit array of enterprise vault keys the agent is temporarily allowed to access.",
           "items": {
@@ -14015,12 +14023,6 @@
           "title": "Allowed Vault Keys",
           "type": "array"
         },
-        "description": {
-          "description": "Audit justification for this temporary secure session.",
-          "maxLength": 2000,
-          "title": "Description",
-          "type": "string"
-        },
         "max_ttl_seconds": {
           "description": "Maximum time-to-live for the unredacted state partition.",
           "maximum": 3600,
@@ -14028,12 +14030,10 @@
           "title": "Max Ttl Seconds",
           "type": "integer"
         },
-        "session_cid": {
-          "description": "Unique identifier for the secure session.",
-          "maxLength": 255,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Session Cid",
+        "description": {
+          "description": "Audit justification for this temporary secure session.",
+          "maxLength": 2000,
+          "title": "Description",
           "type": "string"
         }
       },
@@ -14085,16 +14085,23 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates zero-shot latent capability routing by computing the geometric Cosine Distance between the agent's epistemic deficit vector and the available tool manifold.\n\nCAUSAL AFFORDANCE: Unlocks the dynamic, runtime mounting of tools and MCP servers whose dense vector embeddings (`query_vector`) align mathematically with the query tensor, bypassing hardcoded tool schemas.\n\nEPISTEMIC BOUNDS: Mechanically rejects capabilities that fall below the `min_isometry_score` (`ge=-1.0, le=1.0`) boundary. The returned toolsets are strictly limited to the deterministically sorted `required_structural_types` array (`max_length=1000`), enforced by the `@model_validator`.\n\nMCP ROUTING TRIGGERS: Zero-Shot Tool Discovery, Capability Routing, Dense Vector Embedding, Epistemic Deficit Resolution",
       "properties": {
+        "topology_class": {
+          "const": "semantic_discovery",
+          "default": "semantic_discovery",
+          "description": "Discriminator for geometric boundary of latent tool discovery.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "query_vector": {
+          "$ref": "#/$defs/VectorEmbeddingState",
+          "description": "The latent vector representation of the epistemic deficit the agent is trying to solve."
+        },
         "min_isometry_score": {
           "description": "The minimum cosine similarity required to authorize a capability mount.",
           "maximum": 1.0,
           "minimum": -1.0,
           "title": "Min Isometry Score",
           "type": "number"
-        },
-        "query_vector": {
-          "$ref": "#/$defs/VectorEmbeddingState",
-          "description": "The latent vector representation of the epistemic deficit the agent is trying to solve."
         },
         "required_structural_types": {
           "description": "The strict array of strings defining topological limits on the discovered tools.",
@@ -14105,13 +14112,6 @@
           "maxItems": 1000,
           "title": "Required Structural Types",
           "type": "array"
-        },
-        "topology_class": {
-          "const": "semantic_discovery",
-          "default": "semantic_discovery",
-          "description": "Discriminator for geometric boundary of latent tool discovery.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -14126,16 +14126,28 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A mathematical tensor bridging two SemanticNodeStates, executing\nJudea Pearl's Structural Causal Models (SCMs) to explicitly formalize causality,\ncorrelation, or confounding relationships across the Knowledge Graph. As a ...State\nsuffix, this is a frozen N-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Empowers the orchestrator's traversal engine to execute directed\ngraph algorithms (e.g., Random Walk with Restart) via subject_node_id and\nobject_node_id (both 128-char CIDs), utilizing the continuous confidence_score\n(optional, ge=0.0, le=1.0, default=None) to probabilistically prune uncertain paths.\nThe predicate (max_length=2000) carries the semantic relationship label.\n\nEPISTEMIC BOUNDS: Causal directionality is restricted to a strict Literal automaton\n[\"causes\", \"confounds\", \"correlates_with\", \"undirected\"] (default=\"undirected\").\nOptional typed fields (embedding: VectorEmbeddingState, provenance:\nEpistemicProvenanceReceipt, temporal_bounds: TemporalBoundsProfile) extend the edge\ngeometry without mandatory overhead.\n\nMCP ROUTING TRIGGERS: Structural Causal Models, Pearlian Directed Edge, Semantic\nTriplet, Adjacency Matrix, Epistemic Link",
       "properties": {
-        "causal_relationship": {
-          "default": "undirected",
-          "description": "The Pearlian directionality of the semantic relationship.",
-          "enum": [
-            "causes",
-            "confounds",
-            "correlates_with",
-            "undirected"
-          ],
-          "title": "Causal Relationship",
+        "edge_id": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic edge to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Edge Id",
+          "type": "string"
+        },
+        "subject_node_id": {
+          "description": "The origin SemanticNodeState Content Identifier (CID).",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Subject Node Id",
+          "type": "string"
+        },
+        "object_node_id": {
+          "description": "The destination SemanticNodeState Content Identifier (CID).",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Object Node Id",
           "type": "string"
         },
         "confidence_score": {
@@ -14153,12 +14165,10 @@
           "description": "The probabilistic certainty of this logical connection.",
           "title": "Confidence Score"
         },
-        "edge_id": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic edge to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Edge Id",
+        "predicate": {
+          "description": "The string representation of the relationship (e.g., 'WORKS_FOR').",
+          "maxLength": 2000,
+          "title": "Predicate",
           "type": "string"
         },
         "embedding": {
@@ -14173,20 +14183,6 @@
           "default": null,
           "description": "Topologically Bounded Latent Spaces used to calculate exact geometric distance and preserve structural Isometry."
         },
-        "object_node_id": {
-          "description": "The destination SemanticNodeState Content Identifier (CID).",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Object Node Id",
-          "type": "string"
-        },
-        "predicate": {
-          "description": "The string representation of the relationship (e.g., 'WORKS_FOR').",
-          "maxLength": 2000,
-          "title": "Predicate",
-          "type": "string"
-        },
         "provenance": {
           "anyOf": [
             {
@@ -14199,14 +14195,6 @@
           "default": null,
           "description": "Optional distinct provenance if the relationship was inferred separately from the nodes."
         },
-        "subject_node_id": {
-          "description": "The origin SemanticNodeState Content Identifier (CID).",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Subject Node Id",
-          "type": "string"
-        },
         "temporal_bounds": {
           "anyOf": [
             {
@@ -14218,6 +14206,18 @@
           ],
           "default": null,
           "description": "The time window during which this relationship holds true."
+        },
+        "causal_relationship": {
+          "default": "undirected",
+          "description": "The Pearlian directionality of the semantic relationship.",
+          "enum": [
+            "causes",
+            "confounds",
+            "correlates_with",
+            "undirected"
+          ],
+          "title": "Causal Relationship",
+          "type": "string"
         },
         "volumetric_geometry": {
           "anyOf": [
@@ -14245,15 +14245,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements an execution-layer Semantic Firewall guarding against\nadversarial control-flow overrides and prompt injection attacks. As a ...Policy suffix,\nthis object defines rigid mathematical boundaries that the orchestrator must enforce\nglobally.\n\nCAUSAL AFFORDANCE: Intercepts and physically severs incoming observation topologies if\ntheir classification matches forbidden_intents, executing the deterministic\naction_on_violation (Literal[\"drop\", \"quarantine\", \"redact\"]).\n\nEPISTEMIC BOUNDS: VRAM exhaustion is mathematically prevented by capping max_input_tokens\n(gt=0, le=1000000000). The forbidden_intents array is deterministically sorted by the\n@model_validator to preserve RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Semantic Firewall, Prompt Injection Defense, Adversarial Override,\nZero-Trust Perimeter, Control-Flow Hijacking",
       "properties": {
-        "action_on_violation": {
-          "description": "The deterministic action the orchestrator must take if a firewall rule is violated.",
-          "enum": [
-            "drop",
-            "quarantine",
-            "redact"
-          ],
-          "title": "Action On Violation",
-          "type": "string"
+        "max_input_tokens": {
+          "description": "The absolute physical ceiling of tokens allowed in a single ingress payload.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Max Input Tokens",
+          "type": "integer"
         },
         "forbidden_intents": {
           "description": "A strict array of semantic intents (e.g., 'role_override', 'system_prompt_leak') that trigger immediate quarantine.",
@@ -14264,12 +14261,15 @@
           "title": "Forbidden Intents",
           "type": "array"
         },
-        "max_input_tokens": {
-          "description": "The absolute physical ceiling of tokens allowed in a single ingress payload.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Max Input Tokens",
-          "type": "integer"
+        "action_on_violation": {
+          "description": "The deterministic action the orchestrator must take if a firewall rule is violated.",
+          "enum": [
+            "drop",
+            "quarantine",
+            "redact"
+          ],
+          "title": "Action On Violation",
+          "type": "string"
         }
       },
       "required": [
@@ -14283,6 +14283,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Synchronous Epistemic Signaling within a Mixed-Initiative Control paradigm. Indicates that the presented manifold requires acknowledgment without reciprocal causal action.\n\nCAUSAL AFFORDANCE: Conditionally suspends the continuous execution DAG to project a read-only observational state manifold to the human operator. Resumption is dynamically governed by the deterministic `timeout_action`.\n\nEPISTEMIC BOUNDS: The semantic payload (`message`) is physically clamped to `max_length=2000` to prevent UI dictionary bombing. The `timeout_action` is locked to a strict Finite State Machine Literal `[\"rollback\", \"proceed_default\", \"terminate\"]`.\n\nMCP ROUTING TRIGGERS: Synchronous Epistemic Signaling, Mixed-Initiative Control, Finite State Machine, Oracle Projection, Halting Problem",
       "properties": {
+        "topology_class": {
+          "const": "informational",
+          "default": "informational",
+          "description": "The discriminative topological boundary for read-only informational handoffs.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "message": {
           "description": "The context or summary to display to the human operator.",
           "maxLength": 2000,
@@ -14298,13 +14305,6 @@
           ],
           "title": "Timeout Action",
           "type": "string"
-        },
-        "topology_class": {
-          "const": "informational",
-          "default": "informational",
-          "description": "The discriminative topological boundary for read-only informational handoffs.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -14318,6 +14318,37 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen N-dimensional coordinate representing a\ndiscrete entity vertex within a Resource Description Framework (RDF) or continuous\nProperty Graph. As a ...State suffix, this is a mathematically immutable snapshot.\n\nCAUSAL AFFORDANCE: Unlocks privacy-preserving mathematical operations on encrypted\nstate via fhe_profile (HomomorphicEncryptionProfile, optional) and enables zero-shot\nsemantic routing based on dense vector distances (embedding: VectorEmbeddingState,\noptional). Provenance (EpistemicProvenanceReceipt) is required.\n\nEPISTEMIC BOUNDS: The vertex geometry is physically anchored by node_cid (128-char CID\nregex). The internal representation (text_chunk) is capped at max_length=50000. The\nscope Literal [\"global\", \"tenant\", \"session\"] (default=\"session\") partitions the\ncryptographic namespace. The tier (CognitiveTierProfile, default=\"semantic\") and\nsalience (SalienceProfile, optional) govern structural pruning.\n\nMCP ROUTING TRIGGERS: Resource Description Framework, Property Graph, Fully\nHomomorphic Encryption, Semantic Coordinate, Vector Embedding",
       "properties": {
+        "node_cid": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic node to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Node Cid",
+          "type": "string"
+        },
+        "label": {
+          "description": "The categorical label of the node (e.g., 'Person', 'Concept').",
+          "maxLength": 2000,
+          "title": "Label",
+          "type": "string"
+        },
+        "scope": {
+          "default": "session",
+          "description": "The cryptographic namespace partitioning boundary. Global is public, Tenant is corporate, Session is ephemeral.",
+          "enum": [
+            "global",
+            "tenant",
+            "session"
+          ],
+          "title": "Scope",
+          "type": "string"
+        },
+        "text_chunk": {
+          "description": "The raw natural language representation of the semantic node.",
+          "maxLength": 50000,
+          "title": "Text Chunk",
+          "type": "string"
+        },
         "embedding": {
           "anyOf": [
             {
@@ -14330,58 +14361,14 @@
           "default": null,
           "description": "Topologically Bounded Latent Spaces used to calculate exact geometric distance and preserve structural Isometry."
         },
-        "fhe_profile": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/HomomorphicEncryptionProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The cryptographic envelope enabling privacy-preserving computation directly on this node's encrypted state."
-        },
-        "label": {
-          "description": "The categorical label of the node (e.g., 'Person', 'Concept').",
-          "maxLength": 2000,
-          "title": "Label",
-          "type": "string"
-        },
-        "node_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this semantic node to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Node Cid",
-          "type": "string"
-        },
         "provenance": {
           "$ref": "#/$defs/EpistemicProvenanceReceipt",
           "description": "The cryptographic chain of custody for this semantic state."
         },
-        "salience": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SalienceProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical importance profile governing structural pruning."
-        },
-        "scope": {
-          "default": "session",
-          "description": "The cryptographic namespace partitioning boundary. Global is public, Tenant is corporate, Session is ephemeral.",
-          "enum": [
-            "global",
-            "tenant",
-            "session"
-          ],
-          "title": "Scope",
-          "type": "string"
+        "tier": {
+          "$ref": "#/$defs/CognitiveTierProfile",
+          "default": "semantic",
+          "description": "The cognitive tier this latent state resides in."
         },
         "temporal_bounds": {
           "anyOf": [
@@ -14395,16 +14382,29 @@
           "default": null,
           "description": "The time window during which this node is considered valid."
         },
-        "text_chunk": {
-          "description": "The raw natural language representation of the semantic node.",
-          "maxLength": 50000,
-          "title": "Text Chunk",
-          "type": "string"
+        "salience": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SalienceProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical importance profile governing structural pruning."
         },
-        "tier": {
-          "$ref": "#/$defs/CognitiveTierProfile",
-          "default": "semantic",
-          "description": "The cognitive tier this latent state resides in."
+        "fhe_profile": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/HomomorphicEncryptionProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The cryptographic envelope enabling privacy-preserving computation directly on this node's encrypted state."
         }
       },
       "required": [
@@ -14420,13 +14420,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Mandatory Access Control (MAC) and Cognitive Load Theory to aggressively cull context window topologies and prevent VRAM exhaustion.\n\nCAUSAL AFFORDANCE: Forces the attention mechanism to physically ignore state representations that lack the whitelisted `required_semantic_labels` or exceed the `permitted_classification_tiers`.\n\nEPISTEMIC BOUNDS: VRAM exhaustion is clamped by `context_window_token_ceiling` (`gt=0, le=2000000`). The validation pipeline mechanically sorts the tier arrays via `@model_validator` for invariant RFC 8785 canonical determinism.\n\nMCP ROUTING TRIGGERS: Mandatory Access Control, Zero-Trust Execution, Context Window Partitioning, Cognitive Load Theory, Epistemic Firewall",
       "properties": {
-        "context_window_token_ceiling": {
-          "description": "The mathematical physical limit of the active context partition to prevent VRAM exhaustion.",
-          "exclusiveMinimum": 0,
-          "maximum": 2000000,
-          "title": "Context Window Token Ceiling",
-          "type": "integer"
-        },
         "permitted_classification_tiers": {
           "description": "The explicit whitelist of sensitivity bounds allowed into context.",
           "items": {
@@ -14452,6 +14445,13 @@
           "default": null,
           "description": "The declarative whitelist of strictly typed ontological node labels authorized for context projection.",
           "title": "Required Semantic Labels"
+        },
+        "context_window_token_ceiling": {
+          "description": "The mathematical physical limit of the active context partition to prevent VRAM exhaustion.",
+          "exclusiveMinimum": 0,
+          "maximum": 2000000,
+          "title": "Context Window Token Ceiling",
+          "type": "integer"
         }
       },
       "required": [
@@ -14506,10 +14506,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Cooperative Game Theory to compute the exact Shapley\nvalue ($\\phi_i$) for a specific agent's marginal contribution to a collective outcome.\nAs a ...Receipt suffix, this is an append-only coordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Unlocks deterministic credit assignment and thermodynamic reward\ndistribution, allowing the orchestrator to equitably distribute escrow payouts or\npolicy gradient updates to the participating target_node_cid (NodeCIDState).\n\nEPISTEMIC BOUNDS: normalized_contribution_percentage is strictly clamped (ge=0.0,\nle=1.0). The causal_attribution_score has only le=1.0 (no ge bound). The Monte Carlo\napproximation confidence bounds (confidence_interval_lower/upper) are capped at\nle=1000000000.0.\n\nMCP ROUTING TRIGGERS: Cooperative Game Theory, Shapley Value, Credit Assignment,\nMarginal Contribution, Monte Carlo Approximation",
       "properties": {
+        "target_node_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The agent whose causal influence is being measured."
+        },
         "causal_attribution_score": {
           "description": "The exact Shapley value (\\phi_i) satisfying efficiency, symmetry, and additivity axioms.",
           "maximum": 1.0,
           "title": "Causal Attribution Score",
+          "type": "number"
+        },
+        "normalized_contribution_percentage": {
+          "description": "The relative fractional contribution bounded between 0.0 and 1.0.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Normalized Contribution Percentage",
           "type": "number"
         },
         "confidence_interval_lower": {
@@ -14523,17 +14534,6 @@
           "maximum": 1000000000.0,
           "title": "Confidence Interval Upper",
           "type": "number"
-        },
-        "normalized_contribution_percentage": {
-          "description": "The relative fractional contribution bounded between 0.0 and 1.0.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Normalized Contribution Percentage",
-          "type": "number"
-        },
-        "target_node_cid": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The agent whose causal influence is being measured."
         }
       },
       "required": [
@@ -14616,16 +14616,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a discrete, point-in-time OpenTelemetry annotation within a broader Dapper-style `ExecutionSpanReceipt`.\n\nCAUSAL AFFORDANCE: Provides fine-grained, localized state-machine logging within an active span, anchoring semantic attributes to a precise nanosecond coordinate without spawning a new causal branch.\n\nEPISTEMIC BOUNDS: `timestamp_unix_nano` physically bounded `[0, 253402300799000000000]`. The `attributes` payload strictly constrained by a dictionary with string keys (`max_length=255`) to prevent dictionary bombing.\n\nMCP ROUTING TRIGGERS: Span Annotation, Point-in-Time Event, Micro-State Logging, OpenTelemetry, Telemetry Serialization",
       "properties": {
-        "attributes": {
-          "additionalProperties": true,
-          "description": "Typed metadata bound to the event.",
-          "maxProperties": 1000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Attributes",
-          "type": "object"
-        },
         "name": {
           "description": "The semantic name of the event.",
           "maxLength": 2000,
@@ -14638,6 +14628,16 @@
           "minimum": 0,
           "title": "Timestamp Unix Nano",
           "type": "integer"
+        },
+        "attributes": {
+          "additionalProperties": true,
+          "description": "Typed metadata bound to the event.",
+          "maxProperties": 1000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Attributes",
+          "type": "object"
         }
       },
       "required": [
@@ -14669,15 +14669,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a kinematic constraint binding a 2D typographic or geometric matrix to a 3D SE(3) coordinate mesh.\n\nCAUSAL AFFORDANCE: Authorizes the spatial renderer to project 2D semantics over a 3D topology, mathematically guaranteeing invariant visual alignment relative to the observer's view frustum.\n\nEPISTEMIC BOUNDS: Strictly bounded by boolean physics gates (`always_face_camera`, `occlude_behind_meshes`) defining Z-buffer collision behavior. `distance_scaling_factor` is bounded `[0.0, 10.0]` to control orthographic size invariance.\n\nMCP ROUTING TRIGGERS: Spherical Billboarding, View Frustum Alignment, Z-Buffer Occlusion, Projective Geometry, UI Anchoring",
       "properties": {
+        "anchoring_node_id": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The target 3D SE(3) vertex to which the 2D matrix is mathematically bound."
+        },
         "always_face_camera": {
           "default": true,
           "description": "Forces the normal vector of the 2D matrix to continuously align with the observer's camera.",
           "title": "Always Face Camera",
           "type": "boolean"
         },
-        "anchoring_node_id": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The target 3D SE(3) vertex to which the 2D matrix is mathematically bound."
+        "occlude_behind_meshes": {
+          "default": false,
+          "description": "If true, subjects the 2D plane to depth-testing, allowing 3D geometry to block line-of-sight.",
+          "title": "Occlude Behind Meshes",
+          "type": "boolean"
         },
         "distance_scaling_factor": {
           "default": 1.0,
@@ -14686,12 +14692,6 @@
           "minimum": 0.0,
           "title": "Distance Scaling Factor",
           "type": "number"
-        },
-        "occlude_behind_meshes": {
-          "default": false,
-          "description": "If true, subjects the 2D plane to depth-testing, allowing 3D geometry to block line-of-sight.",
-          "title": "Occlude Behind Meshes",
-          "type": "boolean"
         },
         "spherical_cylindrical_lock": {
           "default": "spherical",
@@ -14713,15 +14713,10 @@
     },
     "SpatialHardwareProfile": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of the physical hardware boundaries and thermodynamic constraints required to instantiate this node. As a ...Profile suffix, this defines a rigid mathematical boundary.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's provisioning layer to allocate exact silicon resources (Compute Tier, VRAM, and Accelerator Type) before allowing the node to execute generative operations.\n\nEPISTEMIC BOUNDS: VRAM allocation is physically bounded by min_vram_gb (gt=0.0). The literal enumerations ComputeTier and AcceleratorProfile mathematically prevent the hallucination of non-existent silicon. The provider_whitelist is deterministically sorted for invariant RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Thermodynamic Bounding, VRAM Allocation, Spot Market Routing, Hardware Provisioning, Silicon Constraints",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot of the physical hardware boundaries and thermodynamic constraints required to instantiate this node. As a ...Profile suffix, this defines a rigid mathematical boundary.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's provisioning layer to allocate exact silicon resources (Compute Tier, VRAM, and Accelerator Type) before allowing the node to execute generative operations.\n\nEPISTEMIC BOUNDS: VRAM allocation is physically bounded by min_vram_gb (gt=0.0). The literal enumerations ComputeTierProfile and AcceleratorProfile mathematically prevent the hallucination of non-existent silicon. The provider_whitelist is deterministically sorted for invariant RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Thermodynamic Bounding, VRAM Allocation, Spot Market Routing, Hardware Provisioning, Silicon Constraints",
       "properties": {
-        "accelerator_type": {
-          "$ref": "#/$defs/AcceleratorProfile",
-          "default": "BF16_TENSOR",
-          "description": "The rigid silicon precision format required to execute this node's neural circuits."
-        },
         "compute_tier": {
-          "$ref": "#/$defs/ComputeTier",
+          "$ref": "#/$defs/ComputeTierProfile",
           "default": "KINETIC",
           "description": "The discrete architectural boundary of the node (KINETIC for edge/consumer, ORACLE for datacenter)."
         },
@@ -14731,6 +14726,11 @@
           "exclusiveMinimum": 0.0,
           "title": "Min Vram Gb",
           "type": "number"
+        },
+        "accelerator_type": {
+          "$ref": "#/$defs/AcceleratorProfile",
+          "default": "BF16_TENSOR",
+          "description": "The rigid silicon precision format required to execute this node's neural circuits."
         },
         "provider_whitelist": {
           "description": "The explicit array of cloud infrastructure providers authorized to run this node.",
@@ -14762,28 +14762,6 @@
           "title": "Action Class",
           "type": "string"
         },
-        "bezier_control_points": {
-          "description": "Waypoints for constructing non-linear, bot-evasive movement curves.",
-          "items": {
-            "$ref": "#/$defs/SE3TransformProfile"
-          },
-          "title": "Bezier Control Points",
-          "type": "array"
-        },
-        "expected_visual_concept": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The visual anchor (e.g., 'Submit Button'). The orchestrator must verify this semantic concept exists at the target_coordinate before executing the macro, preventing blind clicks.",
-          "title": "Expected Visual Concept"
-        },
         "target_coordinate": {
           "anyOf": [
             {
@@ -14810,6 +14788,28 @@
           "default": null,
           "description": "The exact temporal duration of the movement, simulating human kinematics.",
           "title": "Trajectory Duration Ms"
+        },
+        "bezier_control_points": {
+          "description": "Waypoints for constructing non-linear, bot-evasive movement curves.",
+          "items": {
+            "$ref": "#/$defs/SE3TransformProfile"
+          },
+          "title": "Bezier Control Points",
+          "type": "array"
+        },
+        "expected_visual_concept": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The visual anchor (e.g., 'Submit Button'). The orchestrator must verify this semantic concept exists at the target_coordinate before executing the macro, preventing blind clicks.",
+          "title": "Expected Visual Concept"
         }
       },
       "required": [
@@ -14822,6 +14822,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes a Federated Pose Graph anchor. Establishes a deterministic localized origin point (e.g., a physical room geometry or SLAM feature map) allowing disjoint spatial topologies to mathematically synchronize.\n\nCAUSAL AFFORDANCE: Instructs the spatial orchestrator to align the tracking coordinate systems of multiple observer devices by computing the affine transformation matrix between this shared cryptographic anchor and their local origins.\n\nEPISTEMIC BOUNDS: The semantic locus is cryptographically locked to a 128-char CID (`frame_cid`). The alignment math is strictly bounded to the `anchor_protocol` literal automaton. An optional `physical_room_hash` prevents holographic spoofing across zero-trust domains.\n\nMCP ROUTING TRIGGERS: Federated Pose Graph, Spatial Reference Frame, SLAM Anchor, Relative Coordinate Geometry, Origin Point",
       "properties": {
+        "frame_cid": {
+          "description": "The unique cryptographic identifier for this local spatial volume.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Frame Cid",
+          "type": "string"
+        },
         "anchor_protocol": {
           "description": "The scientific tracking standard utilized to establish this reference frame.",
           "enum": [
@@ -14831,14 +14839,6 @@
             "relative_virtual"
           ],
           "title": "Anchor Protocol",
-          "type": "string"
-        },
-        "frame_cid": {
-          "description": "The unique cryptographic identifier for this local spatial volume.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Frame Cid",
           "type": "string"
         },
         "physical_room_hash": {
@@ -14867,6 +14867,19 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the discrete formalization of a Gibsonian Affordance within the agent's Reinforcement Learning Action Space ($A$). As a ...Manifest suffix, this is a declarative, frozen N-dimensional coordinate of a capability.\n\nCAUSAL AFFORDANCE: Unlocks a specific, localized Pearlian Do-Operator intervention ($do(X=x)$) mapped to an external kinetic capability. Governed by side_effects, permissions, and an optional execution SLA.\n\nEPISTEMIC BOUNDS: The operational perimeter is rigidly confined by `input_schema` and `output_schema` (dictionaries bounded to `max_length=1000` properties). The `is_preemptible` boolean (default=False) establishes a physical Halting Problem limit by authorizing the orchestrator to abort execution mid-flight.\n\nMCP ROUTING TRIGGERS: Gibsonian Affordance, MDP Action Space, Pearlian Do-Operator, Capability-Based Security, Halting Problem",
       "properties": {
+        "topology_class": {
+          "const": "native_tool",
+          "default": "native_tool",
+          "description": "Discriminator type for a native tool.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "tool_name": {
+          "description": "The deterministically bounded structural identifier mapping this capability within the zero-trust manifold.",
+          "maxLength": 2000,
+          "title": "Tool Name",
+          "type": "string"
+        },
         "description": {
           "description": "The mathematically bounded semantic projection defining the tool's causal affordances.",
           "maxLength": 2000,
@@ -14884,12 +14897,6 @@
           },
           "title": "Input Schema",
           "type": "object"
-        },
-        "is_preemptible": {
-          "default": false,
-          "description": "If True, the orchestrator is authorized to send a SIGINT to abort this tool's execution mid-flight if a BargeInInterruptEvent occurs.",
-          "title": "Is Preemptible",
-          "type": "boolean"
         },
         "output_schema": {
           "anyOf": [
@@ -14911,13 +14918,13 @@
           "description": "The strict JSON Schema dictionary defining the pure domain-specific arguments ($T$). The framework orchestrator will automatically wrap this in the ExecutionEnvelopeState at runtime.",
           "title": "Output Schema"
         },
-        "permissions": {
-          "$ref": "#/$defs/PermissionBoundaryPolicy",
-          "description": "The zero-trust security boundaries for the tool's execution."
-        },
         "side_effects": {
           "$ref": "#/$defs/SideEffectProfile",
           "description": "The declarative side-effect and idempotency profile of the tool."
+        },
+        "permissions": {
+          "$ref": "#/$defs/PermissionBoundaryPolicy",
+          "description": "The zero-trust security boundaries for the tool's execution."
         },
         "sla": {
           "anyOf": [
@@ -14931,18 +14938,11 @@
           "default": null,
           "description": "Execution limits for the tool."
         },
-        "tool_name": {
-          "description": "The deterministically bounded structural identifier mapping this capability within the zero-trust manifold.",
-          "maxLength": 2000,
-          "title": "Tool Name",
-          "type": "string"
-        },
-        "topology_class": {
-          "const": "native_tool",
-          "default": "native_tool",
-          "description": "Discriminator type for a native tool.",
-          "title": "Topology Class",
-          "type": "string"
+        "is_preemptible": {
+          "default": false,
+          "description": "If True, the orchestrator is authorized to send a SIGINT to abort this tool's execution mid-flight if a BargeInInterruptEvent occurs.",
+          "title": "Is Preemptible",
+          "type": "boolean"
         }
       },
       "required": [
@@ -14967,30 +14967,18 @@
           "title": "Boundary Cid",
           "type": "string"
         },
+        "is_speculative": {
+          "default": true,
+          "description": "Strict boolean indicating whether the boundary forces probabilistic execution paths.",
+          "title": "Is Speculative",
+          "type": "boolean"
+        },
         "commit_probability": {
           "description": "The assigned mathematical likelihood that the speculative branch will merge successfully.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Commit Probability",
           "type": "number"
-        },
-        "competing_hypotheses": {
-          "description": "CIDs for concurrent alternative paths generated during speculation.",
-          "items": {
-            "maxLength": 128,
-            "minLength": 1,
-            "pattern": "^[a-zA-Z0-9_.:-]+$",
-            "type": "string"
-          },
-          "maxItems": 10000,
-          "title": "Competing Hypotheses",
-          "type": "array"
-        },
-        "is_speculative": {
-          "default": true,
-          "description": "Strict boolean indicating whether the boundary forces probabilistic execution paths.",
-          "title": "Is Speculative",
-          "type": "boolean"
         },
         "rollback_pointers": {
           "description": "CIDs referencing the deterministic states the orchestrator must rewind to upon branch falsification.",
@@ -15002,6 +14990,18 @@
           },
           "maxItems": 10000,
           "title": "Rollback Pointers",
+          "type": "array"
+        },
+        "competing_hypotheses": {
+          "description": "CIDs for concurrent alternative paths generated during speculation.",
+          "items": {
+            "maxLength": 128,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_.:-]+$",
+            "type": "string"
+          },
+          "maxItems": 10000,
+          "title": "Competing Hypotheses",
           "type": "array"
         }
       },
@@ -15016,18 +15016,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a Cryptographic Tuple Space (Blackboard Pattern)\nserving as the strictly typed epistemic synchronization layer for multi-agent\nmanifolds. As a ...Contract suffix, this enforces rigid mathematical boundaries\nglobally.\n\nCAUSAL AFFORDANCE: Physically restricts all state mutations within the topology\nto conform to the explicit schema_definition (JSON Schema dict, key\nmax_length=255), acting as a deterministic Schema-on-Write validation gate.\n\nEPISTEMIC BOUNDS: The strict_validation boolean (default=True) acts as a\nphysical barrier against stochastic drift, forcing the orchestrator to reject\nany state mutation that fails the schema definition. Property names are capped\nat max_length=255 to prevent dictionary bombing.\n\nMCP ROUTING TRIGGERS: Tuple Space, Blackboard Architecture, Schema-on-Write,\nFinite State Automaton, Epistemic Synchronization",
       "properties": {
-        "decoding_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ConstrainedDecodingPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The optional hardware-level execution limits for token masking."
-        },
         "schema_definition": {
           "additionalProperties": {
             "$ref": "#/$defs/JsonPrimitiveState"
@@ -15044,6 +15032,18 @@
           "description": "If True, the orchestrator must reject any state mutation that fails the schema definition.",
           "title": "Strict Validation",
           "type": "boolean"
+        },
+        "decoding_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConstrainedDecodingPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The optional hardware-level execution limits for token masking."
         }
       },
       "required": [
@@ -15079,14 +15079,6 @@
         }
       ],
       "properties": {
-        "author_node_cid": {
-          "description": "The exact Lineage Watermark of the agent or system that authored this state mutation.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Author Node Cid",
-          "type": "string"
-        },
         "diff_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark for this state differential.",
           "maxLength": 128,
@@ -15095,20 +15087,20 @@
           "title": "Diff Cid",
           "type": "string"
         },
+        "author_node_cid": {
+          "description": "The exact Lineage Watermark of the agent or system that authored this state mutation.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Author Node Cid",
+          "type": "string"
+        },
         "lamport_timestamp": {
           "description": "Strict scalar logical clock governing deterministic LWW (Last-Writer-Wins) conflict resolution.",
           "maximum": 1000000000,
           "minimum": 0,
           "title": "Lamport Timestamp",
           "type": "integer"
-        },
-        "patches": {
-          "description": "The exact, ordered sequence of deterministic state vector mutations.",
-          "items": {
-            "$ref": "#/$defs/StateMutationIntent"
-          },
-          "title": "Patches",
-          "type": "array"
         },
         "vector_clock": {
           "additionalProperties": {
@@ -15121,6 +15113,14 @@
           },
           "title": "Vector Clock",
           "type": "object"
+        },
+        "patches": {
+          "description": "The exact, ordered sequence of deterministic state vector mutations.",
+          "items": {
+            "$ref": "#/$defs/StateMutationIntent"
+          },
+          "title": "Patches",
+          "type": "array"
         }
       },
       "required": [
@@ -15136,6 +15136,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Manages the Epistemic Hydration of an agent's active context\npartition from cold storage, bridging immutable EpistemicLedgerState checkpoints and\nephemeral working memory. As a ...Manifest suffix, this defines a frozen configuration\nstate.\n\nCAUSAL AFFORDANCE: Authorizes the physical injection of serialized semantic data\n(working_context_variables) into the LLM's forward-pass generation window, seeding\nthe context prior to probability wave collapse. The crystallized_ledger_cids (SHA-256\npointers) bind to past immutable ledger blocks.\n\nEPISTEMIC BOUNDS: VRAM exhaustion is prevented by max_retained_tokens (gt=0,\nle=1000000000). The @field_validator enforce_payload_topology calls\n_validate_payload_bounds to prevent Dictionary Bombing on working_context_variables.\nThe @model_validator sort_arrays deterministically sorts crystallized_ledger_cids for\nRFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Epistemic Hydration, Working Memory Injection, Context Window\nPartitioning, VRAM Bounding, Serialization Geometry",
       "properties": {
+        "epistemic_coordinate": {
+          "description": "A string ID representing the session or specific spatial trace binding.",
+          "maxLength": 2000,
+          "title": "Epistemic Coordinate",
+          "type": "string"
+        },
         "crystallized_ledger_cids": {
           "description": "The explicit array of cryptographic pointers to past immutable EpistemicLedgerState blocks.",
           "items": {
@@ -15145,18 +15151,16 @@
           "title": "Crystallized Ledger Cids",
           "type": "array"
         },
-        "epistemic_coordinate": {
-          "description": "A string ID representing the session or specific spatial trace binding.",
-          "maxLength": 2000,
-          "title": "Epistemic Coordinate",
-          "type": "string"
-        },
-        "max_retained_tokens": {
-          "description": "An integer representing the physical limit of the context window.",
-          "exclusiveMinimum": 0,
-          "maximum": 1000000000,
-          "title": "Max Retained Tokens",
-          "type": "integer"
+        "working_context_variables": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonPrimitiveState"
+          },
+          "description": "A strictly typed dictionary for ephemeral context variables injected at runtime. AGENT INSTRUCTION: This matrix is deterministically sorted by CoreasonBaseState natively. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Working Context Variables",
+          "type": "object"
         },
         "unfolding_policy": {
           "anyOf": [
@@ -15170,16 +15174,12 @@
           "default": null,
           "description": "The mathematical bounds for lazy state unfolding."
         },
-        "working_context_variables": {
-          "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitiveState"
-          },
-          "description": "A strictly typed dictionary for ephemeral context variables injected at runtime. AGENT INSTRUCTION: This matrix is deterministically sorted by CoreasonBaseState natively. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Working Context Variables",
-          "type": "object"
+        "max_retained_tokens": {
+          "description": "An integer representing the physical limit of the context window.",
+          "exclusiveMinimum": 0,
+          "maximum": 1000000000,
+          "title": "Max Retained Tokens",
+          "type": "integer"
         }
       },
       "required": [
@@ -15195,20 +15195,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements the formal RFC 6902 JSON Patch standard to execute atomic,\ndeterministic state vector mutations across the swarm's N-dimensional blackboard. As an\n...Intent suffix, this represents an authorized kinetic execution trigger.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's algebraic engine to surgically apply,\ntest, or ablate targeted JSON pointers without requiring full payload transmission.\n\nEPISTEMIC BOUNDS: The `value` (JsonPrimitiveState) mutation payload is volumetrically\nclamped by `enforce_payload_topology` to guarantee that the resulting state matrix $S'$\ndoes not expand beyond VRAM constraints. The operation geometry is rigidly restricted by\nthe op field to the PatchOperationProfile. Target topological coordinates (path and\nfrom_path) are physically bounded to max_length=2000.\n\nMCP ROUTING TRIGGERS: RFC 6902, JSON Patch, Atomic Mutation, State Vector Projection,\nDeterministic Operator",
       "properties": {
-        "from": {
-          "anyOf": [
-            {
-              "maxLength": 2000,
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The JSON pointer from which to copy or move the state vector, if applicable.",
-          "title": "From"
-        },
         "op": {
           "$ref": "#/$defs/PatchOperationProfile",
           "description": "The strict RFC 6902 JSON Patch operation, acting as a deterministic state vector mutation."
@@ -15223,6 +15209,20 @@
           "$ref": "#/$defs/JsonPrimitiveState",
           "default": null,
           "description": "The payload to insert or test, if applicable, for this deterministic state vector mutation. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion."
+        },
+        "from": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The JSON pointer from which to copy or move the state vector, if applicable.",
+          "title": "From"
         }
       },
       "required": [
@@ -15247,12 +15247,6 @@
           "title": "Immutable Matrix",
           "type": "object"
         },
-        "is_delta": {
-          "default": false,
-          "description": "A flag allowing the output to only return the keys in mutable_matrix that changed, rather than forcing the entire array back up the network.",
-          "title": "Is Delta",
-          "type": "boolean"
-        },
         "mutable_matrix": {
           "anyOf": [
             {
@@ -15271,6 +15265,12 @@
           "default": null,
           "description": "The agent's scratchpad, chat history, and any writable states.",
           "title": "Mutable Matrix"
+        },
+        "is_delta": {
+          "default": false,
+          "description": "A flag allowing the output to only return the keys in mutable_matrix that changed, rather than forcing the entire array back up the network.",
+          "title": "Is Delta",
+          "type": "boolean"
         }
       },
       "title": "StateVectorProfile",
@@ -15280,6 +15280,19 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Inter-Process Communication (IPC) utilizing POSIX standard streams to execute highly isolated, local binary sandboxing.\n\nCAUSAL AFFORDANCE: Physically spawns a child process restricted to the host's operating system namespace, mapping remote procedure calls directly into the binary's stdin/stdout descriptors via `command` (`max_length=2000`).\n\nEPISTEMIC BOUNDS: To prevent buffer overflow and command injection, `args` are structurally constrained (`max_length=1000`, string `max_length=2000`) and `env_vars` keys/values are strictly delimited via `StringConstraints` (`max_length=255` and `2000`).\n\nMCP ROUTING TRIGGERS: Inter-Process Communication, POSIX Standard Streams, Local Sandboxing, Binary Execution, Subprocess Spawn",
       "properties": {
+        "topology_class": {
+          "const": "stdio",
+          "default": "stdio",
+          "description": "Type of transport.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "command": {
+          "description": "The command executable to run (e.g., 'node', 'python').",
+          "maxLength": 2000,
+          "title": "Command",
+          "type": "string"
+        },
         "args": {
           "description": "The explicit array of arguments to pass to the command.",
           "items": {
@@ -15289,12 +15302,6 @@
           "maxItems": 1000,
           "title": "Args",
           "type": "array"
-        },
-        "command": {
-          "description": "The command executable to run (e.g., 'node', 'python').",
-          "maxLength": 2000,
-          "title": "Command",
-          "type": "string"
         },
         "env_vars": {
           "additionalProperties": {
@@ -15307,13 +15314,6 @@
           },
           "title": "Env Vars",
           "type": "object"
-        },
-        "topology_class": {
-          "const": "stdio",
-          "default": "stdio",
-          "description": "Type of transport.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -15369,6 +15369,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements non-monotonic disfluency and \"forget gate\" triggers to repair continuous ingestion streams.\n\nCAUSAL AFFORDANCE: Triggers the orchestrator to excise or repair segments of the token stream when the `repair_marker_regex` matches, probabilistically governed by the `decay_threshold`.\n\nEPISTEMIC BOUNDS: `repair_marker_regex` is strictly capped at `max_length=2000` to prevent ReDoS CPU exhaustion. `decay_threshold` geometrically bounded (`ge=0.0, le=1.0`). Maximum temporal lookback clamped (`ge=0, le=1000000000`).\n\nMCP ROUTING TRIGGERS: Streaming Disfluency, Forget Gate, Token Excise, Sequence Repair, Temporal Lookback",
       "properties": {
+        "repair_marker_regex": {
+          "description": "The regular expression pattern identifying a structural disfluency marker in the stream.",
+          "maxLength": 2000,
+          "title": "Repair Marker Regex",
+          "type": "string"
+        },
         "decay_threshold": {
           "description": "The probability boundary below which historical stream data is aggressively decayed.",
           "maximum": 1.0,
@@ -15382,12 +15388,6 @@
           "minimum": 0,
           "title": "Max Lookback Window",
           "type": "integer"
-        },
-        "repair_marker_regex": {
-          "description": "The regular expression pattern identifying a structural disfluency marker in the stream.",
-          "maxLength": 2000,
-          "title": "Repair Marker Regex",
-          "type": "string"
         }
       },
       "required": [
@@ -15402,12 +15402,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Judea Pearl's Structural Causal Models (SCMs) by mapping the causal topology of observed and latent variables.\n\nCAUSAL AFFORDANCE: Unlocks do-calculus and interventional logic by providing the orchestrator with the explicit DAG required to identify confounders and compute causal effects.\n\nEPISTEMIC BOUNDS: Variables are constrained by strict bounds (max_length=255). The @model_validator deterministically sorts observed_variables, latent_variables, and causal_edges to mathematically guarantee zero-variance RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Structural Causal Models, Pearlian DAG, Latent Confounder, d-separation, Interventional Topology",
       "properties": {
-        "causal_edges": {
-          "description": "The declared topological mapping of causality.",
+        "observed_variables": {
+          "description": "The nodes in the DAG that the agent can passively measure.",
           "items": {
-            "$ref": "#/$defs/CausalDirectedEdgeState"
+            "maxLength": 255,
+            "type": "string"
           },
-          "title": "Causal Edges",
+          "maxItems": 1000,
+          "title": "Observed Variables",
           "type": "array"
         },
         "latent_variables": {
@@ -15420,14 +15422,12 @@
           "title": "Latent Variables",
           "type": "array"
         },
-        "observed_variables": {
-          "description": "The nodes in the DAG that the agent can passively measure.",
+        "causal_edges": {
+          "description": "The declared topological mapping of causality.",
           "items": {
-            "maxLength": 255,
-            "type": "string"
+            "$ref": "#/$defs/CausalDirectedEdgeState"
           },
-          "maxItems": 1000,
-          "title": "Observed Variables",
+          "title": "Causal Edges",
           "type": "array"
         }
       },
@@ -15443,13 +15443,27 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative, frozen snapshot defining a Complex Adaptive System representing a fluid, decentralized Swarm topology governed by Algorithmic Mechanism Design and Spot Market dynamics.\n\nCAUSAL AFFORDANCE: Unlocks dynamic agent instantiation, allowing the topology to spawn concurrent workers up to `max_concurrent_agents` and resolve consensus probabilistically via `active_prediction_markets`.\n\nEPISTEMIC BOUNDS: Horizontal compute explosion is governed by `spawning_threshold` (`ge=1, le=100`) and `max_concurrent_agents` (`le=100`). The `@model_validator` guarantees spawning threshold cannot exceed max agents. Markets are deterministically sorted by `market_cid` for RFC 8785 hashing.\n\nMCP ROUTING TRIGGERS: Complex Adaptive Systems, Swarm Intelligence, Algorithmic Mechanism Design, Spot Market Routing, Multi-Agent Reinforcement Learning",
       "properties": {
-        "active_prediction_markets": {
-          "description": "The live algorithmic betting markets resolving swarm consensus.",
-          "items": {
-            "$ref": "#/$defs/PredictionMarketState"
-          },
-          "title": "Active Prediction Markets",
-          "type": "array"
+        "epistemic_enforcement": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/TruthMaintenancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Ties the topology to the Truth Maintenance layer."
+        },
+        "lifecycle_phase": {
+          "default": "live",
+          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
+          "enum": [
+            "draft",
+            "live"
+          ],
+          "title": "Lifecycle Phase",
+          "type": "string"
         },
         "architectural_intent": {
           "anyOf": [
@@ -15465,30 +15479,6 @@
           "description": "The AI's declarative rationale for selecting this topology.",
           "title": "Architectural Intent"
         },
-        "auction_policy": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/AuctionPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The mathematical policy governing task decentralization via Spot Markets."
-        },
-        "epistemic_enforcement": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/TruthMaintenancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Ties the topology to the Truth Maintenance layer."
-        },
         "justification": {
           "anyOf": [
             {
@@ -15503,23 +15493,6 @@
           "description": "Cryptographic/audit justification for this topology's configuration.",
           "title": "Justification"
         },
-        "lifecycle_phase": {
-          "default": "live",
-          "description": "The execution phase of the graph. 'draft' allows incomplete structural state.",
-          "enum": [
-            "draft",
-            "live"
-          ],
-          "title": "Lifecycle Phase",
-          "type": "string"
-        },
-        "max_concurrent_agents": {
-          "default": 10,
-          "description": "The mathematically bounded limit for concurrent agent threads.",
-          "maximum": 100,
-          "title": "Max Concurrent Agents",
-          "type": "integer"
-        },
         "nodes": {
           "additionalProperties": {
             "$ref": "#/$defs/AnyNodeProfile"
@@ -15530,38 +15503,6 @@
           },
           "title": "Nodes",
           "type": "object"
-        },
-        "observability": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/ObservabilityLODPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
-        },
-        "resolved_markets": {
-          "description": "The immutable records of finalized markets and reputation capital distributions.",
-          "items": {
-            "$ref": "#/$defs/MarketResolutionState"
-          },
-          "title": "Resolved Markets",
-          "type": "array"
-        },
-        "semantic_flow": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/InformationFlowPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
         },
         "shared_state_contract": {
           "anyOf": [
@@ -15575,6 +15516,37 @@
           "default": null,
           "description": "The schema-on-write contract governing the internal state of this topology."
         },
+        "semantic_flow": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/InformationFlowPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural Payload Loss Prevention (PLP) contract governing all state mutations in this topology."
+        },
+        "observability": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ObservabilityLODPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The dynamic Level of Detail and Spectral Coarsening physics bound to this macroscopic execution graph."
+        },
+        "topology_class": {
+          "const": "swarm",
+          "default": "swarm",
+          "description": "Discriminator for a Swarm topology.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "spawning_threshold": {
           "default": 3,
           "description": "Threshold limit for dynamic spawning of additional nodes.",
@@ -15583,12 +15555,40 @@
           "title": "Spawning Threshold",
           "type": "integer"
         },
-        "topology_class": {
-          "const": "swarm",
-          "default": "swarm",
-          "description": "Discriminator for a Swarm topology.",
-          "title": "Topology Class",
-          "type": "string"
+        "max_concurrent_agents": {
+          "default": 10,
+          "description": "The mathematically bounded limit for concurrent agent threads.",
+          "maximum": 100,
+          "title": "Max Concurrent Agents",
+          "type": "integer"
+        },
+        "auction_policy": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AuctionPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The mathematical policy governing task decentralization via Spot Markets."
+        },
+        "active_prediction_markets": {
+          "description": "The live algorithmic betting markets resolving swarm consensus.",
+          "items": {
+            "$ref": "#/$defs/PredictionMarketState"
+          },
+          "title": "Active Prediction Markets",
+          "type": "array"
+        },
+        "resolved_markets": {
+          "description": "The immutable records of finalized markets and reputation capital distributions.",
+          "items": {
+            "$ref": "#/$defs/MarketResolutionState"
+          },
+          "title": "Resolved Markets",
+          "type": "array"
         }
       },
       "required": [
@@ -15601,10 +15601,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a formal blueprint for Model-Based Fuzzing and\nGenerative Adversarial Testing against the Universal Unified Ontology. As a\n...Profile suffix, this is a declarative, frozen snapshot of an evaluation\ngeometry.\n\nCAUSAL AFFORDANCE: Instructs exogenous fuzzing engines to synthesize\npermutations of the target_schema_ref (min_length=1), actively injecting\nstructural entropy into the system while strictly adhering to the bounding\nmanifold_sla (GenerativeManifoldSLA).\n\nEPISTEMIC BOUNDS: The profile identity is cryptographically anchored to the\nprofile_cid (128-char CID regex ^[a-zA-Z0-9_.:-]+$). The simulation scope is\nphysically restricted by the underlying manifold_sla.\n\nMCP ROUTING TRIGGERS: Model-Based Fuzzing, Generative Adversarial Testing,\nStructural Entropy, Fuzzing Blueprint, Synthetic Permutation",
       "properties": {
-        "manifold_sla": {
-          "$ref": "#/$defs/GenerativeManifoldSLA",
-          "description": "The structural topological gas limit."
-        },
         "profile_cid": {
           "description": "Unique identifier for this simulation profile.",
           "maxLength": 128,
@@ -15612,6 +15608,10 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Profile Cid",
           "type": "string"
+        },
+        "manifold_sla": {
+          "$ref": "#/$defs/GenerativeManifoldSLA",
+          "description": "The structural topological gas limit."
         },
         "target_schema_ref": {
           "description": "The string name of the Pydantic class to synthesize.",
@@ -15633,6 +15633,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Kahneman's Dual-Process Theory (System 1) to execute\nrapid, heuristic-based reflex actions without invoking deep logical search trees. As a\n...Policy suffix, this enforces a rigid computational boundary.\n\nCAUSAL AFFORDANCE: Unlocks zero-shot execution of side-effect-free capabilities when\nthe working context matches established high-probability priors, intentionally bypassing\nexpensive System 2 Monte Carlo Tree Search (MCTS).\n\nEPISTEMIC BOUNDS: Execution is mathematically gated by the confidence_threshold\n(ge=0.0, le=1.0). The allowed_passive_tools array (max_length=1000,\nStringConstraints max_length=2000) strictly bounds the agent to non-mutating\ncapabilities, deterministically sorted via @model_validator.\n\nMCP ROUTING TRIGGERS: Dual-Process Theory, System 1 Heuristics, Zero-Shot Reflex,\nMetacognition, Amygdala Hijack Prevention",
       "properties": {
+        "confidence_threshold": {
+          "description": "The confidence threshold required to execute a reflex action.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Confidence Threshold",
+          "type": "number"
+        },
         "allowed_passive_tools": {
           "description": "The explicit, bounded array of strictly non-mutating tool capabilities.",
           "items": {
@@ -15642,13 +15649,6 @@
           "maxItems": 1000,
           "title": "Allowed Passive Tools",
           "type": "array"
-        },
-        "confidence_threshold": {
-          "description": "The confidence threshold required to execute a reflex action.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Confidence Threshold",
-          "type": "number"
         }
       },
       "required": [
@@ -15746,11 +15746,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Initiates a Request for Proposal (RFP) within a decentralized Spot Market to dynamically allocate thermodynamic compute based on task complexity.\n\nCAUSAL AFFORDANCE: Triggers an active, non-monotonic bidding phase where eligible Swarm nodes evaluate their internal Q-K matrices to formulate competitive execution bids.\n\nEPISTEMIC BOUNDS: The economic payload is physically capped by `max_budget_magnitude` (`le=1000000000`). The topological routing is strictly constrained if `required_action_space_id` is defined (optional, `max_length=128`, CID regex). Anchored by a mandatory `task_cid` CID.\n\nMCP ROUTING TRIGGERS: Decentralized Spot Market, Request for Proposal, Thermodynamic Compute Allocation, Algorithmic Mechanism Design, Kinetic Execution Trigger",
       "properties": {
-        "max_budget_magnitude": {
-          "description": "The absolute ceiling price the orchestrator is willing to pay.",
-          "maximum": 1000000000,
-          "title": "Max Budget Magnitude",
-          "type": "integer"
+        "task_cid": {
+          "description": "Unique identifier for the required task.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Cid",
+          "type": "string"
         },
         "required_action_space_id": {
           "anyOf": [
@@ -15768,13 +15770,11 @@
           "description": "Optional restriction forcing bidders to possess a specific toolset.",
           "title": "Required Action Space Id"
         },
-        "task_cid": {
-          "description": "Unique identifier for the required task.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Cid",
-          "type": "string"
+        "max_budget_magnitude": {
+          "description": "The absolute ceiling price the orchestrator is willing to pay.",
+          "maximum": 1000000000,
+          "title": "Max Budget Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -15788,6 +15788,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the successful clearing of an algorithmic auction and the mathematically proven allocation of compute capital.\n\nCAUSAL AFFORDANCE: Definitively terminates the auction phase and authorizes the awarded syndicate to execute their task trajectory using the locked EscrowPolicy funds.\n\nEPISTEMIC BOUNDS: Two `@model_validators` execute physical invariants: (1) Conservation of Compute (sum of `awarded_syndicate` values must exactly equal `cleared_price_magnitude` `le=1000000000`); (2) Escrow Ceiling (`escrow_locked_magnitude` cannot exceed `cleared_price_magnitude`).\n\nMCP ROUTING TRIGGERS: Market Clearing, Escrow Lock, Cryptographic Provenance, Syndicate Allocation, Thermodynamic Execution",
       "properties": {
+        "task_cid": {
+          "description": "The identifier of the resolved task.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Task Cid",
+          "type": "string"
+        },
         "awarded_syndicate": {
           "additionalProperties": {
             "minimum": 0,
@@ -15817,14 +15825,6 @@
           ],
           "default": null,
           "description": "The conditional escrow locking the compute budget."
-        },
-        "task_cid": {
-          "description": "The identifier of the resolved task.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Task Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -15839,6 +15839,20 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Hierarchical Agglomerative Clustering to project continuous,\ndense latent vector spaces into a deterministic, discrete N-ary tree structure. As a\n...State suffix, this is a declarative, frozen snapshot of a specific geometric coordinate.\n\nCAUSAL AFFORDANCE: Establishes a strictly bounded, navigable spatial coordinate within\nthe Virtual File System (VFS), allowing agents to traverse high-dimensional semantic\nspaces without consuming excessive context window tokens.\n\nEPISTEMIC BOUNDS: Spatial geometry is locked via node_cid (a strictly typed 128-character\nCID). The children_node_cids array is deterministically sorted, and the leaf_provenance\narray is sorted by source_event_cid, both via @model_validator to guarantee invariant\nRFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Dimensionality Reduction, Hierarchical Clustering, N-ary Tree,\nVirtual File System, Semantic Coordinate",
       "properties": {
+        "node_cid": {
+          "description": "A Content Identifier (CID) bounding this specific taxonomic coordinate.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Node Cid",
+          "type": "string"
+        },
+        "semantic_label": {
+          "description": "The human-legible, dynamically synthesized categorical label (e.g., 'High Risk Policies').",
+          "maxLength": 2000,
+          "title": "Semantic Label",
+          "type": "string"
+        },
         "children_node_cids": {
           "description": "Explicit array of child node CIDs to enforce the Directed Acyclic Graph.",
           "items": {
@@ -15857,14 +15871,6 @@
           "title": "Leaf Provenance",
           "type": "array"
         },
-        "node_cid": {
-          "description": "A Content Identifier (CID) bounding this specific taxonomic coordinate.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Node Cid",
-          "type": "string"
-        },
         "optical_physics": {
           "anyOf": [
             {
@@ -15876,12 +15882,6 @@
           ],
           "default": null,
           "description": "The strict microfacet BRDF physics governing the visual representation of this node."
-        },
-        "semantic_label": {
-          "description": "The human-legible, dynamically synthesized categorical label (e.g., 'High Risk Policies').",
-          "maxLength": 2000,
-          "title": "Semantic Label",
-          "type": "string"
         }
       },
       "required": [
@@ -15895,6 +15895,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Executes a kinetic Graph Isomorphism transformation, dynamically mutating the UI's spatial organization via heuristic regrouping without altering the underlying epistemic truth.\n\nCAUSAL AFFORDANCE: Forces the Hollow Data Plane to immediately discard the current semantic manifold and re-render the hierarchical projection according to the newly synthesized `target_taxonomy` and spatial heuristic.\n\nEPISTEMIC BOUNDS: Execution is rigidly constrained by the `restructure_heuristic`, strictly bounded to a Literal automaton `[\"chronological\", \"entity_centric\", \"semantic_cluster\", \"confidence_decay\"]`, mathematically preventing out-of-distribution UI mutations.\n\nMCP ROUTING TRIGGERS: Graph Isomorphism, UI State Mutation, Heuristic Regrouping, Dynamic Manifold, Spatial Reorganization",
       "properties": {
+        "topology_class": {
+          "const": "taxonomic_restructure",
+          "default": "taxonomic_restructure",
+          "description": "Strict discriminator for dynamic UI regrouping.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "restructure_heuristic": {
           "description": "The SOTA mathematical heuristic used to project the new manifold.",
           "enum": [
@@ -15909,13 +15916,6 @@
         "target_taxonomy": {
           "$ref": "#/$defs/GenerativeTaxonomyManifest",
           "description": "The newly synthesized topology projected to the frontend."
-        },
-        "topology_class": {
-          "const": "taxonomic_restructure",
-          "default": "taxonomic_restructure",
-          "description": "Strict discriminator for dynamic UI regrouping.",
-          "title": "Topology Class",
-          "type": "string"
         }
       },
       "required": [
@@ -15929,15 +15929,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements a deterministic Softmax Router Gate, leveraging Cognitive Load Theory to map high-entropy natural language intents into explicitly bounded spatial organizing frameworks.\n\nCAUSAL AFFORDANCE: Preemptively routes classified intents to optimized taxonomic layouts, mechanically preventing token exhaustion and attention dilution in downstream processing nodes before compute is allocated.\n\nEPISTEMIC BOUNDS: The `intent_to_heuristic_matrix` physically restricts state-space explosion by capping at `max_length=1000` dictionary properties. The matrix keys are strictly bounded to 255 characters via `StringConstraints` to mathematically prevent Dictionary Bombing.\n\nMCP ROUTING TRIGGERS: Softmax Gating, Cognitive Load Theory, Pre-Flight Routing, Dictionary Bombing Prevention, Token Exhaustion Mitigation",
       "properties": {
-        "fallback_heuristic": {
-          "description": "The deterministic default applied if intent classification falls below the safety threshold.",
-          "enum": [
-            "chronological",
-            "entity_centric",
-            "semantic_cluster",
-            "confidence_decay"
-          ],
-          "title": "Fallback Heuristic",
+        "policy_cid": {
+          "description": "Unique identifier for this pre-flight routing policy.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Policy Cid",
           "type": "string"
         },
         "intent_to_heuristic_matrix": {
@@ -15958,12 +15955,15 @@
           "title": "Intent To Heuristic Matrix",
           "type": "object"
         },
-        "policy_cid": {
-          "description": "Unique identifier for this pre-flight routing policy.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Policy Cid",
+        "fallback_heuristic": {
+          "description": "The deterministic default applied if intent classification falls below the safety threshold.",
+          "enum": [
+            "chronological",
+            "entity_centric",
+            "semantic_cluster",
+            "confidence_decay"
+          ],
+          "title": "Fallback Heuristic",
           "type": "string"
         }
       },
@@ -15979,19 +15979,18 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the Observer Effect to dynamically modulate the thermodynamic flow of network egress based on the observer's spatial view frustum.\nCAUSAL AFFORDANCE: Instructs the orchestrator's telemetry manifold to aggressively shed bandwidth load by calculating the dot product of topology nodes against the observer's focal vector. It starves occluded or peripheral subgraphs of kinematic updates to preserve system liveness.\nEPISTEMIC BOUNDS: Temporal refresh velocities are strictly clamped to physical Hertz frequencies. The mathematical invariant guarantees that flow rate monotonically increases as nodes approach the focal center.\nMCP ROUTING TRIGGERS: Observer Effect, Frustum Culling, Thermodynamic Flow Control, Telemetry Backpressure, Spatial Masking",
       "properties": {
-        "epsilon_derivative_threshold": {
-          "default": 0.0,
-          "description": "Minimum spatial or state magnitude delta required to authorize network egress.",
-          "maximum": 1000.0,
-          "minimum": 0.0,
-          "title": "Epsilon Derivative Threshold",
-          "type": "number"
-        },
         "focal_refresh_rate_hz": {
           "description": "The high-velocity telemetry budget (Hz) allocated exclusively to topologies intersecting the center of the observer's view frustum.",
           "maximum": 240,
           "minimum": 1,
           "title": "Focal Refresh Rate Hz",
+          "type": "integer"
+        },
+        "peripheral_refresh_rate_hz": {
+          "description": "The degraded telemetry budget (Hz) for nodes at the edges of the optical projection.",
+          "maximum": 60,
+          "minimum": 1,
+          "title": "Peripheral Refresh Rate Hz",
           "type": "integer"
         },
         "occluded_refresh_rate_hz": {
@@ -16002,12 +16001,13 @@
           "title": "Occluded Refresh Rate Hz",
           "type": "integer"
         },
-        "peripheral_refresh_rate_hz": {
-          "description": "The degraded telemetry budget (Hz) for nodes at the edges of the optical projection.",
-          "maximum": 60,
-          "minimum": 1,
-          "title": "Peripheral Refresh Rate Hz",
-          "type": "integer"
+        "epsilon_derivative_threshold": {
+          "default": 0.0,
+          "description": "Minimum spatial or state magnitude delta required to authorize network egress.",
+          "maximum": 1000.0,
+          "minimum": 0.0,
+          "title": "Epsilon Derivative Threshold",
+          "type": "number"
         }
       },
       "required": [
@@ -16060,10 +16060,16 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Teleological Isometry by measuring the exact mathematical alignment between a stated generative deficit and the empirical behavior of a forged tool.\n\n    CAUSAL AFFORDANCE: Approves or severs the final node promotion. If the cosine similarity bounds fall below the threshold, the orchestrator triggers an immediate rollback logic.\n\n    EPISTEMIC BOUNDS: Evaluated via deterministic cosine similarity constraints measuring between -1.0 and 1.0. The validator explicitly modifies the Boolean passing state if the float threshold isn't met.\n\n    MCP ROUTING TRIGGERS: Teleological Isometry, Tool Forging Validation, Cosine Similarity, Generative Deficit, Empirical Behavior",
       "properties": {
-        "alignment_threshold_passed": {
-          "description": "The absolute Boolean threshold indicating structural compliance.",
-          "title": "Alignment Threshold Passed",
-          "type": "boolean"
+        "source_intent_id": {
+          "description": "The structural 128-char DID boundary pointing to the foundational semantic deficit vector.",
+          "maxLength": 128,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Source Intent Id",
+          "type": "string"
+        },
+        "target_intent_vector": {
+          "$ref": "#/$defs/VectorEmbeddingState",
+          "description": "The dense mathematical representation of the initial multi-dimensional epistemic deficit."
         },
         "forged_output_vector": {
           "$ref": "#/$defs/VectorEmbeddingState",
@@ -16076,16 +16082,10 @@
           "title": "Measured Cosine Similarity",
           "type": "number"
         },
-        "source_intent_id": {
-          "description": "The structural 128-char DID boundary pointing to the foundational semantic deficit vector.",
-          "maxLength": 128,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Source Intent Id",
-          "type": "string"
-        },
-        "target_intent_vector": {
-          "$ref": "#/$defs/VectorEmbeddingState",
-          "description": "The dense mathematical representation of the initial multi-dimensional epistemic deficit."
+        "alignment_threshold_passed": {
+          "description": "The absolute Boolean threshold indicating structural compliance.",
+          "title": "Alignment Threshold Passed",
+          "type": "boolean"
         }
       },
       "required": [
@@ -16102,18 +16102,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Allen's Interval Algebra to definitively lock a state coordinate within an exact chronological boundary on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to computationally evaluate overlapping or preceding topological events to govern temporal state transitions and eviction.\n\nEPISTEMIC BOUNDS: Both `valid_from` and `valid_to` are physically clamped (`le=1000000000.0`, `ge=0.0`). The `@model_validator` mathematically forbids inverted temporal geometry by guaranteeing `valid_to` is strictly greater than `valid_from`.\n\nMCP ROUTING TRIGGERS: Allen's Interval Algebra, Temporal Geometry, Chronological Bounding, Topological Time, State Transition",
       "properties": {
-        "interval_type": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/CausalIntervalProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The Allen's interval algebra or causal relationship classification."
-        },
         "valid_from": {
           "anyOf": [
             {
@@ -16142,6 +16130,18 @@
           "default": null,
           "description": "The UNIX timestamp when this coordinate was invalidated.",
           "title": "Valid To"
+        },
+        "interval_type": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/CausalIntervalProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The Allen's interval algebra or causal relationship classification."
         }
       },
       "title": "TemporalBoundsProfile",
@@ -16199,30 +16199,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents the discrete, deterministic crystallization of an ephemeral POSIX/TTY execution buffer into a verifiable Merkle-DAG state vector.\n\nCAUSAL AFFORDANCE: Acts as the structural sensor array for shell interactions, capturing continuous stdout/stderr streams and environment matrices as cryptographically locked exogenous perturbations.\n\nEPISTEMIC BOUNDS: Physically restricted to SHA-256 canonical fingerprints (`stdout_hash`, `stderr_hash`, `env_variables_hash`, all matching `^[a-f0-9]{64}$`) to mathematically prevent VRAM memory exhaustion from unbounded shell logs.\n\nMCP ROUTING TRIGGERS: POSIX Environment, Exogenous Perturbation, TTY Buffer, Causal Actuator, Stream Crystallization",
       "properties": {
-        "env_variables_hash": {
-          "description": "The SHA-256 hash of the state-space context matrix.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Env Variables Hash",
-          "type": "string"
-        },
-        "stderr_hash": {
-          "description": "The SHA-256 hash tracking structural deviation anomalies.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Stderr Hash",
-          "type": "string"
-        },
-        "stdout_hash": {
-          "description": "The SHA-256 hash of the Exogenous Perturbations captured.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Stdout Hash",
-          "type": "string"
-        },
         "topology_class": {
           "const": "terminal",
           "default": "terminal",
@@ -16234,6 +16210,30 @@
           "description": "Capability Perimeters defining context bounds.",
           "maxLength": 2000,
           "title": "Working Directory",
+          "type": "string"
+        },
+        "stdout_hash": {
+          "description": "The SHA-256 hash of the Exogenous Perturbations captured.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Stdout Hash",
+          "type": "string"
+        },
+        "stderr_hash": {
+          "description": "The SHA-256 hash tracking structural deviation anomalies.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Stderr Hash",
+          "type": "string"
+        },
+        "env_variables_hash": {
+          "description": "The SHA-256 hash of the state-space context matrix.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Env Variables Hash",
           "type": "string"
         }
       },
@@ -16250,9 +16250,9 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A terminal state object generated when the Proposer-Verifier macro-topology exhausts its max_revision_loops without achieving ontological alignment. Packages the failure state for HITL routing.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to halt the active execution wave and physically route the exact contextual state of failure to a human supervisor for manual evaluation.\n\nEPISTEMIC BOUNDS: The cycle count is mathematically bounded by loops_exhausted (ge=1, le=100). The specific mathematical penalty gradient the proposer failed to resolve is locked via final_critique_schema. The last_rejected_hypothesis_hash is a cryptographically locked string (max_length=64).\n\nMCP ROUTING TRIGGERS: Proposer-Verifier Macro-Topology, Terminal State, Execution Halting, Human-in-the-Loop Routing, Cognitive Failure Packaging",
       "properties": {
-        "final_critique_schema": {
-          "$ref": "#/$defs/CognitiveCritiqueProfile",
-          "description": "The exact penalty gradient that the Proposer failed to resolve."
+        "source_entity": {
+          "$ref": "#/$defs/ContextualizedSourceEntity",
+          "description": "The original contextualized input data the system attempted to process."
         },
         "last_rejected_hypothesis_hash": {
           "description": "A pointer to the final abductive guess generated by the Proposer.",
@@ -16260,16 +16260,16 @@
           "title": "Last Rejected Hypothesis Hash",
           "type": "string"
         },
+        "final_critique_schema": {
+          "$ref": "#/$defs/CognitiveCritiqueProfile",
+          "description": "The exact penalty gradient that the Proposer failed to resolve."
+        },
         "loops_exhausted": {
           "description": "The cycle count at the time of failure.",
           "maximum": 100,
           "minimum": 1,
           "title": "Loops Exhausted",
           "type": "integer"
-        },
-        "source_entity": {
-          "$ref": "#/$defs/ContextualizedSourceEntity",
-          "description": "The original contextualized input data the system attempted to process."
         }
       },
       "required": [
@@ -16321,6 +16321,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Bayesian Theory of Mind (BToM) and Multi-Agent Epistemic Logic to model the hidden cognitive state and knowledge gaps of foreign agents.\n\nCAUSAL AFFORDANCE: Empowers the orchestrator to dynamically compress and target interpersonal communication by referencing assumed_shared_beliefs to avoid redundant information transfer across the swarm.\n\nEPISTEMIC BOUNDS: The predictive certainty is physically bounded by empathy_confidence_score (ge=0.0, le=1.0). The target_agent_cid is anchored to a 128-char CID. Arrays are deterministically sorted by the @model_validator to preserve cryptographic canonicalization.\n\nMCP ROUTING TRIGGERS: Bayesian Theory of Mind, Epistemic Logic, Cognitive Modeling, Common Knowledge, Multi-Agent Inference",
       "properties": {
+        "target_agent_cid": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the agent whose mind is being modeled.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Agent Cid",
+          "type": "string"
+        },
         "assumed_shared_beliefs": {
           "description": "The explicit array of Content Identifiers (CIDs) acting as cryptographic Lineage Watermarks that the modeling agent assumes the target already possesses.",
           "items": {
@@ -16330,13 +16338,6 @@
           },
           "title": "Assumed Shared Beliefs",
           "type": "array"
-        },
-        "empathy_confidence_score": {
-          "description": "The mathematical confidence (0.0 to 1.0) the agent has in its model of the target's mind.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Empathy Confidence Score",
-          "type": "number"
         },
         "identified_knowledge_gaps": {
           "description": "Specific topics or logical premises the target agent is assumed to be missing.",
@@ -16348,13 +16349,12 @@
           "title": "Identified Knowledge Gaps",
           "type": "array"
         },
-        "target_agent_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the agent whose mind is being modeled.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Target Agent Cid",
-          "type": "string"
+        "empathy_confidence_score": {
+          "description": "The mathematical confidence (0.0 to 1.0) the agent has in its model of the target's mind.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Empathy Confidence Score",
+          "type": "number"
         }
       },
       "required": [
@@ -16378,14 +16378,6 @@
           "title": "Branch Cid",
           "type": "string"
         },
-        "latent_content_hash": {
-          "description": "The SHA-256 hash of the raw latent dimensions explored in this branch.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Latent Content Hash",
-          "type": "string"
-        },
         "parent_branch_id": {
           "anyOf": [
             {
@@ -16401,6 +16393,14 @@
           "default": null,
           "description": "The branch this thought diverged from, enabling tree reconstruction.",
           "title": "Parent Branch Id"
+        },
+        "latent_content_hash": {
+          "description": "The SHA-256 hash of the raw latent dimensions explored in this branch.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Latent Content Hash",
+          "type": "string"
         },
         "prm_score": {
           "anyOf": [
@@ -16438,13 +16438,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Landauer's Principle of thermodynamic computing within the neurosymbolic network, serving as a lock-free, cryptographically frozen record of irreversible token and energy expenditure.\n\nCAUSAL AFFORDANCE: Deducts exact computational magnitude from the agent's localized Proof-of-Stake (PoS) execution escrow, progressively narrowing its available search depth. Bound to causal origin via `tool_invocation_cid`.\n\nEPISTEMIC BOUNDS: Integer bounds (`ge=0, le=1000000000`) on `input_tokens`, `output_tokens`, and `burn_magnitude` mathematically prevent integer overflow and fractional bypasses during ledger tallying.\n\nMCP ROUTING TRIGGERS: Landauer's Principle, Thermodynamic Compute, Token Burn, Resource Exhaustion, Lock-Free Tallying",
       "properties": {
-        "burn_magnitude": {
-          "description": "The normalized economic cost magnitude representing thermodynamic burn.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Burn Magnitude",
-          "type": "integer"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -16452,20 +16445,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "input_tokens": {
-          "description": "The mathematical measure of input tokens consumed.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Input Tokens",
-          "type": "integer"
-        },
-        "output_tokens": {
-          "description": "The mathematical measure of output tokens generated.",
-          "maximum": 1000000000,
-          "minimum": 0,
-          "title": "Output Tokens",
-          "type": "integer"
         },
         "prior_event_hash": {
           "anyOf": [
@@ -16490,6 +16469,13 @@
           "title": "Timestamp",
           "type": "number"
         },
+        "topology_class": {
+          "const": "token_burn",
+          "default": "token_burn",
+          "description": "Discriminator type for a token burn receipt.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "tool_invocation_cid": {
           "description": "A string linking this burn back to the specific ToolInvocationEvent CID.",
           "maxLength": 128,
@@ -16498,12 +16484,26 @@
           "title": "Tool Invocation Cid",
           "type": "string"
         },
-        "topology_class": {
-          "const": "token_burn",
-          "default": "token_burn",
-          "description": "Discriminator type for a token burn receipt.",
-          "title": "Topology Class",
-          "type": "string"
+        "input_tokens": {
+          "description": "The mathematical measure of input tokens consumed.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Input Tokens",
+          "type": "integer"
+        },
+        "output_tokens": {
+          "description": "The mathematical measure of output tokens generated.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Output Tokens",
+          "type": "integer"
+        },
+        "burn_magnitude": {
+          "description": "The normalized economic cost magnitude representing thermodynamic burn.",
+          "maximum": 1000000000,
+          "minimum": 0,
+          "title": "Burn Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -16521,16 +16521,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Judea Pearl's Do-Operator ($do(X=x)$) on an external or internal toolset, acting as an A Priori Kinetic Commitment.\n\nCAUSAL AFFORDANCE: Transitions the swarm from internal epistemic deliberation to kinetic execution. Targets a specific `tool_name` with bound parameters, demanding a valid `agent_attestation` identity.\n\nEPISTEMIC BOUNDS: `parameters` payload is volumetrically capped by `enforce_payload_topology`. To prevent infinite compute loops, `authorized_budget_magnitude` is mandated `ge=1`. `zk_proof` serves as mathematical authorization proof.\n\nMCP ROUTING TRIGGERS: Pearlian Do-Operator, Kinetic Commitment, Active Inference, Thermodynamic Escrow, Zero-Trust Actuation",
       "properties": {
-        "agent_attestation": {
-          "$ref": "#/$defs/AgentAttestationReceipt"
-        },
-        "authorized_budget_magnitude": {
-          "description": "The mandatory discrete thermodynamic token cost reserved for this specific run.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Authorized Budget Magnitude",
-          "type": "integer"
-        },
         "event_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
           "maxLength": 128,
@@ -16538,18 +16528,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "parameters": {
-          "additionalProperties": {
-            "$ref": "#/$defs/JsonPrimitiveState"
-          },
-          "description": "The intended JSON-RPC payload. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
-          "maxProperties": 1000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Parameters",
-          "type": "object"
         },
         "prior_event_hash": {
           "anyOf": [
@@ -16574,18 +16552,40 @@
           "title": "Timestamp",
           "type": "number"
         },
-        "tool_name": {
-          "description": "The exact tool targeted in the CognitiveActionSpaceManifest.",
-          "maxLength": 2000,
-          "title": "Tool Name",
-          "type": "string"
-        },
         "topology_class": {
           "const": "tool_invocation",
           "default": "tool_invocation",
           "description": "Discriminator type for a tool invocation event.",
           "title": "Topology Class",
           "type": "string"
+        },
+        "tool_name": {
+          "description": "The exact tool targeted in the CognitiveActionSpaceManifest.",
+          "maxLength": 2000,
+          "title": "Tool Name",
+          "type": "string"
+        },
+        "parameters": {
+          "additionalProperties": {
+            "$ref": "#/$defs/JsonPrimitiveState"
+          },
+          "description": "The intended JSON-RPC payload. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
+          "maxProperties": 1000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Parameters",
+          "type": "object"
+        },
+        "authorized_budget_magnitude": {
+          "description": "The mandatory discrete thermodynamic token cost reserved for this specific run.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Authorized Budget Magnitude",
+          "type": "integer"
+        },
+        "agent_attestation": {
+          "$ref": "#/$defs/AgentAttestationReceipt"
         },
         "zk_proof": {
           "$ref": "#/$defs/ZeroKnowledgeReceipt",
@@ -16633,6 +16633,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the rigid traversal perimeters for Graph Convolutional Network\n(GCN) or Random Walk with Restart (RWR) operations across the Causal DAG. As a ...Contract\nsuffix, this object defines rigid mathematical boundaries that the orchestrator must\nenforce globally.\n\nCAUSAL AFFORDANCE: Restricts graph hopping algorithms to explicit Pearlian edge types\n(Literal[\"causes\", \"confounds\", \"correlates_with\", \"undirected\"]), mathematically\npreventing epistemic drift and hallucination during deep multi-hop retrieval.\n\nEPISTEMIC BOUNDS: Bounded recursively by max_hop_depth (ge=1, le=1000000000). The\n@model_validator physically enforces deterministic sorting of\nallowed_causal_relationships (min_length=1) to guarantee RFC 8785 canonical hashing.\nGeometric distance preservation is toggled via enforce_isometry (default=True).\n\nMCP ROUTING TRIGGERS: Directed Acyclic Graph, Pearlian Traversal, Isometry Preservation,\nRandom Walk with Restart",
       "properties": {
+        "max_hop_depth": {
+          "description": "The strictly typed search depth bound for the cDAG.",
+          "maximum": 1000000000,
+          "minimum": 1,
+          "title": "Max Hop Depth",
+          "type": "integer"
+        },
         "allowed_causal_relationships": {
           "description": "The explicit whitelist of permissible causal edges to traverse.",
           "items": {
@@ -16653,13 +16660,6 @@
           "description": "Enforces preservation of geometric distances.",
           "title": "Enforce Isometry",
           "type": "boolean"
-        },
-        "max_hop_depth": {
-          "description": "The strictly typed search depth bound for the cDAG.",
-          "maximum": 1000000000,
-          "minimum": 1,
-          "title": "Max Hop Depth",
-          "type": "integer"
         }
       },
       "required": [
@@ -16673,16 +16673,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces Graph Representation Learning (GCN/GAT) constraints to shape the epistemic reward based purely on the topological centrality and spectral connectivity of the extracted axioms.\n\nCAUSAL AFFORDANCE: Commands the orchestrator to execute deterministic graph traversal algorithms (Random Walk with Restart, Spatial GCN) to compute node reachability and vector similarity before allocating policy gradients.\n\nEPISTEMIC BOUNDS: Clamps structural relevance geometrically using `min_edge_criticality_score` and `min_semantic_relevance_score` (`ge=0.0, le=1.0`). `aggregation_method` restricts the orchestrator to a strict Literal automaton.\n\nMCP ROUTING TRIGGERS: Graph Convolutional Networks, Spectral Graph Theory, Random Walk with Restart, Topological Reward Shaping, PageRank",
       "properties": {
-        "aggregation_method": {
-          "description": "The deterministic protocol the orchestrator must use to compute these scores.",
-          "enum": [
-            "gcn_spatial",
-            "attention_gat",
-            "rwr_topological"
-          ],
-          "title": "Aggregation Method",
-          "type": "string"
-        },
         "min_edge_criticality_score": {
           "description": "The lower bound for Random Walk with Restart (RWR) reachability.",
           "maximum": 1.0,
@@ -16696,6 +16686,16 @@
           "minimum": 0.0,
           "title": "Min Semantic Relevance Score",
           "type": "number"
+        },
+        "aggregation_method": {
+          "description": "The deterministic protocol the orchestrator must use to compute these scores.",
+          "enum": [
+            "gcn_spatial",
+            "attention_gat",
+            "rwr_topological"
+          ],
+          "title": "Aggregation Method",
+          "type": "string"
         }
       },
       "required": [
@@ -16715,12 +16715,21 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Distributed Causality using Vector Clocks and rho-calculus. It forms the foundational causality boundary.\n\n    CAUSAL AFFORDANCE: Acts as a Causal Graph Identifier, ensuring deterministic traceability and state boundary enforcement without relying on hidden states.\n\n    EPISTEMIC BOUNDS: Relies on ULID or UUIDv7 string identifiers for strict topological ordering, bounded by 26-36 chars. Causal clocks enforce ge=0 budget decay boundaries.\n\n    MCP ROUTING TRIGGERS: Distributed Causality, Vector Clocks, Trace Context, Topological Ordering, Causal Graph",
       "properties": {
-        "causal_clock": {
-          "default": 0,
-          "description": "Tracks the recursion depth/vector clock required for compute budget decay.",
-          "minimum": 0,
-          "title": "Causal Clock",
-          "type": "integer"
+        "trace_cid": {
+          "description": "Globally unique ID generated once at the root user prompt. Must be a ULID or UUIDv7.",
+          "maxLength": 36,
+          "minLength": 26,
+          "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$|^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+          "title": "Trace Cid",
+          "type": "string"
+        },
+        "span_cid": {
+          "description": "Unique identifier for the specific execution of this actionSpaceId. Must be a ULID or UUIDv7.",
+          "maxLength": 36,
+          "minLength": 26,
+          "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$|^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+          "title": "Span Cid",
+          "type": "string"
         },
         "parent_span_cid": {
           "anyOf": [
@@ -16738,21 +16747,12 @@
           "description": "The span_cid of the caller. If null, this node is the mathematically proven root.",
           "title": "Parent Span Cid"
         },
-        "span_cid": {
-          "description": "Unique identifier for the specific execution of this actionSpaceId. Must be a ULID or UUIDv7.",
-          "maxLength": 36,
-          "minLength": 26,
-          "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$|^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
-          "title": "Span Cid",
-          "type": "string"
-        },
-        "trace_cid": {
-          "description": "Globally unique ID generated once at the root user prompt. Must be a ULID or UUIDv7.",
-          "maxLength": 36,
-          "minLength": 26,
-          "pattern": "^[0-9A-HJKMNP-TV-Z]{26}$|^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
-          "title": "Trace Cid",
-          "type": "string"
+        "causal_clock": {
+          "default": 0,
+          "description": "Tracks the recursion depth/vector clock required for compute budget decay.",
+          "minimum": 0,
+          "title": "Causal Clock",
+          "type": "integer"
         }
       },
       "required": [
@@ -16793,48 +16793,12 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a directed acyclic Markov edge for traversing the Action Space topology. As a ...Profile suffix, this is a declarative, frozen snapshot of a routing geometry.\n\nCAUSAL AFFORDANCE: Unlocks stochastic pathfinding and graph traversal by projecting a probabilistic weight and thermodynamic cost required to advance to the next state node in the DCG.\n\nEPISTEMIC BOUNDS: The semantic path relies on `target_node_cid` (max_length=255). Mathematical optimization is bounded by `probability_weight` (ge=0.0, le=1.0) and `compute_weight_magnitude` (ge=0).\n\nMCP ROUTING TRIGGERS: Markov Decision Process, Acyclic Edge, Stochastic Routing, Transition Probability, Directed Graph",
       "properties": {
-        "compute_weight_magnitude": {
-          "description": "The thermodynamic cost to traverse this edge.",
-          "minimum": 0,
-          "title": "Compute Weight Magnitude",
-          "type": "integer"
-        },
-        "eval_strategy": {
-          "default": "strict",
-          "description": "The evaluation strategy: 'strict' pre-fetches schemas, 'lazy' uses Coalgebraic Thunking to prevent State-Space Explosion.",
-          "enum": [
-            "strict",
-            "lazy"
-          ],
-          "title": "Eval Strategy",
+        "topology_class": {
+          "const": "acyclic",
+          "default": "acyclic",
+          "description": "Discriminator type for an acyclic edge.",
+          "title": "Topology Class",
           "type": "string"
-        },
-        "payload_mappings": {
-          "description": "The algebraic translation matrix mapping the source's Covariant output to the Contravariant input.",
-          "items": {
-            "$ref": "#/$defs/EdgeMappingContract"
-          },
-          "title": "Payload Mappings",
-          "type": "array"
-        },
-        "probability_weight": {
-          "description": "The stochastic heuristic preference of this path.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Probability Weight",
-          "type": "number"
-        },
-        "target_intent": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/SemanticDiscoveryIntent"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Dynamic discovery intent for bridging nodes."
         },
         "target_node_cid": {
           "anyOf": [
@@ -16850,12 +16814,48 @@
           "description": "The coinductive pointer to the destination capability.",
           "title": "Target Node Cid"
         },
-        "topology_class": {
-          "const": "acyclic",
-          "default": "acyclic",
-          "description": "Discriminator type for an acyclic edge.",
-          "title": "Topology Class",
+        "target_intent": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/SemanticDiscoveryIntent"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Dynamic discovery intent for bridging nodes."
+        },
+        "payload_mappings": {
+          "description": "The algebraic translation matrix mapping the source's Covariant output to the Contravariant input.",
+          "items": {
+            "$ref": "#/$defs/EdgeMappingContract"
+          },
+          "title": "Payload Mappings",
+          "type": "array"
+        },
+        "eval_strategy": {
+          "default": "strict",
+          "description": "The evaluation strategy: 'strict' pre-fetches schemas, 'lazy' uses Coalgebraic Thunking to prevent State-Space Explosion.",
+          "enum": [
+            "strict",
+            "lazy"
+          ],
+          "title": "Eval Strategy",
           "type": "string"
+        },
+        "probability_weight": {
+          "description": "The stochastic heuristic preference of this path.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Probability Weight",
+          "type": "number"
+        },
+        "compute_weight_magnitude": {
+          "description": "The thermodynamic cost to traverse this edge.",
+          "minimum": 0,
+          "title": "Compute Weight Magnitude",
+          "type": "integer"
         }
       },
       "required": [
@@ -16876,18 +16876,18 @@
           "title": "Decay Propagation Rate",
           "type": "number"
         },
-        "enforce_cross_agent_quarantine": {
-          "default": false,
-          "description": "If True, the orchestrator must automatically emit global QuarantineIntents to sever infected SemanticEdges across the swarm to prevent epistemic contagion.",
-          "title": "Enforce Cross Agent Quarantine",
-          "type": "boolean"
-        },
         "epistemic_quarantine_threshold": {
           "description": "The minimum certainty boundary. If an event's propagated confidence drops below this threshold, it is structurally quarantined.",
           "maximum": 1.0,
           "minimum": 0.0,
           "title": "Epistemic Quarantine Threshold",
           "type": "number"
+        },
+        "enforce_cross_agent_quarantine": {
+          "default": false,
+          "description": "If True, the orchestrator must automatically emit global QuarantineIntents to sever infected SemanticEdges across the swarm to prevent epistemic contagion.",
+          "title": "Enforce Cross Agent Quarantine",
+          "type": "boolean"
         },
         "max_cascade_depth": {
           "description": "The absolute recursion depth limit for state retractions.",
@@ -16917,32 +16917,6 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Multi-Attribute Utility Theory (MAUT) to capture the exact multi-dimensional trade-offs (Pareto vectors) of a given routing decision.\n\nCAUSAL AFFORDANCE: Provides explicit mathematical justification for an agent's trajectory. If the variance of the utility distribution exceeds the threshold, it physically forces the orchestrator to deploy the embedded ensemble specification for deterministic resolution.\n\nEPISTEMIC BOUNDS: The `superposition_variance_threshold` is physically clamped strictly above zero (`gt=0.0`, `le=1000000000.0`), as a variance of absolute 0.0 represents mathematical certainty, which physically precludes superposition geometry. Vector dictionaries are bounded purely by spatial cardinality (`max_length=1000`).\n\nMCP ROUTING TRIGGERS: Multi-Attribute Utility Theory, Pareto Efficiency, Variance Reduction, Fallback Superposition, Utility Routing",
       "properties": {
-        "degrading_vectors": {
-          "additionalProperties": {
-            "maximum": 1000.0,
-            "minimum": -1000.0,
-            "type": "number"
-          },
-          "description": "Multi-dimensional continuous values representing degradations.",
-          "maxProperties": 1000,
-          "propertyNames": {
-            "maxLength": 255
-          },
-          "title": "Degrading Vectors",
-          "type": "object"
-        },
-        "ensemble_spec": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/EnsembleTopologyProfile"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The deterministic ensemble specification to fall back on when threshold falls below delta."
-        },
         "optimizing_vectors": {
           "additionalProperties": {
             "maximum": 1000.0,
@@ -16957,12 +16931,38 @@
           "title": "Optimizing Vectors",
           "type": "object"
         },
+        "degrading_vectors": {
+          "additionalProperties": {
+            "maximum": 1000.0,
+            "minimum": -1000.0,
+            "type": "number"
+          },
+          "description": "Multi-dimensional continuous values representing degradations.",
+          "maxProperties": 1000,
+          "propertyNames": {
+            "maxLength": 255
+          },
+          "title": "Degrading Vectors",
+          "type": "object"
+        },
         "superposition_variance_threshold": {
           "description": "The statistical variance threshold below which deterministic fallback is enforced.",
           "exclusiveMinimum": 0.0,
           "maximum": 1000000000.0,
           "title": "Superposition Variance Threshold",
           "type": "number"
+        },
+        "ensemble_spec": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/EnsembleTopologyProfile"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The deterministic ensemble specification to fall back on when threshold falls below delta."
         }
       },
       "required": [
@@ -16975,6 +16975,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a declarative, frozen geometric coordinate\nwithin a high-dimensional latent manifold, acting as a dense vector anchor\nfor zero-shot semantic routing. As a ...State suffix, this is a frozen\nN-dimensional coordinate.\n\nCAUSAL AFFORDANCE: Unlocks Maximum Inner Product Search (MIPS) and k-Nearest\nNeighbors (k-NN) retrieval without invoking stochastic token generation. The\nfoundation_matrix_name (max_length=2000) traces embedding provenance. The dimensionality\n(int, unbounded) specifies the vector array size.\n\nEPISTEMIC BOUNDS: The vector_base64 enforces a strict Base64 regex\n(^[A-Za-z0-9+/]*={0,2}$) and is physically capped at max_length=5000000 to\nprevent VRAM exhaustion during deserialization.\n\nMCP ROUTING TRIGGERS: Topological Data Analysis, Dense Vector Embedding,\nLatent Manifold, Maximum Inner Product Search, k-Nearest Neighbors",
       "properties": {
+        "vector_base64": {
+          "description": "The base64-encoded dense vector array.",
+          "maxLength": 5000000,
+          "pattern": "^[A-Za-z0-9+/]*={0,2}$",
+          "title": "Vector Base64",
+          "type": "string"
+        },
         "dimensionality": {
           "description": "The size of the vector array.",
           "title": "Dimensionality",
@@ -16984,13 +16991,6 @@
           "description": "The provenance of the embedding model used (e.g., 'text-embedding-3-large').",
           "maxLength": 2000,
           "title": "Foundation Matrix Name",
-          "type": "string"
-        },
-        "vector_base64": {
-          "description": "The base64-encoded dense vector array.",
-          "maxLength": 5000000,
-          "pattern": "^[A-Za-z0-9+/]*={0,2}$",
-          "title": "Vector Base64",
           "type": "string"
         }
       },
@@ -17006,6 +17006,27 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the W3C Verifiable Credentials Data Model (VCDM v2.0) to establish a decentralized, Zero-Trust identity perimeter on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Unlocks isolated execution bounds by projecting cryptographically verified geometric predicates (`authorization_claims`) into the orchestrator via `issuer_did`, allowing an agent to prove authorization clearance without centralized identity brokers.\n\nEPISTEMIC BOUNDS: The `authorization_claims` dict (`max_length=86400000`) is volumetrically bounded by the `enforce_payload_topology` hook (`_validate_payload_bounds`) to completely sever Predicate Exhaustion Attacks during selective disclosure verification. `cryptographic_proof_blob` capped at `max_length=100000`.\n\nMCP ROUTING TRIGGERS: W3C VCDM, Zero-Knowledge Proofs, Selective Disclosure, Decentralized Identifiers, Object Capability Model",
       "properties": {
+        "presentation_format": {
+          "description": "The exact cryptographic standard used to encode this credential presentation.",
+          "enum": [
+            "jwt_vc",
+            "ldp_vc",
+            "sd_jwt",
+            "zkp_vc"
+          ],
+          "title": "Presentation Format",
+          "type": "string"
+        },
+        "issuer_did": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "The globally unique decentralized identifier (DID) anchoring the trusted authority that cryptographically signed the credential, explicitly representing the delegation of authority from a human or parent principal."
+        },
+        "cryptographic_proof_blob": {
+          "description": "The base64-encoded cryptographic proof (e.g., ZK-SNARKs, zkVM receipts, or programmable trust attestations) proving the claims without revealing the private key.",
+          "maxLength": 100000,
+          "title": "Cryptographic Proof Blob",
+          "type": "string"
+        },
         "authorization_claims": {
           "additionalProperties": {
             "$ref": "#/$defs/JsonPrimitiveState"
@@ -17017,27 +17038,6 @@
           },
           "title": "Authorization Claims",
           "type": "object"
-        },
-        "cryptographic_proof_blob": {
-          "description": "The base64-encoded cryptographic proof (e.g., ZK-SNARKs, zkVM receipts, or programmable trust attestations) proving the claims without revealing the private key.",
-          "maxLength": 100000,
-          "title": "Cryptographic Proof Blob",
-          "type": "string"
-        },
-        "issuer_did": {
-          "$ref": "#/$defs/NodeCIDState",
-          "description": "The globally unique decentralized identifier (DID) anchoring the trusted authority that cryptographically signed the credential, explicitly representing the delegation of authority from a human or parent principal."
-        },
-        "presentation_format": {
-          "description": "The exact cryptographic standard used to encode this credential presentation.",
-          "enum": [
-            "jwt_vc",
-            "ldp_vc",
-            "sd_jwt",
-            "zkp_vc"
-          ],
-          "title": "Presentation Format",
-          "type": "string"
         }
       },
       "required": [
@@ -17053,6 +17053,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen receipt representing a Verifiable Random Function (VRF) output via elliptic curve cryptography. As an append-only coordinate on the Merkle-DAG, the LLM must never hallucinate a mutation to it.\n\nCAUSAL AFFORDANCE: Unlocks stochastic graph mutations (EvolutionaryTopology crossovers or prediction market resolutions) by providing mathematical proof that randomness was uniformly distributed and not manipulated by a Byzantine node.\n\nEPISTEMIC BOUNDS: Validity is physically bound to `seed_hash` (strict SHA-256 pattern `^[a-f0-9]{64}$`, `max_length=128`, `min_length=10`) and `public_key` (`max_length=8192`). `vrf_proof` is capped at `max_length=5000000`. Prevents adversarial Hash Poisoning.\n\nMCP ROUTING TRIGGERS: Verifiable Random Function, VRF, Stochastic Fairness, Elliptic Curve Cryptography, Zero-Knowledge Entropy",
       "properties": {
+        "vrf_proof": {
+          "description": "The zero-knowledge cryptographic proof of fair random generation.",
+          "maxLength": 5000000,
+          "minLength": 10,
+          "title": "Vrf Proof",
+          "type": "string"
+        },
         "public_key": {
           "description": "The public key of the oracle or node used to verify the VRF proof.",
           "maxLength": 8192,
@@ -17066,13 +17073,6 @@
           "minLength": 10,
           "pattern": "^[a-f0-9]{64}$",
           "title": "Seed Hash",
-          "type": "string"
-        },
-        "vrf_proof": {
-          "description": "The zero-knowledge cryptographic proof of fair random generation.",
-          "maxLength": 5000000,
-          "minLength": 10,
-          "title": "Vrf Proof",
           "type": "string"
         }
       },
@@ -17088,17 +17088,14 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines the linear algebraic projection matrix required to map N-dimensional spatial geometries onto a normalized View Frustum.\n\nCAUSAL AFFORDANCE: Authorizes an external rendering client to mathematically multiply a 3D SE(3) topology by a projection matrix, safely collapsing depth dimensions into an SE(2) plane for flat-screen rendering without fracturing topological relationships.\n\nEPISTEMIC BOUNDS: Bounding rules physically enforce valid optical geometry. The `clipping_plane_near` (`ge=0.001`) must mathematically precede `clipping_plane_far`. Perspective projections unconditionally mandate a valid `field_of_view_degrees` (`ge=1.0, le=179.0`) to prevent division-by-zero optical singularities.\n\nMCP ROUTING TRIGGERS: Viewport Projection Matrix, View Frustum, Field of View, Clipping Planes, Linear Algebraic Projection",
       "properties": {
-        "clipping_plane_far": {
-          "description": "The far frustum clipping plane.",
-          "minimum": 0.01,
-          "title": "Clipping Plane Far",
-          "type": "number"
-        },
-        "clipping_plane_near": {
-          "description": "The near frustum clipping plane.",
-          "minimum": 0.001,
-          "title": "Clipping Plane Near",
-          "type": "number"
+        "projection_class": {
+          "description": "The linear algebraic projection operator applied to collapse the topology.",
+          "enum": [
+            "perspective",
+            "orthographic"
+          ],
+          "title": "Projection Class",
+          "type": "string"
         },
         "field_of_view_degrees": {
           "anyOf": [
@@ -17115,14 +17112,17 @@
           "description": "The Y-axis optical field of view. Mandatory for perspective projections.",
           "title": "Field Of View Degrees"
         },
-        "projection_class": {
-          "description": "The linear algebraic projection operator applied to collapse the topology.",
-          "enum": [
-            "perspective",
-            "orthographic"
-          ],
-          "title": "Projection Class",
-          "type": "string"
+        "clipping_plane_near": {
+          "description": "The near frustum clipping plane.",
+          "minimum": 0.001,
+          "title": "Clipping Plane Near",
+          "type": "number"
+        },
+        "clipping_plane_far": {
+          "description": "The far frustum clipping plane.",
+          "minimum": 0.01,
+          "title": "Clipping Plane Far",
+          "type": "number"
         }
       },
       "required": [
@@ -17228,12 +17228,12 @@
           "title": "Curve Class",
           "type": "string"
         },
-        "edge_thickness": {
-          "default": 0.1,
-          "description": "The physical volumetric width of the connection manifold in meters.",
-          "maximum": 10.0,
-          "minimum": 0.01,
-          "title": "Edge Thickness",
+        "tension": {
+          "default": 0.5,
+          "description": "The mathematical rigidity scalar of the spline interpolation.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Tension",
           "type": "number"
         },
         "flow_velocity": {
@@ -17244,20 +17244,20 @@
           "title": "Flow Velocity",
           "type": "number"
         },
+        "edge_thickness": {
+          "default": 0.1,
+          "description": "The physical volumetric width of the connection manifold in meters.",
+          "maximum": 10.0,
+          "minimum": 0.01,
+          "title": "Edge Thickness",
+          "type": "number"
+        },
         "spatial_repulsion_scalar": {
           "default": 0.0,
           "description": "The mathematical gravity or repulsion field the edge asserts to avoid intersecting with volumetric bounding cages.",
           "maximum": 100.0,
           "minimum": 0.0,
           "title": "Spatial Repulsion Scalar",
-          "type": "number"
-        },
-        "tension": {
-          "default": 0.5,
-          "description": "The mathematical rigidity scalar of the spline interpolation.",
-          "maximum": 1.0,
-          "minimum": 0.0,
-          "title": "Tension",
           "type": "number"
         }
       },
@@ -17271,6 +17271,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Hierarchical Spatial Hashing and Area of Interest (AOI) Management to prevent $O(N^2)$ network saturation in massive spatial hypermedia environments.\n\nCAUSAL AFFORDANCE: Allows a distributed client to mathematically define a spatial perimeter. The orchestrator restricts the egress of KinematicDeltaManifest streams exclusively to nodes residing within this specific volumetric boundary.\n\nEPISTEMIC BOUNDS: The temporal liveness is guillotined by `subscription_ttl_ms` (`ge=1, le=86400000`). The volume is physically restricted by the nested `VolumetricBoundingProfile`.\n\nMCP ROUTING TRIGGERS: Area of Interest Management, Hierarchical Spatial Hashing, Telemetry Isolation, Spatial Partitioning, Culling",
       "properties": {
+        "partition_boundary": {
+          "$ref": "#/$defs/VolumetricBoundingProfile",
+          "description": "The 3D physical cage defining the observer's subscribed spatial area."
+        },
+        "subscription_ttl_ms": {
+          "description": "The exact Time-To-Live in milliseconds before the orchestrator forcibly drops the telemetry stream to prevent zombie subscriptions.",
+          "maximum": 86400000,
+          "minimum": 1,
+          "title": "Subscription Ttl Ms",
+          "type": "integer"
+        },
         "optical_hardware_constraint_proof": {
           "anyOf": [
             {
@@ -17282,17 +17293,6 @@
           ],
           "default": null,
           "description": "zk-SNARK proof that the requested spatial volume mathematically intersects with and does not exceed the physical rendering frustum of the client's authenticated optical hardware."
-        },
-        "partition_boundary": {
-          "$ref": "#/$defs/VolumetricBoundingProfile",
-          "description": "The 3D physical cage defining the observer's subscribed spatial area."
-        },
-        "subscription_ttl_ms": {
-          "description": "The exact Time-To-Live in milliseconds before the orchestrator forcibly drops the telemetry stream to prevent zombie subscriptions.",
-          "maximum": 86400000,
-          "minimum": 1,
-          "title": "Subscription Ttl Ms",
-          "type": "integer"
         }
       },
       "required": [
@@ -17306,6 +17306,17 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Hardware-Backed Human-in-the-Loop (HITL)\nauthentication, utilizing FIDO2/WebAuthn or Post-Quantum physical security\nkeys to verify human intent. As a ...Contract suffix, this enforces rigid\nmathematical boundaries globally.\n\nCAUSAL AFFORDANCE: Translates physical human entropy (e.g., a biometric tap or\nhardware key touch) into a definitive mathematical signature via mechanism\n(AttestationMechanismProfile), authorizing the orchestrator to break a\nMixed-Initiative execution halt. The did_subject (DID pattern\n^did:[a-z0-9]+:.*$) anchors the human identity.\n\nEPISTEMIC BOUNDS: Physically binds the signature to a specific Merkle-DAG\ncoordinate via dag_node_nonce (UUID), strictly preventing cryptographic Replay\nAttacks. The cryptographic_payload is restricted by regex\n(^[A-Za-z0-9+/=_-]+$) to prevent injection anomalies. The liveness_challenge_hash\nis tightly bounded to SHA-256 (^[a-f0-9]{64}$) to prove real-time human presence.\n\nMCP ROUTING TRIGGERS: WebAuthn, FIDO2, Cryptographic Nonce, Replay Attack\nPrevention, Wetware Entropy",
       "properties": {
+        "mechanism": {
+          "$ref": "#/$defs/AttestationMechanismProfile",
+          "description": "The SOTA cryptographic mechanism used to generate the proof."
+        },
+        "did_subject": {
+          "description": "The Decentralized Identifier (DID) of the human operator.",
+          "maxLength": 1024,
+          "pattern": "^did:[a-z0-9]+:.*$",
+          "title": "Did Subject",
+          "type": "string"
+        },
         "cryptographic_payload": {
           "description": "The strictly formatted (Base64url/Hex/Multibase) signature or proof.",
           "maxLength": 100000,
@@ -17321,13 +17332,6 @@
           "title": "Dag Node Nonce",
           "type": "string"
         },
-        "did_subject": {
-          "description": "The Decentralized Identifier (DID) of the human operator.",
-          "maxLength": 1024,
-          "pattern": "^did:[a-z0-9]+:.*$",
-          "title": "Did Subject",
-          "type": "string"
-        },
         "liveness_challenge_hash": {
           "description": "The SHA-256 hash of the dynamic, temporally bound challenge emitted by the orchestrator to guarantee real-time human presence.",
           "maxLength": 128,
@@ -17335,10 +17339,6 @@
           "pattern": "^[a-f0-9]{64}$",
           "title": "Liveness Challenge Hash",
           "type": "string"
-        },
-        "mechanism": {
-          "$ref": "#/$defs/AttestationMechanismProfile",
-          "description": "The SOTA cryptographic mechanism used to generate the proof."
         }
       },
       "required": [
@@ -17376,6 +17376,74 @@
         }
       ],
       "properties": {
+        "genesis_provenance": {
+          "$ref": "#/$defs/EpistemicProvenanceReceipt",
+          "description": "The cryptographic chain of custody anchoring this execution graph to its genesis block."
+        },
+        "manifest_version": {
+          "$ref": "#/$defs/SemanticVersionState",
+          "description": "The semantic version of this workflow manifestation schema."
+        },
+        "topology": {
+          "$ref": "#/$defs/AnyTopologyManifest",
+          "description": "The underlying topology governing execution routing."
+        },
+        "governance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/GlobalGovernancePolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Macro-economic circuit breakers and TTL limits for the swarm."
+        },
+        "tenant_cid": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The enterprise tenant boundary for this execution.",
+          "title": "Tenant Cid"
+        },
+        "session_cid": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "minLength": 1,
+              "pattern": "^[a-zA-Z0-9_.:-]+$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The ephemeral session boundary for this execution.",
+          "title": "Session Cid"
+        },
+        "max_risk_tolerance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/RiskLevelPolicy"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The absolute maximum enterprise risk threshold permitted for this topology."
+        },
         "allowed_semantic_classifications": {
           "anyOf": [
             {
@@ -17416,38 +17484,6 @@
           "default": null,
           "description": "The B2B Service Level Agreement contract that must be mathematically satisfied before multi-tenant graph coupling."
         },
-        "genesis_provenance": {
-          "$ref": "#/$defs/EpistemicProvenanceReceipt",
-          "description": "The cryptographic chain of custody anchoring this execution graph to its genesis block."
-        },
-        "governance": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/GlobalGovernancePolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "Macro-economic circuit breakers and TTL limits for the swarm."
-        },
-        "manifest_version": {
-          "$ref": "#/$defs/SemanticVersionState",
-          "description": "The semantic version of this workflow manifestation schema."
-        },
-        "max_risk_tolerance": {
-          "anyOf": [
-            {
-              "$ref": "#/$defs/RiskLevelPolicy"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The absolute maximum enterprise risk threshold permitted for this topology."
-        },
         "pq_signature": {
           "anyOf": [
             {
@@ -17459,42 +17495,6 @@
           ],
           "default": null,
           "description": "The quantum-resistant signature securing the root execution graph."
-        },
-        "session_cid": {
-          "anyOf": [
-            {
-              "maxLength": 255,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The ephemeral session boundary for this execution.",
-          "title": "Session Cid"
-        },
-        "tenant_cid": {
-          "anyOf": [
-            {
-              "maxLength": 255,
-              "minLength": 1,
-              "pattern": "^[a-zA-Z0-9_.:-]+$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The enterprise tenant boundary for this execution.",
-          "title": "Tenant Cid"
-        },
-        "topology": {
-          "$ref": "#/$defs/AnyTopologyManifest",
-          "description": "The underlying topology governing execution routing."
         }
       },
       "required": [
@@ -17509,6 +17509,41 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces Computational Integrity via Verifiable Computing, utilizing succinct non-interactive arguments of knowledge (zk-SNARKs/STARKs) to prove execution correctness without revealing private state.\n\nCAUSAL AFFORDANCE: Authorizes the zero-trust orchestrator to accept and merge off-chain state mutations by verifying the `cryptographic_blob` against the `public_inputs_hash` and `verifier_key_cid`.\n\nEPISTEMIC BOUNDS: `proof_protocol` is strictly clamped to a Literal automaton `[\"zk-SNARK\", \"zk-STARK\", \"plonk\", \"bulletproofs\"]`. `public_inputs_hash` guarantees linkage via SHA-256 regex `^[a-f0-9]{64}$`. `cryptographic_blob` is capped at `max_length=5000000`. `latent_state_commitments` restricts dictionary to `le=1000000000`.\n\nMCP ROUTING TRIGGERS: Computational Integrity, Verifiable Computing, Zero-Knowledge Proofs, zk-SNARK, State Attestation",
       "properties": {
+        "proof_protocol": {
+          "description": "The mathematical dialect of the cryptographic proof.",
+          "enum": [
+            "zk-SNARK",
+            "zk-STARK",
+            "plonk",
+            "bulletproofs"
+          ],
+          "title": "Proof Protocol",
+          "type": "string"
+        },
+        "logical_circuit_hash": {
+          "description": "The SHA-256 hash of the exact prompt, weights, and constraints evaluated by the prover.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Logical Circuit Hash",
+          "type": "string"
+        },
+        "public_inputs_hash": {
+          "description": "The SHA-256 hash of the public inputs (e.g., prompt, Lamport clock) anchoring this proof to the specific state index.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-f0-9]{64}$",
+          "title": "Public Inputs Hash",
+          "type": "string"
+        },
+        "verifier_key_cid": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the public evaluation key.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Verifier Key Cid",
+          "type": "string"
+        },
         "cryptographic_blob": {
           "description": "The base64-encoded succinct cryptographic proof payload.",
           "maxLength": 5000000,
@@ -17527,41 +17562,6 @@
           },
           "title": "Latent State Commitments",
           "type": "object"
-        },
-        "logical_circuit_hash": {
-          "description": "The SHA-256 hash of the exact prompt, weights, and constraints evaluated by the prover.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Logical Circuit Hash",
-          "type": "string"
-        },
-        "proof_protocol": {
-          "description": "The mathematical dialect of the cryptographic proof.",
-          "enum": [
-            "zk-SNARK",
-            "zk-STARK",
-            "plonk",
-            "bulletproofs"
-          ],
-          "title": "Proof Protocol",
-          "type": "string"
-        },
-        "public_inputs_hash": {
-          "description": "The SHA-256 hash of the public inputs (e.g., prompt, Lamport clock) anchoring this proof to the specific state index.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-f0-9]{64}$",
-          "title": "Public Inputs Hash",
-          "type": "string"
-        },
-        "verifier_key_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the public evaluation key.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Verifier Key Cid",
-          "type": "string"
         }
       },
       "required": [
@@ -17575,6 +17575,6 @@
       "type": "object"
     }
   },
-  "description": "CoReason Shared Kernel Ontology\n\nUnified JSON Schema for the Coreason Manifest",
-  "title": "CoReason Shared Kernel Ontology"
+  "title": "CoReason Shared Kernel Ontology",
+  "description": "CoReason Shared Kernel Ontology\n\nUnified JSON Schema for the Coreason Manifest"
 }

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -160,7 +160,7 @@ type CrossoverMechanismProfile = Literal["uniform_blend", "single_point", "heuri
 _CLEARANCE_MAPPING: dict[str, int] = {"public": 0, "internal": 1, "confidential": 2, "restricted": 3}
 
 
-class ComputeTier(StrEnum):
+class ComputeTierProfile(StrEnum):
     """
     AGENT INSTRUCTION: Categorizes the latency and reasoning depth of a given logical node, physically segregating cheap syntactic execution from heavy semantic computation.
 
@@ -191,7 +191,7 @@ class AcceleratorProfile(StrEnum):
     CUDA_FP32 = "CUDA_FP32"
 
 
-class EpistemicSecurity(StrEnum):
+class EpistemicSecurityPolicy(StrEnum):
     """
     AGENT INSTRUCTION: Defines the minimum cryptographic isolation perimeter required for this node's thermodynamic execution.
 
@@ -485,7 +485,7 @@ def _inject_workflow_examples(schema: dict[str, Any]) -> None:
     ]
 
 
-class RefusalToReasonError(ValueError):
+class RefusalToReasonEvent(ValueError):
     """
     AGENT INSTRUCTION: Exception raised when inference is aborted due to severe semantic degradation.
 
@@ -6261,13 +6261,13 @@ class SpatialHardwareProfile(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Instructs the orchestrator's provisioning layer to allocate exact silicon resources (Compute Tier, VRAM, and Accelerator Type) before allowing the node to execute generative operations.
 
-    EPISTEMIC BOUNDS: VRAM allocation is physically bounded by min_vram_gb (gt=0.0). The literal enumerations ComputeTier and AcceleratorProfile mathematically prevent the hallucination of non-existent silicon. The provider_whitelist is deterministically sorted for invariant RFC 8785 hashing.
+    EPISTEMIC BOUNDS: VRAM allocation is physically bounded by min_vram_gb (gt=0.0). The literal enumerations ComputeTierProfile and AcceleratorProfile mathematically prevent the hallucination of non-existent silicon. The provider_whitelist is deterministically sorted for invariant RFC 8785 hashing.
 
     MCP ROUTING TRIGGERS: Thermodynamic Bounding, VRAM Allocation, Spot Market Routing, Hardware Provisioning, Silicon Constraints
     """
 
-    compute_tier: ComputeTier = Field(
-        default=ComputeTier.KINETIC,
+    compute_tier: ComputeTierProfile = Field(
+        default=ComputeTierProfile.KINETIC,
         description="The discrete architectural boundary of the node (KINETIC for edge/consumer, ORACLE for datacenter).",
     )
     min_vram_gb: float = Field(
@@ -6301,8 +6301,8 @@ class EpistemicSecurityProfile(CoreasonBaseState):
     MCP ROUTING TRIGGERS: Sovereign Execution, Trusted Execution Environment, Egress Obfuscation, Mixnet Routing, Network Isolation
     """
 
-    epistemic_security: EpistemicSecurity = Field(
-        default=EpistemicSecurity.STANDARD,
+    epistemic_security: EpistemicSecurityPolicy = Field(
+        default=EpistemicSecurityPolicy.STANDARD,
         description="The level of hardware-enforced cryptographic isolation required (STANDARD or CONFIDENTIAL).",
     )
     network_isolation: bool = Field(
@@ -10011,12 +10011,12 @@ class CognitiveAgentNodeProfile(CoreasonBaseState):
         Enforces Thermodynamic, Sovereign Execution, and Network Topology paradox traps.
         """
 
-        if self.hardware.compute_tier == ComputeTier.KINETIC and self.hardware.min_vram_gb > 24.0:
+        if self.hardware.compute_tier == ComputeTierProfile.KINETIC and self.hardware.min_vram_gb > 24.0:
             raise ValueError(
                 "Thermodynamic Constraint Violated: KINETIC tier cannot exceed 24.0 GB VRAM. Escalate to ORACLE tier."
             )
 
-        if self.security.epistemic_security == EpistemicSecurity.CONFIDENTIAL and not set(
+        if self.security.epistemic_security == EpistemicSecurityPolicy.CONFIDENTIAL and not set(
             self.hardware.provider_whitelist
         ).issubset(_TRUSTED_ENVIRONMENTS):
             invalid_targets = set(self.hardware.provider_whitelist) - _TRUSTED_ENVIRONMENTS
@@ -12630,7 +12630,7 @@ class NeurosymbolicInferenceRequest(CoreasonBaseState):
     @model_validator(mode="after")
     def validate_epistemic_gap(self) -> Self:
         if self.uncertainty_profile.epistemic_knowledge_gap >= self.sla.minimum_fidelity_threshold:
-            raise RefusalToReasonError(
+            raise RefusalToReasonEvent(
                 "Inference aborted due to severe semantic degradation. Epistemic gap exceeds SLA."
             )
         return self

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -485,7 +485,7 @@ def _inject_workflow_examples(schema: dict[str, Any]) -> None:
     ]
 
 
-class RefusalToReasonEvent(ValueError):
+class RefusalToReasonEvent(ValueError):  # noqa: N818
     """
     AGENT INSTRUCTION: Exception raised when inference is aborted due to severe semantic degradation.
 

--- a/tests/contracts/test_ontology_validators.py
+++ b/tests/contracts/test_ontology_validators.py
@@ -21,7 +21,7 @@ from coreason_manifest.spec.ontology import (
     CognitiveUncertaintyProfile,
     ComputeEngineProfile,
     ComputeRateContract,
-    ComputeTier,
+    ComputeTierProfile,
     ConsensusPolicy,
     ConstrainedDecodingPolicy,
     ContextualizedSourceEntity,
@@ -30,7 +30,7 @@ from coreason_manifest.spec.ontology import (
     DynamicLayoutManifest,
     EphemeralNamespacePartitionState,
     EpistemicCompressionSLA,
-    EpistemicSecurity,
+    EpistemicSecurityPolicy,
     EpistemicSecurityProfile,
     EpistemicUpsamplingTask,
     GradingCriterionProfile,
@@ -816,9 +816,9 @@ def test_kinematic_delta_manifest_sorting() -> None:
 def test_agent_node_profile_success() -> None:
     """Test that default values instantiate cleanly without triggering traps."""
     agent = CognitiveAgentNodeProfile(description="Test agent")
-    assert agent.hardware.compute_tier == ComputeTier.KINETIC
+    assert agent.hardware.compute_tier == ComputeTierProfile.KINETIC
     assert agent.hardware.min_vram_gb == 8.0
-    assert agent.security.epistemic_security == EpistemicSecurity.STANDARD
+    assert agent.security.epistemic_security == EpistemicSecurityPolicy.STANDARD
 
 
 def test_agent_node_profile_thermodynamic_paradox() -> None:
@@ -826,7 +826,7 @@ def test_agent_node_profile_thermodynamic_paradox() -> None:
     with pytest.raises(ValueError, match="Thermodynamic Constraint Violated"):
         CognitiveAgentNodeProfile(
             description="Test agent",
-            hardware=SpatialHardwareProfile(compute_tier=ComputeTier.KINETIC, min_vram_gb=25.0),
+            hardware=SpatialHardwareProfile(compute_tier=ComputeTierProfile.KINETIC, min_vram_gb=25.0),
         )
 
 
@@ -836,16 +836,16 @@ def test_agent_node_profile_sovereign_execution_paradox() -> None:
         CognitiveAgentNodeProfile(
             description="Test agent",
             hardware=SpatialHardwareProfile(provider_whitelist=["vast", "aws"]),
-            security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+            security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurityPolicy.CONFIDENTIAL),
         )
 
     # Success case for CONFIDENTIAL
     agent = CognitiveAgentNodeProfile(
         description="Test agent",
         hardware=SpatialHardwareProfile(provider_whitelist=["aws", "gcp"]),
-        security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+        security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurityPolicy.CONFIDENTIAL),
     )
-    assert agent.security.epistemic_security == EpistemicSecurity.CONFIDENTIAL
+    assert agent.security.epistemic_security == EpistemicSecurityPolicy.CONFIDENTIAL
 
 
 def test_sovereign_execution_allows_localhost_and_bare_metal() -> None:
@@ -853,10 +853,10 @@ def test_sovereign_execution_allows_localhost_and_bare_metal() -> None:
     profile = CognitiveAgentNodeProfile(
         description="Secure local ETL agent for proprietary schemas.",
         hardware=SpatialHardwareProfile(provider_whitelist=["localhost", "bare-metal"]),
-        security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+        security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurityPolicy.CONFIDENTIAL),
     )
     # If the validation passes without raising ValueError, the contract holds.
-    assert profile.security.epistemic_security == EpistemicSecurity.CONFIDENTIAL
+    assert profile.security.epistemic_security == EpistemicSecurityPolicy.CONFIDENTIAL
     assert "localhost" in profile.hardware.provider_whitelist
 
 

--- a/tests/fuzzing/test_instantiation_bounds.py
+++ b/tests/fuzzing/test_instantiation_bounds.py
@@ -20,11 +20,11 @@ from coreason_manifest.spec.ontology import (
     CognitiveAgentNodeProfile,
     CognitiveSystemNodeProfile,
     CognitiveUncertaintyProfile,
-    ComputeTier,
+    ComputeTierProfile,
     ContextualizedSourceEntity,
     DAGTopologyManifest,
     EpistemicCompressionSLA,
-    EpistemicSecurity,
+    EpistemicSecurityPolicy,
     EpistemicSecurityProfile,
     MultimodalTokenAnchorState,
     NeurosymbolicInferenceRequest,
@@ -279,7 +279,7 @@ def test_fuzz_thermodynamic_paradox(min_vram_gb: float) -> None:
     with pytest.raises((ValueError, ValidationError), match="Thermodynamic Constraint Violated"):
         CognitiveAgentNodeProfile(
             description="Fuzz test agent",
-            hardware=SpatialHardwareProfile(compute_tier=ComputeTier.KINETIC, min_vram_gb=min_vram_gb),
+            hardware=SpatialHardwareProfile(compute_tier=ComputeTierProfile.KINETIC, min_vram_gb=min_vram_gb),
         )
 
 
@@ -300,15 +300,15 @@ def test_fuzz_sovereign_execution_paradox(provider_whitelist: list[str]) -> None
             CognitiveAgentNodeProfile(
                 description="Fuzz test agent",
                 hardware=SpatialHardwareProfile(provider_whitelist=provider_whitelist),
-                security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+                security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurityPolicy.CONFIDENTIAL),
             )
     else:
         agent = CognitiveAgentNodeProfile(
             description="Fuzz test agent",
             hardware=SpatialHardwareProfile(provider_whitelist=provider_whitelist),
-            security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurity.CONFIDENTIAL),
+            security=EpistemicSecurityProfile(epistemic_security=EpistemicSecurityPolicy.CONFIDENTIAL),
         )
-        assert agent.security.epistemic_security == EpistemicSecurity.CONFIDENTIAL
+        assert agent.security.epistemic_security == EpistemicSecurityPolicy.CONFIDENTIAL
         assert agent.hardware.provider_whitelist == sorted(provider_whitelist)
 
 


### PR DESCRIPTION
Renamed classes in `ontology.py` and updated associated tests to comply with Rule 0.3.2 "Missing Categorical Suffixes" which dictates that all object names must terminate with a strict physics suffix (e.g., Profile, Event, Policy).

---
*PR created automatically by Jules for task [13887859722846712867](https://jules.google.com/task/13887859722846712867) started by @gowthamrao*