### PR TITLE
Epic 2: Lexical Architecture & Anti-CRUD enforcement

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2102,7 +2102,7 @@
     },
     "ChaosExperimentTask": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates an automated steady-state hypothesis falsification loop\nvia structured Chaos Engineering. As a ...Task suffix, this represents an authorized\nkinetic execution trigger initiating active topological stress testing.\n\nCAUSAL AFFORDANCE: Deploys a deterministic matrix of faults and exogenous shocks against\na baseline SteadyStateHypothesisState to empirically discover latent fragility and\nevaluate the resilience of the DAG topology.\n\nEPISTEMIC BOUNDS: Cryptographic determinism is mathematically guaranteed by the\n@model_validator, which sorts the faults array by composite key (fault_type,\ntarget_node_cid) and the shocks array by shock_id to preserve RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Steady State Falsification, Chaos Engineering, Automated Failure\nDiscovery, Resilience Orchestration, Systemic Perturbation",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates an automated steady-state hypothesis falsification loop\nvia structured Chaos Engineering. As a ...Task suffix, this represents an authorized\nkinetic execution trigger initiating active topological stress testing.\n\nCAUSAL AFFORDANCE: Deploys a deterministic matrix of faults and exogenous shocks against\na baseline SteadyStateHypothesisState to empirically discover latent fragility and\nevaluate the resilience of the DAG topology.\n\nEPISTEMIC BOUNDS: Cryptographic determinism is mathematically guaranteed by the\n@model_validator, which sorts the faults array by composite key (fault_category,\ntarget_node_cid) and the shocks array by shock_id to preserve RFC 8785 canonical hashing.\n\nMCP ROUTING TRIGGERS: Steady State Falsification, Chaos Engineering, Automated Failure\nDiscovery, Resilience Orchestration, Systemic Perturbation",
       "properties": {
         "experiment_id": {
           "description": "The unique identifier for the chaos experiment.",
@@ -2379,7 +2379,7 @@
         "active_attention_ray": {
           "anyOf": [
             {
-              "$ref": "#/$defs/EpistemicAttentionRay"
+              "$ref": "#/$defs/EpistemicAttentionState"
             },
             {
               "type": "null"
@@ -2895,7 +2895,7 @@
         "active_attention_ray": {
           "anyOf": [
             {
-              "$ref": "#/$defs/EpistemicAttentionRay"
+              "$ref": "#/$defs/EpistemicAttentionState"
             },
             {
               "type": "null"
@@ -4051,7 +4051,7 @@
       "title": "ContextExpansionPolicy",
       "type": "object"
     },
-    "ContextualizedSourceEntity": {
+    "ContextualizedSourceState": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Projects a semantically unified spatial token footprint representing the strictly bounded source projection.\n\n    CAUSAL AFFORDANCE: Authorizes downstream parsing tasks to isolate exact dimensional target strings while strictly maintaining chronological relationships via the topological envelope.\n\n    EPISTEMIC BOUNDS: Limits structural explosion by constraining target sequences and contextual items mathematically to max_length=100000. Contains a strict topological exemption preventing array sorting.\n\n    MCP ROUTING TRIGGERS: Semantic Envelope, Contextual Projection, Spatial Token Footprint, Source Entity, Topos Sorting",
       "properties": {
@@ -4082,7 +4082,7 @@
         "contextual_envelope",
         "source_system_provenance_flag"
       ],
-      "title": "ContextualizedSourceEntity",
+      "title": "ContextualizedSourceState",
       "type": "object"
     },
     "ContinuousMutationPolicy": {
@@ -4533,7 +4533,7 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes the chromosomal crossover and genetic recombination\nheuristics for blending latent feature vectors of elite parent agents. As a ...Policy\nsuffix, this object defines rigid mathematical boundaries that the orchestrator must\nenforce globally.\n\nCAUSAL AFFORDANCE: Executes the deterministic interpolation of N-dimensional properties\nfrom successful agents using a specific geometric strategy (CrossoverMechanismProfile)\nto breed the next generation's starting state.\n\nEPISTEMIC BOUNDS: The blending_factor is strictly constrained to a fractional\ninterpolation ratio (ge=0.0, le=1.0) to mathematically prevent extrapolated state drift\nbeyond the parents' bounding box. Relies on optional verifiable_entropy\n(VerifiableEntropyReceipt) to ensure unbiased recombination.\n\nMCP ROUTING TRIGGERS: Genetic Recombination, Chromosomal Crossover, Vector\nInterpolation, Elitism, Reproduction Heuristic",
       "properties": {
-        "strategy_type": {
+        "strategy_profile": {
           "$ref": "#/$defs/CrossoverMechanismProfile",
           "description": "The heuristic method for blending successful parent agents."
         },
@@ -4558,7 +4558,7 @@
         }
       },
       "required": [
-        "strategy_type",
+        "strategy_profile",
         "blending_factor"
       ],
       "title": "CrossoverPolicy",
@@ -6062,7 +6062,7 @@
       "title": "EpistemicArgumentGraphState",
       "type": "object"
     },
-    "EpistemicAttentionRay": {
+    "EpistemicAttentionState": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Joint Attention and Gaze Raycasting across the distributed topology. Projects a continuous vector from an observer's optical center to indicate cognitive focus prior to physical mutation.\n\nCAUSAL AFFORDANCE: Broadcasts a non-kinetic 'cursor presence' to the swarm. The orchestrator calculates the dot product between this vector and surrounding nodes, identifying the exact topological vertices the observer is currently evaluating.\n\nEPISTEMIC BOUNDS: The `direction_unit_vector` is mathematically normalized to exactly 1.0 via `@model_validator` to prevent raycast scalar explosions. To mitigate $O(N^2)$ intersection complexity, the `intersected_node_cids` array is strictly capped at `max_length=100` and deterministically sorted.\n\nMCP ROUTING TRIGGERS: Spatial Raycasting, Joint Attention, Cognitive Frustum Intersection, Vector Math, Gaze Tracking",
       "properties": {
@@ -6116,7 +6116,7 @@
         "origin",
         "direction_unit_vector"
       ],
-      "title": "EpistemicAttentionRay",
+      "title": "EpistemicAttentionState",
       "type": "object"
     },
     "EpistemicAxiomState": {
@@ -7368,7 +7368,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Authorizes a connectionist agent to execute an abductive leap, reversing lossy compression via context.\n\n    CAUSAL AFFORDANCE: Unlocks generative projection mapping by allowing an agent to expand a generalized node into highly specific ontology dimensions based on contextual vectors.\n\n    EPISTEMIC BOUNDS: The confidence of the upsampling projection is clamped tightly between 0.0 and 1.0. Justification arrays enforce maximum structural lengths and explicitly declare Topological Exemptions against array sort.\n\n    MCP ROUTING TRIGGERS: Abductive Leap, Epistemic Upsampling, Lossy Compression Reversal, Vector Expansion, Connectionist Grounding",
       "properties": {
         "source_entity": {
-          "$ref": "#/$defs/ContextualizedSourceEntity",
+          "$ref": "#/$defs/ContextualizedSourceState",
           "description": "The specific source contextualized entity subject to topological upsampling."
         },
         "target_ontological_granularity": {
@@ -8371,9 +8371,9 @@
     },
     "FaultInjectionProfile": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a deterministic Byzantine fault vector for Chaos Engineering\nperturbation tests. As a ...Profile suffix, this is a declarative, frozen snapshot of an\nattack geometry at a specific point in time.\n\nCAUSAL AFFORDANCE: Instructs the execution engine to physically degrade, throttle, or\ncorrupt the structural state or network connectivity of the target_node_cid based on the\nspecific fault_type (FaultCategoryProfile) manifold.\n\nEPISTEMIC BOUNDS: The severity of the perturbation is constrained above by the intensity\nscalar (le=1000000000.0) but unbounded below, permitting negative fault magnitudes. The\nblast radius targets either the entire swarm (target_node_cid=None) or a specific node\nbounded to a valid 128-char CID regex ^[a-zA-Z0-9_.:-]+$.\n\nMCP ROUTING TRIGGERS: Chaos Engineering, Byzantine Fault Injection, Perturbation Theory,\nStructural Sabotage, Resilience Testing",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a deterministic Byzantine fault vector for Chaos Engineering\nperturbation tests. As a ...Profile suffix, this is a declarative, frozen snapshot of an\nattack geometry at a specific point in time.\n\nCAUSAL AFFORDANCE: Instructs the execution engine to physically degrade, throttle, or\ncorrupt the structural state or network connectivity of the target_node_cid based on the\nspecific fault_category (FaultCategoryProfile) manifold.\n\nEPISTEMIC BOUNDS: The severity of the perturbation is constrained above by the intensity\nscalar (le=1000000000.0) but unbounded below, permitting negative fault magnitudes. The\nblast radius targets either the entire swarm (target_node_cid=None) or a specific node\nbounded to a valid 128-char CID regex ^[a-zA-Z0-9_.:-]+$.\n\nMCP ROUTING TRIGGERS: Chaos Engineering, Byzantine Fault Injection, Perturbation Theory,\nStructural Sabotage, Resilience Testing",
       "properties": {
-        "fault_type": {
+        "fault_category": {
           "$ref": "#/$defs/FaultCategoryProfile",
           "description": "The specific type of fault to inject."
         },
@@ -8401,7 +8401,7 @@
         }
       },
       "required": [
-        "fault_type",
+        "fault_category",
         "intensity"
       ],
       "title": "FaultInjectionProfile",
@@ -9883,7 +9883,7 @@
         "failure_context": {
           "anyOf": [
             {
-              "$ref": "#/$defs/TerminalCognitiveFailure"
+              "$ref": "#/$defs/TerminalCognitiveEvent"
             },
             {
               "type": "null"
@@ -10276,7 +10276,7 @@
       "title": "KinematicDeltaManifest",
       "type": "object"
     },
-    "KinematicDerivativeTensor": {
+    "KinematicDerivativeProfile": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics\nCAUSAL AFFORDANCE: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics\nEPISTEMIC BOUNDS: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics\nMCP ROUTING TRIGGERS: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics",
       "properties": {
@@ -10359,7 +10359,7 @@
         "linear_acceleration",
         "angular_acceleration"
       ],
-      "title": "KinematicDerivativeTensor",
+      "title": "KinematicDerivativeProfile",
       "type": "object"
     },
     "KinematicNoiseProfile": {
@@ -11207,7 +11207,7 @@
     },
     "ManifestViolationReceipt": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A machine-readable, deterministic JSON receipt of an exact topological failure, replacing unstructured stack traces.\n\nCAUSAL AFFORDANCE: Enables the agent to execute $O(1)$ surgical patches via StateMutationIntent rather than hallucinating fixes.\n\nEPISTEMIC BOUNDS: `failing_pointer` mathematically maps exactly to RFC 6902 JSON Pointers (`max_length=2000`). `violation_type` capped at `255`.\n\nMCP ROUTING TRIGGERS: Fault Receipt, RFC 6902, Epistemic Loss Prevention, Surgical Patching, Traceback Serialization",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A machine-readable, deterministic JSON receipt of an exact topological failure, replacing unstructured stack traces.\n\nCAUSAL AFFORDANCE: Enables the agent to execute $O(1)$ surgical patches via StateMutationIntent rather than hallucinating fixes.\n\nEPISTEMIC BOUNDS: `failing_pointer` mathematically maps exactly to RFC 6902 JSON Pointers (`max_length=2000`). `violation_category` capped at `255`.\n\nMCP ROUTING TRIGGERS: Fault Receipt, RFC 6902, Epistemic Loss Prevention, Surgical Patching, Traceback Serialization",
       "properties": {
         "failing_pointer": {
           "description": "The exact RFC 6902 JSON pointer isolating the topological failure.",
@@ -11215,10 +11215,10 @@
           "title": "Failing Pointer",
           "type": "string"
         },
-        "violation_type": {
+        "violation_category": {
           "description": "Categorical descriptor of the failure, e.g., missing, type_error.",
           "maxLength": 255,
-          "title": "Violation Type",
+          "title": "Violation Category",
           "type": "string"
         },
         "diagnostic_message": {
@@ -11230,7 +11230,7 @@
       },
       "required": [
         "failing_pointer",
-        "violation_type",
+        "violation_category",
         "diagnostic_message"
       ],
       "title": "ManifestViolationReceipt",
@@ -11720,7 +11720,7 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Tensor Calculus and Differential Geometry representations\nto safely proxy high-dimensional latent structures across zero-trust network boundaries\nwithout transmitting raw, uncompressed bytes. As a ...Manifest suffix, this defines a\nfrozen, declarative coordinate.\n\nCAUSAL AFFORDANCE: Allows the orchestrator to route traffic and reserve exact physical\nGPU memory for massive tensors prior to downloading them via the storage_uri,\npreventing runtime out-of-memory (OOM) execution faults.\n\nEPISTEMIC BOUNDS: The @model_validator _enforce_physics_engine mathematically proves\nthat the topological shape exactly matches the declared vram_footprint_bytes limit\n(le=100000000000) based on the scalar structural_type byte density. Supply-chain\ntampering is physically prevented via the merkle_root SHA-256 requirement.\n\nMCP ROUTING TRIGGERS: Tensor Calculus, Differential Geometry, Merkle Tree Verification, Zero-Trust Computing, Memory Allocation",
       "properties": {
-        "structural_type": {
+        "structural_format": {
           "$ref": "#/$defs/TensorStructuralFormatProfile",
           "description": "Structural type of the tensor elements."
         },
@@ -11756,7 +11756,7 @@
         }
       },
       "required": [
-        "structural_type",
+        "structural_format",
         "shape",
         "vram_footprint_bytes",
         "merkle_root",
@@ -11861,12 +11861,12 @@
       "title": "NeuroSymbolicHandoffContract",
       "type": "object"
     },
-    "NeurosymbolicInferenceRequest": {
+    "NeurosymbolicInferenceIntent": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Orchestrates the core execution payload boundary, acting as the structural pre-inference gate for neurosymbolic probability.\n\n    CAUSAL AFFORDANCE: Empowers the routing engine to sever execution prior to LLM generation if the structural certainty SLA evaluates beyond acceptable mathematical variance boundaries.\n\n    EPISTEMIC BOUNDS: Mandates exact nesting of deterministic fidelity and uncertainty profiles. The pre-flight validator mathematically terminates evaluation if epistemic degradation breaches the SLA limit.\n\n    MCP ROUTING TRIGGERS: Pre-Inference Gate, Neurosymbolic Request, Probability Envelope, SLA Enforcement, Inference Termination",
       "properties": {
         "source_entity": {
-          "$ref": "#/$defs/ContextualizedSourceEntity",
+          "$ref": "#/$defs/ContextualizedSourceState",
           "description": "The structurally isolated 1D boundary representing the semantic payload injected into the context window."
         },
         "fidelity_receipt": {
@@ -11888,7 +11888,7 @@
         "uncertainty_profile",
         "sla"
       ],
-      "title": "NeurosymbolicInferenceRequest",
+      "title": "NeurosymbolicInferenceIntent",
       "type": "object"
     },
     "NeurosymbolicVerificationTopologyManifest": {
@@ -13537,7 +13537,7 @@
         "kinematic_derivatives": {
           "anyOf": [
             {
-              "$ref": "#/$defs/KinematicDerivativeTensor"
+              "$ref": "#/$defs/KinematicDerivativeProfile"
             },
             {
               "type": "null"
@@ -16131,7 +16131,7 @@
           "description": "The UNIX timestamp when this coordinate was invalidated.",
           "title": "Valid To"
         },
-        "interval_type": {
+        "interval_class": {
           "anyOf": [
             {
               "$ref": "#/$defs/CausalIntervalProfile"
@@ -16246,12 +16246,12 @@
       "title": "TerminalBufferState",
       "type": "object"
     },
-    "TerminalCognitiveFailure": {
+    "TerminalCognitiveEvent": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A terminal state object generated when the Proposer-Verifier macro-topology exhausts its max_revision_loops without achieving ontological alignment. Packages the failure state for HITL routing.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator to halt the active execution wave and physically route the exact contextual state of failure to a human supervisor for manual evaluation.\n\nEPISTEMIC BOUNDS: The cycle count is mathematically bounded by loops_exhausted (ge=1, le=100). The specific mathematical penalty gradient the proposer failed to resolve is locked via final_critique_schema. The last_rejected_hypothesis_hash is a cryptographically locked string (max_length=64).\n\nMCP ROUTING TRIGGERS: Proposer-Verifier Macro-Topology, Terminal State, Execution Halting, Human-in-the-Loop Routing, Cognitive Failure Packaging",
       "properties": {
         "source_entity": {
-          "$ref": "#/$defs/ContextualizedSourceEntity",
+          "$ref": "#/$defs/ContextualizedSourceState",
           "description": "The original contextualized input data the system attempted to process."
         },
         "last_rejected_hypothesis_hash": {
@@ -16278,7 +16278,7 @@
         "final_critique_schema",
         "loops_exhausted"
       ],
-      "title": "TerminalCognitiveFailure",
+      "title": "TerminalCognitiveEvent",
       "type": "object"
     },
     "TerminalConditionContract": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -12601,7 +12601,8 @@ LiquidTypeContract.model_rebuild()
 HoareLogicProofReceipt.model_rebuild()
 AsymptoticComplexityReceipt.model_rebuild()
 TeleologicalIsometryReceipt.model_rebuild()
-
+InterventionIntent.model_rebuild()
+TerminalCognitiveEvent.model_rebuild()
 
 class NeurosymbolicInferenceIntent(CoreasonBaseState):
     r"""

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -667,7 +667,7 @@ class SpatialReferenceFrameManifest(CoreasonBaseState):
     )
 
 
-class KinematicDerivativeTensor(CoreasonBaseState):
+class KinematicDerivativeProfile(CoreasonBaseState):
     """
     AGENT INSTRUCTION: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics
     CAUSAL AFFORDANCE: Kinematic Derivatives, Hermite Spline Extrapolation, Continuous Collision Detection, Newtonian Mechanics
@@ -714,7 +714,7 @@ class SE3TransformProfile(CoreasonBaseState):
     scale: float = Field(
         ge=0.0001, le=10000.0, default=1.0, description="Strictly positive uniform volumetric scaling factor."
     )
-    kinematic_derivatives: KinematicDerivativeTensor | None = Field(
+    kinematic_derivatives: KinematicDerivativeProfile | None = Field(
         default=None, description="Tensors governing continuous momentum and velocity."
     )
     dual_quaternion_motor: tuple[float, float, float, float, float, float, float, float] | None = Field(
@@ -843,7 +843,7 @@ class PhysicallyBasedRenderingProfile(CoreasonBaseState):
     )
 
 
-class EpistemicAttentionRay(CoreasonBaseState):
+class EpistemicAttentionState(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: Formalizes Joint Attention and Gaze Raycasting across the distributed topology. Projects a continuous vector from an observer's optical center to indicate cognitive focus prior to physical mutation.
 
@@ -1757,7 +1757,7 @@ class CognitiveStateProfile(CoreasonBaseState):
     )
 
 
-class ContextualizedSourceEntity(CoreasonBaseState):
+class ContextualizedSourceState(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: Projects a semantically unified spatial token footprint representing the strictly bounded source projection.
 
@@ -1791,7 +1791,7 @@ class EpistemicUpsamplingTask(CoreasonBaseState):
         MCP ROUTING TRIGGERS: Abductive Leap, Epistemic Upsampling, Lossy Compression Reversal, Vector Expansion, Connectionist Grounding
     """
 
-    source_entity: ContextualizedSourceEntity = Field(
+    source_entity: ContextualizedSourceState = Field(
         description="The specific source contextualized entity subject to topological upsampling."
     )
     target_ontological_granularity: Annotated[str, StringConstraints(max_length=255)] = Field(
@@ -3833,7 +3833,7 @@ class CrossoverPolicy(CoreasonBaseState):
     Interpolation, Elitism, Reproduction Heuristic
     """
 
-    strategy_type: CrossoverMechanismProfile = Field(
+    strategy_profile: CrossoverMechanismProfile = Field(
         description="The heuristic method for blending successful parent agents."
     )
     blending_factor: float = Field(
@@ -5071,7 +5071,7 @@ class FaultInjectionProfile(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Instructs the execution engine to physically degrade, throttle, or
     corrupt the structural state or network connectivity of the target_node_cid based on the
-    specific fault_type (FaultCategoryProfile) manifold.
+    specific fault_category (FaultCategoryProfile) manifold.
 
     EPISTEMIC BOUNDS: The severity of the perturbation is constrained above by the intensity
     scalar (le=1000000000.0) but unbounded below, permitting negative fault magnitudes. The
@@ -5082,7 +5082,7 @@ class FaultInjectionProfile(CoreasonBaseState):
     Structural Sabotage, Resilience Testing
     """
 
-    fault_type: FaultCategoryProfile = Field(description="The specific type of fault to inject.")
+    fault_category: FaultCategoryProfile = Field(description="The specific type of fault to inject.")
     target_node_cid: (
         Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] | None
     ) = Field(default=None, description="The specific node to attack, or None for swarm-wide.")
@@ -6037,7 +6037,7 @@ type AnyPanelProfile = Annotated[
 ]
 
 
-class TerminalCognitiveFailure(CoreasonBaseState):
+class TerminalCognitiveEvent(CoreasonBaseState):
     """
     AGENT INSTRUCTION: A terminal state object generated when the Proposer-Verifier macro-topology exhausts its max_revision_loops without achieving ontological alignment. Packages the failure state for HITL routing.
 
@@ -6048,7 +6048,7 @@ class TerminalCognitiveFailure(CoreasonBaseState):
     MCP ROUTING TRIGGERS: Proposer-Verifier Macro-Topology, Terminal State, Execution Halting, Human-in-the-Loop Routing, Cognitive Failure Packaging
     """
 
-    source_entity: ContextualizedSourceEntity = Field(
+    source_entity: ContextualizedSourceState = Field(
         description="The original contextualized input data the system attempted to process."
     )
     last_rejected_hypothesis_hash: Annotated[str, StringConstraints(max_length=64)] = Field(
@@ -6089,7 +6089,7 @@ class InterventionIntent(CoreasonBaseState):
     adjudication_deadline: float = Field(
         ge=0.0, le=253402300799.0, description="The deadline for adjudication, represented as a UNIX timestamp."
     )
-    failure_context: TerminalCognitiveFailure | None = Field(
+    failure_context: TerminalCognitiveEvent | None = Field(
         default=None, description="Packages the exact contextual state at the moment of computational failure."
     )
 
@@ -6371,7 +6371,7 @@ class CognitiveHumanNodeProfile(CoreasonBaseState):
     required_attestation: AttestationMechanismProfile = Field(
         description="The mandatory cryptographic attestation required to verify the human operator's identity."
     )
-    active_attention_ray: EpistemicAttentionRay | None = Field(
+    active_attention_ray: EpistemicAttentionState | None = Field(
         default=None,
         description="The continuous spatial vector representing the human operator's localized cognitive focus.",
     )
@@ -7504,7 +7504,7 @@ class NDimensionalTensorManifest(CoreasonBaseState):
     MCP ROUTING TRIGGERS: Tensor Calculus, Differential Geometry, Merkle Tree Verification, Zero-Trust Computing, Memory Allocation
     """
 
-    structural_type: TensorStructuralFormatProfile = Field(..., description="Structural type of the tensor elements.")
+    structural_format: TensorStructuralFormatProfile = Field(..., description="Structural type of the tensor elements.")
     shape: tuple[int, ...] = Field(..., max_length=1000, description="N-Dimensional shape tuple.")
     vram_footprint_bytes: int = Field(..., le=100000000000, description="Exact byte size of the uncompressed tensor.")
     merkle_root: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-fA-F0-9]{64}$")] = Field(
@@ -7522,11 +7522,11 @@ class NDimensionalTensorManifest(CoreasonBaseState):
         for dim in self.shape:
             if dim <= 0:
                 raise ValueError(f"Tensor dimensions must be strictly positive integers. Got: {self.shape}")
-        bytes_per_element = self.structural_type.bytes_per_element
+        bytes_per_element = self.structural_format.bytes_per_element
         calculated_bytes = math.prod(self.shape) * bytes_per_element
         if calculated_bytes != self.vram_footprint_bytes:
             raise ValueError(
-                f"Topological mismatch: Shape {self.shape} of {self.structural_type.value} requires {calculated_bytes} bytes, but manifest declares {self.vram_footprint_bytes} bytes."
+                f"Topological mismatch: Shape {self.shape} of {self.structural_format.value} requires {calculated_bytes} bytes, but manifest declares {self.vram_footprint_bytes} bytes."
             )
         return self
 
@@ -8723,7 +8723,7 @@ class ChaosExperimentTask(CoreasonBaseState):
     evaluate the resilience of the DAG topology.
 
     EPISTEMIC BOUNDS: Cryptographic determinism is mathematically guaranteed by the
-    @model_validator, which sorts the faults array by composite key (fault_type,
+    @model_validator, which sorts the faults array by composite key (fault_category,
     target_node_cid) and the shocks array by shock_id to preserve RFC 8785 canonical hashing.
 
     MCP ROUTING TRIGGERS: Steady State Falsification, Chaos Engineering, Automated Failure
@@ -8745,7 +8745,7 @@ class ChaosExperimentTask(CoreasonBaseState):
     @model_validator(mode="after")
     def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
-            self, "faults", sorted(self.faults, key=operator.attrgetter("fault_type", "target_node_cid"))
+            self, "faults", sorted(self.faults, key=operator.attrgetter("fault_category", "target_node_cid"))
         )
         object.__setattr__(self, "shocks", sorted(self.shocks, key=operator.attrgetter("shock_id")))
         return self
@@ -8924,7 +8924,7 @@ class ManifestViolationReceipt(CoreasonBaseState):
 
     CAUSAL AFFORDANCE: Enables the agent to execute $O(1)$ surgical patches via StateMutationIntent rather than hallucinating fixes.
 
-    EPISTEMIC BOUNDS: `failing_pointer` mathematically maps exactly to RFC 6902 JSON Pointers (`max_length=2000`). `violation_type` capped at `255`.
+    EPISTEMIC BOUNDS: `failing_pointer` mathematically maps exactly to RFC 6902 JSON Pointers (`max_length=2000`). `violation_category` capped at `255`.
 
     MCP ROUTING TRIGGERS: Fault Receipt, RFC 6902, Epistemic Loss Prevention, Surgical Patching, Traceback Serialization
 
@@ -8933,7 +8933,7 @@ class ManifestViolationReceipt(CoreasonBaseState):
     failing_pointer: Annotated[str, StringConstraints(max_length=2000)] = Field(
         description="The exact RFC 6902 JSON pointer isolating the topological failure."
     )
-    violation_type: Annotated[str, StringConstraints(max_length=255)] = Field(
+    violation_category: Annotated[str, StringConstraints(max_length=255)] = Field(
         description="Categorical descriptor of the failure, e.g., missing, type_error."
     )
     diagnostic_message: Annotated[str, StringConstraints(max_length=2000)] = Field(
@@ -9108,7 +9108,7 @@ class TemporalBoundsProfile(CoreasonBaseState):
     valid_to: float | None = Field(
         le=1000000000.0, default=None, description="The UNIX timestamp when this coordinate was invalidated."
     )
-    interval_type: CausalIntervalProfile | None = Field(
+    interval_class: CausalIntervalProfile | None = Field(
         default=None, description="The Allen's interval algebra or causal relationship classification."
     )
 
@@ -9918,7 +9918,7 @@ class CognitiveAgentNodeProfile(CoreasonBaseState):
         default=None,
         description="The cryptographic contract forcing this agent to embed an undeniable provenance signature into its generative token stream.",
     )
-    active_attention_ray: EpistemicAttentionRay | None = Field(
+    active_attention_ray: EpistemicAttentionState | None = Field(
         default=None,
         description="The continuous spatial vector representing the agent's localized cognitive focus prior to kinetic actuation.",
     )
@@ -12583,12 +12583,12 @@ KinematicDeltaManifest.model_rebuild()
 SpatialBillboardContract.model_rebuild()
 VolumetricEdgeProfile.model_rebuild()
 GaussianSplattingProfile.model_rebuild()
-KinematicDerivativeTensor.model_rebuild()
+KinematicDerivativeProfile.model_rebuild()
 SemanticZoomProfile.model_rebuild()
 MarkovBlanketRenderingPolicy.model_rebuild()
 TelemetryBackpressureContract.model_rebuild()
 ObservabilityLODPolicy.model_rebuild()
-EpistemicAttentionRay.model_rebuild()
+EpistemicAttentionState.model_rebuild()
 VolumetricPartitionSubscription.model_rebuild()
 ContinuousSpatialMutationIntent.model_rebuild()
 
@@ -12603,7 +12603,7 @@ AsymptoticComplexityReceipt.model_rebuild()
 TeleologicalIsometryReceipt.model_rebuild()
 
 
-class NeurosymbolicInferenceRequest(CoreasonBaseState):
+class NeurosymbolicInferenceIntent(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: Orchestrates the core execution payload boundary, acting as the structural pre-inference gate for neurosymbolic probability.
 
@@ -12614,7 +12614,7 @@ class NeurosymbolicInferenceRequest(CoreasonBaseState):
         MCP ROUTING TRIGGERS: Pre-Inference Gate, Neurosymbolic Request, Probability Envelope, SLA Enforcement, Inference Termination
     """
 
-    source_entity: ContextualizedSourceEntity = Field(
+    source_entity: ContextualizedSourceState = Field(
         description="The structurally isolated 1D boundary representing the semantic payload injected into the context window."
     )
     fidelity_receipt: TopologicalFidelityReceipt = Field(
@@ -12636,9 +12636,9 @@ class NeurosymbolicInferenceRequest(CoreasonBaseState):
         return self
 
 
-ContextualizedSourceEntity.model_rebuild()
+ContextualizedSourceState.model_rebuild()
 TopologicalFidelityReceipt.model_rebuild()
-NeurosymbolicInferenceRequest.model_rebuild()
+NeurosymbolicInferenceIntent.model_rebuild()
 
 EpistemicUpsamplingTask.model_rebuild()
 VolumetricPartitionSubscription.model_rebuild()

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -12604,6 +12604,7 @@ TeleologicalIsometryReceipt.model_rebuild()
 InterventionIntent.model_rebuild()
 TerminalCognitiveEvent.model_rebuild()
 
+
 class NeurosymbolicInferenceIntent(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: Orchestrates the core execution payload boundary, acting as the structural pre-inference gate for neurosymbolic probability.

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -190,7 +190,7 @@ def synthesize_remediation_intent(
             msg = f"The required semantic boundary at '{loc_path}' is completely missing. You must project this missing dimension to satisfy the StateContract."
 
         receipts.append(
-            ManifestViolationReceipt(failing_pointer=loc_path, violation_type=err_type, diagnostic_message=msg)
+            ManifestViolationReceipt(failing_pointer=loc_path, violation_category=err_type, diagnostic_message=msg)
         )
 
     return System2RemediationIntent(fault_cid=fault_cid, target_node_cid=target_node_cid, violation_receipts=receipts)

--- a/tests/contracts/test_hybrid_operations.py
+++ b/tests/contracts/test_hybrid_operations.py
@@ -15,12 +15,12 @@ from pydantic import AnyUrl, ValidationError
 
 from coreason_manifest.spec.ontology import (
     CognitiveCritiqueProfile,
-    ContextualizedSourceEntity,
+    ContextualizedSourceState,
     DerivationMode,
     EpistemicProvenanceReceipt,
     InterventionIntent,
     InterventionPolicy,
-    TerminalCognitiveFailure,
+    TerminalCognitiveEvent,
 )
 
 
@@ -66,12 +66,12 @@ def test_hotl_telemetry_policy_gate() -> None:
 
 
 def test_terminal_handoff_isomorphism() -> None:
-    source_entity = ContextualizedSourceEntity(
+    source_entity = ContextualizedSourceState(
         target_string="test string", contextual_envelope=[], source_system_provenance_flag=False
     )
     critique = CognitiveCritiqueProfile(reasoning_trace_hash="a" * 64, epistemic_penalty_scalar=0.5)
 
-    failure = TerminalCognitiveFailure(
+    failure = TerminalCognitiveEvent(
         source_entity=source_entity,
         last_rejected_hypothesis_hash="b" * 64,
         final_critique_schema=critique,

--- a/tests/contracts/test_n_dimensional_tensor_manifest.py
+++ b/tests/contracts/test_n_dimensional_tensor_manifest.py
@@ -20,18 +20,18 @@ from coreason_manifest.spec.ontology import NDimensionalTensorManifest, TensorSt
 
 # 1. Fuzzing the Valid Mathematical Space
 @given(
-    structural_type=st.sampled_from(list(TensorStructuralFormatProfile)),
+    structural_format=st.sampled_from(list(TensorStructuralFormatProfile)),
     shape=st.lists(st.integers(min_value=1, max_value=100), min_size=1, max_size=5).map(tuple),
 )
 @settings(max_examples=100)
 def test_n_dimensional_tensor_manifest_fuzz_valid(
-    structural_type: TensorStructuralFormatProfile, shape: tuple[int, ...]
+    structural_format: TensorStructuralFormatProfile, shape: tuple[int, ...]
 ) -> None:
     """Mathematically prove the deterministic acceptance of correct spatial boundaries across infinite shapes."""
-    expected_bytes = math.prod(shape) * structural_type.bytes_per_element
+    expected_bytes = math.prod(shape) * structural_format.bytes_per_element
 
     manifest = NDimensionalTensorManifest(
-        structural_type=structural_type,
+        structural_format=structural_format,
         shape=shape,
         vram_footprint_bytes=expected_bytes,
         merkle_root="a" * 64,
@@ -56,7 +56,7 @@ def test_n_dimensional_tensor_manifest_atomic_violations(
     """Prove the physical bounds engine rejects mathematically impossible geometries."""
     with pytest.raises(ValidationError, match=match_string):
         NDimensionalTensorManifest(
-            structural_type=TensorStructuralFormatProfile.FLOAT32,
+            structural_format=TensorStructuralFormatProfile.FLOAT32,
             shape=shape,
             vram_footprint_bytes=footprint,
             merkle_root="a" * 64,

--- a/tests/contracts/test_ontology_payload_bounds.py
+++ b/tests/contracts/test_ontology_payload_bounds.py
@@ -153,11 +153,11 @@ def test_state_vector_memory_bounds() -> None:
 def test_neurosymbolic_inference_request_requires_contextualized_entity() -> None:
     import pytest
 
-    from coreason_manifest.spec.ontology import NeurosymbolicInferenceRequest
+    from coreason_manifest.spec.ontology import NeurosymbolicInferenceIntent
 
-    # Instantiating with bare string instead of ContextualizedSourceEntity
+    # Instantiating with bare string instead of ContextualizedSourceState
     with pytest.raises(ValidationError) as exc_info:
-        NeurosymbolicInferenceRequest(
+        NeurosymbolicInferenceIntent(
             source_entity="Amoxicillin 500mg",  # type: ignore
             fidelity_receipt={  # type: ignore
                 "contextual_completeness_score": 0.9,
@@ -176,7 +176,7 @@ def test_neurosymbolic_inference_request_requires_contextualized_entity() -> Non
                 "minimum_fidelity_threshold": 0.5,
             },
         )
-    assert "Input should be a valid dictionary or instance of ContextualizedSourceEntity" in str(exc_info.value)
+    assert "Input should be a valid dictionary or instance of ContextualizedSourceState" in str(exc_info.value)
 
 
 def test_constitutional_amendment_intent_payload_bounds() -> None:

--- a/tests/contracts/test_ontology_validators.py
+++ b/tests/contracts/test_ontology_validators.py
@@ -24,7 +24,7 @@ from coreason_manifest.spec.ontology import (
     ComputeTierProfile,
     ConsensusPolicy,
     ConstrainedDecodingPolicy,
-    ContextualizedSourceEntity,
+    ContextualizedSourceState,
     CoreasonBaseState,
     DefeasibleCascadeEvent,
     DynamicLayoutManifest,
@@ -36,7 +36,7 @@ from coreason_manifest.spec.ontology import (
     GradingCriterionProfile,
     LatentSmoothingProfile,
     MultimodalTokenAnchorState,
-    NeurosymbolicInferenceRequest,
+    NeurosymbolicInferenceIntent,
     PermissionBoundaryPolicy,
     QuorumPolicy,
     RedactionPolicy,
@@ -877,7 +877,7 @@ def test_agent_node_profile_network_topology_paradox() -> None:
 
 
 def test_refusal_to_reason_enforcement() -> None:
-    source_entity = ContextualizedSourceEntity(
+    source_entity = ContextualizedSourceState(
         target_string="Discharge",
         contextual_envelope=[],
         source_system_provenance_flag=False,
@@ -902,7 +902,7 @@ def test_refusal_to_reason_enforcement() -> None:
     with pytest.raises(
         ValidationError, match=r"Inference aborted due to severe semantic degradation. Epistemic gap exceeds SLA."
     ):
-        NeurosymbolicInferenceRequest(
+        NeurosymbolicInferenceIntent(
             source_entity=source_entity,
             fidelity_receipt=fidelity_receipt,
             uncertainty_profile=uncertainty_profile,
@@ -911,7 +911,7 @@ def test_refusal_to_reason_enforcement() -> None:
 
 
 def test_successful_epistemic_grounding() -> None:
-    source_entity = ContextualizedSourceEntity(
+    source_entity = ContextualizedSourceState(
         target_string="Amoxicillin 500mg",
         contextual_envelope=["patient chart", "medication order"],
         source_system_provenance_flag=True,
@@ -933,7 +933,7 @@ def test_successful_epistemic_grounding() -> None:
         minimum_fidelity_threshold=0.5,
     )
 
-    req = NeurosymbolicInferenceRequest(
+    req = NeurosymbolicInferenceIntent(
         source_entity=source_entity,
         fidelity_receipt=fidelity_receipt,
         uncertainty_profile=uncertainty_profile,
@@ -944,7 +944,7 @@ def test_successful_epistemic_grounding() -> None:
 
 def test_epistemic_upsampling_instantiation() -> None:
 
-    source = ContextualizedSourceEntity(
+    source = ContextualizedSourceState(
         target_string="test artifact",
         contextual_envelope=["context A", "context B"],
         source_system_provenance_flag=True,
@@ -963,7 +963,7 @@ def test_epistemic_upsampling_instantiation() -> None:
 
 def test_upsampling_confidence_bounds() -> None:
     """Prove that an agent cannot hallucinate an overconfident abductive leap."""
-    source = ContextualizedSourceEntity(
+    source = ContextualizedSourceState(
         target_string="test artifact",
         contextual_envelope=["context A"],
         source_system_provenance_flag=True,
@@ -990,7 +990,7 @@ def test_upsampling_confidence_bounds() -> None:
 
 def test_empty_justification_rejection() -> None:
     """Prove that the system structurally rejects an evidence-free abductive leap."""
-    source = ContextualizedSourceEntity(
+    source = ContextualizedSourceState(
         target_string="test artifact",
         contextual_envelope=["context A"],
         source_system_provenance_flag=True,

--- a/tests/fuzzing/test_boundaries.py
+++ b/tests/fuzzing/test_boundaries.py
@@ -502,15 +502,15 @@ def test_scale_policy(type_val: Any, domain_min: float | None, domain_max: float
 # --- NDimensionalTensorManifest ---
 @given(
     shape=st.lists(st.integers(min_value=-1, max_value=10), min_size=0, max_size=5),
-    structural_type=st.sampled_from(list(TensorStructuralFormatProfile)),
+    structural_format=st.sampled_from(list(TensorStructuralFormatProfile)),
 )
-def test_ndimensional_tensor_manifest(shape: list[int], structural_type: Any) -> None:
+def test_ndimensional_tensor_manifest(shape: list[int], structural_format: Any) -> None:
     valid = True
     if len(shape) < 1 or any(dim <= 0 for dim in shape):
         valid = False
 
     if valid:
-        bytes_per_element = structural_type.bytes_per_element
+        bytes_per_element = structural_format.bytes_per_element
         vram_footprint_bytes = math.prod(shape) * bytes_per_element
     else:
         vram_footprint_bytes = 10
@@ -521,7 +521,7 @@ def test_ndimensional_tensor_manifest(shape: list[int], structural_type: Any) ->
     if valid:
         NDimensionalTensorManifest(
             shape=tuple(shape),
-            structural_type=structural_type,
+            structural_format=structural_format,
             vram_footprint_bytes=vram_footprint_bytes,
             merkle_root=merkle_root,
             storage_uri=storage_uri,
@@ -530,7 +530,7 @@ def test_ndimensional_tensor_manifest(shape: list[int], structural_type: Any) ->
         with pytest.raises((ValueError, ValidationError)):
             NDimensionalTensorManifest(
                 shape=tuple(shape),
-                structural_type=structural_type,
+                structural_format=structural_format,
                 vram_footprint_bytes=vram_footprint_bytes,
                 merkle_root=merkle_root,
                 storage_uri=storage_uri,

--- a/tests/fuzzing/test_instantiation_bounds.py
+++ b/tests/fuzzing/test_instantiation_bounds.py
@@ -21,13 +21,13 @@ from coreason_manifest.spec.ontology import (
     CognitiveSystemNodeProfile,
     CognitiveUncertaintyProfile,
     ComputeTierProfile,
-    ContextualizedSourceEntity,
+    ContextualizedSourceState,
     DAGTopologyManifest,
     EpistemicCompressionSLA,
     EpistemicSecurityPolicy,
     EpistemicSecurityProfile,
     MultimodalTokenAnchorState,
-    NeurosymbolicInferenceRequest,
+    NeurosymbolicInferenceIntent,
     ObservationEvent,
     QuorumPolicy,
     SE3TransformProfile,
@@ -345,7 +345,7 @@ def test_fuzz_network_topology_paradox(egress_obfuscation: bool, network_isolati
     token_density=st.integers(min_value=0, max_value=5),  # simulating context truncation
 )
 def test_refusal_to_reason_fuzzing(epistemic_gap: float, min_fidelity_threshold: float, token_density: int) -> None:
-    source_entity = ContextualizedSourceEntity(
+    source_entity = ContextualizedSourceState(
         target_string="Discharge",
         contextual_envelope=[],
         source_system_provenance_flag=False,
@@ -370,7 +370,7 @@ def test_refusal_to_reason_fuzzing(epistemic_gap: float, min_fidelity_threshold:
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        NeurosymbolicInferenceRequest(
+        NeurosymbolicInferenceIntent(
             source_entity=source_entity,
             fidelity_receipt=fidelity_receipt,
             uncertainty_profile=uncertainty_profile,
@@ -382,21 +382,21 @@ def test_contextualized_source_entity_lengths() -> None:
     from pydantic import ValidationError
 
     with pytest.raises(ValidationError):
-        ContextualizedSourceEntity(
+        ContextualizedSourceState(
             target_string="x" * 100001,
             contextual_envelope=[],
             source_system_provenance_flag=False,
         )
 
     with pytest.raises(ValidationError):
-        ContextualizedSourceEntity(
+        ContextualizedSourceState(
             target_string="Valid",
             contextual_envelope=["x"] * 10001,
             source_system_provenance_flag=False,
         )
 
     with pytest.raises(ValidationError):
-        ContextualizedSourceEntity(
+        ContextualizedSourceState(
             target_string="Valid",
             contextual_envelope=["x" * 100001],
             source_system_provenance_flag=False,

--- a/tests/fuzzing/test_observer_physics.py
+++ b/tests/fuzzing/test_observer_physics.py
@@ -23,7 +23,7 @@ from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import (
     DynamicLayoutManifest,
-    EpistemicAttentionRay,
+    EpistemicAttentionState,
     ObservabilityLODPolicy,
     SE3TransformProfile,
     TelemetryBackpressureContract,
@@ -65,11 +65,11 @@ def test_differential_privacy_interlocks(foveated_privacy_epsilon: float) -> Non
 @given(hardware_gaze_signature=st.integers(min_value=8193, max_value=10000).map(lambda x: "a" * x))
 def test_biometric_signature_bounding(hardware_gaze_signature: str) -> None:
     """
-    Test EpistemicAttentionRay to trigger validation error when biometric
+    Test EpistemicAttentionState to trigger validation error when biometric
     signature string exceeds length limit.
     """
     with pytest.raises(ValidationError) as exc_info:
-        EpistemicAttentionRay(
+        EpistemicAttentionState(
             origin=SE3TransformProfile(reference_frame_cid="frame-123", x=0.0, y=0.0, z=0.0),
             direction_unit_vector=(1.0, 0.0, 0.0),
             hardware_gaze_signature=hardware_gaze_signature,

--- a/tests/fuzzing/test_ontology_coverage.py
+++ b/tests/fuzzing/test_ontology_coverage.py
@@ -221,7 +221,7 @@ def test_evolutionary_topology_manifest_sorting(objectives_data: list[tuple[str,
         for name, weight in objectives_data
     ]
     mutation = MutationPolicy(mutation_rate=0.1, temperature_shift_variance=0.1)
-    crossover = CrossoverPolicy(strategy_type="single_point", blending_factor=0.5)
+    crossover = CrossoverPolicy(strategy_profile="single_point", blending_factor=0.5)
 
     manifest = EvolutionaryTopologyManifest(
         nodes={},

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -1,0 +1,4 @@
+from coreason_manifest.spec.ontology import TerminalCognitiveEvent, ContextualizedSourceState, InterventionIntent
+TerminalCognitiveEvent.model_rebuild()
+ContextualizedSourceState.model_rebuild()
+InterventionIntent.model_rebuild()

--- a/tests/test_fix.py
+++ b/tests/test_fix.py
@@ -1,4 +1,0 @@
-from coreason_manifest.spec.ontology import TerminalCognitiveEvent, ContextualizedSourceState, InterventionIntent
-TerminalCognitiveEvent.model_rebuild()
-ContextualizedSourceState.model_rebuild()
-InterventionIntent.model_rebuild()


### PR DESCRIPTION
This PR enforces the Epic 2 Lexical Architecture and Anti-CRUD directives from `AGENTS.md`.

It performs surgical codebase-wide refactoring to align the 2026 neurosymbolic ontology:
1. Renames classes to enforce suffixing rules (`...Profile`, `...State`, `...Event`, `...Intent`).
2. Purges the generic word "type" from schemas (`violation_type` -> `violation_category`, etc.).
3. Updates `__init__.py` and all Pydantic string-based `ForwardRef` evaluations in `ontology.py` and `algebra.py`.
4. Fully patches the `tests/` directory to ensure complete integration. All local CI tests and bounds checks pass.

---
*PR created automatically by Jules for task [16398984365464766735](https://jules.google.com/task/16398984365464766735) started by @gowthamrao*