### PR TITLE
Feat: Stochastic Ideation Topologies

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -9868,6 +9868,17 @@
       "title": "HypothesisStakeReceipt",
       "type": "object"
     },
+    "IdeationPhase": {
+      "description": "AGENT INSTRUCTION: Categorizes the thermodynamic phase of the generative ensemble's exploration.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator on the execution status of the topology, governing state transitions.\n\nEPISTEMIC BOUNDS: Strictly bounded to the predefined string enumeration values.\n\nMCP ROUTING TRIGGERS: Phase Tracking, Thermodynamic Orchestration, State Machine",
+      "enum": [
+        "STOCHASTIC_DIFFUSION",
+        "ENTROPIC_EXPLORATION",
+        "TOPOLOGICAL_CRITIQUE",
+        "MANIFOLD_COLLAPSE"
+      ],
+      "title": "IdeationPhase",
+      "type": "string"
+    },
     "IllocutionaryForceProfile": {
       "description": "AGENT INSTRUCTION: Mathematically categorizes the structural intent of a proposition to prevent reasoning agents from hallucinating contextual truth values. Dictates whether the swarm evaluates the node as an empirical fact, a normative constraint, a guaranteed promise, or a simulation.",
       "enum": [
@@ -16247,6 +16258,137 @@
         "max_loops_allowed"
       ],
       "title": "SteadyStateHypothesisState",
+      "type": "object"
+    },
+    "StochasticConsensus": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A topological bridge mathematically projecting high-dimensional unverified graphs into actionable manifolds.\n\nCAUSAL AFFORDANCE: Authorizes a lossy deterministic projection or signals the continuation of diffusion if residual entropy is too high.\n\nEPISTEMIC BOUNDS: convergence_confidence is mathematically clamped to `[0.0, 1.0]`.\n\nMCP ROUTING TRIGGERS: Topological Consensus, Persistent Homology, Manifold Collapse Verification",
+      "properties": {
+        "consensus_cid": {
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Consensus Cid",
+          "type": "string"
+        },
+        "proposed_manifold": {
+          "title": "Proposed Manifold",
+          "type": "string"
+        },
+        "convergence_confidence": {
+          "title": "Convergence Confidence",
+          "type": "number"
+        },
+        "residual_entropy_vectors": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Residual Entropy Vectors",
+          "type": "array"
+        }
+      },
+      "required": [
+        "proposed_manifold",
+        "convergence_confidence",
+        "residual_entropy_vectors"
+      ],
+      "title": "StochasticConsensus",
+      "type": "object"
+    },
+    "StochasticStateNode": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A single discrete latent coordinate (a generated hypothesis or critique) inside an unverified stochastic diffusion search space.\n\nCAUSAL AFFORDANCE: Used by the ensemble as a vertex to map out Monte Carlo Tree Search (MCTS) exploration before manifold collapse.\n\nEPISTEMIC BOUNDS: epistemic_entropy is mathematically clamped to `[0.0, 1.0]` bounds (Shannon entropy).\n\nMCP ROUTING TRIGGERS: Latent Space Coordinates, MCTS Nodes, Shannon Entropy Bounding",
+      "properties": {
+        "node_cid": {
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Node Cid",
+          "type": "string"
+        },
+        "parent_node_cid": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parent Node Cid"
+        },
+        "agent_role": {
+          "enum": [
+            "generator",
+            "critic",
+            "synthesizer"
+          ],
+          "title": "Agent Role",
+          "type": "string"
+        },
+        "stochastic_tensor": {
+          "description": "Unbounded semantic payload",
+          "title": "Stochastic Tensor",
+          "type": "string"
+        },
+        "epistemic_entropy": {
+          "title": "Epistemic Entropy",
+          "type": "number"
+        }
+      },
+      "required": [
+        "agent_role",
+        "stochastic_tensor",
+        "epistemic_entropy"
+      ],
+      "title": "StochasticStateNode",
+      "type": "object"
+    },
+    "StochasticTopology": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The structurally unbounded root container modeling multi-agent generative reasoning as a Topological DAG.\n\nCAUSAL AFFORDANCE: Holds unverified, high-variance semantic coordinates and manages MCTS execution.\n\nEPISTEMIC BOUNDS: Inherently enforces referential integrity for acyclic DAG sorting via `verify_acyclic_dag_integrity`. `epistemic_status` is locked strictly to 'stochastically_unbounded'.\n\nMCP ROUTING TRIGGERS: Directed Acyclic Graphs, Topological MCTS Container, Epistemic Immutability, Acyclic Integrity",
+      "properties": {
+        "topology_cid": {
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Topology Cid",
+          "type": "string"
+        },
+        "topology_class": {
+          "const": "stochastic_ensemble",
+          "default": "stochastic_ensemble",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "phase": {
+          "$ref": "#/$defs/IdeationPhase"
+        },
+        "stochastic_graph": {
+          "items": {
+            "$ref": "#/$defs/StochasticStateNode"
+          },
+          "title": "Stochastic Graph",
+          "type": "array"
+        },
+        "consensus": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/StochasticConsensus"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "epistemic_status": {
+          "const": "stochastically_unbounded",
+          "default": "stochastically_unbounded",
+          "title": "Epistemic Status",
+          "type": "string"
+        }
+      },
+      "required": [
+        "phase",
+        "stochastic_graph"
+      ],
+      "title": "StochasticTopology",
       "type": "object"
     },
     "StreamingDisfluencyContract": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -742,12 +742,11 @@ class StochasticTopology(CoreasonBaseState):
     def verify_acyclic_dag_integrity(self) -> Self:
         seen_cids = set()
         for node in self.stochastic_graph:
-            if node.parent_node_cid is not None:
-                if node.parent_node_cid not in seen_cids:
-                    raise ValueError(
-                        f"Topological Violation: parent_node_cid '{node.parent_node_cid}' "
-                        f"must appear before child node '{node.node_cid}' to prevent infinite cycles."
-                    )
+            if node.parent_node_cid is not None and node.parent_node_cid not in seen_cids:
+                raise ValueError(
+                    f"Topological Violation: parent_node_cid '{node.parent_node_cid}' "
+                    f"must appear before child node '{node.node_cid}' to prevent infinite cycles."
+                )
             seen_cids.add(node.node_cid)
         return self
 

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1780,25 +1780,25 @@ class RoutingFrontierPolicy(CoreasonBaseState):
                 try:
                     val = int(values["max_latency_ms"])
                     values["max_latency_ms"] = int(max(1, min(val, 86400000)))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if "max_cost_magnitude_per_token" in values:
                 try:
                     val = int(values["max_cost_magnitude_per_token"])
                     values["max_cost_magnitude_per_token"] = int(max(1, min(val, 1000000000)))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if "min_capability_score" in values:
                 try:
                     val_float = float(values["min_capability_score"])
                     values["min_capability_score"] = float(max(0.0, min(val_float, 1.0)))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             if values.get("max_carbon_intensity_gco2eq_kwh") is not None:
                 try:
                     val_float = float(values["max_carbon_intensity_gco2eq_kwh"])
                     values["max_carbon_intensity_gco2eq_kwh"] = float(max(0.0, min(val_float, 10000.0)))
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
         return values
 
@@ -7613,7 +7613,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except (ValueError, TypeError):
+                except ValueError, TypeError:
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -21,6 +21,7 @@ import threading
 import time
 import typing
 import urllib.parse
+import uuid
 from enum import StrEnum
 from typing import Annotated, Any, Literal, Self
 
@@ -645,6 +646,110 @@ class CoreasonBaseState(BaseModel):
 
 
 T = typing.TypeVar("T")
+
+
+class IdeationPhase(StrEnum):
+    """
+    AGENT INSTRUCTION: Categorizes the thermodynamic phase of the generative ensemble's exploration.
+
+    CAUSAL AFFORDANCE: Instructs the orchestrator on the execution status of the topology, governing state transitions.
+
+    EPISTEMIC BOUNDS: Strictly bounded to the predefined string enumeration values.
+
+    MCP ROUTING TRIGGERS: Phase Tracking, Thermodynamic Orchestration, State Machine
+    """
+
+    STOCHASTIC_DIFFUSION = "STOCHASTIC_DIFFUSION"
+    ENTROPIC_EXPLORATION = "ENTROPIC_EXPLORATION"
+    TOPOLOGICAL_CRITIQUE = "TOPOLOGICAL_CRITIQUE"
+    MANIFOLD_COLLAPSE = "MANIFOLD_COLLAPSE"
+
+
+class StochasticStateNode(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A single discrete latent coordinate (a generated hypothesis or critique) inside an unverified stochastic diffusion search space.
+
+    CAUSAL AFFORDANCE: Used by the ensemble as a vertex to map out Monte Carlo Tree Search (MCTS) exploration before manifold collapse.
+
+    EPISTEMIC BOUNDS: epistemic_entropy is mathematically clamped to `[0.0, 1.0]` bounds (Shannon entropy).
+
+    MCP ROUTING TRIGGERS: Latent Space Coordinates, MCTS Nodes, Shannon Entropy Bounding
+    """
+
+    node_cid: Annotated[str, StringConstraints(pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        default_factory=lambda: str(uuid.uuid4())
+    )
+    parent_node_cid: str | None = Field(default=None)
+    agent_role: Literal["generator", "critic", "synthesizer"] = Field()
+    stochastic_tensor: str = Field(description="Unbounded semantic payload")
+    epistemic_entropy: float = Field()
+
+    @field_validator("epistemic_entropy", mode="after")
+    @classmethod
+    def enforce_entropy_bounds(cls, v: float) -> float:
+        if not (0.0 <= v <= 1.0):
+            raise ValueError("epistemic_entropy must be strictly between 0.0 and 1.0 (Shannon entropy limits)")
+        return v
+
+
+class StochasticConsensus(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A topological bridge mathematically projecting high-dimensional unverified graphs into actionable manifolds.
+
+    CAUSAL AFFORDANCE: Authorizes a lossy deterministic projection or signals the continuation of diffusion if residual entropy is too high.
+
+    EPISTEMIC BOUNDS: convergence_confidence is mathematically clamped to `[0.0, 1.0]`.
+
+    MCP ROUTING TRIGGERS: Topological Consensus, Persistent Homology, Manifold Collapse Verification
+    """
+
+    consensus_cid: Annotated[str, StringConstraints(pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        default_factory=lambda: str(uuid.uuid4())
+    )
+    proposed_manifold: str = Field()
+    convergence_confidence: float = Field()
+    residual_entropy_vectors: list[str] = Field()
+
+    @field_validator("convergence_confidence", mode="after")
+    @classmethod
+    def enforce_confidence_bounds(cls, v: float) -> float:
+        if not (0.0 <= v <= 1.0):
+            raise ValueError("convergence_confidence must be strictly between 0.0 and 1.0")
+        return v
+
+
+class StochasticTopology(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: The structurally unbounded root container modeling multi-agent generative reasoning as a Topological DAG.
+
+    CAUSAL AFFORDANCE: Holds unverified, high-variance semantic coordinates and manages MCTS execution.
+
+    EPISTEMIC BOUNDS: Inherently enforces referential integrity for acyclic DAG sorting via `verify_acyclic_dag_integrity`. `epistemic_status` is locked strictly to 'stochastically_unbounded'.
+
+    MCP ROUTING TRIGGERS: Directed Acyclic Graphs, Topological MCTS Container, Epistemic Immutability, Acyclic Integrity
+    """
+
+    topology_cid: Annotated[str, StringConstraints(pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        default_factory=lambda: str(uuid.uuid4())
+    )
+    topology_class: Literal["stochastic_ensemble"] = Field(default="stochastic_ensemble")
+    phase: IdeationPhase = Field()
+    stochastic_graph: list[StochasticStateNode] = Field()
+    consensus: StochasticConsensus | None = Field(default=None)
+    epistemic_status: Literal["stochastically_unbounded"] = Field(default="stochastically_unbounded")
+
+    @model_validator(mode="after")
+    def verify_acyclic_dag_integrity(self) -> Self:
+        seen_cids = set()
+        for node in self.stochastic_graph:
+            if node.parent_node_cid is not None:
+                if node.parent_node_cid not in seen_cids:
+                    raise ValueError(
+                        f"Topological Violation: parent_node_cid '{node.parent_node_cid}' "
+                        f"must appear before child node '{node.node_cid}' to prevent infinite cycles."
+                    )
+            seen_cids.add(node.node_cid)
+        return self
 
 
 class TraceContextState(CoreasonBaseState):
@@ -1676,25 +1781,25 @@ class RoutingFrontierPolicy(CoreasonBaseState):
                 try:
                     val = int(values["max_latency_ms"])
                     values["max_latency_ms"] = int(max(1, min(val, 86400000)))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             if "max_cost_magnitude_per_token" in values:
                 try:
                     val = int(values["max_cost_magnitude_per_token"])
                     values["max_cost_magnitude_per_token"] = int(max(1, min(val, 1000000000)))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             if "min_capability_score" in values:
                 try:
                     val_float = float(values["min_capability_score"])
                     values["min_capability_score"] = float(max(0.0, min(val_float, 1.0)))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             if values.get("max_carbon_intensity_gco2eq_kwh") is not None:
                 try:
                     val_float = float(values["max_carbon_intensity_gco2eq_kwh"])
                     values["max_carbon_intensity_gco2eq_kwh"] = float(max(0.0, min(val_float, 10000.0)))
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
         return values
 
@@ -7509,7 +7614,7 @@ class MarketContract(CoreasonBaseState):
                 try:
                     mc_int = int(mc)
                     sp_int = int(sp)
-                except ValueError, TypeError:
+                except (ValueError, TypeError):
                     pass
             cmc = max(0, min(mc_int, 1000000000))
             if sp_int > cmc:
@@ -13178,3 +13283,7 @@ DiscourseNodeState.model_rebuild()
 DiscourseTreeManifest.model_rebuild()
 OntologyDiscoveryIntent.model_rebuild()
 SemanticMappingHeuristicProposal.model_rebuild()
+
+StochasticStateNode.model_rebuild()
+StochasticConsensus.model_rebuild()
+StochasticTopology.model_rebuild()

--- a/tests/contracts/test_stochastic_topology.py
+++ b/tests/contracts/test_stochastic_topology.py
@@ -3,7 +3,12 @@ from hypothesis import given
 from hypothesis import strategies as st
 from pydantic import ValidationError
 
-from coreason_manifest.spec.ontology import IdeationPhase, StochasticStateNode, StochasticTopology
+from coreason_manifest.spec.ontology import (
+    IdeationPhase,
+    StochasticConsensus,
+    StochasticStateNode,
+    StochasticTopology,
+)
 
 
 @given(
@@ -43,6 +48,9 @@ def test_immutability_of_epistemic_status(topology):
                 epistemic_entropy=st.floats(min_value=0.0, max_value=1.0),
             ),
             max_size=5,
+        ),
+        consensus=st.one_of(
+            st.none(), st.builds(StochasticConsensus, convergence_confidence=st.floats(min_value=0.0, max_value=1.0))
         ),
     )
 )

--- a/tests/contracts/test_stochastic_topology.py
+++ b/tests/contracts/test_stochastic_topology.py
@@ -1,0 +1,58 @@
+import pytest
+from pydantic import ValidationError
+from hypothesis import given, strategies as st
+from coreason_manifest.spec.ontology import (
+    IdeationPhase,
+    StochasticStateNode,
+    StochasticConsensus,
+    StochasticTopology
+)
+
+@given(
+    st.lists(
+        st.builds(StochasticStateNode, parent_node_cid=st.none(), epistemic_entropy=st.floats(min_value=0.0, max_value=1.0)),
+        min_size=2,
+        max_size=10
+    )
+)
+def test_acyclic_dag_forward_reference(nodes):
+    # Setup a cycle: The first node points to the second node
+    nodes[0] = nodes[0].model_copy(update={'parent_node_cid': nodes[1].node_cid})
+
+    with pytest.raises(ValidationError) as excinfo:
+        StochasticTopology(
+            phase=IdeationPhase.STOCHASTIC_DIFFUSION,
+            stochastic_graph=nodes
+        )
+    assert "must appear before child node" in str(excinfo.value)
+
+@given(st.builds(StochasticTopology, stochastic_graph=st.just([])))
+def test_immutability_of_epistemic_status(topology):
+    assert topology.epistemic_status == "stochastically_unbounded"
+
+    with pytest.raises(ValidationError):
+        # Attempting to assign to a model with validate_assignment=True
+        topology.epistemic_status = "bounded"
+
+@given(
+    st.builds(
+        StochasticTopology,
+        stochastic_graph=st.lists(
+            st.builds(StochasticStateNode, parent_node_cid=st.none(), epistemic_entropy=st.floats(min_value=0.0, max_value=1.0)),
+            max_size=5
+        )
+    )
+)
+def test_serialization_isomorphism(topology):
+    # Check serialization
+    json_data = topology.model_dump_json()
+    reconstructed = StochasticTopology.model_validate_json(json_data)
+
+    # Assert zero-loss by ensuring they are completely equal
+    assert topology == reconstructed
+
+    # Prove the _cid lineages remain intact
+    assert topology.topology_cid == reconstructed.topology_cid
+    assert len(topology.stochastic_graph) == len(reconstructed.stochastic_graph)
+    for orig, recon in zip(topology.stochastic_graph, reconstructed.stochastic_graph):
+        assert orig.node_cid == recon.node_cid

--- a/tests/contracts/test_stochastic_topology.py
+++ b/tests/contracts/test_stochastic_topology.py
@@ -8,21 +8,21 @@ from coreason_manifest.spec.ontology import IdeationPhase, StochasticStateNode, 
 
 @given(
     st.lists(
-        st.builds(StochasticStateNode, parent_node_cid=st.none(), epistemic_entropy=st.floats(min_value=0.0, max_value=1.0)),
+        st.builds(
+            StochasticStateNode, parent_node_cid=st.none(), epistemic_entropy=st.floats(min_value=0.0, max_value=1.0)
+        ),
         min_size=2,
-        max_size=10
+        max_size=10,
     )
 )
 def test_acyclic_dag_forward_reference(nodes):
     # Setup a cycle: The first node points to the second node
-    nodes[0] = nodes[0].model_copy(update={'parent_node_cid': nodes[1].node_cid})
+    nodes[0] = nodes[0].model_copy(update={"parent_node_cid": nodes[1].node_cid})
 
     with pytest.raises(ValidationError) as excinfo:
-        StochasticTopology(
-            phase=IdeationPhase.STOCHASTIC_DIFFUSION,
-            stochastic_graph=nodes
-        )
+        StochasticTopology(phase=IdeationPhase.STOCHASTIC_DIFFUSION, stochastic_graph=nodes)
     assert "must appear before child node" in str(excinfo.value)
+
 
 @given(st.builds(StochasticTopology, stochastic_graph=st.just([])))
 def test_immutability_of_epistemic_status(topology):
@@ -32,13 +32,18 @@ def test_immutability_of_epistemic_status(topology):
         # Attempting to assign to a model with validate_assignment=True
         topology.epistemic_status = "bounded"
 
+
 @given(
     st.builds(
         StochasticTopology,
         stochastic_graph=st.lists(
-            st.builds(StochasticStateNode, parent_node_cid=st.none(), epistemic_entropy=st.floats(min_value=0.0, max_value=1.0)),
-            max_size=5
-        )
+            st.builds(
+                StochasticStateNode,
+                parent_node_cid=st.none(),
+                epistemic_entropy=st.floats(min_value=0.0, max_value=1.0),
+            ),
+            max_size=5,
+        ),
     )
 )
 def test_serialization_isomorphism(topology):

--- a/tests/contracts/test_stochastic_topology.py
+++ b/tests/contracts/test_stochastic_topology.py
@@ -1,12 +1,10 @@
 import pytest
+from hypothesis import given
+from hypothesis import strategies as st
 from pydantic import ValidationError
-from hypothesis import given, strategies as st
-from coreason_manifest.spec.ontology import (
-    IdeationPhase,
-    StochasticStateNode,
-    StochasticConsensus,
-    StochasticTopology
-)
+
+from coreason_manifest.spec.ontology import IdeationPhase, StochasticStateNode, StochasticTopology
+
 
 @given(
     st.lists(
@@ -54,5 +52,5 @@ def test_serialization_isomorphism(topology):
     # Prove the _cid lineages remain intact
     assert topology.topology_cid == reconstructed.topology_cid
     assert len(topology.stochastic_graph) == len(reconstructed.stochastic_graph)
-    for orig, recon in zip(topology.stochastic_graph, reconstructed.stochastic_graph):
+    for orig, recon in zip(topology.stochastic_graph, reconstructed.stochastic_graph, strict=True):
         assert orig.node_cid == recon.node_cid

--- a/tests/contracts/test_stochastic_topology.py
+++ b/tests/contracts/test_stochastic_topology.py
@@ -20,7 +20,7 @@ from coreason_manifest.spec.ontology import (
         max_size=10,
     )
 )
-def test_acyclic_dag_forward_reference(nodes):
+def test_acyclic_dag_forward_reference(nodes: list[StochasticStateNode]) -> None:
     # Setup a cycle: The first node points to the second node
     nodes[0] = nodes[0].model_copy(update={"parent_node_cid": nodes[1].node_cid})
 
@@ -30,12 +30,12 @@ def test_acyclic_dag_forward_reference(nodes):
 
 
 @given(st.builds(StochasticTopology, stochastic_graph=st.just([])))
-def test_immutability_of_epistemic_status(topology):
+def test_immutability_of_epistemic_status(topology: StochasticTopology) -> None:
     assert topology.epistemic_status == "stochastically_unbounded"
 
     with pytest.raises(ValidationError):
         # Attempting to assign to a model with validate_assignment=True
-        topology.epistemic_status = "bounded"
+        topology.epistemic_status = "bounded"  # type: ignore[misc,assignment]
 
 
 @given(
@@ -54,7 +54,7 @@ def test_immutability_of_epistemic_status(topology):
         ),
     )
 )
-def test_serialization_isomorphism(topology):
+def test_serialization_isomorphism(topology: StochasticTopology) -> None:
     # Check serialization
     json_data = topology.model_dump_json()
     reconstructed = StochasticTopology.model_validate_json(json_data)

--- a/tests/fuzzing/test_entropic_simulation.py
+++ b/tests/fuzzing/test_entropic_simulation.py
@@ -1,11 +1,12 @@
-import pytest
-from pydantic import ValidationError
-from hypothesis import given, strategies as st
-from coreason_manifest.spec.ontology import (
-    StochasticStateNode,
-    StochasticConsensus
-)
 import math
+
+import pytest
+from hypothesis import given
+from hypothesis import strategies as st
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import StochasticConsensus, StochasticStateNode
+
 
 @given(st.text(max_size=100000))
 def test_maximum_entropy_injection(chaotic_text):

--- a/tests/fuzzing/test_entropic_simulation.py
+++ b/tests/fuzzing/test_entropic_simulation.py
@@ -11,39 +11,22 @@ from coreason_manifest.spec.ontology import StochasticConsensus, StochasticState
 @given(st.text(max_size=100000))
 def test_maximum_entropy_injection(chaotic_text):
     # Ensure Pydantic successfully parses the chaotic unicode payload
-    node = StochasticStateNode(
-        agent_role="generator",
-        stochastic_tensor=chaotic_text,
-        epistemic_entropy=0.5
-    )
+    node = StochasticStateNode(agent_role="generator", stochastic_tensor=chaotic_text, epistemic_entropy=0.5)
     assert node.stochastic_tensor == chaotic_text
+
 
 @given(st.floats())
 def test_float_boundary_warfare(chaotic_float):
     # If the float is within bounds [0.0, 1.0] and not NaN, it should succeed
     if 0.0 <= chaotic_float <= 1.0 and not math.isnan(chaotic_float):
-        StochasticStateNode(
-            agent_role="critic",
-            stochastic_tensor="test",
-            epistemic_entropy=chaotic_float
-        )
-        StochasticConsensus(
-            proposed_manifold="test",
-            convergence_confidence=chaotic_float,
-            residual_entropy_vectors=[]
-        )
+        StochasticStateNode(agent_role="critic", stochastic_tensor="test", epistemic_entropy=chaotic_float)
+        StochasticConsensus(proposed_manifold="test", convergence_confidence=chaotic_float, residual_entropy_vectors=[])
     else:
         # Otherwise it should raise ValidationError, proving deterministic bounds
         with pytest.raises(ValidationError):
-            StochasticStateNode(
-                agent_role="critic",
-                stochastic_tensor="test",
-                epistemic_entropy=chaotic_float
-            )
+            StochasticStateNode(agent_role="critic", stochastic_tensor="test", epistemic_entropy=chaotic_float)
 
         with pytest.raises(ValidationError):
             StochasticConsensus(
-                proposed_manifold="test",
-                convergence_confidence=chaotic_float,
-                residual_entropy_vectors=[]
+                proposed_manifold="test", convergence_confidence=chaotic_float, residual_entropy_vectors=[]
             )

--- a/tests/fuzzing/test_entropic_simulation.py
+++ b/tests/fuzzing/test_entropic_simulation.py
@@ -1,0 +1,48 @@
+import pytest
+from pydantic import ValidationError
+from hypothesis import given, strategies as st
+from coreason_manifest.spec.ontology import (
+    StochasticStateNode,
+    StochasticConsensus
+)
+import math
+
+@given(st.text(max_size=100000))
+def test_maximum_entropy_injection(chaotic_text):
+    # Ensure Pydantic successfully parses the chaotic unicode payload
+    node = StochasticStateNode(
+        agent_role="generator",
+        stochastic_tensor=chaotic_text,
+        epistemic_entropy=0.5
+    )
+    assert node.stochastic_tensor == chaotic_text
+
+@given(st.floats())
+def test_float_boundary_warfare(chaotic_float):
+    # If the float is within bounds [0.0, 1.0] and not NaN, it should succeed
+    if 0.0 <= chaotic_float <= 1.0 and not math.isnan(chaotic_float):
+        StochasticStateNode(
+            agent_role="critic",
+            stochastic_tensor="test",
+            epistemic_entropy=chaotic_float
+        )
+        StochasticConsensus(
+            proposed_manifold="test",
+            convergence_confidence=chaotic_float,
+            residual_entropy_vectors=[]
+        )
+    else:
+        # Otherwise it should raise ValidationError, proving deterministic bounds
+        with pytest.raises(ValidationError):
+            StochasticStateNode(
+                agent_role="critic",
+                stochastic_tensor="test",
+                epistemic_entropy=chaotic_float
+            )
+
+        with pytest.raises(ValidationError):
+            StochasticConsensus(
+                proposed_manifold="test",
+                convergence_confidence=chaotic_float,
+                residual_entropy_vectors=[]
+            )

--- a/tests/fuzzing/test_entropic_simulation.py
+++ b/tests/fuzzing/test_entropic_simulation.py
@@ -9,14 +9,14 @@ from coreason_manifest.spec.ontology import StochasticConsensus, StochasticState
 
 
 @given(st.text(max_size=100000))
-def test_maximum_entropy_injection(chaotic_text):
+def test_maximum_entropy_injection(chaotic_text: str) -> None:
     # Ensure Pydantic successfully parses the chaotic unicode payload
     node = StochasticStateNode(agent_role="generator", stochastic_tensor=chaotic_text, epistemic_entropy=0.5)
     assert node.stochastic_tensor == chaotic_text
 
 
 @given(st.floats())
-def test_float_boundary_warfare(chaotic_float):
+def test_float_boundary_warfare(chaotic_float: float) -> None:
     # If the float is within bounds [0.0, 1.0] and not NaN, it should succeed
     if 0.0 <= chaotic_float <= 1.0 and not math.isnan(chaotic_float):
         StochasticStateNode(agent_role="critic", stochastic_tensor="test", epistemic_entropy=chaotic_float)


### PR DESCRIPTION
Implemented `Stochastic Ideation Topologies` (Epic 1) de novo within the `coreason-manifest` architecture. 

All modifications strictly adhered to the `God Context Monolith` architectural mandate, with new structures injected exclusively into `src/coreason_manifest/spec/ontology.py`. 

**Architectural Changes**:
1. Added the `IdeationPhase` enum.
2. Formatted node topologies representing high-dimensional generative states: `StochasticStateNode`, `StochasticConsensus`, `StochasticTopology`. 
3. Re-enforced systemic security via 4-part docstrings across all structures outlining Agent Instruction, Causal Affordance, Epistemic Bounds, and MCP Routing Triggers.
4. Corrected older Python exception syntax to avoid `SyntaxError`.

**Mathematical Guarantees:**
Acyclic structural integrity and epistemic constraint (e.g. `epistemic_status` mapping, boundaries around Shannon entropy `0.0 <= x <= 1.0`) were strictly tested using `hypothesis`. Tested properties include float boundary warfare (`NaN`, `Infinity`, negative, or out of bounds limits) and maximum entropy unicode payload injections.

---
*PR created automatically by Jules for task [17680671186602019125](https://jules.google.com/task/17680671186602019125) started by @gowthamrao*