### PR TITLE
Feature/epic 3 epistemic rejection 13409598800311028195 (#1523)

### DIFF
--- a/tests/fuzzing/test_active_inference_epochs.py
+++ b/tests/fuzzing/test_active_inference_epochs.py
@@ -1,5 +1,7 @@
+import pytest
 from hypothesis import given
 from hypothesis import strategies as st
+from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import ActiveInferenceEpoch, EpistemicRejectionReceipt
 
@@ -51,3 +53,22 @@ def test_serialization_isomorphism(
     cids_original = [receipt.receipt_cid for receipt in epoch.rejection_history]
     cids_deserialized = [receipt.receipt_cid for receipt in deserialized.rejection_history]
     assert cids_original == cids_deserialized
+
+
+@given(
+    st.lists(receipt_strategy),
+    st.one_of(
+        st.floats(max_value=-0.0001, allow_nan=False, allow_infinity=False),
+        st.just(float("nan")),
+        st.just(float("-inf")),
+    ),
+)
+def test_free_energy_paradox_trapping(
+    rejection_history: list[EpistemicRejectionReceipt], invalid_free_energy: float
+) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        ActiveInferenceEpoch(
+            rejection_history=rejection_history,
+            current_free_energy=invalid_free_energy,
+        )
+    assert "Mathematical paradox" in str(exc_info.value) or "Input should be a valid number" in str(exc_info.value)


### PR DESCRIPTION
* feat: add EpistemicRejectionReceipt and ActiveInferenceEpoch to ontology

- Implements SOTA 2026+ Epistemic Rejection and Free Energy Feedback.
- Adds `EpistemicRejectionReceipt` schema.
- Adds `ActiveInferenceEpoch` schema.
- Uses strict Pydantic constraints and validators, preventing negative, `NaN`, or `Infinity` inputs.
- Implements deterministic canonical sorting of arrays.
- Adds hypothesis-driven property tests for bounds validation and serializability.

* fix: update generated JSON schema for Epic 3 changes

- Fixed missing `math` import in test files.
- Regenerated `coreason_ontology.schema.json` via semantic\_diff build pipeline to satisfy schema drift CI checks.
- Confirmed strict test passage without ruff linter warnings or type check anomalies.

* fix: run ruff formatter on test files

- Ran `uvx ruff format .` (and `uvx ruff check . --fix`) on newly created test files to pass strict CI checks.

* test: add coverage for ActiveInferenceEpoch validation paradox trapping

- Add property-based test `test_free_energy_paradox_trapping` explicitly covering the validation pathways guarding against Negative, `NaN`, and `-Infinity` input to the `current_free_energy` field in `ActiveInferenceEpoch`.