### PR TITLE
feat: Add computational thermodynamics bounds and circuit breakers

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -3762,6 +3762,54 @@
       "title": "CompositeNodeProfile",
       "type": "object"
     },
+    "ComputationalThermodynamics": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The macroscopic envelope that tracks the thermodynamic cost of stochastic ideation and violently halts execution when energy budgets or spatial limits are depleted.\n\nCAUSAL AFFORDANCE: Operates as the absolute mathematical circuit breaker for MCTS DAG expansion, physically revoking generative privileges if thresholds are breached.\n\nEPISTEMIC BOUNDS: Bounded by strict topological limits: max_stochastic_diffusions (ge=1) and computational_free_energy_budget (ge=0.0). current_diffusions must be strictly <= max_stochastic_diffusions.\n\nMCP ROUTING TRIGGERS: Computational Thermodynamics, Spatial Circuit Breaker, MCTS Halting, Epistemic Bounding, Thermodynamic Cost",
+      "properties": {
+        "thermodynamics_cid": {
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Thermodynamics Cid",
+          "type": "string"
+        },
+        "target_topology_cid": {
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Topology Cid",
+          "type": "string"
+        },
+        "max_stochastic_diffusions": {
+          "minimum": 1,
+          "title": "Max Stochastic Diffusions",
+          "type": "integer"
+        },
+        "computational_free_energy_budget": {
+          "minimum": 0.0,
+          "title": "Computational Free Energy Budget",
+          "type": "number"
+        },
+        "current_diffusions": {
+          "default": 0,
+          "minimum": 0,
+          "title": "Current Diffusions",
+          "type": "integer"
+        },
+        "remaining_free_energy": {
+          "title": "Remaining Free Energy",
+          "type": "number"
+        },
+        "system_state": {
+          "$ref": "#/$defs/ThermodynamicState",
+          "default": "ACTIVE_DIFFUSION"
+        }
+      },
+      "required": [
+        "target_topology_cid",
+        "max_stochastic_diffusions",
+        "computational_free_energy_budget",
+        "remaining_free_energy"
+      ],
+      "title": "ComputationalThermodynamics",
+      "type": "object"
+    },
     "ComputeEngineProfile": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as the liquid compute substrate abstraction, defining the\nfoundational LLM matrix available on the Spot Market for dynamic routing. As a ...Profile\nsuffix, this is a declarative, frozen snapshot of a compute geometry.\n\nCAUSAL AFFORDANCE: Projects the physical LLM capabilities, contextual memory constraints,\nand thermodynamic rate cards (ComputeRateContract) into the orchestrator's active routing\nmanifold, allowing cost-aware topological planning.\n\nEPISTEMIC BOUNDS: The token working memory is mathematically bounded by\ncontext_window_size (le=1000000000). To guarantee RFC 8785 canonical hashing across\ndisparate nodes, the capabilities and supported_functional_experts arrays are strictly\nsorted at instantiation via @model_validator.\n\nMCP ROUTING TRIGGERS: Liquid Compute, Spot Market Routing, Foundation Model Matrix,\nThermodynamic Rate Card, Substrate Abstraction",
@@ -17516,6 +17564,15 @@
       ],
       "title": "TheoryOfMindSnapshot",
       "type": "object"
+    },
+    "ThermodynamicState": {
+      "description": "AGENT INSTRUCTION: A rigid string enumeration mapping the kinetic liveness of the computational budget.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator on whether the thermodynamic search envelope is active or mathematically depleted.\n\nEPISTEMIC BOUNDS: Strictly bounded to the explicit kinetic states ACTIVE_DIFFUSION and ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION.\n\nMCP ROUTING TRIGGERS: Thermodynamic State, Budget Envelope, MCTS Liveness, Entropy Tracking",
+      "enum": [
+        "ACTIVE_DIFFUSION",
+        "ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION"
+      ],
+      "title": "ThermodynamicState",
+      "type": "string"
     },
     "ThoughtBranchState": {
       "additionalProperties": false,

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -868,6 +868,53 @@ class ActiveInferenceEpoch(CoreasonBaseState):
         return self
 
 
+class ThermodynamicState(StrEnum):
+    """
+    AGENT INSTRUCTION: A rigid string enumeration mapping the kinetic liveness of the computational budget.
+
+    CAUSAL AFFORDANCE: Instructs the orchestrator on whether the thermodynamic search envelope is active or mathematically depleted.
+
+    EPISTEMIC BOUNDS: Strictly bounded to the explicit kinetic states ACTIVE_DIFFUSION and ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION.
+
+    MCP ROUTING TRIGGERS: Thermodynamic State, Budget Envelope, MCTS Liveness, Entropy Tracking
+    """
+
+    ACTIVE_DIFFUSION = "ACTIVE_DIFFUSION"
+    ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION = "ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION"
+
+
+class ComputationalThermodynamics(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: The macroscopic envelope that tracks the thermodynamic cost of stochastic ideation and violently halts execution when energy budgets or spatial limits are depleted.
+
+    CAUSAL AFFORDANCE: Operates as the absolute mathematical circuit breaker for MCTS DAG expansion, physically revoking generative privileges if thresholds are breached.
+
+    EPISTEMIC BOUNDS: Bounded by strict topological limits: max_stochastic_diffusions (ge=1) and computational_free_energy_budget (ge=0.0). current_diffusions must be strictly <= max_stochastic_diffusions.
+
+    MCP ROUTING TRIGGERS: Computational Thermodynamics, Spatial Circuit Breaker, MCTS Halting, Epistemic Bounding, Thermodynamic Cost
+    """
+
+    thermodynamics_cid: Annotated[str, StringConstraints(pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        default_factory=lambda: str(uuid.uuid4())
+    )
+    target_topology_cid: Annotated[str, StringConstraints(pattern="^[a-zA-Z0-9_.:-]+$")]
+    max_stochastic_diffusions: int = Field(ge=1)
+    computational_free_energy_budget: float = Field(ge=0.0)
+    current_diffusions: int = Field(default=0, ge=0)
+    remaining_free_energy: float
+    system_state: ThermodynamicState = Field(default=ThermodynamicState.ACTIVE_DIFFUSION)
+
+    @model_validator(mode="after")
+    def validate_thermodynamic_circuit_breaker(self) -> Self:
+        if self.current_diffusions > self.max_stochastic_diffusions:
+            raise ValueError("Topological Fracture: current_diffusions strictly exceeds max_stochastic_diffusions.")
+
+        if self.remaining_free_energy <= 0.0:
+            object.__setattr__(self, "system_state", ThermodynamicState.ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION)
+
+        return self
+
+
 class TraceContextState(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: Implements Distributed Causality using Vector Clocks and rho-calculus. It forms the foundational causality boundary.
@@ -13407,3 +13454,4 @@ CryptographicProvenanceMixin.model_rebuild()
 TopologicalProjectionIntent.model_rebuild()
 EpistemicRejectionReceipt.model_rebuild()
 ActiveInferenceEpoch.model_rebuild()
+ComputationalThermodynamics.model_rebuild()

--- a/tests/fuzzing/test_free_energy_exhaustion.py
+++ b/tests/fuzzing/test_free_energy_exhaustion.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2026 CoReason, Inc
+#
+# This software is proprietary and dual-licensed
+# Licensed under the Prosperity Public License 3.0 (the "License")
+# A copy of the license is available at <https://prosperitylicense.com/versions/3.0.0>
+# For details, see the LICENSE file
+# Commercial use beyond a 30-day trial requires a separate license
+#
+# Source Code: <https://github.com/CoReason-AI/coreason-manifest>
+
+import json
+from hypothesis import given, strategies as st
+from coreason_manifest.spec.ontology import ComputationalThermodynamics, ThermodynamicState
+import math
+
+
+@given(
+    max_diff=st.integers(min_value=1, max_value=1000),
+    current_diff=st.integers(min_value=0, max_value=1000),
+    free_energy=st.floats(max_value=0.0, allow_nan=False, allow_infinity=False),
+)
+def test_depletion_transition_mapping(max_diff: int, current_diff: int, free_energy: float) -> None:
+    """
+    Assertion 1 (Depletion Transition Mapping):
+    Use st.floats(max_value=0.0) to generate depleted/negative energy states.
+    Initialize ComputationalThermodynamics.
+    Assert that the @model_validator correctly intercepted the initialization and forced system_state to equal ThermodynamicState.ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION without raising a fatal exception.
+    """
+    if current_diff > max_diff:
+        current_diff = max_diff
+
+    thermo = ComputationalThermodynamics(
+        target_topology_cid="topology-1234",
+        max_stochastic_diffusions=max_diff,
+        computational_free_energy_budget=100.0,
+        current_diffusions=current_diff,
+        remaining_free_energy=free_energy,
+    )
+
+    assert thermo.system_state == ThermodynamicState.ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION
+
+
+@given(
+    max_diff=st.integers(min_value=1, max_value=1000),
+    current_diff=st.integers(min_value=0, max_value=1000),
+    free_energy_active=st.floats(min_value=0.1, max_value=100.0, allow_nan=False, allow_infinity=False),
+    free_energy_exhausted=st.floats(max_value=0.0, min_value=-100000.0, allow_nan=False, allow_infinity=False),
+)
+def test_serialization_isomorphism(
+    max_diff: int, current_diff: int, free_energy_active: float, free_energy_exhausted: float
+) -> None:
+    """
+    Assertion 2 (Serialization Isomorphism):
+    Fuzz the ComputationalThermodynamics object through canonical JSON serialization/deserialization.
+    Ensure you test objects in BOTH the ACTIVE_DIFFUSION and ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION states.
+    """
+    if current_diff > max_diff:
+        current_diff = max_diff
+
+    # Test ACTIVE_DIFFUSION state
+    thermo_active = ComputationalThermodynamics(
+        target_topology_cid="topology-1234",
+        max_stochastic_diffusions=max_diff,
+        computational_free_energy_budget=100.0,
+        current_diffusions=current_diff,
+        remaining_free_energy=free_energy_active,
+    )
+
+    assert thermo_active.system_state == ThermodynamicState.ACTIVE_DIFFUSION
+
+    serialized_active = thermo_active.model_dump_canonical()
+    deserialized_active = ComputationalThermodynamics.model_validate_json(serialized_active)
+
+    assert deserialized_active.thermodynamics_cid == thermo_active.thermodynamics_cid
+    assert deserialized_active.target_topology_cid == thermo_active.target_topology_cid
+    assert deserialized_active.max_stochastic_diffusions == thermo_active.max_stochastic_diffusions
+    assert deserialized_active.current_diffusions == thermo_active.current_diffusions
+    assert deserialized_active.remaining_free_energy == thermo_active.remaining_free_energy
+    assert deserialized_active.system_state == thermo_active.system_state
+
+    # Test ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION state
+    thermo_exhausted = ComputationalThermodynamics(
+        target_topology_cid="topology-1234",
+        max_stochastic_diffusions=max_diff,
+        computational_free_energy_budget=100.0,
+        current_diffusions=current_diff,
+        remaining_free_energy=free_energy_exhausted,
+    )
+
+    assert thermo_exhausted.system_state == ThermodynamicState.ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION
+
+    serialized_exhausted = thermo_exhausted.model_dump_canonical()
+    deserialized_exhausted = ComputationalThermodynamics.model_validate_json(serialized_exhausted)
+
+    assert deserialized_exhausted.thermodynamics_cid == thermo_exhausted.thermodynamics_cid
+    assert deserialized_exhausted.target_topology_cid == thermo_exhausted.target_topology_cid
+    assert deserialized_exhausted.max_stochastic_diffusions == thermo_exhausted.max_stochastic_diffusions
+    assert deserialized_exhausted.current_diffusions == thermo_exhausted.current_diffusions
+    assert deserialized_exhausted.remaining_free_energy == thermo_exhausted.remaining_free_energy
+    assert deserialized_exhausted.system_state == thermo_exhausted.system_state

--- a/tests/fuzzing/test_free_energy_exhaustion.py
+++ b/tests/fuzzing/test_free_energy_exhaustion.py
@@ -8,10 +8,10 @@
 #
 # Source Code: <https://github.com/CoReason-AI/coreason-manifest>
 
-import json
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
+
 from coreason_manifest.spec.ontology import ComputationalThermodynamics, ThermodynamicState
-import math
 
 
 @given(

--- a/tests/fuzzing/test_thermodynamic_bounds.py
+++ b/tests/fuzzing/test_thermodynamic_bounds.py
@@ -9,7 +9,8 @@
 # Source Code: <https://github.com/CoReason-AI/coreason-manifest>
 
 import pytest
-from hypothesis import given, strategies as st
+from hypothesis import given
+from hypothesis import strategies as st
 from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import ComputationalThermodynamics, ThermodynamicState

--- a/tests/fuzzing/test_thermodynamic_bounds.py
+++ b/tests/fuzzing/test_thermodynamic_bounds.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2026 CoReason, Inc
+#
+# This software is proprietary and dual-licensed
+# Licensed under the Prosperity Public License 3.0 (the "License")
+# A copy of the license is available at <https://prosperitylicense.com/versions/3.0.0>
+# For details, see the LICENSE file
+# Commercial use beyond a 30-day trial requires a separate license
+#
+# Source Code: <https://github.com/CoReason-AI/coreason-manifest>
+
+import pytest
+from hypothesis import given, strategies as st
+from pydantic import ValidationError
+
+from coreason_manifest.spec.ontology import ComputationalThermodynamics, ThermodynamicState
+
+
+@given(
+    max_diff=st.integers(min_value=1, max_value=1000),
+    current_diff=st.integers(min_value=1001, max_value=10000),
+    free_energy=st.floats(min_value=0.1, max_value=100.0, exclude_max=False),
+)
+def test_diffusion_overload(max_diff: int, current_diff: int, free_energy: float) -> None:
+    """
+    Assertion 1 (Diffusion Overload):
+    Prove the spatial circuit breakers using only hypothesis.
+    Generate configurations where current_diffusions is strictly greater than max_stochastic_diffusions.
+    Assert that attempting to instantiate ComputationalThermodynamics with these values universally raises a Pydantic ValidationError.
+    """
+    # Overriding to ensure current_diff > max_diff
+    if current_diff <= max_diff:
+        current_diff = max_diff + 1
+
+    with pytest.raises(ValidationError) as exc_info:
+        ComputationalThermodynamics(
+            target_topology_cid="topology-1234",
+            max_stochastic_diffusions=max_diff,
+            computational_free_energy_budget=100.0,
+            current_diffusions=current_diff,
+            remaining_free_energy=free_energy,
+        )
+    assert "current_diffusions strictly exceeds max_stochastic_diffusions" in str(exc_info.value)
+
+
+@given(
+    max_diff=st.integers(min_value=1, max_value=1000),
+    current_diff=st.integers(min_value=0, max_value=1000),
+    free_energy=st.floats(min_value=0.1, max_value=100.0),
+)
+def test_valid_operational_state(max_diff: int, current_diff: int, free_energy: float) -> None:
+    """
+    Assertion 2 (Valid Operational State):
+    Generate configurations where current_diffusions <= max_stochastic_diffusions and remaining_free_energy > 0.0.
+    Assert successful instantiation and mathematically prove that system_state remains ThermodynamicState.ACTIVE_DIFFUSION.
+    """
+    if current_diff > max_diff:
+        current_diff = max_diff
+
+    thermo = ComputationalThermodynamics(
+        target_topology_cid="topology-1234",
+        max_stochastic_diffusions=max_diff,
+        computational_free_energy_budget=100.0,
+        current_diffusions=current_diff,
+        remaining_free_energy=free_energy,
+    )
+
+    assert thermo.system_state == ThermodynamicState.ACTIVE_DIFFUSION


### PR DESCRIPTION
Implements the Computational Thermodynamics Bounds framework to prevent infinite MCTS loops by enforcing strict spatial (diffusion count) and continuous (free-energy decay) budgets on the stochastic ensemble.

- Injects `ThermodynamicState` and `ComputationalThermodynamics` into the God Context monolith `ontology.py`.
- Includes Pydantic model validation to physically raise a Topological Fracture (`ValueError`) on spatial limit exhaustion or transition to `ENTROPIC_EXHAUSTION_ORACLE_INTERVENTION` on energy depletion.
- Creates `tests/fuzzing/test_thermodynamic_bounds.py` to formally verify the spatial circuit breaker.
- Creates `tests/fuzzing/test_free_energy_exhaustion.py` to formally verify the free energy depletion transition and JSON serialization isomorphism.

---
*PR created automatically by Jules for task [11946470610414817927](https://jules.google.com/task/11946470610414817927) started by @gowthamrao*