### PR TITLE
Fix topological orphans in structural graph

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -2897,6 +2897,14 @@
           ],
           "default": null,
           "description": "Authorizes trajectory balance optimization during non-monotonic reasoning."
+        },
+        "emitted_intents": {
+          "description": "The array of cognitive intents and structural proposals emitted by this agent.",
+          "items": {
+            "$ref": "#/$defs/AnyIntent"
+          },
+          "title": "Emitted Intents",
+          "type": "array"
         }
       },
       "required": [
@@ -12256,14 +12264,6 @@
             "$ref": "#/$defs/InterventionPolicy"
           },
           "title": "Intervention Policies",
-          "type": "array"
-        },
-        "emitted_intents": {
-          "description": "The array of cognitive intents and structural proposals emitted by this agent.",
-          "items": {
-            "$ref": "#/$defs/AnyIntent"
-          },
-          "title": "Emitted Intents",
           "type": "array"
         },
         "domain_extensions": {

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -586,6 +586,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents a probabilistic agentic bid in a multi-objective optimization market, factoring in projected compute latency, carbon constraints, and internal epistemic certainty.\n\nCAUSAL AFFORDANCE: Injects a competitive trajectory into the AuctionState order book, seeking authorization from the orchestrator to execute a specific TaskAnnouncementIntent branch.\n\nEPISTEMIC BOUNDS: Geometrically bounded by `estimated_cost_magnitude` (`le=1000000000`), `estimated_latency_ms` (`le=86400000, ge=0`), `estimated_carbon_gco2eq` (`le=10000.0, ge=0.0`), and `confidence_score` (`ge=0.0, le=1.0`). `agent_cid` is a 128-char CID.\n\nMCP ROUTING TRIGGERS: Expected Utility Theory, Multi-Objective Optimization, Epistemic Certainty, Spot Market Bid, Cost Estimation",
       "properties": {
+        "topology_class": {
+          "const": "agent_bid",
+          "default": "agent_bid",
+          "description": "The discriminative topological boundary for agent bid intents.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "agent_cid": {
           "description": "The NodeCIDState of the bidder.",
           "maxLength": 128,
@@ -803,6 +810,87 @@
         },
         {
           "$ref": "#/$defs/StochasticTopology"
+        }
+      ]
+    },
+    "AnyIntent": {
+      "discriminator": {
+        "mapping": {
+          "agent_bid": "#/$defs/AgentBidIntent",
+          "compute_provisioning": "#/$defs/ComputeProvisioningIntent",
+          "contextual_semantic_resolution": "#/$defs/ContextualSemanticResolutionIntent",
+          "continuous_spatial_mutation": "#/$defs/ContinuousSpatialMutationIntent",
+          "drafting": "#/$defs/DraftingIntent",
+          "escalation": "#/$defs/EscalationIntent",
+          "forced_adjudication": "#/$defs/AdjudicationIntent",
+          "human_directive": "#/$defs/HumanDirectiveIntent",
+          "informational": "#/$defs/SemanticIntent",
+          "latent_projection": "#/$defs/LatentProjectionIntent",
+          "latent_schema_inference": "#/$defs/LatentSchemaInferenceIntent",
+          "ontology_discovery": "#/$defs/OntologyDiscoveryIntent",
+          "quarantine_intent": "#/$defs/QuarantineIntent",
+          "request": "#/$defs/InterventionIntent",
+          "semantic_discovery": "#/$defs/SemanticDiscoveryIntent",
+          "semantic_mapping_proposal": "#/$defs/SemanticMappingHeuristicProposal",
+          "task_announcement": "#/$defs/TaskAnnouncementIntent",
+          "taxonomic_restructure": "#/$defs/TaxonomicRestructureIntent"
+        },
+        "propertyName": "topology_class"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SemanticIntent"
+        },
+        {
+          "$ref": "#/$defs/DraftingIntent"
+        },
+        {
+          "$ref": "#/$defs/AdjudicationIntent"
+        },
+        {
+          "$ref": "#/$defs/EscalationIntent"
+        },
+        {
+          "$ref": "#/$defs/SemanticDiscoveryIntent"
+        },
+        {
+          "$ref": "#/$defs/TaxonomicRestructureIntent"
+        },
+        {
+          "$ref": "#/$defs/LatentProjectionIntent"
+        },
+        {
+          "$ref": "#/$defs/LatentSchemaInferenceIntent"
+        },
+        {
+          "$ref": "#/$defs/HumanDirectiveIntent"
+        },
+        {
+          "$ref": "#/$defs/ContextualSemanticResolutionIntent"
+        },
+        {
+          "$ref": "#/$defs/OntologyDiscoveryIntent"
+        },
+        {
+          "$ref": "#/$defs/SemanticMappingHeuristicProposal"
+        },
+        {
+          "$ref": "#/$defs/ContinuousSpatialMutationIntent"
+        },
+        {
+          "$ref": "#/$defs/AgentBidIntent"
+        },
+        {
+          "$ref": "#/$defs/ComputeProvisioningIntent"
+        },
+        {
+          "$ref": "#/$defs/TaskAnnouncementIntent"
+        },
+        {
+          "$ref": "#/$defs/QuarantineIntent"
+        },
+        {
+          "$ref": "#/$defs/InterventionIntent"
         }
       ]
     },
@@ -3517,6 +3605,14 @@
           "title": "Intervention Policies",
           "type": "array"
         },
+        "emitted_intents": {
+          "description": "The array of cognitive intents and structural proposals emitted by this agent.",
+          "items": {
+            "$ref": "#/$defs/AnyIntent"
+          },
+          "title": "Emitted Intents",
+          "type": "array"
+        },
         "domain_extensions": {
           "anyOf": [
             {
@@ -3952,6 +4048,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formulates a constrained Knapsack Problem for dynamically allocating liquid compute resources based on exact Quality of Service (QoS) priorities and semantic load shedding rules.\n\nCAUSAL AFFORDANCE: Emits a structural demand to the swarm orchestrator to negotiate, acquire, and cryptographically lock the requisite token escrow before allocating kinetic execution cycles to a sub-graph.\n\nEPISTEMIC BOUNDS: Economic velocity is strictly clamped by `max_budget` (`le=1000000000`), physically typed as an integer to prevent floating-point fractures during spot market bidding. The `required_capabilities` array is deterministically sorted by a `@model_validator`.\n\nMCP ROUTING TRIGGERS: Knapsack Optimization, Semantic Load Shedding, Spot Compute Bidding, QoS Classification, Resource Provisioning",
       "properties": {
+        "topology_class": {
+          "const": "compute_provisioning",
+          "default": "compute_provisioning",
+          "description": "The discriminative topological boundary for compute provisioning intents.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "max_budget": {
           "description": "The maximum atomic cost budget allowable for the provisioned compute.",
           "maximum": 1000000000,
@@ -4515,6 +4618,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes an Affine Conflict-free Replicated Data Type (CRDT) to execute Optimistic Concurrency Control across geometric manipulations.\n\nCAUSAL AFFORDANCE: Authorizes a participant to kinetically drag, rotate, or scale a topological node. The orchestrator uses the provided Lamport clock to mathematically resolve Spherical Linear Interpolation (SLERP) and translation collisions between concurrent actors.\n\nEPISTEMIC BOUNDS: The mutation strictly targets a verified `NodeCIDState`. The `lamport_clock` (`ge=0, le=1000000000`) prevents temporal overflow during logical state reconciliation.\n\nMCP ROUTING TRIGGERS: Optimistic Locking, Affine CRDT, Spherical Linear Interpolation, Continuous Reconciliation, Kinematic Drag",
       "properties": {
+        "topology_class": {
+          "const": "continuous_spatial_mutation",
+          "default": "continuous_spatial_mutation",
+          "description": "The discriminative topological boundary for spatial mutation intents.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "target_node_cid": {
           "$ref": "#/$defs/NodeCIDState",
           "description": "The specific topology vertex undergoing spatial mutation."
@@ -17090,6 +17200,13 @@
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Initiates a Request for Proposal (RFP) within a decentralized Spot Market to dynamically allocate thermodynamic compute based on task complexity.\n\nCAUSAL AFFORDANCE: Triggers an active, non-monotonic bidding phase where eligible Swarm nodes evaluate their internal Q-K matrices to formulate competitive execution bids.\n\nEPISTEMIC BOUNDS: The economic payload is physically capped by `max_budget_magnitude` (`le=1000000000`). The topological routing is strictly constrained if `required_action_space_cid` is defined (optional, `max_length=128`, CID regex). Anchored by a mandatory `task_cid` CID.\n\nMCP ROUTING TRIGGERS: Decentralized Spot Market, Request for Proposal, Thermodynamic Compute Allocation, Algorithmic Mechanism Design, Kinetic Execution Trigger",
       "properties": {
+        "topology_class": {
+          "const": "task_announcement",
+          "default": "task_announcement",
+          "description": "The discriminative topological boundary for task announcement intents.",
+          "title": "Topology Class",
+          "type": "string"
+        },
         "task_cid": {
           "description": "Unique identifier for the required task.",
           "maxLength": 128,

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -813,87 +813,6 @@
         }
       ]
     },
-    "AnyIntent": {
-      "discriminator": {
-        "mapping": {
-          "agent_bid": "#/$defs/AgentBidIntent",
-          "compute_provisioning": "#/$defs/ComputeProvisioningIntent",
-          "contextual_semantic_resolution": "#/$defs/ContextualSemanticResolutionIntent",
-          "continuous_spatial_mutation": "#/$defs/ContinuousSpatialMutationIntent",
-          "drafting": "#/$defs/DraftingIntent",
-          "escalation": "#/$defs/EscalationIntent",
-          "forced_adjudication": "#/$defs/AdjudicationIntent",
-          "human_directive": "#/$defs/HumanDirectiveIntent",
-          "informational": "#/$defs/SemanticIntent",
-          "latent_projection": "#/$defs/LatentProjectionIntent",
-          "latent_schema_inference": "#/$defs/LatentSchemaInferenceIntent",
-          "ontology_discovery": "#/$defs/OntologyDiscoveryIntent",
-          "quarantine_intent": "#/$defs/QuarantineIntent",
-          "request": "#/$defs/InterventionIntent",
-          "semantic_discovery": "#/$defs/SemanticDiscoveryIntent",
-          "semantic_mapping_proposal": "#/$defs/SemanticMappingHeuristicProposal",
-          "task_announcement": "#/$defs/TaskAnnouncementIntent",
-          "taxonomic_restructure": "#/$defs/TaxonomicRestructureIntent"
-        },
-        "propertyName": "topology_class"
-      },
-      "oneOf": [
-        {
-          "$ref": "#/$defs/SemanticIntent"
-        },
-        {
-          "$ref": "#/$defs/DraftingIntent"
-        },
-        {
-          "$ref": "#/$defs/AdjudicationIntent"
-        },
-        {
-          "$ref": "#/$defs/EscalationIntent"
-        },
-        {
-          "$ref": "#/$defs/SemanticDiscoveryIntent"
-        },
-        {
-          "$ref": "#/$defs/TaxonomicRestructureIntent"
-        },
-        {
-          "$ref": "#/$defs/LatentProjectionIntent"
-        },
-        {
-          "$ref": "#/$defs/LatentSchemaInferenceIntent"
-        },
-        {
-          "$ref": "#/$defs/HumanDirectiveIntent"
-        },
-        {
-          "$ref": "#/$defs/ContextualSemanticResolutionIntent"
-        },
-        {
-          "$ref": "#/$defs/OntologyDiscoveryIntent"
-        },
-        {
-          "$ref": "#/$defs/SemanticMappingHeuristicProposal"
-        },
-        {
-          "$ref": "#/$defs/ContinuousSpatialMutationIntent"
-        },
-        {
-          "$ref": "#/$defs/AgentBidIntent"
-        },
-        {
-          "$ref": "#/$defs/ComputeProvisioningIntent"
-        },
-        {
-          "$ref": "#/$defs/TaskAnnouncementIntent"
-        },
-        {
-          "$ref": "#/$defs/QuarantineIntent"
-        },
-        {
-          "$ref": "#/$defs/InterventionIntent"
-        }
-      ]
-    },
     "AnyNodeProfile": {
       "description": "A discriminated union of all valid workflow nodes.",
       "discriminator": {
@@ -3603,14 +3522,6 @@
             "$ref": "#/$defs/InterventionPolicy"
           },
           "title": "Intervention Policies",
-          "type": "array"
-        },
-        "emitted_intents": {
-          "description": "The array of cognitive intents and structural proposals emitted by this agent.",
-          "items": {
-            "$ref": "#/$defs/AnyIntent"
-          },
-          "title": "Emitted Intents",
           "type": "array"
         },
         "domain_extensions": {

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -813,6 +813,87 @@
         }
       ]
     },
+    "AnyIntent": {
+      "discriminator": {
+        "mapping": {
+          "agent_bid": "#/$defs/AgentBidIntent",
+          "compute_provisioning": "#/$defs/ComputeProvisioningIntent",
+          "contextual_semantic_resolution": "#/$defs/ContextualSemanticResolutionIntent",
+          "continuous_spatial_mutation": "#/$defs/ContinuousSpatialMutationIntent",
+          "drafting": "#/$defs/DraftingIntent",
+          "escalation": "#/$defs/EscalationIntent",
+          "forced_adjudication": "#/$defs/AdjudicationIntent",
+          "human_directive": "#/$defs/HumanDirectiveIntent",
+          "informational": "#/$defs/SemanticIntent",
+          "latent_projection": "#/$defs/LatentProjectionIntent",
+          "latent_schema_inference": "#/$defs/LatentSchemaInferenceIntent",
+          "ontology_discovery": "#/$defs/OntologyDiscoveryIntent",
+          "quarantine_intent": "#/$defs/QuarantineIntent",
+          "request": "#/$defs/InterventionIntent",
+          "semantic_discovery": "#/$defs/SemanticDiscoveryIntent",
+          "semantic_mapping_proposal": "#/$defs/SemanticMappingHeuristicProposal",
+          "task_announcement": "#/$defs/TaskAnnouncementIntent",
+          "taxonomic_restructure": "#/$defs/TaxonomicRestructureIntent"
+        },
+        "propertyName": "topology_class"
+      },
+      "oneOf": [
+        {
+          "$ref": "#/$defs/SemanticIntent"
+        },
+        {
+          "$ref": "#/$defs/DraftingIntent"
+        },
+        {
+          "$ref": "#/$defs/AdjudicationIntent"
+        },
+        {
+          "$ref": "#/$defs/EscalationIntent"
+        },
+        {
+          "$ref": "#/$defs/SemanticDiscoveryIntent"
+        },
+        {
+          "$ref": "#/$defs/TaxonomicRestructureIntent"
+        },
+        {
+          "$ref": "#/$defs/LatentProjectionIntent"
+        },
+        {
+          "$ref": "#/$defs/LatentSchemaInferenceIntent"
+        },
+        {
+          "$ref": "#/$defs/HumanDirectiveIntent"
+        },
+        {
+          "$ref": "#/$defs/ContextualSemanticResolutionIntent"
+        },
+        {
+          "$ref": "#/$defs/OntologyDiscoveryIntent"
+        },
+        {
+          "$ref": "#/$defs/SemanticMappingHeuristicProposal"
+        },
+        {
+          "$ref": "#/$defs/ContinuousSpatialMutationIntent"
+        },
+        {
+          "$ref": "#/$defs/AgentBidIntent"
+        },
+        {
+          "$ref": "#/$defs/ComputeProvisioningIntent"
+        },
+        {
+          "$ref": "#/$defs/TaskAnnouncementIntent"
+        },
+        {
+          "$ref": "#/$defs/QuarantineIntent"
+        },
+        {
+          "$ref": "#/$defs/InterventionIntent"
+        }
+      ]
+    },
     "AnyNodeProfile": {
       "description": "A discriminated union of all valid workflow nodes.",
       "discriminator": {
@@ -12175,6 +12256,14 @@
             "$ref": "#/$defs/InterventionPolicy"
           },
           "title": "Intervention Policies",
+          "type": "array"
+        },
+        "emitted_intents": {
+          "description": "The array of cognitive intents and structural proposals emitted by this agent.",
+          "items": {
+            "$ref": "#/$defs/AnyIntent"
+          },
+          "title": "Emitted Intents",
           "type": "array"
         },
         "domain_extensions": {

--- a/scripts/evaluate_topological_reachability.py
+++ b/scripts/evaluate_topological_reachability.py
@@ -29,13 +29,11 @@ def get_all_subclasses(cls):
 EXCLUDED_BASE_CLASSES = {
     "CryptographicProvenanceMixin",
     "BoundedJSONRPCIntent",
-    "AnyToolchainState" # (if implemented as an ABC/union wrapper rather than a concrete node)
+    "AnyToolchainState",  # (if implemented as an ABC/union wrapper rather than a concrete node)
 }
 
 CLASS_REGISTRY = {
-    cls.__name__: cls
-    for cls in get_all_subclasses(onto.CoreasonBaseState)
-    if cls.__name__ not in EXCLUDED_BASE_CLASSES
+    cls.__name__: cls for cls in get_all_subclasses(onto.CoreasonBaseState) if cls.__name__ not in EXCLUDED_BASE_CLASSES
 }
 
 ALIAS_REGISTRY = {name: obj.__value__ for name, obj in vars(onto).items() if isinstance(obj, TypeAliasType)}

--- a/scripts/evaluate_topological_reachability.py
+++ b/scripts/evaluate_topological_reachability.py
@@ -26,7 +26,17 @@ def get_all_subclasses(cls):
     return subclasses
 
 
-CLASS_REGISTRY = {cls.__name__: cls for cls in get_all_subclasses(onto.CoreasonBaseState)}
+EXCLUDED_BASE_CLASSES = {
+    "CryptographicProvenanceMixin",
+    "BoundedJSONRPCIntent",
+    "AnyToolchainState" # (if implemented as an ABC/union wrapper rather than a concrete node)
+}
+
+CLASS_REGISTRY = {
+    cls.__name__: cls
+    for cls in get_all_subclasses(onto.CoreasonBaseState)
+    if cls.__name__ not in EXCLUDED_BASE_CLASSES
+}
 
 ALIAS_REGISTRY = {name: obj.__value__ for name, obj in vars(onto).items() if isinstance(obj, TypeAliasType)}
 

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -7081,10 +7081,6 @@ class CognitiveSystemNodeProfile(CoreasonBaseState):
         default_factory=list,
         description="The declarative array of proactive oversight hooks bound to this node's lifecycle.",
     )
-    emitted_intents: list[AnyIntent] = Field(
-        default_factory=list,
-        description="The array of cognitive intents and structural proposals emitted by this agent.",
-    )
     domain_extensions: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] | None = Field(
         default=None,
         description="Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -7013,6 +7013,10 @@ class MemoizedNodeProfile(CoreasonBaseState):
         default_factory=list,
         description="The declarative array of proactive oversight hooks bound to this node's lifecycle.",
     )
+    emitted_intents: list[AnyIntent] = Field(
+        default_factory=list,
+        description="The array of cognitive intents and structural proposals emitted by this agent.",
+    )
     domain_extensions: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] | None = Field(
         default=None,
         description="Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -1399,6 +1399,10 @@ class ContinuousSpatialMutationIntent(CoreasonBaseState):
 
     """
 
+    topology_class: Literal["continuous_spatial_mutation"] = Field(
+        default="continuous_spatial_mutation",
+        description="The discriminative topological boundary for spatial mutation intents.",
+    )
     target_node_cid: NodeCIDState = Field(description="The specific topology vertex undergoing spatial mutation.")
     proposed_transform: SE3TransformProfile = Field(description="The requested absolute SE(3) spatial terminus.")
     lamport_clock: int = Field(
@@ -3516,6 +3520,10 @@ class AgentBidIntent(CoreasonBaseState):
 
     """
 
+    topology_class: Literal["agent_bid"] = Field(
+        default="agent_bid",
+        description="The discriminative topological boundary for agent bid intents.",
+    )
     agent_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         description="The NodeCIDState of the bidder."
     )
@@ -6545,7 +6553,13 @@ type AnyIntent = Annotated[
     | HumanDirectiveIntent
     | ContextualSemanticResolutionIntent
     | OntologyDiscoveryIntent
-    | SemanticMappingHeuristicProposal,
+    | SemanticMappingHeuristicProposal
+    | ContinuousSpatialMutationIntent
+    | AgentBidIntent
+    | ComputeProvisioningIntent
+    | TaskAnnouncementIntent
+    | QuarantineIntent
+    | InterventionIntent,
     Field(discriminator="topology_class"),
 ]
 
@@ -6998,6 +7012,10 @@ class MemoizedNodeProfile(CoreasonBaseState):
     intervention_policies: list[InterventionPolicy] = Field(
         default_factory=list,
         description="The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+    )
+    emitted_intents: list[AnyIntent] = Field(
+        default_factory=list,
+        description="The array of cognitive intents and structural proposals emitted by this agent.",
     )
     domain_extensions: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] | None = Field(
         default=None,
@@ -8726,6 +8744,10 @@ class ComputeProvisioningIntent(CoreasonBaseState):
 
     """
 
+    topology_class: Literal["compute_provisioning"] = Field(
+        default="compute_provisioning",
+        description="The discriminative topological boundary for compute provisioning intents.",
+    )
     max_budget: int = Field(
         le=1000000000, description="The maximum atomic cost budget allowable for the provisioned compute."
     )
@@ -9577,6 +9599,10 @@ class TaskAnnouncementIntent(CoreasonBaseState):
 
     """
 
+    topology_class: Literal["task_announcement"] = Field(
+        default="task_announcement",
+        description="The discriminative topological boundary for task announcement intents.",
+    )
     task_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         description="Unique identifier for the required task."
     )

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -7013,10 +7013,6 @@ class MemoizedNodeProfile(CoreasonBaseState):
         default_factory=list,
         description="The declarative array of proactive oversight hooks bound to this node's lifecycle.",
     )
-    emitted_intents: list[AnyIntent] = Field(
-        default_factory=list,
-        description="The array of cognitive intents and structural proposals emitted by this agent.",
-    )
     domain_extensions: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] | None = Field(
         default=None,
         description="Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
@@ -7084,6 +7080,10 @@ class CognitiveSystemNodeProfile(CoreasonBaseState):
     intervention_policies: list[InterventionPolicy] = Field(
         default_factory=list,
         description="The declarative array of proactive oversight hooks bound to this node's lifecycle.",
+    )
+    emitted_intents: list[AnyIntent] = Field(
+        default_factory=list,
+        description="The array of cognitive intents and structural proposals emitted by this agent.",
     )
     domain_extensions: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] | None = Field(
         default=None,

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -7013,10 +7013,6 @@ class MemoizedNodeProfile(CoreasonBaseState):
         default_factory=list,
         description="The declarative array of proactive oversight hooks bound to this node's lifecycle.",
     )
-    emitted_intents: list[AnyIntent] = Field(
-        default_factory=list,
-        description="The array of cognitive intents and structural proposals emitted by this agent.",
-    )
     domain_extensions: dict[Annotated[str, StringConstraints(max_length=255)], JsonPrimitiveState] | None = Field(
         default=None,
         description="Passive, untyped extension point for vertical domain context. Strictly bounded to prevent JSON-bomb memory leaks. AGENT INSTRUCTION: Payload volume is strictly limited to an absolute $O(N)$ limit of 10,000 nodes and a maximum recursion depth of 10 to prevent VRAM exhaustion.",
@@ -10704,6 +10700,10 @@ class CognitiveAgentNodeProfile(CoreasonBaseState):
     )
     gflownet_balance_policy: CognitiveDetailedBalanceContract | None = Field(
         default=None, description="Authorizes trajectory balance optimization during non-monotonic reasoning."
+    )
+    emitted_intents: list[AnyIntent] = Field(
+        default_factory=list,
+        description="The array of cognitive intents and structural proposals emitted by this agent.",
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
- Excluded specific structural base classes from graph generation in `evaluate_topological_reachability.py`
- Expanded `AnyIntent` union in `ontology.py` to correctly include `ContinuousSpatialMutationIntent`, `AgentBidIntent`, `ComputeProvisioningIntent`, `TaskAnnouncementIntent`, `QuarantineIntent`, and `InterventionIntent`.
- Added required discriminator `topology_class` to all new Intent payloads.
- Added causal edge `emitted_intents` to `CognitiveAgentNodeProfile` to restore semantic connectivity to the subgraph.

---
*PR created automatically by Jules for task [2412920066727231253](https://jules.google.com/task/2412920066727231253) started by @gowthamrao*