### PR TITLE
ci: verify topological integrity in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,6 +32,9 @@ jobs:
       - name: Install dependencies
         run: uv sync --all-extras --dev
 
+      - name: Verify Topological Integrity Before Compilation
+        run: uv run python scripts/evaluate_topological_reachability.py
+
       - name: Export JSON Schema
         run: uv run python -c "import json; from coreason_manifest.utils.algebra import get_ontology_schema; schema = get_ontology_schema(); open('coreason_ontology.schema.json', 'w', encoding='utf-8').write(json.dumps(schema, indent=2, ensure_ascii=False) + '\n')"
 


### PR DESCRIPTION
Adds the Verify Topological Integrity Before Compilation step to the publish.yml GitHub Actions workflow to block generation of a fractured JSON schema artifact.

---
*PR created automatically by Jules for task [9293925611824171647](https://jules.google.com/task/9293925611824171647) started by @gowthamrao*