### PR TITLE
The Semantic Web & LinkML Boundary (OntoGPT)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -447,10 +447,12 @@ We physically separate probabilistic textual generation (System 1) from schema v
 * **Mechanistic Penalty:** If the Docling subsystem crashes due to DRM-locks or malformed byte streams, the wrapper must immediately emit an `ArtifactCorruptionEvent` to sever the topology and halt epistemic contagion.
 
 ### 8.2 `OntologicalGroundingSpecialist` (The Semantic Web Engine)
-* **Open-Source Substrate:** Monarch Initiative `ontogpt` / `linkml`
+* **Open-Source Substrate:** Monarch Initiative `ontogpt` / `linkml` / `oaklib`
 * **Compute Plane Profile:** `CognitiveSystemNodeProfile` (Sandboxed SPIRES Engine)
-* **Data Plane Boundary:** `SchemaDrivenExtractionSLA` (`ontogpt_spires`)
-* **Routing Constraints:** Automatically triggered when extracting into academic biological, chemical, or legal ontologies. Uses the SPIRES framework to mathematically force the LLM to recursively map unstructured text into peer-reviewed W3C LinkML hierarchies, emitting strict `CausalDirectedEdgeState` objects with CURIE predicates.
+* **Data Plane Boundary:** `SchemaDrivenExtractionSLA` (`ontogpt_spires`) combined strictly with `LinkMLValidationSLA`.
+* **Routing Constraints:** Automatically triggered when extracting into academic biological, chemical, or legal ontologies.
+* **Bipartite Crosswalk Execution:** Processes the `OntologicalCrosswalkIntent` by routing ungrounded strings through the Ontology Access Kit (OAK), searching only the bounded `target_ontology_registries`. It emits a `CrosswalkResolutionReceipt` to cryptographically freeze the translation.
+* **Mechanistic Penalty (Graph-Shape Governance):** If the LLM generates a semantic edge violating the Domain/Range constraints declared in the `linkml_schema_uri`, this wrapper must physically sever the connection or trigger the defined `validation_failure_action`, guaranteeing absolute structural isomorphism without crashing the global DAG.
 
 ### 8.3 `EpistemicGroundingOracle` (The Verification Engine)
 * **Open-Source Substrate:** `coolgenerator/CurioCat`

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -899,6 +899,7 @@
           "latent_projection": "#/$defs/LatentProjectionIntent",
           "latent_schema_inference": "#/$defs/LatentSchemaInferenceIntent",
           "neurosymbolic_inference": "#/$defs/NeurosymbolicInferenceIntent",
+          "ontological_crosswalk": "#/$defs/OntologicalCrosswalkIntent",
           "ontology_discovery": "#/$defs/OntologyDiscoveryIntent",
           "override": "#/$defs/OverrideIntent",
           "quarantine_intent": "#/$defs/QuarantineIntent",
@@ -917,6 +918,9 @@
         "propertyName": "topology_class"
       },
       "oneOf": [
+        {
+          "$ref": "#/$defs/OntologicalCrosswalkIntent"
+        },
         {
           "$ref": "#/$defs/EpistemicZeroTrustContract"
         },
@@ -1098,6 +1102,7 @@
           "cognitive_prediction": "#/$defs/CognitivePredictionReceipt",
           "cognitive_reward_evaluation": "#/$defs/CognitiveRewardEvaluationReceipt",
           "counterfactual_regret": "#/$defs/CounterfactualRegretEvent",
+          "crosswalk_resolution": "#/$defs/CrosswalkResolutionReceipt",
           "custody_receipt": "#/$defs/CustodyReceipt",
           "defeasible_attack": "#/$defs/DefeasibleAttackEvent",
           "epistemic_axiom_verification": "#/$defs/EpistemicAxiomVerificationReceipt",
@@ -1125,6 +1130,9 @@
         "propertyName": "topology_class"
       },
       "oneOf": [
+        {
+          "$ref": "#/$defs/CrosswalkResolutionReceipt"
+        },
         {
           "$ref": "#/$defs/EpistemicZeroTrustReceipt"
         },
@@ -5496,6 +5504,86 @@
         "blending_factor"
       ],
       "title": "CrossoverPolicy",
+      "type": "object"
+    },
+    "CrosswalkResolutionReceipt": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The immutable, cryptographically frozen result of an OntoGPT semantic grounding pass.\n\nCAUSAL AFFORDANCE: Commits the successful translation of raw strings to formal CURIEs into the Epistemic Ledger, physically preserving traceability and preventing 'Traceability Collapse'.\n\nEPISTEMIC BOUNDS: The `resolved_curies` dictionary mathematically locks arbitrary strings to strict W3C CURIE regex patterns (`^[a-zA-Z0-9_]+:[a-zA-Z0-9_]+$`). The alignment certainty is captured by the `grounding_confidence` tri-vector.\n\nMCP ROUTING TRIGGERS: Epistemic Provenance, Crosswalk Resolution, Grounding Receipt, Ontology Access Kit, CURIE",
+      "properties": {
+        "event_cid": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Event Cid",
+          "type": "string"
+        },
+        "prior_event_hash": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Prior Event Hash"
+        },
+        "timestamp": {
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "topology_class": {
+          "const": "crosswalk_resolution",
+          "default": "crosswalk_resolution",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "receipt_cid": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Receipt Cid",
+          "type": "string"
+        },
+        "target_graph_cid": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Graph Cid",
+          "type": "string"
+        },
+        "resolved_curies": {
+          "additionalProperties": {
+            "pattern": "^[a-zA-Z0-9_]+:[a-zA-Z0-9_]+$",
+            "type": "string"
+          },
+          "description": "Strict dictionary mapping the original strings to formal W3C CURIEs.",
+          "propertyNames": {
+            "maxLength": 2000
+          },
+          "title": "Resolved Curies",
+          "type": "object"
+        },
+        "grounding_confidence": {
+          "$ref": "#/$defs/DempsterShaferBeliefVector",
+          "description": "Quantifies the semantic alignment and epistemic conflict of the applied crosswalk."
+        }
+      },
+      "required": [
+        "event_cid",
+        "timestamp",
+        "receipt_cid",
+        "target_graph_cid",
+        "resolved_curies",
+        "grounding_confidence"
+      ],
+      "title": "CrosswalkResolutionReceipt",
       "type": "object"
     },
     "CryptographicProvenancePolicy": {
@@ -12775,6 +12863,36 @@
       "title": "LineageWatermarkReceipt",
       "type": "object"
     },
+    "LinkMLValidationSLA": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes Graph-Shape Governance, acting as the execution contract instructing the orchestrator to validate extracted nodes and edges against an external LinkML YAML shape graph before committing them.\n\nCAUSAL AFFORDANCE: Forces the structural validation of all causal edges. Authorizes the orchestrator to mechanically sever relations that violate the predicate's declared Domain, Range, or Cardinality constraints.\n\nEPISTEMIC BOUNDS: The `linkml_schema_uri` strictly clamps the topological ruleset to a remote, verifiable YAML definition.\n\nMCP ROUTING TRIGGERS: LinkML, Graph-Shape Governance, Structural Isomorphism, SHACL, Domain and Range Enforcement",
+      "properties": {
+        "linkml_schema_uri": {
+          "description": "RFC 8785 canonicalized URI pointing to the canonical LinkML YAML definition.",
+          "format": "uri",
+          "minLength": 1,
+          "title": "Linkml Schema Uri",
+          "type": "string"
+        },
+        "strict_domain_range_checking": {
+          "default": true,
+          "description": "If True, the orchestrator physically severs any CausalDirectedEdgeState where the subject/object node classes violate the predicate's declared LinkML domain/range.",
+          "title": "Strict Domain Range Checking",
+          "type": "boolean"
+        },
+        "allow_unmapped_entities": {
+          "default": false,
+          "description": "A boolean gate dictating whether the resulting graph is permitted to retain high-entropy text nodes that OntoGPT failed to resolve into a formal CURIE.",
+          "title": "Allow Unmapped Entities",
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "linkml_schema_uri"
+      ],
+      "title": "LinkMLValidationSLA",
+      "type": "object"
+    },
     "LogitSteganographyContract": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographic mandate for neural watermarking. Uses a Pseudo-Random Function (PRF) seeded by previous token context to deterministically split the vocabulary during Gumbel-Softmax sampling.\n\nCAUSAL AFFORDANCE: Physically manipulates the LLM's residual stream logit distribution just before the final softmax activation, embedding an undeniable, high-entropy Shannon information signature directly into the generated text without degrading model perplexity.\n\nEPISTEMIC BOUNDS: Injection is mathematically clamped by `watermark_strength_delta` (`gt=0.0, le=1.0`). Resistance to cropping attacks is geometrically enforced by `context_history_window` (`ge=0, le=1000000000`). Information density is bounded by `target_bits_per_token` (`gt=0.0, le=1000000000.0`). Locked by `prf_seed_hash` (SHA-256).\n\nMCP ROUTING TRIGGERS: Logit Steganography, Gumbel-Softmax Watermarking, Pseudo-Random Function, Shannon Entropy, Provenance Tracking",
@@ -14373,6 +14491,60 @@
         "require_isometry_proof"
       ],
       "title": "OntologicalAlignmentPolicy",
+      "type": "object"
+    },
+    "OntologicalCrosswalkIntent": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A kinetic trigger instructing the orchestrator to route an array of ungrounded text entities through a grounding oracle (OntoGPT/OAK) to map them to formal ontology CURIEs.\n\nCAUSAL AFFORDANCE: Authorizes the runtime to execute Bipartite Ontological Mapping, collapsing high-entropy natural language strings into zero-entropy Semantic Web identifiers.\n\nEPISTEMIC BOUNDS: The search space is rigidly clamped by the `target_ontology_registries` array (e.g., ['MONDO', 'HP']). The `minimum_isometry_threshold` physically restricts acceptable mappings to a strictly positive cosine/BM25 similarity (`ge=0.0, le=1.0`).\n\nMCP ROUTING TRIGGERS: Bipartite Ontological Mapping, Grounding Oracle, CURIE Resolution, Isometry Thresholding, Semantic Crosswalk",
+      "properties": {
+        "topology_class": {
+          "const": "ontological_crosswalk",
+          "default": "ontological_crosswalk",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "target_graph_cid": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Target Graph Cid",
+          "type": "string"
+        },
+        "source_strings": {
+          "description": "The ungrounded natural language concepts extracted by the LLM.",
+          "items": {
+            "maxLength": 2000,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Source Strings",
+          "type": "array"
+        },
+        "target_ontology_registries": {
+          "description": "The strictly typed standard ontology namespaces to search (e.g., 'MONDO', 'CHEBI').",
+          "items": {
+            "maxLength": 255,
+            "type": "string"
+          },
+          "minItems": 1,
+          "title": "Target Ontology Registries",
+          "type": "array"
+        },
+        "minimum_isometry_threshold": {
+          "description": "The semantic distance threshold required to automatically accept a mapping.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Minimum Isometry Threshold",
+          "type": "number"
+        }
+      },
+      "required": [
+        "target_graph_cid",
+        "source_strings",
+        "target_ontology_registries",
+        "minimum_isometry_threshold"
+      ],
+      "title": "OntologicalCrosswalkIntent",
       "type": "object"
     },
     "OntologicalHandshakeReceipt": {
@@ -16461,6 +16633,18 @@
           ],
           "title": "Validation Failure Action",
           "type": "string"
+        },
+        "linkml_governance": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/LinkMLValidationSLA"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The structural shape constraints for the graph."
         }
       },
       "required": [

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -5181,6 +5181,91 @@ class EpistemicScanningPolicy(CoreasonBaseState):
     )
 
 
+class LinkMLValidationSLA(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: Establishes Graph-Shape Governance, acting as the execution contract instructing the orchestrator to validate extracted nodes and edges against an external LinkML YAML shape graph before committing them.
+
+    CAUSAL AFFORDANCE: Forces the structural validation of all causal edges. Authorizes the orchestrator to mechanically sever relations that violate the predicate's declared Domain, Range, or Cardinality constraints.
+
+    EPISTEMIC BOUNDS: The `linkml_schema_uri` strictly clamps the topological ruleset to a remote, verifiable YAML definition.
+
+    MCP ROUTING TRIGGERS: LinkML, Graph-Shape Governance, Structural Isomorphism, SHACL, Domain and Range Enforcement
+    """
+
+    linkml_schema_uri: AnyUrl = Field(
+        description="RFC 8785 canonicalized URI pointing to the canonical LinkML YAML definition."
+    )
+    strict_domain_range_checking: bool = Field(
+        default=True,
+        description="If True, the orchestrator physically severs any CausalDirectedEdgeState where the subject/object node classes violate the predicate's declared LinkML domain/range.",
+    )
+    allow_unmapped_entities: bool = Field(
+        default=False,
+        description="A boolean gate dictating whether the resulting graph is permitted to retain high-entropy text nodes that OntoGPT failed to resolve into a formal CURIE.",
+    )
+
+
+class OntologicalCrosswalkIntent(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A kinetic trigger instructing the orchestrator to route an array of ungrounded text entities through a grounding oracle (OntoGPT/OAK) to map them to formal ontology CURIEs.
+
+    CAUSAL AFFORDANCE: Authorizes the runtime to execute Bipartite Ontological Mapping, collapsing high-entropy natural language strings into zero-entropy Semantic Web identifiers.
+
+    EPISTEMIC BOUNDS: The search space is rigidly clamped by the `target_ontology_registries` array (e.g., ['MONDO', 'HP']). The `minimum_isometry_threshold` physically restricts acceptable mappings to a strictly positive cosine/BM25 similarity (`ge=0.0, le=1.0`).
+
+    MCP ROUTING TRIGGERS: Bipartite Ontological Mapping, Grounding Oracle, CURIE Resolution, Isometry Thresholding, Semantic Crosswalk
+    """
+
+    topology_class: Literal["ontological_crosswalk"] = "ontological_crosswalk"
+    target_graph_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    source_strings: list[Annotated[str, StringConstraints(max_length=2000)]] = Field(
+        min_length=1, description="The ungrounded natural language concepts extracted by the LLM."
+    )
+    target_ontology_registries: list[Annotated[str, StringConstraints(max_length=255)]] = Field(
+        min_length=1, description="The strictly typed standard ontology namespaces to search (e.g., 'MONDO', 'CHEBI')."
+    )
+    minimum_isometry_threshold: float = Field(
+        ge=0.0, le=1.0, description="The semantic distance threshold required to automatically accept a mapping."
+    )
+
+    @model_validator(mode="after")
+    def _enforce_canonical_sort(self) -> Self:
+        object.__setattr__(self, "source_strings", sorted(self.source_strings))
+        object.__setattr__(self, "target_ontology_registries", sorted(self.target_ontology_registries))
+        return self
+
+
+class CrosswalkResolutionReceipt(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: The immutable, cryptographically frozen result of an OntoGPT semantic grounding pass.
+
+    CAUSAL AFFORDANCE: Commits the successful translation of raw strings to formal CURIEs into the Epistemic Ledger, physically preserving traceability and preventing 'Traceability Collapse'.
+
+    EPISTEMIC BOUNDS: The `resolved_curies` dictionary mathematically locks arbitrary strings to strict W3C CURIE regex patterns (`^[a-zA-Z0-9_]+:[a-zA-Z0-9_]+$`). The alignment certainty is captured by the `grounding_confidence` tri-vector.
+
+    MCP ROUTING TRIGGERS: Epistemic Provenance, Crosswalk Resolution, Grounding Receipt, Ontology Access Kit, CURIE
+    """
+
+    event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        ...
+    )
+    prior_event_hash: (
+        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
+    ) = Field(default=None)
+    timestamp: float = Field(ge=0.0, le=253402300799.0)
+
+    topology_class: Literal["crosswalk_resolution"] = "crosswalk_resolution"
+    receipt_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    target_graph_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
+    resolved_curies: dict[
+        Annotated[str, StringConstraints(max_length=2000)],
+        Annotated[str, StringConstraints(pattern=r"^[a-zA-Z0-9_]+:[a-zA-Z0-9_]+$")],
+    ] = Field(description="Strict dictionary mapping the original strings to formal W3C CURIEs.")
+    grounding_confidence: DempsterShaferBeliefVector = Field(
+        description="Quantifies the semantic alignment and epistemic conflict of the applied crosswalk."
+    )
+
+
 class SchemaDrivenExtractionSLA(CoreasonBaseState):
     schema_registry_uri: AnyUrl = Field(
         description="RFC 8785 canonicalized URI to the exact Pydantic template or LinkML definition."
@@ -5188,6 +5273,17 @@ class SchemaDrivenExtractionSLA(CoreasonBaseState):
     extraction_framework: Literal["docling_graph_explicit", "ontogpt_spires"] = Field(...)
     max_schema_retries: int = Field(ge=0, le=10)
     validation_failure_action: Literal["quarantine_chunk", "escalate_to_human", "drop_edge"]
+    linkml_governance: LinkMLValidationSLA | None = Field(
+        default=None, description="The structural shape constraints for the graph."
+    )
+
+    @model_validator(mode="after")
+    def enforce_linkml_for_ontogpt(self) -> Self:
+        if self.extraction_framework == "ontogpt_spires" and self.linkml_governance is None:
+            raise ValueError(
+                "Epistemic Violation: Using the 'ontogpt_spires' framework mathematically requires a LinkMLValidationSLA to govern shape constraints."
+            )
+        return self
 
 
 class EvidentiaryGroundingSLA(CoreasonBaseState):
@@ -6949,7 +7045,8 @@ class SubstrateHydrationManifest(CoreasonBaseState):
 
 
 type AnyIntent = Annotated[
-    EpistemicZeroTrustContract
+    OntologicalCrosswalkIntent
+    | EpistemicZeroTrustContract
     | SemanticIntent
     | DraftingIntent
     | AdjudicationIntent
@@ -14009,7 +14106,8 @@ class EpistemicZeroTrustReceipt(CoreasonBaseState):
 
 
 type AnyStateEvent = Annotated[
-    EpistemicZeroTrustReceipt
+    CrosswalkResolutionReceipt
+    | EpistemicZeroTrustReceipt
     | ObservationEvent
     | BeliefMutationEvent
     | SystemFaultEvent
@@ -14511,3 +14609,7 @@ EpistemicZeroTrustReceipt.model_rebuild()
 
 ExecutionSubstrateProfile.model_rebuild()
 SubstrateHydrationManifest.model_rebuild()
+
+LinkMLValidationSLA.model_rebuild()
+OntologicalCrosswalkIntent.model_rebuild()
+CrosswalkResolutionReceipt.model_rebuild()

--- a/tests/test_epic_3_schemas.py
+++ b/tests/test_epic_3_schemas.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2026 CoReason, Inc
+#
+# This software is proprietary and dual-licensed
+# Licensed under the Prosperity Public License 3.0 (the "License")
+# A copy of the license is available at <https://prosperitylicense.com/versions/3.0.0>
+# For details, see the LICENSE file
+# Commercial use beyond a 30-day trial requires a separate license
+#
+# Source Code: <https://github.com/CoReason-AI/coreason-manifest>
+
+import pytest
+from pydantic import AnyUrl, TypeAdapter
+
+from coreason_manifest.spec.ontology import (
+    LinkMLValidationSLA,
+    OntologicalCrosswalkIntent,
+    SchemaDrivenExtractionSLA,
+)
+
+url_adapter = TypeAdapter(AnyUrl)
+
+
+def test_ontological_crosswalk_intent_sorting() -> None:
+    intent = OntologicalCrosswalkIntent(
+        target_graph_cid="bafybeigdyrzt5sfp7udm7hu76uh7y26nf3efuylqabf3oclgtqy55fbzdi",
+        source_strings=["zebra", "apple", "banana"],
+        target_ontology_registries=["HP", "CHEBI", "MONDO"],
+        minimum_isometry_threshold=0.8,
+    )
+    assert intent.source_strings == ["apple", "banana", "zebra"]
+    assert intent.target_ontology_registries == ["CHEBI", "HP", "MONDO"]
+
+
+def test_schema_driven_extraction_sla_validation() -> None:
+    with pytest.raises(ValueError, match="Epistemic Violation"):
+        SchemaDrivenExtractionSLA(
+            schema_registry_uri=url_adapter.validate_python("https://example.com/schema"),
+            extraction_framework="ontogpt_spires",
+            max_schema_retries=3,
+            validation_failure_action="drop_edge",
+            linkml_governance=None,
+        )
+
+    # Should pass
+    sla = SchemaDrivenExtractionSLA(
+        schema_registry_uri=url_adapter.validate_python("https://example.com/schema"),
+        extraction_framework="ontogpt_spires",
+        max_schema_retries=3,
+        validation_failure_action="drop_edge",
+        linkml_governance=LinkMLValidationSLA(
+            linkml_schema_uri=url_adapter.validate_python("https://example.com/linkml")
+        ),
+    )
+    assert sla.linkml_governance is not None


### PR DESCRIPTION
**Epic:** Epic 3 - The Semantic Web & LinkML Boundary (OntoGPT)

### **Abstract**
This commit extends the declarative state space of the `coreason-manifest` to natively support Semantic Web grounding and structural graph isomorphism. By formalizing the execution boundaries for the Monarch Initiative's OntoGPT and Ontology Access Kit (OAK), this refactor mathematically guarantees that dynamically generated knowledge graphs conform to rigid domain and range constraints (via LinkML/SHACL). Furthermore, it establishes the cryptographic envelopes required to execute bipartite ontological mapping, ensuring that high-entropy natural language strings are deterministically resolved into standardized Compact URIs (CURIEs) without sacrificing epistemic provenance.

---

### **1. Semantic Shape Governance (`LinkMLValidationSLA`)**
*Objective: Enforce structural isomorphism across generated knowledge graphs by physically validating causal edges against formal ontology shapes.*

* **Implementation:** Introduced the `LinkMLValidationSLA` to act as the declarative execution contract for graph-shape governance. This schema provides the orchestrator with the explicit `linkml_schema_uri` and strict boolean gates (`strict_domain_range_checking`, `allow_unmapped_entities`) required to mathematically validate extracted nodes and relations.
* **Extraction Interlock:** Injected `linkml_governance` directly into the `SchemaDrivenExtractionSLA`. Implemented the `enforce_linkml_for_ontogpt` validator to create a strict hardware-level interlock: the orchestrator is now mechanically forbidden from deploying the `ontogpt_spires` extraction framework unless it is explicitly bound to a formal LinkML shape contract.

### **2. Bipartite Ontological Mapping (`OntologicalCrosswalkIntent`)**
*Objective: Systematically resolve raw, context-dependent text entities into zero-entropy W3C standard identifiers while preventing unbounded latent space searches.*

* **Crosswalk Intent:** Defined the `OntologicalCrosswalkIntent` to trigger the translation of ungrounded concepts (`source_strings`). The search space is rigidly clamped to predefined vocabularies via the `target_ontology_registries` array, and validation is gated by a continuous `minimum_isometry_threshold` to mathematically reject low-confidence semantic matches.
* **Cryptographic Provenance:** Established the `CrosswalkResolutionReceipt` as an immutable coordinate on the Merkle-DAG. This receipt safely records the `resolved_curies` dictionary alongside the chronological ledger attributes (`event_cid`, `prior_event_hash`, `timestamp`). This physically prevents traceability collapse by permanently linking the origin string to its formal identifier, utilizing the `grounding_confidence` (`DempsterShaferBeliefVector`) to quantify semantic alignment.
* **Canonical Hashing:** Applied deterministic sorting logic via `@model_validator` hooks across array properties (such as sorting `source_strings` and `target_ontology_registries`) to guarantee zero-variance RFC 8785 canonical representation.

### **3. Topological Registration & Reachability**
*Objective: Ensure the global execution graph can mathematically navigate and instantiate the newly defined Semantic Web boundaries.*

* **Union Integration:** Appended `OntologicalCrosswalkIntent` to the `AnyIntent` discriminated union and `CrosswalkResolutionReceipt` to the `AnyStateEvent` union.
* **Registry Finalization:** Executed the requisite `.model_rebuild()` functions at the module boundary to resolve forward references and satisfy the Zero-Orphan Invariant, ensuring complete topological reachability for the orchestration engine.

### **4. Fleet Taxonomy Expansion (`AGENTS.md`)**
*Objective: Formally declare the routing taxonomy and operational constraints for Semantic Web execution nodes.*

* **Taxonomy Update:** Completely refactored Section 8.2 to define the `OntologicalGroundingSpecialist`. The taxonomy now explicitly documents the node's reliance on the Ontology Access Kit (OAK) for bipartite mapping.
* **Execution Directives:** Formalized the mechanistic penalty for edge violation: if a connectionist agent generates a semantic edge that violates the Domain/Range constraints declared in the LinkML schema, the specialist node is authorized to physically sever the connection without crashing the global directed acyclic graph (DAG).

### **5. Continuous Integration & Code Coverage Baseline**
*Objective: Maintain structural integrity, formatting standards, and universal JSON schema synchronization.*

* **Schema Regeneration:** Executed `scripts/universal_ontology_compiler.py project_ontology_manifold` to regenerate `coreason_ontology.schema.json`, ensuring downstream parsers have immediate access to the expanded schema boundaries.
* **AST Formatting:** Executed `ruff format` and `ruff check --fix` across the Python source files (including `tests/test_epic_3_schemas.py`) to resolve abstract syntax tree (AST) compilation faults and unsorted import violations.
* **Test Factory Remediation:** Implemented targeted unit testing (`test_epic_3_schemas.py`) and updated legacy extraction tests to cleanly instantiate the new `LinkMLValidationSLA` properties, successfully preserving the >95% statement coverage floor required by the CI/CD pipeline.


---
commit notes
---

* feat: Implement Semantic Web & LinkML Boundary for Epic 3

- Added `LinkMLValidationSLA` and integrated it with `SchemaDrivenExtractionSLA` to govern Domain/Range rules.
- Added `OntologicalCrosswalkIntent` and `CrosswalkResolutionReceipt` to track bipartite grounding mapping via OntoGPT/OAK.
- Injected `AnyIntent` and `AnyStateEvent` type unions with new schemas and provided `model_rebuild()` calls.
- Updated `AGENTS.md` to reflect `OntologicalGroundingSpecialist` operational constraints.
- Removed throw-away scripts and included relevant testing checks matching coverage thresholds.

* fix: Format python code and regenerate json schema

The CI failed due to two reasons:
1. `coreason_ontology.schema.json` was out of date because new schemas were added but the JSON wasn't regenerated.
2. `ruff check .` failed on `tests/test_epic_3_schemas.py` due to unsorted/unformatted imports.

This commit regenerates the schema by running the script and formats the python tests file.

* fix: format python code