### PR TITLE
Epic 4: Evidentiary Citation & Epistemic Starvation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -459,7 +459,8 @@ We physically separate probabilistic textual generation (System 1) from schema v
 * **Compute Plane Profile:** `CognitiveSystemNodeProfile` (Sandboxed NLI & Web Search)
 * **Data Plane Boundary:** `CausalPropagationIntent` / `EvidentiaryGroundingSLA`
 * **Routing Constraints (The Golden Rule):** Standard LLMs are mathematically forbidden from assigning their own `DempsterShaferBeliefVector` weights due to the "Blind Causal Inference" anomaly (confusing correlation with causation). Any newly generated edge lacking empirical evidence MUST be routed through this Oracle.
-* **Mechanistic Penalty:** If CurioCat fails to find external Natural Language Inference (NLI) entailment backing the proposed edge, it mathematically drops the belief mass to zero and emits a `DefeasibleCascadeEvent` to aggressively quarantine the epistemic contagion.
+* **Evidentiary Output:** The CurioCat substrate is mathematically required to output its findings as discrete `EvidentiaryCitationState` objects, injecting them directly into the `supporting_citations` array of the target edge's belief vector.
+* **Mechanistic Penalty (Epistemic Starvation):** If the oracle fails to retrieve external evidence that breaches the SLA's NLI entailment threshold, it must mathematically drop the edge's belief mass to zero by emitting an `EpistemicStarvationEvent`. This definitively records the empirical failure and sequentially triggers a `DefeasibleCascadeEvent` to dynamically sever the ungrounded edge and aggressively quarantine the epistemic contagion across the DAG.
 
 ### 8.4 `SemanticWebArchivist` (The Egress Gateway)
 * **Open-Source Substrate:** `omegaice/pydantic-rdf` & `rdflib`

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -1122,6 +1122,7 @@
           "epistemic_log": "#/$defs/EpistemicLogEvent",
           "epistemic_promotion": "#/$defs/EpistemicPromotionEvent",
           "epistemic_rejection": "#/$defs/EpistemicRejectionReceipt",
+          "epistemic_starvation": "#/$defs/EpistemicStarvationEvent",
           "epistemic_telemetry": "#/$defs/EpistemicTelemetryEvent",
           "exogenous_event": "#/$defs/ExogenousEpistemicEvent",
           "formal_logic_proof": "#/$defs/FormalLogicProofReceipt",
@@ -1261,6 +1262,9 @@
         },
         {
           "$ref": "#/$defs/RDFExportReceipt"
+        },
+        {
+          "$ref": "#/$defs/EpistemicStarvationEvent"
         }
       ]
     },
@@ -6295,6 +6299,15 @@
           "minimum": 0.0,
           "title": "Epistemic Conflict Mass",
           "type": "number"
+        },
+        "supporting_citations": {
+          "description": "The array of external NLI-scored citations aggregating to form this belief mass.",
+          "items": {
+            "$ref": "#/$defs/EvidentiaryCitationState"
+          },
+          "maxItems": 100,
+          "title": "Supporting Citations",
+          "type": "array"
         }
       },
       "required": [
@@ -8931,6 +8944,77 @@
       "title": "EpistemicSeedInjectionPolicy",
       "type": "object"
     },
+    "EpistemicStarvationEvent": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An append-only historical coordinate recording the definitive failure of empirical validation.\n\nCAUSAL AFFORDANCE: Acts as the kinetic trigger for non-monotonic Truth Maintenance. By dropping belief mass to zero, it forces the orchestrator to emit a DefeasibleCascadeEvent to prune the ungrounded edge from the graph.\n\nEPISTEMIC BOUNDS: The `failed_citations` array mathematically proves that an exhaustive search was attempted but no retrieved snippet breached the required SLA threshold. The array is deterministically sorted for invariant hashing.\n\nMCP ROUTING TRIGGERS: Epistemic Starvation, Natural Language Inference, Truth Maintenance System, Defeasible Logic, Belief Mass Depletion",
+      "properties": {
+        "event_cid": {
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Event Cid",
+          "type": "string"
+        },
+        "prior_event_hash": {
+          "anyOf": [
+            {
+              "maxLength": 128,
+              "minLength": 1,
+              "pattern": "^[a-f0-9]{64}$",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Prior Event Hash"
+        },
+        "timestamp": {
+          "maximum": 253402300799.0,
+          "minimum": 0.0,
+          "title": "Timestamp",
+          "type": "number"
+        },
+        "topology_class": {
+          "const": "epistemic_starvation",
+          "default": "epistemic_starvation",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "starved_edge_cid": {
+          "description": "The cryptographic pointer to the specific edge that failed empirical grounding.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Starved Edge Cid",
+          "type": "string"
+        },
+        "failed_citations": {
+          "description": "The array of citations evaluated that fell below the required NLI threshold.",
+          "items": {
+            "$ref": "#/$defs/EvidentiaryCitationState"
+          },
+          "title": "Failed Citations",
+          "type": "array"
+        },
+        "diagnostic_reason": {
+          "description": "The semantic explanation for the starvation (e.g., 'Maximum search retries exhausted').",
+          "maxLength": 2000,
+          "title": "Diagnostic Reason",
+          "type": "string"
+        }
+      },
+      "required": [
+        "event_cid",
+        "timestamp",
+        "starved_edge_cid",
+        "failed_citations",
+        "diagnostic_reason"
+      ],
+      "title": "EpistemicStarvationEvent",
+      "type": "object"
+    },
     "EpistemicTelemetryEvent": {
       "additionalProperties": false,
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Human-in-the-Loop (HITL) Supervisory Control Theory and Epistemic Regret tracking to measure out-of-band human physical attention kinematics.\n\nCAUSAL AFFORDANCE: Emits passive structural telemetry to update retrieval gradients and Bayesian priors based on human spatial interaction, without halting the underlying execution DAG.\n\nEPISTEMIC BOUNDS: The human interaction is rigidly confined to the `interaction_modality` Literal automaton. Temporal liveness of attention is bounded by `dwell_duration_ms` (`ge=0, le=86400000`). Target is locked to `target_node_cid` CID.\n\nMCP ROUTING TRIGGERS: Epistemic Regret, Supervisory Control Theory, Human-in-the-Loop, Dwell Time, Spatial Telemetry",
@@ -9633,6 +9717,64 @@
         "max_retained_tokens"
       ],
       "title": "EvictionPolicy",
+      "type": "object"
+    },
+    "EvidentiaryCitationState": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A declarative coordinate representing an immutable, localized snippet of external evidence retrieved by an oracle, coupled with its calculated Natural Language Inference (NLI) score.\n\nCAUSAL AFFORDANCE: Physically anchors an abductive hypothesis to empirical reality, providing the exact string evaluated by the NLI cross-encoder to prevent source drift.\n\nEPISTEMIC BOUNDS: Network resolution is strictly gated by the `_enforce_ssrf_quarantine` hook to prevent Bogon/loopback execution. The textual premise is volumetrically clamped by `extracted_snippet` (`max_length=10000`). Entailment probability is bounded `[0.0, 1.0]`.\n\nMCP ROUTING TRIGGERS: Retrieval-Augmented Fact-Checking, Natural Language Inference, SSRF Quarantine, Evidentiary Coordinate, Cross-Encoder Validation",
+      "properties": {
+        "citation_cid": {
+          "description": "Cryptographic anchor for the specific piece of evidence.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Citation Cid",
+          "type": "string"
+        },
+        "source_url": {
+          "description": "The canonical origin of the evidence.",
+          "format": "uri",
+          "maxLength": 2083,
+          "minLength": 1,
+          "title": "Source Url",
+          "type": "string"
+        },
+        "extracted_snippet": {
+          "description": "The exact text evaluated by the NLI model.",
+          "maxLength": 10000,
+          "title": "Extracted Snippet",
+          "type": "string"
+        },
+        "nli_entailment_score": {
+          "description": "The conditional probability that the snippet entails the proposed causal edge.",
+          "maximum": 1.0,
+          "minimum": 0.0,
+          "title": "Nli Entailment Score",
+          "type": "number"
+        },
+        "publication_timestamp": {
+          "anyOf": [
+            {
+              "maximum": 253402300799.0,
+              "minimum": 0.0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Optional temporal boundary allowing downstream algorithms to apply temporal discounting.",
+          "title": "Publication Timestamp"
+        }
+      },
+      "required": [
+        "citation_cid",
+        "source_url",
+        "extracted_snippet",
+        "nli_entailment_score"
+      ],
+      "title": "EvidentiaryCitationState",
       "type": "object"
     },
     "EvidentiaryGroundingSLA": {

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -14250,9 +14250,48 @@ type AnyStateEvent = Annotated[
     | FormalLogicProofReceipt
     | PrologDeductionReceipt
     | BeliefModulationReceipt
-    | RDFExportReceipt,
+    | RDFExportReceipt
+    | EpistemicStarvationEvent,
     Field(discriminator="topology_class", description="A discriminated union of state events."),
 ]
+
+
+class EvidentiaryCitationState(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: A declarative coordinate representing an immutable, localized snippet of external evidence retrieved by an oracle, coupled with its calculated Natural Language Inference (NLI) score.
+
+    CAUSAL AFFORDANCE: Physically anchors an abductive hypothesis to empirical reality, providing the exact string evaluated by the NLI cross-encoder to prevent source drift.
+
+    EPISTEMIC BOUNDS: Network resolution is strictly gated by the `_enforce_ssrf_quarantine` hook to prevent Bogon/loopback execution. The textual premise is volumetrically clamped by `extracted_snippet` (`max_length=10000`). Entailment probability is bounded `[0.0, 1.0]`.
+
+    MCP ROUTING TRIGGERS: Retrieval-Augmented Fact-Checking, Natural Language Inference, SSRF Quarantine, Evidentiary Coordinate, Cross-Encoder Validation
+    """
+
+    citation_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        description="Cryptographic anchor for the specific piece of evidence."
+    )
+    source_url: HttpUrl = Field(description="The canonical origin of the evidence.")
+    extracted_snippet: Annotated[str, StringConstraints(max_length=10000)] = Field(
+        description="The exact text evaluated by the NLI model."
+    )
+    nli_entailment_score: float = Field(
+        ge=0.0, le=1.0, description="The conditional probability that the snippet entails the proposed causal edge."
+    )
+    publication_timestamp: float | None = Field(
+        default=None,
+        ge=0.0,
+        le=253402300799.0,
+        description="Optional temporal boundary allowing downstream algorithms to apply temporal discounting.",
+    )
+
+    @field_validator("source_url", mode="after")
+    @classmethod
+    def _enforce_ssrf_quarantine(cls, url: HttpUrl) -> HttpUrl:
+        """
+        AGENT INSTRUCTION: Implements Network Topology and Server-Side Request Forgery (SSRF) Quarantine logic.
+        """
+        _validate_ssrf_safety(str(url))
+        return url
 
 
 class DempsterShaferBeliefVector(CoreasonBaseState):
@@ -14284,6 +14323,56 @@ class DempsterShaferBeliefVector(CoreasonBaseState):
         le=1.0,
         description="The calculated mathematical contradiction or dissonance between the three vectors. High conflict mass triggers evidence discounting.",
     )
+    supporting_citations: list[EvidentiaryCitationState] = Field(
+        default_factory=list,
+        max_length=100,
+        description="The array of external NLI-scored citations aggregating to form this belief mass.",
+    )
+
+    @model_validator(mode="after")
+    def _enforce_canonical_sort_citations(self) -> Self:
+        object.__setattr__(
+            self, "supporting_citations", sorted(self.supporting_citations, key=operator.attrgetter("citation_cid"))
+        )
+        return self
+
+
+class EpistemicStarvationEvent(CoreasonBaseState):
+    """
+    AGENT INSTRUCTION: An append-only historical coordinate recording the definitive failure of empirical validation.
+
+    CAUSAL AFFORDANCE: Acts as the kinetic trigger for non-monotonic Truth Maintenance. By dropping belief mass to zero, it forces the orchestrator to emit a DefeasibleCascadeEvent to prune the ungrounded edge from the graph.
+
+    EPISTEMIC BOUNDS: The `failed_citations` array mathematically proves that an exhaustive search was attempted but no retrieved snippet breached the required SLA threshold. The array is deterministically sorted for invariant hashing.
+
+    MCP ROUTING TRIGGERS: Epistemic Starvation, Natural Language Inference, Truth Maintenance System, Defeasible Logic, Belief Mass Depletion
+    """
+
+    event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
+        ...
+    )
+    prior_event_hash: (
+        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
+    ) = Field(default=None)
+    timestamp: float = Field(ge=0.0, le=253402300799.0)
+
+    topology_class: Literal["epistemic_starvation"] = "epistemic_starvation"
+    starved_edge_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = (
+        Field(description="The cryptographic pointer to the specific edge that failed empirical grounding.")
+    )
+    failed_citations: list[EvidentiaryCitationState] = Field(
+        description="The array of citations evaluated that fell below the required NLI threshold."
+    )
+    diagnostic_reason: Annotated[str, StringConstraints(max_length=2000)] = Field(
+        description="The semantic explanation for the starvation (e.g., 'Maximum search retries exhausted')."
+    )
+
+    @model_validator(mode="after")
+    def _enforce_canonical_sort_failed_citations(self) -> Self:
+        object.__setattr__(
+            self, "failed_citations", sorted(self.failed_citations, key=operator.attrgetter("citation_cid"))
+        )
+        return self
 
 
 class OntologicalReificationReceipt(CoreasonBaseState):
@@ -14729,3 +14818,6 @@ SubstrateHydrationManifest.model_rebuild()
 LinkMLValidationSLA.model_rebuild()
 OntologicalCrosswalkIntent.model_rebuild()
 CrosswalkResolutionReceipt.model_rebuild()
+
+EvidentiaryCitationState.model_rebuild()
+EpistemicStarvationEvent.model_rebuild()

--- a/tests/test_evidentiary_grounding.py
+++ b/tests/test_evidentiary_grounding.py
@@ -16,6 +16,7 @@ from coreason_manifest.spec.ontology import EvidentiaryCitationState
 def test_evidentiary_citation_state_ssrf_quarantine() -> None:
     # Test that instantiating EvidentiaryCitationState with a Bogon IP raises a validation error
     from pydantic import HttpUrl, TypeAdapter
+
     url_adapter = TypeAdapter(HttpUrl)
     with pytest.raises(ValueError, match="SSRF restricted IP detected"):
         EvidentiaryCitationState(

--- a/tests/test_evidentiary_grounding.py
+++ b/tests/test_evidentiary_grounding.py
@@ -25,3 +25,74 @@ def test_evidentiary_citation_state_ssrf_quarantine() -> None:
             extracted_snippet="Some test snippet.",
             nli_entailment_score=0.9,
         )
+
+
+def test_evidentiary_citation_state_valid() -> None:
+    from pydantic import HttpUrl, TypeAdapter
+
+    url_adapter = TypeAdapter(HttpUrl)
+    state = EvidentiaryCitationState(
+        citation_cid="test_cid_123",
+        source_url=url_adapter.validate_python("http://example.com"),
+        extracted_snippet="Some test snippet.",
+        nli_entailment_score=0.9,
+    )
+    assert state.source_url == url_adapter.validate_python("http://example.com")
+
+
+def test_dempster_shafer_belief_vector_sorting() -> None:
+    from pydantic import HttpUrl, TypeAdapter
+
+    from coreason_manifest.spec.ontology import DempsterShaferBeliefVector
+
+    url_adapter = TypeAdapter(HttpUrl)
+    c1 = EvidentiaryCitationState(
+        citation_cid="b_cid",
+        source_url=url_adapter.validate_python("http://example.com"),
+        extracted_snippet="Some test snippet.",
+        nli_entailment_score=0.9,
+    )
+    c2 = EvidentiaryCitationState(
+        citation_cid="a_cid",
+        source_url=url_adapter.validate_python("http://example.com"),
+        extracted_snippet="Some test snippet.",
+        nli_entailment_score=0.8,
+    )
+    vector = DempsterShaferBeliefVector(
+        lexical_confidence=0.5,
+        semantic_distance=0.5,
+        structural_graph_confidence=0.5,
+        epistemic_conflict_mass=0.5,
+        supporting_citations=[c1, c2],
+    )
+    assert vector.supporting_citations[0].citation_cid == "a_cid"
+    assert vector.supporting_citations[1].citation_cid == "b_cid"
+
+
+def test_epistemic_starvation_event_sorting() -> None:
+    from pydantic import HttpUrl, TypeAdapter
+
+    from coreason_manifest.spec.ontology import EpistemicStarvationEvent
+
+    url_adapter = TypeAdapter(HttpUrl)
+    c1 = EvidentiaryCitationState(
+        citation_cid="b_cid",
+        source_url=url_adapter.validate_python("http://example.com"),
+        extracted_snippet="Some test snippet.",
+        nli_entailment_score=0.9,
+    )
+    c2 = EvidentiaryCitationState(
+        citation_cid="a_cid",
+        source_url=url_adapter.validate_python("http://example.com"),
+        extracted_snippet="Some test snippet.",
+        nli_entailment_score=0.8,
+    )
+    event = EpistemicStarvationEvent(
+        event_cid="test_event_123",
+        timestamp=0.0,
+        starved_edge_cid="test_edge_123",
+        failed_citations=[c1, c2],
+        diagnostic_reason="Exhausted retries",
+    )
+    assert event.failed_citations[0].citation_cid == "a_cid"
+    assert event.failed_citations[1].citation_cid == "b_cid"

--- a/tests/test_evidentiary_grounding.py
+++ b/tests/test_evidentiary_grounding.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2026 CoReason, Inc
+#
+# This software is proprietary and dual-licensed
+# Licensed under the Prosperity Public License 3.0 (the "License")
+# A copy of the license is available at <https://prosperitylicense.com/versions/3.0.0>
+# For details, see the LICENSE file
+# Commercial use beyond a 30-day trial requires a separate license
+#
+# Source Code: <https://github.com/CoReason-AI/coreason-manifest>
+
+import pytest
+
+from coreason_manifest.spec.ontology import EvidentiaryCitationState
+
+
+def test_evidentiary_citation_state_ssrf_quarantine() -> None:
+    # Test that instantiating EvidentiaryCitationState with a Bogon IP raises a validation error
+    from pydantic import TypeAdapter, HttpUrl
+    url_adapter = TypeAdapter(HttpUrl)
+    with pytest.raises(ValueError, match="SSRF restricted IP detected"):
+        EvidentiaryCitationState(
+            citation_cid="test_cid_123",
+            source_url=url_adapter.validate_python("http://127.0.0.1"),
+            extracted_snippet="Some test snippet.",
+            nli_entailment_score=0.9,
+        )

--- a/tests/test_evidentiary_grounding.py
+++ b/tests/test_evidentiary_grounding.py
@@ -15,7 +15,7 @@ from coreason_manifest.spec.ontology import EvidentiaryCitationState
 
 def test_evidentiary_citation_state_ssrf_quarantine() -> None:
     # Test that instantiating EvidentiaryCitationState with a Bogon IP raises a validation error
-    from pydantic import TypeAdapter, HttpUrl
+    from pydantic import HttpUrl, TypeAdapter
     url_adapter = TypeAdapter(HttpUrl)
     with pytest.raises(ValueError, match="SSRF restricted IP detected"):
         EvidentiaryCitationState(


### PR DESCRIPTION
Epic 4: The Evidentiary Citation & NLI Boundary (Manifest V2.0).

Expanded the data plane to support Retrieval-Augmented Fact-Checking, Natural Language Inference (NLI) scoring, and Dempster-Shafer evidence aggregation using the CurioCat engine. Implemented citation schemas and the Epistemic Starvation circuit breaker within `src/coreason_manifest/spec/ontology.py`, updated the routing taxonomy in `AGENTS.md`, and added testing.

---
*PR created automatically by Jules for task [8614753660912378692](https://jules.google.com/task/8614753660912378692) started by @gowthamrao*