### PR TITLE
Epic 3: Contract Re-Alignment and Verification Integration

### DIFF
--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -895,6 +895,7 @@
           "epistemic_prolog_premise": "#/$defs/EpistemicPrologPremise",
           "escalation": "#/$defs/EscalationIntent",
           "fallback_intent": "#/$defs/FallbackIntent",
+          "falsification_contract": "#/$defs/FalsificationContract",
           "forced_adjudication": "#/$defs/AdjudicationIntent",
           "fyi": "#/$defs/FYIIntent",
           "human_directive": "#/$defs/HumanDirectiveIntent",
@@ -922,6 +923,9 @@
       "oneOf": [
         {
           "$ref": "#/$defs/EpistemicZeroTrustContract"
+        },
+        {
+          "$ref": "#/$defs/FalsificationContract"
         },
         {
           "$ref": "#/$defs/SemanticIntent"
@@ -7563,6 +7567,18 @@
           "default": null,
           "description": "The undeniable pointer proving the source prediction traversed the Zero-Trust contract before being verified as an axiom.",
           "title": "Zero Trust Receipt Cid"
+        },
+        "formal_backing_receipt_cid": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeCIDState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Cryptographic pointer to the deterministic Triad execution receipt (Proof-Carrying Data)."
         }
       },
       "required": [
@@ -9581,6 +9597,18 @@
           },
           "title": "Allowed Evidence Domains",
           "type": "array"
+        },
+        "required_deduction_receipt_cid": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeCIDState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "If grounding via strict hierarchies (e.g., medical ontologies), this MUST point to a PrologDeductionReceipt with truth_value=True."
         }
       },
       "required": [
@@ -10279,47 +10307,43 @@
     },
     "FalsificationContract": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces strict Popperian Falsificationism by defining the exact empirical boundary conditions that would logically invalidate a non-monotonic causal hypothesis.\n\nCAUSAL AFFORDANCE: Provides the deterministic pattern-matching criteria (`falsifying_observation_signature`) that triggers a DefeasibleCascadeEvent, instantly quarantining the collapsed subgraph if met.\n\nEPISTEMIC BOUNDS: Limits the falsification logic to a strictly typed `condition_cid` (`max_length=128`) and physically binds the empirical test to an explicit `required_tool_name` (`max_length=2000`) to prevent unbounded or hallucinated search spaces.\n\nMCP ROUTING TRIGGERS: Popperian Falsification, Null Hypothesis, Defeasible Logic, Empirical Falsifiability, Structural Boundary",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A contract deploying constraint oracles to hunt for counter-models to falsify a hypothesis.",
       "properties": {
-        "condition_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this falsification test to the Merkle-DAG.",
-          "maxLength": 128,
-          "minLength": 1,
-          "pattern": "^[a-zA-Z0-9_.:-]+$",
-          "title": "Condition Cid",
+        "topology_class": {
+          "const": "falsification_contract",
+          "default": "falsification_contract",
+          "title": "Topology Class",
           "type": "string"
         },
-        "description": {
-          "description": "Semantic description of what observation would prove the parent hypothesis is false.",
-          "maxLength": 2000,
-          "title": "Description",
+        "falsification_solver": {
+          "default": "clingo",
+          "description": "The constraint oracle tasked with finding a counter-model.",
+          "enum": [
+            "clingo",
+            "z3"
+          ],
+          "title": "Falsification Solver",
           "type": "string"
         },
-        "required_tool_name": {
+        "target_hypothesis_cid": {
+          "$ref": "#/$defs/NodeCIDState",
+          "description": "Pointer to the hypothesis claim being challenged."
+        },
+        "counter_model_receipt_cid": {
           "anyOf": [
             {
-              "maxLength": 2000,
-              "type": "string"
+              "$ref": "#/$defs/NodeCIDState"
             },
             {
               "type": "null"
             }
           ],
           "default": null,
-          "description": "The specific CognitiveActionSpaceManifest tool required to test this condition (e.g., 'sql_query_db').",
-          "title": "Required Tool Name"
-        },
-        "falsifying_observation_signature": {
-          "description": "The expected data schema or regex pattern that, if returned by the tool, kills the hypothesis.",
-          "maxLength": 2000,
-          "title": "Falsifying Observation Signature",
-          "type": "string"
+          "description": "MUST point to a FormalLogicProofReceipt evaluating to SATISFIABLE to collapse the hypothesis."
         }
       },
       "required": [
-        "condition_cid",
-        "description",
-        "falsifying_observation_signature"
+        "target_hypothesis_cid"
       ],
       "title": "FalsificationContract",
       "type": "object"
@@ -10732,6 +10756,18 @@
           "pattern": "^[a-f0-9]{64}$",
           "title": "Compiled Proof Hash",
           "type": "string"
+        },
+        "verified_receipt_cid": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/NodeCIDState"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Pointer to a Lean4VerificationReceipt or HoareLogicProofReceipt validating the logic."
         }
       },
       "required": [

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -890,6 +890,7 @@
           "contextual_semantic_resolution": "#/$defs/ContextualSemanticResolutionIntent",
           "continuous_spatial_mutation": "#/$defs/ContinuousSpatialMutationIntent",
           "drafting": "#/$defs/DraftingIntent",
+          "empirical_falsification_contract": "#/$defs/EmpiricalFalsificationContract",
           "epistemic_lean4_premise": "#/$defs/EpistemicLean4Premise",
           "epistemic_logic_premise": "#/$defs/EpistemicLogicPremise",
           "epistemic_prolog_premise": "#/$defs/EpistemicPrologPremise",
@@ -923,6 +924,9 @@
       "oneOf": [
         {
           "$ref": "#/$defs/EpistemicZeroTrustContract"
+        },
+        {
+          "$ref": "#/$defs/EmpiricalFalsificationContract"
         },
         {
           "$ref": "#/$defs/FalsificationContract"
@@ -7076,6 +7080,60 @@
         "temporal_duration_ms"
       ],
       "title": "EmbodiedSensoryVectorProfile",
+      "type": "object"
+    },
+    "EmpiricalFalsificationContract": {
+      "additionalProperties": false,
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Enforces strict Popperian Falsificationism by defining the exact empirical boundary conditions that would logically invalidate a non-monotonic causal hypothesis.\n\nCAUSAL AFFORDANCE: Provides the deterministic pattern-matching criteria (`falsifying_observation_signature`) that triggers a DefeasibleCascadeEvent, instantly quarantining the collapsed subgraph if met.\n\nEPISTEMIC BOUNDS: Limits the falsification logic to a strictly typed `condition_cid` (`max_length=128`) and physically binds the empirical test to an explicit `required_tool_name` (`max_length=2000`) to prevent unbounded or hallucinated search spaces.\n\nMCP ROUTING TRIGGERS: Popperian Falsification, Null Hypothesis, Defeasible Logic, Empirical Falsifiability, Structural Boundary",
+      "properties": {
+        "topology_class": {
+          "const": "empirical_falsification_contract",
+          "default": "empirical_falsification_contract",
+          "description": "Discriminator type for empirical falsification contract.",
+          "title": "Topology Class",
+          "type": "string"
+        },
+        "condition_cid": {
+          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this falsification test to the Merkle-DAG.",
+          "maxLength": 128,
+          "minLength": 1,
+          "pattern": "^[a-zA-Z0-9_.:-]+$",
+          "title": "Condition Cid",
+          "type": "string"
+        },
+        "description": {
+          "description": "Semantic description of what observation would prove the parent hypothesis is false.",
+          "maxLength": 2000,
+          "title": "Description",
+          "type": "string"
+        },
+        "required_tool_name": {
+          "anyOf": [
+            {
+              "maxLength": 2000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "The specific CognitiveActionSpaceManifest tool required to test this condition (e.g., 'sql_query_db').",
+          "title": "Required Tool Name"
+        },
+        "falsifying_observation_signature": {
+          "description": "The expected data schema or regex pattern that, if returned by the tool, kills the hypothesis.",
+          "maxLength": 2000,
+          "title": "Falsifying Observation Signature",
+          "type": "string"
+        }
+      },
+      "required": [
+        "condition_cid",
+        "description",
+        "falsifying_observation_signature"
+      ],
+      "title": "EmpiricalFalsificationContract",
       "type": "object"
     },
     "EmpiricalStatisticalProfile": {

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -11637,7 +11637,7 @@
         "falsification_conditions": {
           "description": "The strict array of strict conditions that the orchestrator must test to attempt to disprove this premise.",
           "items": {
-            "$ref": "#/$defs/FalsificationContract"
+            "$ref": "#/$defs/EmpiricalFalsificationContract"
           },
           "minItems": 1,
           "title": "Falsification Conditions",

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -13215,9 +13215,7 @@ class EpistemicAxiomVerificationReceipt(CoreasonBaseState):
     @model_validator(mode="after")
     def enforce_proof_carrying_data(self) -> "Self":
         if getattr(self, "fact_score_passed", False) is True and self.formal_backing_receipt_cid is None:
-            raise ValueError(
-                "Proof-Carrying Data required: Cannot verify axiom without a formal_backing_receipt_cid."
-            )
+            raise ValueError("Proof-Carrying Data required: Cannot verify axiom without a formal_backing_receipt_cid.")
         return self
 
 

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -5695,6 +5695,11 @@ class EmpiricalFalsificationContract(CoreasonBaseState):
 
     """
 
+    topology_class: Literal["empirical_falsification_contract"] = Field(
+        default="empirical_falsification_contract",
+        description="Discriminator type for empirical falsification contract.",
+    )
+
     condition_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = (
         Field(
             description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this falsification test to the Merkle-DAG.",
@@ -7070,6 +7075,7 @@ class SubstrateHydrationManifest(CoreasonBaseState):
 
 type AnyIntent = Annotated[
     EpistemicZeroTrustContract
+    | EmpiricalFalsificationContract
     | FalsificationContract
     | SemanticIntent
     | DraftingIntent

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -10016,7 +10016,7 @@ class HypothesisGenerationEvent(CoreasonBaseState):
     bayesian_prior: float = Field(
         ge=0.0, le=1.0, description="The agent's initial probabilistic belief in this hypothesis before testing."
     )
-    falsification_conditions: list[FalsificationContract] = Field(
+    falsification_conditions: list[EmpiricalFalsificationContract] = Field(
         min_length=1,
         description="The strict array of strict conditions that the orchestrator must test to attempt to disprove this premise.",
     )

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -5205,6 +5205,10 @@ class EvidentiaryGroundingSLA(CoreasonBaseState):
     require_independent_sources: int = Field(ge=1, le=10, default=1)
     ungrounded_link_action: Literal["sever_edge", "flag_for_human", "decay_weight"] = Field(default="sever_edge")
     allowed_evidence_domains: list[Annotated[str, StringConstraints(max_length=255)]] = Field(default_factory=list)
+    required_deduction_receipt_cid: NodeCIDState | None = Field(
+        default=None,
+        description="If grounding via strict hierarchies (e.g., medical ontologies), this MUST point to a PrologDeductionReceipt with truth_value=True.",
+    )
 
     @model_validator(mode="after")
     def _enforce_canonical_sort(self) -> Self:
@@ -5679,7 +5683,7 @@ class FallbackIntent(CoreasonBaseState):
     )
 
 
-class FalsificationContract(CoreasonBaseState):
+class EmpiricalFalsificationContract(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: Enforces strict Popperian Falsificationism by defining the exact empirical boundary conditions that would logically invalidate a non-monotonic causal hypothesis.
 
@@ -5827,6 +5831,20 @@ class FitnessObjectiveProfile(CoreasonBaseState):
     )
 
 
+class FalsificationContract(CoreasonBaseState):
+    """AGENT INSTRUCTION: A contract deploying constraint oracles to hunt for counter-models to falsify a hypothesis."""
+
+    topology_class: Literal["falsification_contract"] = Field(default="falsification_contract")
+    falsification_solver: Literal["clingo", "z3"] = Field(
+        default="clingo", description="The constraint oracle tasked with finding a counter-model."
+    )
+    target_hypothesis_cid: NodeCIDState = Field(description="Pointer to the hypothesis claim being challenged.")
+    counter_model_receipt_cid: NodeCIDState | None = Field(
+        default=None,
+        description="MUST point to a FormalLogicProofReceipt evaluating to SATISFIABLE to collapse the hypothesis.",
+    )
+
+
 class FormalVerificationContract(CoreasonBaseState):
     """
     AGENT INSTRUCTION: Leverages Automated Theorem Proving and the Curry-Howard
@@ -5858,6 +5876,10 @@ class FormalVerificationContract(CoreasonBaseState):
         Field(
             description="The SHA-256 fingerprint of the verified proof object that the Rust/C++ orchestrator must load and check."
         )
+    )
+    verified_receipt_cid: NodeCIDState | None = Field(
+        default=None,
+        description="Pointer to a Lean4VerificationReceipt or HoareLogicProofReceipt validating the logic.",
     )
 
 
@@ -7048,6 +7070,7 @@ class SubstrateHydrationManifest(CoreasonBaseState):
 
 type AnyIntent = Annotated[
     EpistemicZeroTrustContract
+    | FalsificationContract
     | SemanticIntent
     | DraftingIntent
     | AdjudicationIntent
@@ -13178,11 +13201,23 @@ class EpistemicAxiomVerificationReceipt(CoreasonBaseState):
         default=None,
         description="The undeniable pointer proving the source prediction traversed the Zero-Trust contract before being verified as an axiom.",
     )
+    formal_backing_receipt_cid: NodeCIDState | None = Field(
+        default=None,
+        description="Cryptographic pointer to the deterministic Triad execution receipt (Proof-Carrying Data).",
+    )
 
     @model_validator(mode="after")
     def enforce_epistemic_quarantine(self) -> Self:
         if not self.fact_score_passed:
             raise ValueError("Epistemic Contagion Prevented: Axioms failing validation cannot be verified.")
+        return self
+
+    @model_validator(mode="after")
+    def enforce_proof_carrying_data(self) -> "Self":
+        if getattr(self, "fact_score_passed", False) is True and self.formal_backing_receipt_cid is None:
+            raise ValueError(
+                "Proof-Carrying Data required: Cannot verify axiom without a formal_backing_receipt_cid."
+            )
         return self
 
 
@@ -14627,3 +14662,7 @@ EpistemicZeroTrustReceipt.model_rebuild()
 
 ExecutionSubstrateProfile.model_rebuild()
 SubstrateHydrationManifest.model_rebuild()
+FalsificationContract.model_rebuild()
+FormalVerificationContract.model_rebuild()
+EvidentiaryGroundingSLA.model_rebuild()
+EpistemicAxiomVerificationReceipt.model_rebuild()

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -63,6 +63,7 @@ SCHEMA_REGISTRY: dict[str, type[BaseModel]] = {
     "logic_receipt": ontology.FormalLogicProofReceipt,
     "prolog_premise": ontology.EpistemicPrologPremise,
     "prolog_receipt": ontology.PrologDeductionReceipt,
+    "falsification_contract": ontology.FalsificationContract,
 }
 
 

--- a/tests/contracts/test_epistemic_zero_trust.py
+++ b/tests/contracts/test_epistemic_zero_trust.py
@@ -12,10 +12,12 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import (
+    EmpiricalFalsificationContract,
     EpistemicAxiomVerificationReceipt,
     EpistemicConstraintPolicy,
     EpistemicZeroTrustContract,
     EpistemicZeroTrustReceipt,
+    FalsificationContract,
     FormalVerificationContract,
 )
 
@@ -115,13 +117,17 @@ def test_formal_verification_contract_pointer() -> None:
     assert contract.verified_receipt_cid == "did:coreason:receipt-1"
 
 
-def test_epistemic_axiom_guillotine_pass() -> None:
-    receipt = EpistemicAxiomVerificationReceipt(
-        event_cid="receipt-1",
-        timestamp=123.0,
-        source_prediction_cid="did:coreason:agent-1",
-        sequence_similarity_score=0.9,
-        fact_score_passed=True,
-        formal_backing_receipt_cid="did:coreason:receipt-2",
+def test_falsification_contract_instantiation() -> None:
+    contract = FalsificationContract(
+        target_hypothesis_cid="did:coreason:hyp-1", counter_model_receipt_cid="did:coreason:receipt-1"
     )
-    assert receipt.formal_backing_receipt_cid == "did:coreason:receipt-2"
+    assert contract.target_hypothesis_cid == "did:coreason:hyp-1"
+    assert contract.counter_model_receipt_cid == "did:coreason:receipt-1"
+
+
+def test_empirical_falsification_contract_instantiation() -> None:
+    contract = EmpiricalFalsificationContract(
+        condition_cid="condition-1", description="Test condition", falsifying_observation_signature="error.*"
+    )
+    assert contract.condition_cid == "condition-1"
+    assert contract.falsifying_observation_signature == "error.*"

--- a/tests/contracts/test_epistemic_zero_trust.py
+++ b/tests/contracts/test_epistemic_zero_trust.py
@@ -113,3 +113,17 @@ def test_formal_verification_contract_pointer() -> None:
         verified_receipt_cid="did:coreason:receipt-1",
     )
     assert contract.verified_receipt_cid == "did:coreason:receipt-1"
+import pytest
+from pydantic import ValidationError
+from coreason_manifest.spec.ontology import EpistemicAxiomVerificationReceipt
+
+def test_epistemic_axiom_guillotine_pass() -> None:
+    receipt = EpistemicAxiomVerificationReceipt(
+        event_cid="receipt-1",
+        timestamp=123.0,
+        source_prediction_cid="did:coreason:agent-1",
+        sequence_similarity_score=0.9,
+        fact_score_passed=True,
+        formal_backing_receipt_cid="did:coreason:receipt-2"
+    )
+    assert receipt.formal_backing_receipt_cid == "did:coreason:receipt-2"

--- a/tests/contracts/test_epistemic_zero_trust.py
+++ b/tests/contracts/test_epistemic_zero_trust.py
@@ -12,9 +12,11 @@ import pytest
 from pydantic import ValidationError
 
 from coreason_manifest.spec.ontology import (
+    EpistemicAxiomVerificationReceipt,
     EpistemicConstraintPolicy,
     EpistemicZeroTrustContract,
     EpistemicZeroTrustReceipt,
+    FormalVerificationContract,
 )
 
 
@@ -86,3 +88,27 @@ def test_epistemic_zero_trust_receipt_firewall_breach_bypass() -> None:
 
     with pytest.raises(ValueError, match=r"Topological Collapse: Firewall breach detected\. Receipt invalid\."):
         receipt.verify_firewall_integrity()  # type: ignore[operator]
+
+
+def test_epistemic_axiom_guillotine() -> None:
+    with pytest.raises(
+        ValidationError, match=r"Proof-Carrying Data required: Cannot verify axiom without a formal_backing_receipt_cid\."
+    ):
+        EpistemicAxiomVerificationReceipt(
+            event_cid="receipt-1",
+            timestamp=123.0,
+            source_prediction_cid="did:coreason:agent-1",
+            sequence_similarity_score=0.9,
+            fact_score_passed=True,
+            formal_backing_receipt_cid=None,
+        )
+
+
+def test_formal_verification_contract_pointer() -> None:
+    contract = FormalVerificationContract(
+        proof_system="lean4",
+        invariant_theorem="theorem1",
+        compiled_proof_hash="a" * 64,
+        verified_receipt_cid="did:coreason:receipt-1",
+    )
+    assert contract.verified_receipt_cid == "did:coreason:receipt-1"

--- a/tests/contracts/test_epistemic_zero_trust.py
+++ b/tests/contracts/test_epistemic_zero_trust.py
@@ -113,9 +113,7 @@ def test_formal_verification_contract_pointer() -> None:
         verified_receipt_cid="did:coreason:receipt-1",
     )
     assert contract.verified_receipt_cid == "did:coreason:receipt-1"
-import pytest
-from pydantic import ValidationError
-from coreason_manifest.spec.ontology import EpistemicAxiomVerificationReceipt
+
 
 def test_epistemic_axiom_guillotine_pass() -> None:
     receipt = EpistemicAxiomVerificationReceipt(
@@ -124,6 +122,6 @@ def test_epistemic_axiom_guillotine_pass() -> None:
         source_prediction_cid="did:coreason:agent-1",
         sequence_similarity_score=0.9,
         fact_score_passed=True,
-        formal_backing_receipt_cid="did:coreason:receipt-2"
+        formal_backing_receipt_cid="did:coreason:receipt-2",
     )
     assert receipt.formal_backing_receipt_cid == "did:coreason:receipt-2"

--- a/tests/contracts/test_epistemic_zero_trust.py
+++ b/tests/contracts/test_epistemic_zero_trust.py
@@ -92,7 +92,8 @@ def test_epistemic_zero_trust_receipt_firewall_breach_bypass() -> None:
 
 def test_epistemic_axiom_guillotine() -> None:
     with pytest.raises(
-        ValidationError, match=r"Proof-Carrying Data required: Cannot verify axiom without a formal_backing_receipt_cid\."
+        ValidationError,
+        match=r"Proof-Carrying Data required: Cannot verify axiom without a formal_backing_receipt_cid\.",
     ):
         EpistemicAxiomVerificationReceipt(
             event_cid="receipt-1",


### PR DESCRIPTION
This PR implements Epic 3: Contract Re-Alignment and Verification Integration.

It enforces Proof-Carrying Data (PCD) within the "Hollow Data Plane" by requiring cryptographic pointers to deterministic solver receipts before hypotheses can be promoted to axioms.

Specifically, it:
1. Modernizes `FormalVerificationContract` (Lean 4 gate) by adding `verified_receipt_cid`.
2. Creates `FalsificationContract` (Clingo/ASP gate) to deploy constraint oracles (renamed the old one to `EmpiricalFalsificationContract`).
3. Modernizes `EvidentiaryGroundingSLA` (SWI-Prolog gate) by adding `required_deduction_receipt_cid`.
4. Implements the "Epistemic Axiom Guillotine" in `EpistemicAxiomVerificationReceipt` via a Pydantic `@model_validator` to enforce the `formal_backing_receipt_cid` requirement.
5. Updates unions (`AnyIntent`) and the schema registry.
6. Adds corresponding tests and regenerates the universal JSON schema.

---
*PR created automatically by Jules for task [1672120418873627827](https://jules.google.com/task/1672120418873627827) started by @gowthamrao*