### PR TITLE
docs: remove obsolete placeholders and incomplete developer thought comments

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -170,8 +170,6 @@ _CLEARANCE_MAPPING: dict[str, int] = {
     "confidential": 2,
     "restricted": 3,
 }
-# Note: The above mapping aligns with the SemanticClassificationProfile enum values.
-# Enterprise clients should inject their custom mapping to align with their internal OPA/rules engines.
 
 
 class EpistemicSecurityPolicy(StrEnum):
@@ -12590,7 +12588,6 @@ class CognitiveSwarmDeploymentManifest(CoreasonBaseState):
             description="Synthesizing Adjudicator for Swarm Deployment"
         )
 
-        # Need to construct the policy based on mechanism
         if self.consensus_mechanism == "pbft":
             q_rules = QuorumPolicy(
                 max_tolerable_faults=0,

--- a/tests/ontology/test_auto_discovery.py
+++ b/tests/ontology/test_auto_discovery.py
@@ -60,7 +60,6 @@ def test_model_fields_accessible(name: str, model_cls: type[BaseModel]) -> None:
 def test_model_has_docstring(name: str, model_cls: type[BaseModel]) -> None:
     """Architecture mandate: every model should have a class docstring."""
     doc = model_cls.__doc__
-    # Skip (don't fail) models without docstrings — they need to be addressed
     if (
         hasattr(model_cls, "__mro__")
         and any(c.__name__ == "CoreasonBaseState" for c in model_cls.__mro__)


### PR DESCRIPTION
This pull request audits the codebase for inline comments that are placeholders, incomplete thoughts, or developer notes meant to be addressed later, removing them as requested.

The following comments were removed:
- Two notes about enum mappings in `src/coreason_manifest/spec/ontology.py`.
- An incomplete developer thought `Need to construct the policy based on mechanism` in `src/coreason_manifest/spec/ontology.py`.
- A placeholder comment `Skip (don't fail) models without docstrings — they need to be addressed` in `tests/ontology/test_auto_discovery.py`.

All local tests, linting, and type checking passed successfully, ensuring no regressions.

---
*PR created automatically by Jules for task [10246758803933669230](https://jules.google.com/task/10246758803933669230) started by @gowthamrao*