### PR TITLE
refactor(ontology): migrate to TransformerLens hook points

### DIFF
--- a/bindings/typescript/src/ontology.ts
+++ b/bindings/typescript/src/ontology.ts
@@ -53,11 +53,11 @@ export type TimeDerivativeVector = string | null;
  */
 export type SteeringVectorHash = string;
 /**
- * The specific transformer layer indices where this vector must be applied.
+ * The specific TransformerLens hook points (e.g., 'blocks.12.hook_resid_post') where this vector must be applied.
  *
  * @minItems 1
  */
-export type InjectionLayers = [number, ...number[]];
+export type TargetHookPoints = [string, ...string[]];
 /**
  * The mathematical magnitude/strength of the injection (can be negative for ablation).
  */
@@ -2181,9 +2181,9 @@ export type PermittedClassificationTiers = [SemanticClassificationProfile, ...Se
 /**
  * AGENT INSTRUCTION: Implements SPIFFE/SPIRE workload identity bounds and Service Mesh data sensitivity labels, establishing the foundational mathematical axis for Information Flow Control across the distributed swarm via Envoy delegation.
  *
- * CAUSAL AFFORDANCE: Physically authorizes or severs the projection of semantic payloads. By exposing rich comparison operators (e.g., `<=`), it enables the orchestrator's verification engine to natively execute mathematical dominance checks between a payload's classification and an agent's SPIFFE Verifiable Identity Document (SVID).
+ * CAUSAL AFFORDANCE: Physically authorizes or severs the projection of semantic payloads. In an Envoy-native OPA policy enforcement model, this label acts as the primary metadata selector for decentralized identity verification between a payload and an agent's SPIFFE Verifiable Identity Document (SVID).
  *
- * EPISTEMIC BOUNDS: Constrained to a strict, 4-dimensional string literal space to prevent the hallucination of unauthorized clearance levels. The internal `clearance_level` property maps these strings to an immutable integer hierarchy [0, 1, 2, 3], guaranteeing deterministic threshold evaluation for mTLS delegation.
+ * EPISTEMIC BOUNDS: Constrained to a strict, 4-dimensional string literal space to prevent the hallucination of unauthorized workload labels. The platform delegating to mTLS and OPA for enforcement, removing the requirement for scalar manifest-level dominance checks.
  *
  * MCP ROUTING TRIGGERS: SPIFFE/SPIRE, Envoy Service Mesh, Workload Identity, mTLS Delegation, Epistemic Quarantine
  */
@@ -2296,11 +2296,11 @@ export type TriggerConditions = [
   ...("on_tool_call" | "on_belief_mutation" | "on_quarantine" | "on_falsification")[]
 ];
 /**
- * The specific transformer block indices the execution engine must extract from.
+ * The specific TransformerLens hook points the execution engine must extract from.
  *
  * @minItems 1
  */
-export type TargetLayers = [number, ...number[]];
+export type TargetHookPoints1 = [string, ...string[]];
 /**
  * The top-k features to extract, preventing VRAM exhaustion.
  */
@@ -2514,9 +2514,9 @@ export type RuleCid = string;
 /**
  * AGENT INSTRUCTION: Implements SPIFFE/SPIRE workload identity bounds and Service Mesh data sensitivity labels, establishing the foundational mathematical axis for Information Flow Control across the distributed swarm via Envoy delegation.
  *
- * CAUSAL AFFORDANCE: Physically authorizes or severs the projection of semantic payloads. By exposing rich comparison operators (e.g., `<=`), it enables the orchestrator's verification engine to natively execute mathematical dominance checks between a payload's classification and an agent's SPIFFE Verifiable Identity Document (SVID).
+ * CAUSAL AFFORDANCE: Physically authorizes or severs the projection of semantic payloads. In an Envoy-native OPA policy enforcement model, this label acts as the primary metadata selector for decentralized identity verification between a payload and an agent's SPIFFE Verifiable Identity Document (SVID).
  *
- * EPISTEMIC BOUNDS: Constrained to a strict, 4-dimensional string literal space to prevent the hallucination of unauthorized clearance levels. The internal `clearance_level` property maps these strings to an immutable integer hierarchy [0, 1, 2, 3], guaranteeing deterministic threshold evaluation for mTLS delegation.
+ * EPISTEMIC BOUNDS: Constrained to a strict, 4-dimensional string literal space to prevent the hallucination of unauthorized workload labels. The platform delegating to mTLS and OPA for enforcement, removing the requirement for scalar manifest-level dominance checks.
  *
  * MCP ROUTING TRIGGERS: SPIFFE/SPIRE, Envoy Service Mesh, Workload Identity, mTLS Delegation, Epistemic Quarantine
  */
@@ -2558,11 +2558,11 @@ export type ActionOnViolation = "drop" | "quarantine" | "redact";
  */
 export type TargetFeatureIndex = number;
 /**
- * The specific transformer layer indices where this feature activation must be monitored.
+ * The specific TransformerLens hook points where this feature activation must be monitored.
  *
  * @minItems 1
  */
-export type MonitoredLayers = [number, ...number[]];
+export type MonitoredHookPoints = [string, ...string[]];
 /**
  * The mathematical magnitude limit. If the feature activates beyond this, the firewall trips.
  */
@@ -6174,17 +6174,17 @@ export interface VectorEmbeddingState {
 /**
  * CoReason Shared Kernel Ontology
  *
- * AGENT INSTRUCTION: Establishes a hardware-level Representation Engineering (RepE) directive to mechanically manipulate latent dimensions via forward-pass tensor injection.
+ * AGENT INSTRUCTION: Establishes a hardware-level Representation Engineering (RepE) directive to mechanically manipulate latent dimensions via forward-pass tensor injection. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.
  *
- * CAUSAL AFFORDANCE: Physically forces an additive, ablation, or clamping operation onto the model's residual stream at specific `injection_layers`, steering the generator away from unstable hallucination geometries prior to token projection.
+ * CAUSAL AFFORDANCE: Physically forces an additive, ablation, or clamping operation onto the model's residual stream at specific `target_hook_points`, steering the generator away from unstable hallucination geometries prior to token projection.
  *
- * EPISTEMIC BOUNDS: Cryptographically locked by `steering_vector_hash` (SHA-256 pattern `^[a-f0-9]{64}$`). `scaling_factor` is bounded above (`le=100.0`) but unbounded below, permitting negative magnitudes for ablation. The `@model_validator` deterministically sorts `injection_layers` (each `ge=0`).
+ * EPISTEMIC BOUNDS: Cryptographically locked by `steering_vector_hash` (SHA-256 pattern `^[a-f0-9]{64}$`). `scaling_factor` is bounded above (`le=100.0`) but unbounded below, permitting negative magnitudes for ablation. The `@model_validator` deterministically sorts `target_hook_points`.
  *
- * MCP ROUTING TRIGGERS: Representation Engineering, RepE, Activation Steering, Residual Stream Ablation, Concept Vectors
+ * MCP ROUTING TRIGGERS: Representation Engineering, RepE, Activation Steering, Residual Stream Ablation, Concept Vectors, TransformerLens, SAELens
  */
 export interface ActivationSteeringContract {
   steering_vector_hash: SteeringVectorHash;
-  injection_layers: InjectionLayers;
+  target_hook_points: TargetHookPoints;
   scaling_factor: ScalingFactor;
   vector_modality: VectorModality;
 }
@@ -9238,17 +9238,17 @@ export interface NeuroSymbolicHandoffContract {
 /**
  * CoReason Shared Kernel Ontology
  *
- * AGENT INSTRUCTION: Establishes a rigorous Mechanistic Interpretability brain-scan protocol, executing real-time latent state extraction across targeted neural circuits.
+ * AGENT INSTRUCTION: Establishes a rigorous Mechanistic Interpretability brain-scan protocol, executing real-time latent state extraction across targeted neural circuits. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.
  *
- * CAUSAL AFFORDANCE: Authorizes the orchestrator to halt token generation upon specific `trigger_conditions` to physically slice, quantify, and export the top-k SAE features from the designated `target_layers`.
+ * CAUSAL AFFORDANCE: Authorizes the orchestrator to halt token generation upon specific `trigger_conditions` to physically slice, quantify, and export the top-k SAE features from the designated `target_hook_points`.
  *
- * EPISTEMIC BOUNDS: GPU VRAM exhaustion is mathematically prevented by capping `max_features_per_layer` (`gt=0, le=18446744073709551615`). The `@model_validator` deterministically sorts conditions and layers for RFC 8785 hashing. System integrity enforced via `require_zk_commitments`.
+ * EPISTEMIC BOUNDS: GPU VRAM exhaustion is mathematically prevented by capping `max_features_per_layer` (`gt=0, le=18446744073709551615`). The `@model_validator` deterministically sorts conditions and hook points for RFC 8785 hashing. System integrity enforced via `require_zk_commitments`.
  *
- * MCP ROUTING TRIGGERS: Latent State Extraction, Mechanistic Interpretability, Sparse Autoencoder, Zero-Knowledge Commitments, VRAM Optimization
+ * MCP ROUTING TRIGGERS: Latent State Extraction, Mechanistic Interpretability, Sparse Autoencoder, Zero-Knowledge Commitments, VRAM Optimization, TransformerLens, SAELens
  */
 export interface MechanisticAuditContract {
   trigger_conditions: TriggerConditions;
-  target_layers: TargetLayers;
+  target_hook_points: TargetHookPoints1;
   max_features_per_layer: MaxFeaturesPerLayer;
   require_zk_commitments?: RequireZkCommitments;
 }
@@ -9682,17 +9682,17 @@ export interface SemanticFirewallPolicy {
 /**
  * CoReason Shared Kernel Ontology
  *
- * AGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability to actively monitor and steer monosemantic neural circuits during the model's forward pass.
+ * AGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability to actively monitor and steer monosemantic neural circuits during the model's forward pass. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.
  *
  * CAUSAL AFFORDANCE: Executes real-time tensor remediation—clamping, halting, quarantining, or smoothly decaying residual stream activations—when specific features diverge toward adversarial or hallucinated geometries.
  *
  * EPISTEMIC BOUNDS: The `max_activation_threshold` (`ge=0.0, le=18446744073709551615.0`) physically bounds the continuous Euclidean magnitude of the `target_feature_index`. Topologically locked to SAE matrix via `sae_dictionary_hash` (SHA-256). The `@model_validator` `validate_smooth_decay` mathematically enforces asymptotic bounds.
  *
- * MCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream Steering, Tensor Remediation, Monosemantic Features
+ * MCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream Steering, Tensor Remediation, Monosemantic Features, TransformerLens, SAELens
  */
 export interface SaeLatentPolicy {
   target_feature_index: TargetFeatureIndex;
-  monitored_layers: MonitoredLayers;
+  monitored_hook_points: MonitoredHookPoints;
   max_activation_threshold: MaxActivationThreshold;
   violation_action: ViolationAction1;
   clamp_value?: ClampValue;
@@ -11524,21 +11524,21 @@ export interface EmbodiedSensoryVectorProfile {
  *
  * AGENT INSTRUCTION: An append-only, cryptographically frozen coordinate representing the verifiable output of a MechanisticAuditContract.
  *
- * CAUSAL AFFORDANCE: Commits the extracted `SaeFeatureActivationState` matrix (`layer_activations`) to the Merkle-DAG. The `causal_scrubbing_applied` boolean mathematically proves that the orchestrator actively resampled or ablated the circuit to confirm direct causal responsibility.
+ * CAUSAL AFFORDANCE: Commits the extracted `SaeFeatureActivationState` matrix (`hook_activations`) to the Merkle-DAG. The `causal_scrubbing_applied` boolean mathematically proves that the orchestrator actively resampled or ablated the circuit to confirm direct causal responsibility.
  *
- * EPISTEMIC BOUNDS: Cryptographic integrity structurally anchored by `audit_cid` (128-char CID regex). The `@model_validator` sorts each `SaeFeatureActivationState` list within `layer_activations` by `feature_index`, guaranteeing zero-variance RFC 8785 Merkle-DAG hashing.
+ * EPISTEMIC BOUNDS: Cryptographic integrity structurally anchored by `audit_cid` (128-char CID regex). The `@model_validator` sorts each `SaeFeatureActivationState` list within `hook_activations` by `feature_index`, guaranteeing zero-variance RFC 8785 Merkle-DAG hashing.
  *
- * MCP ROUTING TRIGGERS: Causal Scrubbing, Epistemic Provenance, Mechanistic Audit, RFC 8785 Canonicalization, Cryptographic Brain-Scan
+ * MCP ROUTING TRIGGERS: Causal Scrubbing, Epistemic Provenance, Mechanistic Audit, RFC 8785 Canonicalization, Cryptographic Brain-Scan, TransformerLens, SAELens
  */
 export interface NeuralAuditAttestationReceipt {
   audit_cid: AuditCid;
-  layer_activations: LayerActivations;
+  hook_activations: HookActivations;
   causal_scrubbing_applied?: CausalScrubbingApplied;
 }
 /**
- * A mapping of specific transformer layer indices to their top-k activated SAE features.
+ * A mapping of specific TransformerLens hook points to their top-k activated SAE features.
  */
-export interface LayerActivations {
+export interface HookActivations {
   [k: string]: SaeFeatureActivationState[];
 }
 /**

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -53,7 +53,7 @@
     },
     "ActivationSteeringContract": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a hardware-level Representation Engineering (RepE) directive to mechanically manipulate latent dimensions via forward-pass tensor injection.\n\nCAUSAL AFFORDANCE: Physically forces an additive, ablation, or clamping operation onto the model's residual stream at specific `injection_layers`, steering the generator away from unstable hallucination geometries prior to token projection.\n\nEPISTEMIC BOUNDS: Cryptographically locked by `steering_vector_hash` (SHA-256 pattern `^[a-f0-9]{64}$`). `scaling_factor` is bounded above (`le=100.0`) but unbounded below, permitting negative magnitudes for ablation. The `@model_validator` deterministically sorts `injection_layers` (each `ge=0`).\n\nMCP ROUTING TRIGGERS: Representation Engineering, RepE, Activation Steering, Residual Stream Ablation, Concept Vectors",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a hardware-level Representation Engineering (RepE) directive to mechanically manipulate latent dimensions via forward-pass tensor injection. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.\n\nCAUSAL AFFORDANCE: Physically forces an additive, ablation, or clamping operation onto the model's residual stream at specific `target_hook_points`, steering the generator away from unstable hallucination geometries prior to token projection.\n\nEPISTEMIC BOUNDS: Cryptographically locked by `steering_vector_hash` (SHA-256 pattern `^[a-f0-9]{64}$`). `scaling_factor` is bounded above (`le=100.0`) but unbounded below, permitting negative magnitudes for ablation. The `@model_validator` deterministically sorts `target_hook_points`.\n\nMCP ROUTING TRIGGERS: Representation Engineering, RepE, Activation Steering, Residual Stream Ablation, Concept Vectors, TransformerLens, SAELens",
       "properties": {
         "steering_vector_hash": {
           "description": "The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
@@ -63,14 +63,16 @@
           "title": "Steering Vector Hash",
           "type": "string"
         },
-        "injection_layers": {
-          "description": "The specific transformer layer indices where this vector must be applied.",
+        "target_hook_points": {
+          "description": "The specific TransformerLens hook points (e.g., 'blocks.12.hook_resid_post') where this vector must be applied.",
           "items": {
-            "minimum": 0,
-            "type": "integer"
+            "maxLength": 256,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_.]+$",
+            "type": "string"
           },
           "minItems": 1,
-          "title": "Injection Layers",
+          "title": "Target Hook Points",
           "type": "array"
         },
         "scaling_factor": {
@@ -92,7 +94,7 @@
       },
       "required": [
         "steering_vector_hash",
-        "injection_layers",
+        "target_hook_points",
         "scaling_factor",
         "vector_modality"
       ],
@@ -13505,7 +13507,7 @@
     },
     "MechanisticAuditContract": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a rigorous Mechanistic Interpretability brain-scan protocol, executing real-time latent state extraction across targeted neural circuits.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to halt token generation upon specific `trigger_conditions` to physically slice, quantify, and export the top-k SAE features from the designated `target_layers`.\n\nEPISTEMIC BOUNDS: GPU VRAM exhaustion is mathematically prevented by capping `max_features_per_layer` (`gt=0, le=18446744073709551615`). The `@model_validator` deterministically sorts conditions and layers for RFC 8785 hashing. System integrity enforced via `require_zk_commitments`.\n\nMCP ROUTING TRIGGERS: Latent State Extraction, Mechanistic Interpretability, Sparse Autoencoder, Zero-Knowledge Commitments, VRAM Optimization",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Establishes a rigorous Mechanistic Interpretability brain-scan protocol, executing real-time latent state extraction across targeted neural circuits. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.\n\nCAUSAL AFFORDANCE: Authorizes the orchestrator to halt token generation upon specific `trigger_conditions` to physically slice, quantify, and export the top-k SAE features from the designated `target_hook_points`.\n\nEPISTEMIC BOUNDS: GPU VRAM exhaustion is mathematically prevented by capping `max_features_per_layer` (`gt=0, le=18446744073709551615`). The `@model_validator` deterministically sorts conditions and hook points for RFC 8785 hashing. System integrity enforced via `require_zk_commitments`.\n\nMCP ROUTING TRIGGERS: Latent State Extraction, Mechanistic Interpretability, Sparse Autoencoder, Zero-Knowledge Commitments, VRAM Optimization, TransformerLens, SAELens",
       "properties": {
         "trigger_conditions": {
           "description": "The specific architectural events that authorize the orchestrator to halt generation and extract internal activations.",
@@ -13522,14 +13524,16 @@
           "title": "Trigger Conditions",
           "type": "array"
         },
-        "target_layers": {
-          "description": "The specific transformer block indices the execution engine must extract from.",
+        "target_hook_points": {
+          "description": "The specific TransformerLens hook points the execution engine must extract from.",
           "items": {
-            "minimum": 0,
-            "type": "integer"
+            "maxLength": 256,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_.]+$",
+            "type": "string"
           },
           "minItems": 1,
-          "title": "Target Layers",
+          "title": "Target Hook Points",
           "type": "array"
         },
         "max_features_per_layer": {
@@ -13548,7 +13552,7 @@
       },
       "required": [
         "trigger_conditions",
-        "target_layers",
+        "target_hook_points",
         "max_features_per_layer"
       ],
       "title": "MechanisticAuditContract",
@@ -13958,7 +13962,7 @@
     },
     "NeuralAuditAttestationReceipt": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An append-only, cryptographically frozen coordinate representing the verifiable output of a MechanisticAuditContract.\n\nCAUSAL AFFORDANCE: Commits the extracted `SaeFeatureActivationState` matrix (`layer_activations`) to the Merkle-DAG. The `causal_scrubbing_applied` boolean mathematically proves that the orchestrator actively resampled or ablated the circuit to confirm direct causal responsibility.\n\nEPISTEMIC BOUNDS: Cryptographic integrity structurally anchored by `audit_cid` (128-char CID regex). The `@model_validator` sorts each `SaeFeatureActivationState` list within `layer_activations` by `feature_index`, guaranteeing zero-variance RFC 8785 Merkle-DAG hashing.\n\nMCP ROUTING TRIGGERS: Causal Scrubbing, Epistemic Provenance, Mechanistic Audit, RFC 8785 Canonicalization, Cryptographic Brain-Scan",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An append-only, cryptographically frozen coordinate representing the verifiable output of a MechanisticAuditContract.\n\nCAUSAL AFFORDANCE: Commits the extracted `SaeFeatureActivationState` matrix (`hook_activations`) to the Merkle-DAG. The `causal_scrubbing_applied` boolean mathematically proves that the orchestrator actively resampled or ablated the circuit to confirm direct causal responsibility.\n\nEPISTEMIC BOUNDS: Cryptographic integrity structurally anchored by `audit_cid` (128-char CID regex). The `@model_validator` sorts each `SaeFeatureActivationState` list within `hook_activations` by `feature_index`, guaranteeing zero-variance RFC 8785 Merkle-DAG hashing.\n\nMCP ROUTING TRIGGERS: Causal Scrubbing, Epistemic Provenance, Mechanistic Audit, RFC 8785 Canonicalization, Cryptographic Brain-Scan, TransformerLens, SAELens",
       "properties": {
         "audit_cid": {
           "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
@@ -13968,15 +13972,15 @@
           "title": "Audit Cid",
           "type": "string"
         },
-        "layer_activations": {
+        "hook_activations": {
           "additionalProperties": {
             "items": {
               "$ref": "#/$defs/SaeFeatureActivationState"
             },
             "type": "array"
           },
-          "description": "A mapping of specific transformer layer indices to their top-k activated SAE features.",
-          "title": "Layer Activations",
+          "description": "A mapping of specific TransformerLens hook points to their top-k activated SAE features.",
+          "title": "Hook Activations",
           "type": "object"
         },
         "causal_scrubbing_applied": {
@@ -13988,7 +13992,7 @@
       },
       "required": [
         "audit_cid",
-        "layer_activations"
+        "hook_activations"
       ],
       "title": "NeuralAuditAttestationReceipt",
       "type": "object"
@@ -16784,7 +16788,7 @@
     },
     "SaeLatentPolicy": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability to actively monitor and steer monosemantic neural circuits during the model's forward pass.\n\nCAUSAL AFFORDANCE: Executes real-time tensor remediation—clamping, halting, quarantining, or smoothly decaying residual stream activations—when specific features diverge toward adversarial or hallucinated geometries.\n\nEPISTEMIC BOUNDS: The `max_activation_threshold` (`ge=0.0, le=18446744073709551615.0`) physically bounds the continuous Euclidean magnitude of the `target_feature_index`. Topologically locked to SAE matrix via `sae_dictionary_hash` (SHA-256). The `@model_validator` `validate_smooth_decay` mathematically enforces asymptotic bounds.\n\nMCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream Steering, Tensor Remediation, Monosemantic Features",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability to actively monitor and steer monosemantic neural circuits during the model's forward pass. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.\n\nCAUSAL AFFORDANCE: Executes real-time tensor remediation—clamping, halting, quarantining, or smoothly decaying residual stream activations—when specific features diverge toward adversarial or hallucinated geometries.\n\nEPISTEMIC BOUNDS: The `max_activation_threshold` (`ge=0.0, le=18446744073709551615.0`) physically bounds the continuous Euclidean magnitude of the `target_feature_index`. Topologically locked to SAE matrix via `sae_dictionary_hash` (SHA-256). The `@model_validator` `validate_smooth_decay` mathematically enforces asymptotic bounds.\n\nMCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream Steering, Tensor Remediation, Monosemantic Features, TransformerLens, SAELens",
       "properties": {
         "target_feature_index": {
           "description": "The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
@@ -16793,14 +16797,16 @@
           "title": "Target Feature Index",
           "type": "integer"
         },
-        "monitored_layers": {
-          "description": "The specific transformer layer indices where this feature activation must be monitored.",
+        "monitored_hook_points": {
+          "description": "The specific TransformerLens hook points where this feature activation must be monitored.",
           "items": {
-            "minimum": 0,
-            "type": "integer"
+            "maxLength": 256,
+            "minLength": 1,
+            "pattern": "^[a-zA-Z0-9_.]+$",
+            "type": "string"
           },
           "minItems": 1,
-          "title": "Monitored Layers",
+          "title": "Monitored Hook Points",
           "type": "array"
         },
         "max_activation_threshold": {
@@ -16858,7 +16864,7 @@
       },
       "required": [
         "target_feature_index",
-        "monitored_layers",
+        "monitored_hook_points",
         "max_activation_threshold",
         "violation_action",
         "sae_dictionary_hash"

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2122,13 +2122,13 @@ class SaeFeatureActivationState(CoreasonBaseState):
 
 class ActivationSteeringContract(CoreasonBaseState):
     r"""
-    AGENT INSTRUCTION: Establishes a hardware-level Representation Engineering (RepE) directive to mechanically manipulate latent dimensions via forward-pass tensor injection.
+    AGENT INSTRUCTION: Establishes a hardware-level Representation Engineering (RepE) directive to mechanically manipulate latent dimensions via forward-pass tensor injection. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.
 
-    CAUSAL AFFORDANCE: Physically forces an additive, ablation, or clamping operation onto the model's residual stream at specific `injection_layers`, steering the generator away from unstable hallucination geometries prior to token projection.
+    CAUSAL AFFORDANCE: Physically forces an additive, ablation, or clamping operation onto the model's residual stream at specific `target_hook_points`, steering the generator away from unstable hallucination geometries prior to token projection.
 
-    EPISTEMIC BOUNDS: Cryptographically locked by `steering_vector_hash` (SHA-256 pattern `^[a-f0-9]{64}$`). `scaling_factor` is bounded above (`le=100.0`) but unbounded below, permitting negative magnitudes for ablation. The `@model_validator` deterministically sorts `injection_layers` (each `ge=0`).
+    EPISTEMIC BOUNDS: Cryptographically locked by `steering_vector_hash` (SHA-256 pattern `^[a-f0-9]{64}$`). `scaling_factor` is bounded above (`le=100.0`) but unbounded below, permitting negative magnitudes for ablation. The `@model_validator` deterministically sorts `target_hook_points`.
 
-    MCP ROUTING TRIGGERS: Representation Engineering, RepE, Activation Steering, Residual Stream Ablation, Concept Vectors
+    MCP ROUTING TRIGGERS: Representation Engineering, RepE, Activation Steering, Residual Stream Ablation, Concept Vectors, TransformerLens, SAELens
 
     """
 
@@ -2137,8 +2137,8 @@ class ActivationSteeringContract(CoreasonBaseState):
             description="The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
         )
     )
-    injection_layers: list[Annotated[int, Field(ge=0)]] = Field(
-        min_length=1, description="The specific transformer layer indices where this vector must be applied."
+    target_hook_points: list[Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]] = Field(
+        min_length=1, description="The specific TransformerLens hook points (e.g., 'blocks.12.hook_resid_post') where this vector must be applied."
     )
     scaling_factor: float = Field(
         le=100.0, description="The mathematical magnitude/strength of the injection (can be negative for ablation)."
@@ -2149,7 +2149,7 @@ class ActivationSteeringContract(CoreasonBaseState):
 
     @model_validator(mode="after")
     def _enforce_canonical_sort(self) -> Self:
-        object.__setattr__(self, "injection_layers", sorted(self.injection_layers))
+        object.__setattr__(self, "target_hook_points", sorted(self.target_hook_points))
         return self
 
 
@@ -2637,13 +2637,13 @@ class RedactionPolicy(CoreasonBaseState):
 
 class SaeLatentPolicy(CoreasonBaseState):
     r"""
-    AGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability to actively monitor and steer monosemantic neural circuits during the model's forward pass.
+    AGENT INSTRUCTION: Implements Sparse Dictionary Learning and Mechanistic Interpretability to actively monitor and steer monosemantic neural circuits during the model's forward pass. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.
 
     CAUSAL AFFORDANCE: Executes real-time tensor remediation—clamping, halting, quarantining, or smoothly decaying residual stream activations—when specific features diverge toward adversarial or hallucinated geometries.
 
     EPISTEMIC BOUNDS: The `max_activation_threshold` (`ge=0.0, le=18446744073709551615.0`) physically bounds the continuous Euclidean magnitude of the `target_feature_index`. Topologically locked to SAE matrix via `sae_dictionary_hash` (SHA-256). The `@model_validator` `validate_smooth_decay` mathematically enforces asymptotic bounds.
 
-    MCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream Steering, Tensor Remediation, Monosemantic Features
+    MCP ROUTING TRIGGERS: Mechanistic Interpretability, Sparse Autoencoders, Residual Stream Steering, Tensor Remediation, Monosemantic Features, TransformerLens, SAELens
 
     """
 
@@ -2652,9 +2652,9 @@ class SaeLatentPolicy(CoreasonBaseState):
         ge=0,
         description="The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
     )
-    monitored_layers: list[Annotated[int, Field(ge=0)]] = Field(
+    monitored_hook_points: list[Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]] = Field(
         min_length=1,
-        description="The specific transformer layer indices where this feature activation must be monitored.",
+        description="The specific TransformerLens hook points where this feature activation must be monitored.",
     )
     max_activation_threshold: float = Field(
         le=18446744073709551615.0,
@@ -2679,7 +2679,7 @@ class SaeLatentPolicy(CoreasonBaseState):
 
     @model_validator(mode="after")
     def _enforce_canonical_sort(self) -> Self:
-        object.__setattr__(self, "monitored_layers", sorted(self.monitored_layers))
+        object.__setattr__(self, "monitored_hook_points", sorted(self.monitored_hook_points))
         return self
 
     @model_validator(mode="after")
@@ -8583,13 +8583,13 @@ class MarketResolutionState(CoreasonBaseState):
 
 class MechanisticAuditContract(CoreasonBaseState):
     r"""
-    AGENT INSTRUCTION: Establishes a rigorous Mechanistic Interpretability brain-scan protocol, executing real-time latent state extraction across targeted neural circuits.
+    AGENT INSTRUCTION: Establishes a rigorous Mechanistic Interpretability brain-scan protocol, executing real-time latent state extraction across targeted neural circuits. Execution of this policy is strictly delegated to the external `TransformerLens` substrate to preserve the Hollow Data Plane constraints.
 
-    CAUSAL AFFORDANCE: Authorizes the orchestrator to halt token generation upon specific `trigger_conditions` to physically slice, quantify, and export the top-k SAE features from the designated `target_layers`.
+    CAUSAL AFFORDANCE: Authorizes the orchestrator to halt token generation upon specific `trigger_conditions` to physically slice, quantify, and export the top-k SAE features from the designated `target_hook_points`.
 
-    EPISTEMIC BOUNDS: GPU VRAM exhaustion is mathematically prevented by capping `max_features_per_layer` (`gt=0, le=18446744073709551615`). The `@model_validator` deterministically sorts conditions and layers for RFC 8785 hashing. System integrity enforced via `require_zk_commitments`.
+    EPISTEMIC BOUNDS: GPU VRAM exhaustion is mathematically prevented by capping `max_features_per_layer` (`gt=0, le=18446744073709551615`). The `@model_validator` deterministically sorts conditions and hook points for RFC 8785 hashing. System integrity enforced via `require_zk_commitments`.
 
-    MCP ROUTING TRIGGERS: Latent State Extraction, Mechanistic Interpretability, Sparse Autoencoder, Zero-Knowledge Commitments, VRAM Optimization
+    MCP ROUTING TRIGGERS: Latent State Extraction, Mechanistic Interpretability, Sparse Autoencoder, Zero-Knowledge Commitments, VRAM Optimization, TransformerLens, SAELens
 
     """
 
@@ -8599,8 +8599,8 @@ class MechanisticAuditContract(CoreasonBaseState):
             description="The specific architectural events that authorize the orchestrator to halt generation and extract internal activations.",
         )
     )
-    target_layers: list[Annotated[int, Field(ge=0)]] = Field(
-        min_length=1, description="The specific transformer block indices the execution engine must extract from."
+    target_hook_points: list[Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]] = Field(
+        min_length=1, description="The specific TransformerLens hook points the execution engine must extract from."
     )
     max_features_per_layer: int = Field(
         le=18446744073709551615, gt=0, description="The top-k features to extract, preventing VRAM exhaustion."
@@ -8613,7 +8613,7 @@ class MechanisticAuditContract(CoreasonBaseState):
     @model_validator(mode="after")
     def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(self, "trigger_conditions", sorted(self.trigger_conditions))
-        object.__setattr__(self, "target_layers", sorted(self.target_layers))
+        object.__setattr__(self, "target_hook_points", sorted(self.target_hook_points))
         return self
 
 
@@ -8793,19 +8793,19 @@ class NeuralAuditAttestationReceipt(CoreasonBaseState):
     r"""
     AGENT INSTRUCTION: An append-only, cryptographically frozen coordinate representing the verifiable output of a MechanisticAuditContract.
 
-    CAUSAL AFFORDANCE: Commits the extracted `SaeFeatureActivationState` matrix (`layer_activations`) to the Merkle-DAG. The `causal_scrubbing_applied` boolean mathematically proves that the orchestrator actively resampled or ablated the circuit to confirm direct causal responsibility.
+    CAUSAL AFFORDANCE: Commits the extracted `SaeFeatureActivationState` matrix (`hook_activations`) to the Merkle-DAG. The `causal_scrubbing_applied` boolean mathematically proves that the orchestrator actively resampled or ablated the circuit to confirm direct causal responsibility.
 
-    EPISTEMIC BOUNDS: Cryptographic integrity structurally anchored by `audit_cid` (128-char CID regex). The `@model_validator` sorts each `SaeFeatureActivationState` list within `layer_activations` by `feature_index`, guaranteeing zero-variance RFC 8785 Merkle-DAG hashing.
+    EPISTEMIC BOUNDS: Cryptographic integrity structurally anchored by `audit_cid` (128-char CID regex). The `@model_validator` sorts each `SaeFeatureActivationState` list within `hook_activations` by `feature_index`, guaranteeing zero-variance RFC 8785 Merkle-DAG hashing.
 
-    MCP ROUTING TRIGGERS: Causal Scrubbing, Epistemic Provenance, Mechanistic Audit, RFC 8785 Canonicalization, Cryptographic Brain-Scan
+    MCP ROUTING TRIGGERS: Causal Scrubbing, Epistemic Provenance, Mechanistic Audit, RFC 8785 Canonicalization, Cryptographic Brain-Scan, TransformerLens, SAELens
 
     """
 
     audit_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
     )
-    layer_activations: dict[int, list[SaeFeatureActivationState]] = Field(
-        description="A mapping of specific transformer layer indices to their top-k activated SAE features."
+    hook_activations: dict[str, list[SaeFeatureActivationState]] = Field(
+        description="A mapping of specific TransformerLens hook points to their top-k activated SAE features."
     )
     causal_scrubbing_applied: bool = Field(
         default=False,
@@ -8816,12 +8816,12 @@ class NeuralAuditAttestationReceipt(CoreasonBaseState):
     def _enforce_canonical_sort(self) -> Self:
         object.__setattr__(
             self,
-            "layer_activations",
-            {k: sorted(v, key=operator.attrgetter("feature_index")) for k, v in self.layer_activations.items()},
+            "hook_activations",
+            {k: sorted(v, key=operator.attrgetter("feature_index")) for k, v in self.hook_activations.items()},
         )
-        if getattr(self, "layer_activations", None) is not None:
+        if getattr(self, "hook_activations", None) is not None:
             object.__setattr__(
-                self, "layer_activations", sorted(self.layer_activations, key=operator.attrgetter("layer_index"))
+                self, "hook_activations", {k: self.hook_activations[k] for k in sorted(self.hook_activations.keys())}
             )
         return self
 

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -2137,8 +2137,11 @@ class ActivationSteeringContract(CoreasonBaseState):
             description="The SHA-256 hash of the extracted RepE control tensor (e.g., the 'caution' vector).",
         )
     )
-    target_hook_points: list[Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]] = Field(
-        min_length=1, description="The specific TransformerLens hook points (e.g., 'blocks.12.hook_resid_post') where this vector must be applied."
+    target_hook_points: list[
+        Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]
+    ] = Field(
+        min_length=1,
+        description="The specific TransformerLens hook points (e.g., 'blocks.12.hook_resid_post') where this vector must be applied.",
     )
     scaling_factor: float = Field(
         le=100.0, description="The mathematical magnitude/strength of the injection (can be negative for ablation)."
@@ -2652,7 +2655,9 @@ class SaeLatentPolicy(CoreasonBaseState):
         ge=0,
         description="The exact dimensional index of the monosemantic feature in the Sparse Autoencoder dictionary.",
     )
-    monitored_hook_points: list[Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]] = Field(
+    monitored_hook_points: list[
+        Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]
+    ] = Field(
         min_length=1,
         description="The specific TransformerLens hook points where this feature activation must be monitored.",
     )
@@ -8599,7 +8604,9 @@ class MechanisticAuditContract(CoreasonBaseState):
             description="The specific architectural events that authorize the orchestrator to halt generation and extract internal activations.",
         )
     )
-    target_hook_points: list[Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]] = Field(
+    target_hook_points: list[
+        Annotated[str, StringConstraints(min_length=1, max_length=256, pattern="^[a-zA-Z0-9_.]+$")]
+    ] = Field(
         min_length=1, description="The specific TransformerLens hook points the execution engine must extract from."
     )
     max_features_per_layer: int = Field(

--- a/tests/ontology/test_bulk_coverage.py
+++ b/tests/ontology/test_bulk_coverage.py
@@ -225,11 +225,11 @@ class TestBulkInstantiation:
     def test_activation_steering(self) -> None:
         obj = ActivationSteeringContract(
             steering_vector_hash="a" * 64,
-            injection_layers=[0, 1, 2],
+            target_hook_points=["blocks.0.hook_resid_post"],
             scaling_factor=1.0,
             vector_modality="additive",
         )
-        assert len(obj.injection_layers) == 3
+        assert len(obj.target_hook_points) == 1
 
     def test_belief_mutation_event(self) -> None:
         obj = BeliefMutationEvent(

--- a/tests/ontology/test_last_mile.py
+++ b/tests/ontology/test_last_mile.py
@@ -95,7 +95,7 @@ class TestSaeLatentPolicy:
     def test_smooth_decay_requires_profile(self) -> None:
         with pytest.raises(ValidationError, match="smoothing_profile"):
             SaeLatentPolicy(
-                monitored_layers=[1, 2, 3],
+                monitored_hook_points=["blocks.0.hook_resid_post"],
                 target_feature_index=42,
                 max_activation_threshold=1.0,
                 violation_action="smooth_decay",
@@ -107,7 +107,7 @@ class TestSaeLatentPolicy:
     def test_smooth_decay_requires_clamp_value(self) -> None:
         with pytest.raises(ValidationError, match="clamp_value"):
             SaeLatentPolicy(
-                monitored_layers=[1, 2, 3],
+                monitored_hook_points=["blocks.0.hook_resid_post"],
                 target_feature_index=42,
                 max_activation_threshold=1.0,
                 violation_action="smooth_decay",


### PR DESCRIPTION
Closes #1718. Migrates mechanistic interpretability contracts to use target_hook_points for TransformerLens and SAELens.