### PR TITLE
chore(chaos-mesh): Map chaos schemas to CNCF Chaos Mesh CRDs

### DIFF
--- a/bindings/typescript/src/ontology.ts
+++ b/bindings/typescript/src/ontology.ts
@@ -5293,14 +5293,13 @@ export type MutableMatrix = {
  */
 export type IsDelta = boolean;
 export type FaultCategoryProfile =
-  | "context_overload"
-  | "incorrect_context"
-  | "format_corruption"
-  | "latency_spike"
-  | "token_throttle"
-  | "network_degradation"
-  | "temporal_dilation"
-  | "dependency_blackout";
+  | "pod_kill"
+  | "network_delay"
+  | "cpu_burn"
+  | "time_shift"
+  | "io_fault"
+  | "dns_fault"
+  | "kernel_panic";
 /**
  * The mathematical dialect and theorem prover used to compile the proof.
  */
@@ -8302,15 +8301,7 @@ export interface FaultInjectionProfile {
   /**
    * The specific type of fault to inject.
    */
-  fault_category:
-    | "context_overload"
-    | "incorrect_context"
-    | "format_corruption"
-    | "latency_spike"
-    | "token_throttle"
-    | "network_degradation"
-    | "temporal_dilation"
-    | "dependency_blackout";
+  fault_category: "pod_kill" | "network_delay" | "cpu_burn" | "time_shift" | "io_fault" | "dns_fault" | "kernel_panic";
   target_node_cid?: TargetNodeCid1;
   intensity: Intensity;
 }

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -10351,14 +10351,13 @@
     },
     "FaultCategoryProfile": {
       "enum": [
-        "context_overload",
-        "incorrect_context",
-        "format_corruption",
-        "latency_spike",
-        "token_throttle",
-        "network_degradation",
-        "temporal_dilation",
-        "dependency_blackout"
+        "pod_kill",
+        "network_delay",
+        "cpu_burn",
+        "time_shift",
+        "io_fault",
+        "dns_fault",
+        "kernel_panic"
       ],
       "type": "string"
     },

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -257,14 +257,13 @@ class SemanticClassificationProfile(StrEnum):
 
 
 type FaultCategoryProfile = Literal[
-    "context_overload",
-    "incorrect_context",
-    "format_corruption",
-    "latency_spike",
-    "token_throttle",
-    "network_degradation",
-    "temporal_dilation",
-    "dependency_blackout",
+    "pod_kill",
+    "network_delay",
+    "cpu_burn",
+    "time_shift",
+    "io_fault",
+    "dns_fault",
+    "kernel_panic",
 ]
 type CognitiveTierProfile = Literal["working", "episodic", "semantic"]
 type NodeCIDState = Annotated[


### PR DESCRIPTION
Migration to Chaos Mesh for better Byzantine fault injection.