### PR TITLE
refactor(ontology): remove prior_event_hash Merkle-DAG chain and veri…

### DIFF
--- a/bindings/typescript/src/ontology.ts
+++ b/bindings/typescript/src/ontology.ts
@@ -124,13 +124,9 @@ export type StructuralType = string;
  */
 export type TimeoutAction = "rollback" | "proceed_default" | "terminate";
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3199,30 +3195,21 @@ export type AddSet = NodeCIDState[];
 export type TerminateSet = TemporalEdgeInvalidationIntent[];
 export type TopologyClass83 = "mcp_tool_definition";
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid1 = string;
-/**
- * The RFC 8785 Canonical hash of the immediate causal ancestor event. Null for genesis nodes.
- */
-export type PriorEventHash1 = string | null;
 export type Timestamp1 = number;
 export type Name = string;
 export type Description9 = string;
 export type EventCid2 = string;
-export type PriorEventHash2 = string | null;
 export type Timestamp2 = number;
 export type TopologyClass84 = "crosswalk_resolution";
 export type ReceiptCid = string;
 export type TargetGraphCid3 = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid3 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash3 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3252,13 +3239,9 @@ export type RemediationEpochsConsumed = number;
  */
 export type TransmutedPayloadHash = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid4 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash4 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3347,7 +3330,7 @@ export type TemporalDurationMs = number;
  */
 export type SalienceThresholdBreached = boolean;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type AuditCid = string;
 /**
@@ -3397,13 +3380,9 @@ export type DecayThreshold = number;
  */
 export type MaxLookbackWindow = number;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid5 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash5 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3449,13 +3428,9 @@ export type TotalLatentTokens = number;
  */
 export type QuorumSignatures = string[];
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid6 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash6 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3466,13 +3441,9 @@ export type Timestamp6 = number;
 export type TopologyClass90 = "system_fault";
 export type TopologyClass91 = "atomic_proposition";
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid7 = string;
-/**
- * The RFC 8785 Canonical hash of the immediate causal ancestor, securing the Merkle-DAG.
- */
-export type PriorEventHash7 = string | null;
 /**
  * The precise temporal coordinate of the event realization.
  */
@@ -3532,10 +3503,6 @@ export type TopologyClass92 = "post_coordinated_concept";
  */
 export type EventCid8 = string;
 /**
- * The RFC 8785 Canonical hash of the immediate causal ancestor.
- */
-export type PriorEventHash8 = string | null;
-/**
  * The precise temporal coordinate of the event realization.
  */
 export type Timestamp8 = number;
@@ -3552,7 +3519,6 @@ export type ManifoldAlignmentMetricProfile1 = "gromov_wasserstein" | "earth_move
  */
 export type IsometryScore = number;
 export type EventCid9 = string;
-export type PriorEventHash9 = string | null;
 export type Timestamp9 = number;
 export type TopologyClass93 = "artifact_corruption";
 /**
@@ -3562,13 +3528,9 @@ export type ArtifactCid = string;
 export type CorruptionClass = "drm_locked" | "malformed_bytes" | "ocr_failure" | "unsupported_format";
 export type DiagnosticHash = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid10 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash10 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3616,13 +3578,9 @@ export type LatentVariables = string[];
  */
 export type CausalEdges1 = CausalDirectedEdgeState[];
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid11 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash11 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3649,13 +3607,9 @@ export type RetainedPartialPayload =
  */
 export type EpistemicDisposition = "discard" | "retain_as_context" | "mark_as_falsified";
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid12 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash12 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3685,13 +3639,9 @@ export type ExpectedUtilitySimulated = number;
  */
 export type EpistemicRegret = number;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid13 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash13 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3709,13 +3659,9 @@ export type ToolName1 = string;
  */
 export type AuthorizedBudgetMagnitude = number;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid14 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash14 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3737,13 +3683,9 @@ export type CrystallizedSemanticNodeCid = string;
  */
 export type CompressionRatio = number;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid15 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash15 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3765,13 +3707,9 @@ export type CommittedTemporalCrdtCid = string;
  */
 export type TargetTableUri = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid16 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash16 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3797,13 +3735,9 @@ export type OutputTokens = number;
  */
 export type BurnMagnitude = number;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid17 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash17 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3821,13 +3755,9 @@ export type ExhaustedEscrowCid = string;
  */
 export type FinalBurnReceiptCid = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid18 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash18 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3849,13 +3779,9 @@ export type TargetNodeCid = string;
  */
 export type DwellDurationMs = number | null;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid19 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash19 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3868,13 +3794,9 @@ export type TargetSourceConcept = string;
  */
 export type PredictedTopKTokens = [string, ...string[]];
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid20 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash20 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3888,13 +3810,9 @@ export type FactScorePassed = boolean;
  */
 export type ZeroTrustReceiptCid1 = string | null;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid21 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash21 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3913,13 +3831,9 @@ export type EstimatedFlowValue = number;
  */
 export type TerminalRewardFactorized = boolean;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid22 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash22 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3965,13 +3879,9 @@ export type ConfidenceIntervalUpper = number;
  */
 export type AgentAttributions = ShapleyAttributionReceipt[];
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid23 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash23 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -3998,13 +3908,9 @@ export type ConfidenceScore1 = number;
 export type RoutingPolicyCid = string | null;
 export type TopologyClass108 = "semantic_relational_record";
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid24 = string;
-/**
- * The RFC 8785 Canonical hash of the immediate causal ancestor, securing the Merkle-DAG.
- */
-export type PriorEventHash24 = string | null;
 /**
  * The precise temporal coordinate of the event realization.
  */
@@ -4025,10 +3931,6 @@ export type TopologyClass109 = "ontological_reification";
  * Cryptographic Lineage Watermark binding this node to the Merkle-DAG.
  */
 export type EventCid25 = string;
-/**
- * The RFC 8785 Canonical hash of the immediate causal ancestor.
- */
-export type PriorEventHash25 = string | null;
 /**
  * The precise temporal coordinate of the event realization.
  */
@@ -4054,13 +3956,9 @@ export type TransformationMechanismProfile =
  */
 export type IsLatentInference = boolean;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid26 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash26 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -4074,13 +3972,9 @@ export type TopologyClass110 = "circuit_breaker_event";
  */
 export type ErrorSignature = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid27 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash27 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -4106,13 +4000,9 @@ export type BayesianSurpriseScore1 = number;
  */
 export type LockedMagnitude = number;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid28 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash28 = string | null;
 /**
  * Discriminator type for a log event.
  */
@@ -4135,13 +4025,9 @@ export type TelemetryScalarState = string | number | boolean | null;
  */
 export type TopologyClass113 = "verdict";
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid29 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash29 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -4179,13 +4065,9 @@ export type DagNodeNonce = string;
  */
 export type LivenessChallengeHash = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid30 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash30 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -4216,13 +4098,9 @@ export type PostRedactionHash = string;
  */
 export type RedactionTimestampUnixNano = number;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid31 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash31 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -4241,13 +4119,9 @@ export type SourceClaimCid = string;
  */
 export type TargetClaimCid = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid32 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash32 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -4259,13 +4133,9 @@ export type ViolatedAlgebraicConstraint = string;
 export type KlDivergenceToValidity = number;
 export type StochasticMutationGradient = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid33 = string;
-/**
- * The RFC 8785 Canonical hash of the immediate causal ancestor.
- */
-export type PriorEventHash33 = string | null;
 /**
  * The precise temporal coordinate of the event realization.
  */
@@ -4292,13 +4162,9 @@ export type ExtractedBindings = {
 export type TopologyClass118 = "belief_modulation";
 export type ReceiptCid2 = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid34 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash34 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -4308,13 +4174,9 @@ export type SeveredEdgeCids = string[];
 export type TopologyClass119 = "rdf_export_receipt";
 export type ExportCid1 = string;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid35 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash35 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -4323,7 +4185,6 @@ export type SerializedPayload = string;
 export type RdfTripleCount = number;
 export type Sha256GraphHash = string;
 export type EventCid36 = string;
-export type PriorEventHash36 = string | null;
 export type Timestamp36 = number;
 export type TopologyClass120 = "epistemic_starvation";
 /**
@@ -4339,7 +4200,6 @@ export type FailedCitations = EvidentiaryCitationState[];
  */
 export type DiagnosticReason = string;
 export type EventCid37 = string;
-export type PriorEventHash37 = string | null;
 export type Timestamp37 = number;
 export type TopologyClass121 = "sparql_query_result";
 /**
@@ -4371,13 +4231,9 @@ export type TokensBurned = number;
  */
 export type HumanAttestationSignature = string | null;
 /**
- * A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.
+ * A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.
  */
 export type EventCid38 = string;
-/**
- * The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.
- */
-export type PriorEventHash38 = string | null;
 /**
  * Causal Ancestry markers required to resolve decentralized event ordering.
  */
@@ -6010,7 +5866,6 @@ export interface EpistemicProxyStateAny {
  */
 export interface AdjudicationReceipt {
   event_cid: EventCid;
-  prior_event_hash?: PriorEventHash;
   timestamp: Timestamp;
   topology_class?: TopologyClass1;
   rubric_cid: RubricCid;
@@ -10721,7 +10576,6 @@ export interface VectorClock {
 export interface MCPToolDefinition {
   topology_class?: TopologyClass83;
   event_cid?: EventCid1;
-  prior_event_hash?: PriorEventHash1;
   timestamp?: Timestamp1;
   name: Name;
   description: Description9;
@@ -10746,7 +10600,6 @@ export interface Inputschema {
  */
 export interface CrosswalkResolutionReceipt {
   event_cid: EventCid2;
-  prior_event_hash?: PriorEventHash2;
   timestamp: Timestamp2;
   topology_class?: TopologyClass84;
   receipt_cid: ReceiptCid;
@@ -10791,7 +10644,6 @@ export interface DempsterShaferBeliefVector1 {
  */
 export interface EpistemicZeroTrustReceipt {
   event_cid: EventCid3;
-  prior_event_hash?: PriorEventHash3;
   timestamp: Timestamp3;
   topology_class?: TopologyClass85;
   intent_reference_cid: IntentReferenceCid;
@@ -10813,7 +10665,6 @@ export interface EpistemicZeroTrustReceipt {
  */
 export interface ObservationEvent {
   event_cid: EventCid4;
-  prior_event_hash?: PriorEventHash4;
   timestamp: Timestamp4;
   topology_class?: TopologyClass86;
   payload: Payload;
@@ -11017,7 +10868,6 @@ export interface StreamingDisfluencyContract {
  */
 export interface BeliefMutationEvent {
   event_cid: EventCid5;
-  prior_event_hash?: PriorEventHash5;
   timestamp: Timestamp5;
   topology_class?: TopologyClass89;
   payload: Payload1;
@@ -11132,7 +10982,6 @@ export interface LatentScratchpadReceipt {
  */
 export interface SystemFaultEvent {
   event_cid: EventCid6;
-  prior_event_hash?: PriorEventHash6;
   timestamp: Timestamp6;
   topology_class?: TopologyClass90;
 }
@@ -11150,7 +10999,6 @@ export interface SystemFaultEvent {
 export interface AtomicPropositionState {
   topology_class?: TopologyClass91;
   event_cid: EventCid7;
-  prior_event_hash?: PriorEventHash7;
   timestamp: Timestamp7;
   proposition_cid: PropositionCid;
   rhetorical_role: RhetoricalStructureProfile;
@@ -11191,7 +11039,6 @@ export interface EmpiricalStatisticalProfile {
 export interface PostCoordinatedSemanticState {
   topology_class?: TopologyClass92;
   event_cid: EventCid8;
-  prior_event_hash?: PriorEventHash8;
   timestamp: Timestamp8;
   concept_cid: ConceptCid;
   /**
@@ -11221,7 +11068,6 @@ export interface ContextualModifiers {
  */
 export interface ArtifactCorruptionEvent {
   event_cid: EventCid9;
-  prior_event_hash?: PriorEventHash9;
   timestamp: Timestamp9;
   topology_class?: TopologyClass93;
   artifact_cid: ArtifactCid;
@@ -11241,7 +11087,6 @@ export interface ArtifactCorruptionEvent {
  */
 export interface HypothesisGenerationEvent {
   event_cid: EventCid10;
-  prior_event_hash?: PriorEventHash10;
   timestamp: Timestamp10;
   topology_class?: TopologyClass94;
   hypothesis_cid: HypothesisCid;
@@ -11283,7 +11128,6 @@ export interface StructuralCausalGraphProfile {
  */
 export interface BargeInInterruptEvent {
   event_cid: EventCid11;
-  prior_event_hash?: PriorEventHash11;
   timestamp: Timestamp11;
   topology_class?: TopologyClass95;
   target_event_cid: TargetEventCid1;
@@ -11307,7 +11151,6 @@ export interface BargeInInterruptEvent {
  */
 export interface CounterfactualRegretEvent {
   event_cid: EventCid12;
-  prior_event_hash?: PriorEventHash12;
   timestamp: Timestamp12;
   topology_class?: TopologyClass96;
   historical_event_cid: HistoricalEventCid;
@@ -11336,7 +11179,6 @@ export interface PolicyMutationGradients {
  */
 export interface ToolInvocationEvent {
   event_cid: EventCid13;
-  prior_event_hash?: PriorEventHash13;
   timestamp: Timestamp13;
   topology_class?: TopologyClass97;
   tool_name: ToolName1;
@@ -11402,7 +11244,6 @@ export interface ZeroKnowledgeReceipt1 {
  */
 export interface EpistemicPromotionEvent {
   event_cid: EventCid14;
-  prior_event_hash?: PriorEventHash14;
   timestamp: Timestamp14;
   topology_class?: TopologyClass98;
   source_episodic_event_cids: SourceEpisodicEventCids;
@@ -11422,7 +11263,6 @@ export interface EpistemicPromotionEvent {
  */
 export interface PersistenceCommitReceipt {
   event_cid: EventCid15;
-  prior_event_hash?: PriorEventHash15;
   timestamp: Timestamp15;
   topology_class?: TopologyClass99;
   lakehouse_snapshot_cid: LakehouseSnapshotCid;
@@ -11442,7 +11282,6 @@ export interface PersistenceCommitReceipt {
  */
 export interface TokenBurnReceipt {
   event_cid: EventCid16;
-  prior_event_hash?: PriorEventHash16;
   timestamp: Timestamp16;
   topology_class?: TopologyClass100;
   tool_invocation_cid: ToolInvocationCid;
@@ -11463,7 +11302,6 @@ export interface TokenBurnReceipt {
  */
 export interface BudgetExhaustionEvent {
   event_cid: EventCid17;
-  prior_event_hash?: PriorEventHash17;
   timestamp: Timestamp17;
   topology_class?: TopologyClass101;
   exhausted_escrow_cid: ExhaustedEscrowCid;
@@ -11482,7 +11320,6 @@ export interface BudgetExhaustionEvent {
  */
 export interface EpistemicTelemetryEvent {
   event_cid: EventCid18;
-  prior_event_hash?: PriorEventHash18;
   timestamp: Timestamp18;
   topology_class?: TopologyClass102;
   interaction_modality: InteractionModality;
@@ -11506,7 +11343,6 @@ export interface EpistemicTelemetryEvent {
  */
 export interface CognitivePredictionReceipt {
   event_cid: EventCid19;
-  prior_event_hash?: PriorEventHash19;
   timestamp: Timestamp19;
   topology_class?: TopologyClass103;
   source_chain_cid: SourceChainCid;
@@ -11526,7 +11362,6 @@ export interface CognitivePredictionReceipt {
  */
 export interface EpistemicAxiomVerificationReceipt {
   event_cid: EventCid20;
-  prior_event_hash?: PriorEventHash20;
   timestamp: Timestamp20;
   topology_class?: TopologyClass104;
   source_prediction_cid: SourcePredictionCid;
@@ -11560,7 +11395,6 @@ export interface EpistemicAxiomVerificationReceipt {
  */
 export interface EpistemicFlowStateReceipt {
   event_cid: EventCid21;
-  prior_event_hash?: PriorEventHash21;
   timestamp: Timestamp21;
   topology_class?: TopologyClass105;
   source_trajectory_cid: SourceTrajectoryCid;
@@ -11589,7 +11423,6 @@ export interface EpistemicFlowStateReceipt {
  */
 export interface CausalExplanationEvent {
   event_cid: EventCid22;
-  prior_event_hash?: PriorEventHash22;
   timestamp: Timestamp22;
   topology_class?: TopologyClass106;
   target_outcome_event_cid: TargetOutcomeEventCid;
@@ -11653,7 +11486,6 @@ export interface ShapleyAttributionReceipt {
  */
 export interface IntentClassificationReceipt {
   event_cid: EventCid23;
-  prior_event_hash?: PriorEventHash23;
   timestamp: Timestamp23;
   topology_class?: TopologyClass107;
   raw_input_string: RawInputString;
@@ -11675,7 +11507,6 @@ export interface IntentClassificationReceipt {
 export interface SemanticRelationalVectorState {
   topology_class?: TopologyClass108;
   event_cid: EventCid24;
-  prior_event_hash?: PriorEventHash24;
   timestamp: Timestamp24;
   ontology_class: UpperOntologyClassProfile;
   temporal_bounds: TemporalBoundsProfile1;
@@ -11720,7 +11551,6 @@ export interface PayloadInjectionZone {
 export interface OntologicalReificationReceipt {
   topology_class?: TopologyClass109;
   event_cid: EventCid25;
-  prior_event_hash?: PriorEventHash25;
   timestamp: Timestamp25;
   source_data_hash: SourceDataHash;
   target_namespace: TargetNamespace;
@@ -11759,7 +11589,6 @@ export interface DempsterShaferBeliefVector2 {
  */
 export interface CircuitBreakerEvent {
   event_cid: EventCid26;
-  prior_event_hash?: PriorEventHash26;
   timestamp: Timestamp26;
   topology_class?: TopologyClass110;
   /**
@@ -11790,7 +11619,6 @@ export interface CircuitBreakerEvent {
  */
 export interface ExogenousEpistemicEvent {
   event_cid: EventCid27;
-  prior_event_hash?: PriorEventHash27;
   timestamp: Timestamp27;
   topology_class?: TopologyClass111;
   shock_cid: ShockCid;
@@ -11824,7 +11652,6 @@ export interface SimulationEscrowContract {
  */
 export interface EpistemicLogEvent {
   event_cid: EventCid28;
-  prior_event_hash?: PriorEventHash28;
   topology_class?: TopologyClass112;
   timestamp: Timestamp28;
   level: Level;
@@ -11858,7 +11685,6 @@ export interface TelemetryContextProfile {
 export interface InterventionReceipt {
   topology_class?: TopologyClass113;
   event_cid: EventCid29;
-  prior_event_hash?: PriorEventHash29;
   timestamp: Timestamp29;
   intervention_request_cid: InterventionRequestCid;
   /**
@@ -11915,7 +11741,6 @@ export interface WetwareAttestationContract {
  */
 export interface CustodyReceipt {
   event_cid: EventCid30;
-  prior_event_hash?: PriorEventHash30;
   timestamp: Timestamp30;
   topology_class?: TopologyClass114;
   custody_cid: CustodyCid;
@@ -11938,7 +11763,6 @@ export interface CustodyReceipt {
  */
 export interface DefeasibleAttackEvent {
   event_cid: EventCid31;
-  prior_event_hash?: PriorEventHash31;
   timestamp: Timestamp31;
   topology_class?: TopologyClass115;
   attack_cid: AttackCid;
@@ -11962,7 +11786,6 @@ export interface DefeasibleAttackEvent {
  */
 export interface EpistemicRejectionReceipt {
   event_cid: EventCid32;
-  prior_event_hash?: PriorEventHash32;
   timestamp: Timestamp32;
   topology_class?: TopologyClass116;
   receipt_cid: ReceiptCid1;
@@ -11984,7 +11807,6 @@ export interface EpistemicRejectionReceipt {
  */
 export interface FormalVerificationReceipt {
   event_cid: EventCid33;
-  prior_event_hash?: PriorEventHash33;
   timestamp: Timestamp33;
   topology_class?: TopologyClass117;
   /**
@@ -12003,7 +11825,6 @@ export interface BeliefModulationReceipt {
   topology_class?: TopologyClass118;
   receipt_cid: ReceiptCid2;
   event_cid: EventCid34;
-  prior_event_hash?: PriorEventHash34;
   timestamp: Timestamp34;
   target_graph_cid: TargetGraphCid4;
   grounded_edges: GroundedEdges;
@@ -12019,7 +11840,6 @@ export interface RDFExportReceipt {
   topology_class?: TopologyClass119;
   export_cid: ExportCid1;
   event_cid: EventCid35;
-  prior_event_hash?: PriorEventHash35;
   timestamp: Timestamp35;
   serialized_payload: SerializedPayload;
   rdf_triple_count: RdfTripleCount;
@@ -12038,7 +11858,6 @@ export interface RDFExportReceipt {
  */
 export interface EpistemicStarvationEvent {
   event_cid: EventCid36;
-  prior_event_hash?: PriorEventHash36;
   timestamp: Timestamp36;
   topology_class?: TopologyClass120;
   starved_edge_cid: StarvedEdgeCid;
@@ -12058,7 +11877,6 @@ export interface EpistemicStarvationEvent {
  */
 export interface SPARQLQueryResultReceipt {
   event_cid: EventCid37;
-  prior_event_hash?: PriorEventHash37;
   timestamp: Timestamp37;
   topology_class?: TopologyClass121;
   query_intent_cid: QueryIntentCid;
@@ -12102,7 +11920,6 @@ export interface OracleExecutionReceipt {
  */
 export interface GuardrailViolationEvent {
   event_cid: EventCid38;
-  prior_event_hash?: PriorEventHash38;
   timestamp: Timestamp38;
   topology_class?: TopologyClass123;
   violation_id: ViolationId;
@@ -13183,13 +13000,13 @@ export interface EpistemicHydrationPolicy {
 /**
  * CoReason Shared Kernel Ontology
  *
- * AGENT INSTRUCTION: Formalizes Event Sourcing and the Merkle-DAG structure as the absolute, immutable source of truth for the swarm, fully partitioned from volatile memory.
+ * AGENT INSTRUCTION: Formalizes Event Sourcing as the absolute, immutable source of truth for the swarm, fully partitioned from volatile memory. Provenance is delegated to Sigstore (Cosign + Rekor transparency log) via the CI/CD pipeline.
  *
  * CAUSAL AFFORDANCE: Permanently crystallizes validated events into the `history` log. Applies Truth Maintenance, context eviction, and tracks active `DefeasibleCascadeEvents` and `RollbackIntents`.
  *
  * EPISTEMIC BOUNDS: The `@model_validator` `_enforce_canonical_sort` deterministically sorts history by timestamp, checkpoints by ID, and active cascades—guaranteeing invariant RFC 8785 canonical hashing. Validation prevents epistemic paradoxes (child before parent).
  *
- * MCP ROUTING TRIGGERS: Event Sourcing, Merkle-DAG, Immutable Ledger, Truth Crystallization, Chronological Sort
+ * MCP ROUTING TRIGGERS: Event Sourcing, Sigstore, Rekor Transparency Log, Immutable Ledger, Truth Crystallization, Chronological Sort
  */
 export interface EpistemicLedgerState {
   history: History;

--- a/coreason_ontology.schema.json
+++ b/coreason_ontology.schema.json
@@ -219,28 +219,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the\ndefinitive collapse of an MCDA evaluation, acting as a verified Outcome Reward Model\n(ORM) signal. As a ...Receipt suffix, this is an append-only coordinate on the\nMerkle-DAG.\n\nCAUSAL AFFORDANCE: Commits the calculated score and boolean passed verdict to the\nEpistemic Ledger, permanently binding the deterministic evaluation to the specific\ntarget_node_cid (NodeCIDState) and authorizing downstream policy updates.\n\nEPISTEMIC BOUNDS: The evaluation outcome is strictly bounded to an integer score\n(ge=0, le=100). The underlying deductive proof (reasoning) is physically capped at\nmax_length=2000. The entire receipt is cryptographically locked to the originating\nrubric_cid CID (128-char regex).\n\nMCP ROUTING TRIGGERS: Cryptographic Verdict, Deterministic Proof, Grading Execution,\nEpistemic Commitment, Audit Trail",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -1252,21 +1236,6 @@
           "title": "Event Cid",
           "type": "string"
         },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Prior Event Hash"
-        },
         "timestamp": {
           "maximum": 253402300799.0,
           "minimum": 0.0,
@@ -1374,28 +1343,12 @@
           "type": "string"
         },
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The RFC 8785 Canonical hash of the immediate causal ancestor, securing the Merkle-DAG.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "The precise temporal coordinate of the event realization.",
@@ -1642,28 +1595,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Encodes an asynchronous hardware interrupt or exogenous sensory spike that forces a premature probability wave collapse on an active generation trajectory.\n\nCAUSAL AFFORDANCE: Physically severs the continuous multimodal sequence of the `target_event_cid`, injecting the `retained_partial_payload` into the Epistemic Quarantine and forcing the orchestrator to execute the `epistemic_disposition`.\n\nEPISTEMIC BOUNDS: Topologically anchored to `target_event_cid` via a strict 128-char CID regex. The `retained_partial_payload` is volumetrically clamped by the `enforce_payload_topology` hook to prevent VRAM exhaustion.\n\nMCP ROUTING TRIGGERS: Asynchronous Interrupt, Generative Severing, Context Switching, Defeasible Disposition, Wave Collapse",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -1760,28 +1697,12 @@
           "type": "string"
         },
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -1833,28 +1754,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Bayesian Belief Updating and Pearlian Causal Tracing by synthesizing internal cognitive shifts into discrete, hashable facts.\n\nCAUSAL AFFORDANCE: Projects a synthesized conclusion into the shared topology, binding the new belief to `causal_attributions`.\n\nEPISTEMIC BOUNDS: Structural validation is enforced via nested schema instantiation. `payload` is volumetrically clamped by `@field_validator`. `quorum_signatures` prevents Sybil attacks via `@model_validator` `enforce_sybil_resistance`.\n\nMCP ROUTING TRIGGERS: Bayesian Belief Updating, Causal Tracing, Cognitive Synthesis, Merkle-DAG Coordinate, Non-Monotonic Leap",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -2159,28 +2064,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents the definitive algorithmic circuit breaker (Optimal Stopping boundary) triggered the exact millisecond thermodynamic token burn mathematically exceeds the locked Proof-of-Stake escrow.\n\nCAUSAL AFFORDANCE: Instantly collapses the active Latent Scratchpad trajectory and physically severs the kinetic execution loop, preventing Sybil griefing attacks against the swarm's compute pool.\n\nEPISTEMIC BOUNDS: Cryptographically targets the specific `exhausted_escrow_cid` and the exact `final_burn_receipt_cid` (CID regex) that pushed the thermodynamic ledger into a negative state, providing an undeniable audit trail.\n\nMCP ROUTING TRIGGERS: Optimal Stopping Theory, Escrow Exhaustion, Sybil Resistance, Algorithmic Circuit Breaker, Generation Halting",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -2552,28 +2441,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the\nmacroscopic factorization of a collective swarm outcome into its constituent causal\ncomponents. As an ...Event suffix, this is an append-only coordinate on the\nMerkle-DAG.\n\nCAUSAL AFFORDANCE: Commits the system-level CollectiveIntelligenceProfile and the\nindividual ShapleyAttributionReceipt array to the Epistemic Ledger, finalizing the\ncredit assignment for a target_outcome_event_cid.\n\nEPISTEMIC BOUNDS: The target_outcome_event_cid is locked to a 128-char CID regex. The\n@model_validator mathematically enforces deterministic canonical hashing by sorting the\nagent_attributions array by target_node_cid (NodeCIDState), guaranteeing RFC 8785\nalignment.\n\nMCP ROUTING TRIGGERS: Causal Factorization, Epistemic Ledger Commit, Credit Assignment,\nMacroscopic Explanation, Deterministic Sorting",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -2679,28 +2552,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Lyapunov Stability and distributed Control Theory to guarantee that the neurosymbolic network returns to a deterministic equilibrium when facing catastrophic variance. As an ...Event suffix, this is a cryptographically frozen coordinate.\n\nCAUSAL AFFORDANCE: Physically severs the active execution thread for the targeted node, acting as a hardware guillotine that immediately halts out-of-memory cascades, runaway generative loops, or API rate-limit breaches.\n\nEPISTEMIC BOUNDS: The fault perimeter is mathematically restricted to a specific `target_node_cid` (`NodeCIDState`). To prevent log-poisoning and VRAM exhaustion during the crash, the `error_signature` is strictly clamped at `max_length=2000`.\n\nMCP ROUTING TRIGGERS: Lyapunov Stability, Control Theory, Circuit Breaker, Cascading Failure, State Equilibrium",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -3451,28 +3308,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Captures the pre-verification predictive distribution (Softmax logit outputs) of an LLM across a latent conceptual boundary.\n\nCAUSAL AFFORDANCE: Exposes the raw generative probability manifold to the orchestrator, enabling external mechanistic solvers to evaluate token divergence before crystallizing the probability wave into a permanent epistemic axiom.\n\nEPISTEMIC BOUNDS: Mathematical isolation enforced by binding predictions to a strict `source_chain_cid` CID. The prediction vector is physically capped by `predicted_top_k_tokens` (string `max_length=255`) to prevent unbounded tensor serialization.\n\nMCP ROUTING TRIGGERS: Predictive Distribution, Softmax Logits, Generative Manifold, Probability Wave Collapse, Entropy",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -4952,28 +4793,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Employs Counterfactual Regret Minimization (CFR) and Pearlian Do-Calculus to execute simulated alternative timelines for policy refinement.\n\nCAUSAL AFFORDANCE: Commits a simulated causal divergence (intervention) into the ledger, mathematically quantifying the opportunity cost (regret) to backpropagate stateless adjustments to the routing policy.\n\nEPISTEMIC BOUNDS: Anchored to `historical_event_cid` (128-char CID). Expected utilities and `epistemic_regret` are physically capped at `le=18446744073709551615.0`. `policy_mutation_gradients` restrict tensor adjustments.\n\nMCP ROUTING TRIGGERS: Counterfactual Regret Minimization, Pearlian Do-Calculus, Opportunity Cost, Alternative Timeline, Policy Gradient Update",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -5102,21 +4927,6 @@
           "title": "Event Cid",
           "type": "string"
         },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Prior Event Hash"
-        },
         "timestamp": {
           "maximum": 253402300799.0,
           "minimum": 0.0,
@@ -5232,28 +5042,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the successful execution of an SemanticFlowPolicy redaction on the Merkle-DAG. Enforced as fully immutable via `ConfigDict(frozen=True)`.\n\nCAUSAL AFFORDANCE: Unlocks strict audit compliance by mathematically mapping the optional toxic `pre_redaction_hash` to the mandatory safe `post_redaction_hash`, proving non-repudiation via the `applied_policy_cid`.\n\nEPISTEMIC BOUNDS: Temporal geometry strictly clamped to `redaction_timestamp_unix_nano` (`ge=0, le=253402300799000000000`). Both hashes are locked to immutable SHA-256 hexadecimal bounds (`^[a-f0-9]{64}$`). `pre_redaction_hash` is optional (`default=None`) for isolated audit vaults.\n\nMCP ROUTING TRIGGERS: Chain of Custody, Cryptographic Provenance, Merkle-DAG Audit, Non-Repudiation, Data Isomorphism",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -5611,28 +5405,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the binary attack relation in Dung's Abstract Argumentation Framework. As an ...Event suffix, this is an append-only, cryptographically frozen historical fact on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Projects an undercutting or rebutting defeater from a source claim against a target claim. If mathematically validated, it physically triggers a DefeasibleCascadeEvent to sever all downstream nodes relying on the target.\n\nEPISTEMIC BOUNDS: Strictly bounds the attack geometry using AttackVectorProfile enums (`Literal[\"rebuttal\", \"undercutter\", \"underminer\"]`). Source and target mappings are locked to 128-character CIDs, preventing unbounded graph traversals.\n\nMCP ROUTING TRIGGERS: Undercutting Defeater, Dialectical Edge, Truth Maintenance System, Bipartite Mapping, Non-Monotonic Retraction",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -7111,28 +6889,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements automated Natural Language Inference (NLI) and Entailment Verification to mechanically quarantine hallucinated tokens. As a ...Receipt suffix, it represents an immutable cryptographic verdict.\n\nCAUSAL AFFORDANCE: Acts as the definitive logic gate for the Truth Maintenance System. If verification succeeds, it physically unlocks the promotion of the source prediction into the global semantic knowledge graph.\n\nEPISTEMIC BOUNDS: Factual alignment is geometrically bounded by sequence_similarity_score (ge=0.0, le=1.0). The @model_validator enforce_epistemic_quarantine deliberately crashes instantiation if fact_score_passed is False, physically severing the DAG to prevent epistemic contagion. Structural integrity mathematically demands that the `zero_trust_receipt_cid` be present to prove the generative extraction bypassed prompt injection boundaries.\n\nMCP ROUTING TRIGGERS: Entailment Verification, Natural Language Inference, Truth Maintenance System, Epistemic Quarantine, Hallucination Filtering",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -7401,28 +7163,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An immutable cryptographic coordinate recording the successful\nfactorization of a terminal reward into a fractional flow value across a continuous\nCognitiveReasoningTraceState trajectory. As a ...Receipt suffix, this is an append-only\ncoordinate on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Physically anchors the scalar backpropagation of a factored reward\nto a specific source_trajectory_cid, unlocking global flow consistency calculations\nacross the distributed swarm. The terminal_reward_factorized boolean confirms\nsuccessful reward decomposition.\n\nEPISTEMIC BOUNDS: Flow magnitude is geometrically bounded by estimated_flow_value\n(ge=0.0, le=18446744073709551615.0) to prevent exploding gradients during policy updates.\nCryptographically mapped to a rigid 128-char source_trajectory_cid CID.\n\nMCP ROUTING TRIGGERS: Trajectory Balance, Reward Factorization, Flow Network Receipt,\nScalar Backpropagation, Acyclic Path",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -7587,7 +7333,7 @@
     },
     "EpistemicLedgerState": {
       "additionalProperties": false,
-      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Event Sourcing and the Merkle-DAG structure as the absolute, immutable source of truth for the swarm, fully partitioned from volatile memory.\n\nCAUSAL AFFORDANCE: Permanently crystallizes validated events into the `history` log. Applies Truth Maintenance, context eviction, and tracks active `DefeasibleCascadeEvents` and `RollbackIntents`.\n\nEPISTEMIC BOUNDS: The `@model_validator` `_enforce_canonical_sort` deterministically sorts history by timestamp, checkpoints by ID, and active cascades—guaranteeing invariant RFC 8785 canonical hashing. Validation prevents epistemic paradoxes (child before parent).\n\nMCP ROUTING TRIGGERS: Event Sourcing, Merkle-DAG, Immutable Ledger, Truth Crystallization, Chronological Sort",
+      "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Event Sourcing as the absolute, immutable source of truth for the swarm, fully partitioned from volatile memory. Provenance is delegated to Sigstore (Cosign + Rekor transparency log) via the CI/CD pipeline.\n\nCAUSAL AFFORDANCE: Permanently crystallizes validated events into the `history` log. Applies Truth Maintenance, context eviction, and tracks active `DefeasibleCascadeEvents` and `RollbackIntents`.\n\nEPISTEMIC BOUNDS: The `@model_validator` `_enforce_canonical_sort` deterministically sorts history by timestamp, checkpoints by ID, and active cascades—guaranteeing invariant RFC 8785 canonical hashing. Validation prevents epistemic paradoxes (child before parent).\n\nMCP ROUTING TRIGGERS: Event Sourcing, Sigstore, Rekor Transparency Log, Immutable Ledger, Truth Crystallization, Chronological Sort",
       "properties": {
         "history": {
           "description": "An append-only, cryptographic ledger of state events. [SITD-Alpha: Non-Monotonic Epistemic Quarantine Isometry]",
@@ -7696,28 +7442,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Defines a purely out-of-band semantic logging vector, structurally isolated from the rigorous causal constraints of the Dapper trace tree.\n\nCAUSAL AFFORDANCE: Emits asynchronous telemetry for human-in-the-loop debugging or peripheral auditing without mutating the active Epistemic Ledger's topological state.\n\nEPISTEMIC BOUNDS: Temporal reality clamped by `timestamp`. Severity strictly masked by a Literal automaton `[\"DEBUG\", \"INFO\", \"WARNING\", \"ERROR\", \"CRITICAL\"]`. Message bounded to `max_length=2000`.\n\nMCP ROUTING TRIGGERS: Out-of-Band Telemetry, Asynchronous Logging, Severity Masking, Peripheral Audit, Ephemeral Context",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "topology_class": {
           "const": "epistemic_log",
@@ -7770,28 +7500,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Represents Hippocampal-Neocortical Consolidation, proving the successful extraction and transfer of generalized knowledge from short-term episodic traces into the permanent semantic graph.\n\nCAUSAL AFFORDANCE: Emits a permanent Merkle-DAG coordinate (`crystallized_semantic_node_cid`) that downstream agents can zero-shot reference, severing the need to reload raw source logs into active context.\n\nEPISTEMIC BOUNDS: Mathematical chain of custody bound to the strictly sorted array of `source_episodic_event_cids`. Token efficiency proven by `compression_ratio` float (`le=1.0`) guaranteeing Shannon Entropy reduction.\n\nMCP ROUTING TRIGGERS: Hippocampal Consolidation, Knowledge Distillation, Semantic Memory, Shannon Entropy Compression, Epistemic Promotion",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -8072,28 +7786,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: The mathematical backpropagation signal triggered when the Deterministic Compiler rejects a stochastic manifold. Quantifies the rejection and provides a mutation gradient.\n\nCAUSAL AFFORDANCE: Instructs the LLM ensemble on how to perturb the Upper Confidence Bound (UCB) during the next MCTS generation attempt by mathematically quantifying the error.\n\nEPISTEMIC BOUNDS: Kullback-Leibler divergence is strictly non-negative. A negative mathematical distance is a paradox and raises a ValueError.\n\nMCP ROUTING TRIGGERS: Rejection Receipt, Free Energy Feedback, MCTS Backpropagation, Variational Free Energy, Mutation Gradient",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -8420,21 +8118,6 @@
           "title": "Event Cid",
           "type": "string"
         },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Prior Event Hash"
-        },
         "timestamp": {
           "maximum": 253402300799.0,
           "minimum": 0.0,
@@ -8485,28 +8168,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Implements Human-in-the-Loop (HITL) Supervisory Control Theory and Epistemic Regret tracking to measure out-of-band human physical attention kinematics.\n\nCAUSAL AFFORDANCE: Emits passive structural telemetry to update retrieval gradients and Bayesian priors based on human spatial interaction, without halting the underlying execution DAG.\n\nEPISTEMIC BOUNDS: The human interaction is rigidly confined to the `interaction_modality` Literal automaton. Temporal liveness of attention is bounded by `dwell_duration_ms` (`ge=0, le=18446744073709551615`). Target is locked to `target_node_cid` CID.\n\nMCP ROUTING TRIGGERS: Epistemic Regret, Supervisory Control Theory, Human-in-the-Loop, Dwell Time, Spatial Telemetry",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -8816,28 +8483,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact proving the flawless execution of an EpistemicZeroTrustContract.\n\nCAUSAL AFFORDANCE: Permits the orchestrator to append the transmuted payload to the global immutable ledger, certifying that prompt injection was structurally impossible and AST contracts were fulfilled.\n\nEPISTEMIC BOUNDS: `firewall_breach_detected` must strictly be False. Hashes are bounded to RFC 8785 canonicalization requirements.\n\nMCP ROUTING TRIGGERS: Cryptographic Ledger, Formal Verification Receipt, Immutable Provenance, Hash Canonicalization, Data Masking",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -9616,28 +9267,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Nassim Taleb's Black Swan Theory by injecting\nOut-of-Distribution (OOD) epistemic shocks into the causal graph. As an ...Event suffix,\nthis is an append-only coordinate on the Merkle-DAG that the LLM must never hallucinate\na mutation to.\n\nCAUSAL AFFORDANCE: Forces the active reasoning topology to process a high-entropy\nsynthetic_payload, actively testing the swarm's non-monotonic truth maintenance,\ndefeasible reasoning, and overall topological resilience.\n\nEPISTEMIC BOUNDS: Cryptographically targets a specific Merkle root via target_node_hash\n(strict SHA-256 pattern ^[a-f0-9]{64}$) and bounds the Variational Free Energy via\nbayesian_surprise_score [ge=0.0, le=1.0, allow_inf_nan=False]. The @model_validator\nphysically guarantees execution is halted if the attached escrow is not strictly positive.\n\nMCP ROUTING TRIGGERS: Black Swan Theory, Out-of-Distribution Shock, Variational Free\nEnergy, Exogenous Perturbation, Epistemic Stress Test",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -10026,28 +9661,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the unified outcome of a formal logic evaluation or theorem proof.\n\nCAUSAL AFFORDANCE: Unlocks System 2 remediation loops or graph progression by providing deterministic, algebraically verified execution traces and truth values.\n\nEPISTEMIC BOUNDS: Cryptographically anchored to the Merkle-DAG. The boolean 'is_proved' definitively represents mathematical truth.\n\nMCP ROUTING TRIGGERS: System 2 Remediation, Mathematical Truth, Proof Verification, Epistemic Ledger",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The RFC 8785 Canonical hash of the immediate causal ancestor.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "The precise temporal coordinate of the event realization.",
@@ -10540,28 +10159,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Tracks a deterministic security boundary violation emitted by the NeMo Guardrails proxy. This event is a frozen historical fact representing a failed cryptographic or semantic check.\n\nCAUSAL AFFORDANCE: Triggers an immediate suspension of the active execution trajectory and publishes a high-severity alert to the telemetry broker for remediation.\n\nEPISTEMIC BOUNDS: The event must include the specific HTTP status code (e.g., 401, 403, 406, 422) and the opaque violation manifest emitted by the proxy.\n\nMCP ROUTING TRIGGERS: Security, Guardrails, Data Loss Prevention, Policy Violation, Telemetry",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -10880,28 +10483,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Instantiates an abductive reasoning branch governed by Popperian Falsification and Bayesian updating on the Merkle-DAG.\n\nCAUSAL AFFORDANCE: Commits a formalized causal premise into the EpistemicLedgerState, unlocking the orchestration of empirical testing via active inference to falsify or verify the embedded causal model.\n\nEPISTEMIC BOUNDS: `bayesian_prior` is clamped `[ge=0.0, le=1.0]`. Identity is cryptographically locked via `hypothesis_cid` (128-char CID). `falsification_conditions` deterministically sorted by `@model_validator`.\n\nMCP ROUTING TRIGGERS: Abductive Reasoning, Popperian Falsification, Bayesian Prior, Causal Hypothesis, Epistemic Commitment",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -11176,28 +10763,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the non-monotonic\ncollapse of a high-entropy human natural language string into a discrete, mathematically\nbounded routing heuristic. As a ...Receipt suffix, this is an append-only Merkle-DAG coordinate.\n\nCAUSAL AFFORDANCE: Commits the LLM's Softmax classification verdict to the Epistemic Ledger,\nauthorizing the TaxonomicRoutingPolicy or router gate to physically execute the targeted\ntopology or sub-agent.\n\nEPISTEMIC BOUNDS: The raw_input_string is physically clamped (max_length=100000) to prevent\ncontext window buffer overflows. The classification confidence is strictly bound to a\nnormalized float (ge=0.0, le=1.0).\n\nMCP ROUTING TRIGGERS: Intent Classification, Softmax Gating, High-Entropy Parsing,\nRouting Heuristic, Semantic Wave Collapse",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -11559,28 +11130,12 @@
           "type": "string"
         },
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -12721,28 +12276,12 @@
         },
         "event_cid": {
           "default": "mcp_tool_cid",
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The RFC 8785 Canonical hash of the immediate causal ancestor event. Null for genesis nodes.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "default": 0.0,
@@ -13437,7 +12976,7 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: An append-only, cryptographically frozen coordinate representing the verifiable output of a MechanisticAuditContract.\n\nCAUSAL AFFORDANCE: Commits the extracted `SaeFeatureActivationState` matrix (`hook_activations`) to the Merkle-DAG. The `causal_scrubbing_applied` boolean mathematically proves that the orchestrator actively resampled or ablated the circuit to confirm direct causal responsibility.\n\nEPISTEMIC BOUNDS: Cryptographic integrity structurally anchored by `audit_cid` (128-char CID regex). The `@model_validator` sorts each `SaeFeatureActivationState` list within `hook_activations` by `feature_index`, guaranteeing zero-variance RFC 8785 Merkle-DAG hashing.\n\nMCP ROUTING TRIGGERS: Causal Scrubbing, Epistemic Provenance, Mechanistic Audit, RFC 8785 Canonicalization, Cryptographic Brain-Scan, TransformerLens, SAELens",
       "properties": {
         "audit_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
@@ -13942,28 +13481,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes the ingestion of Bayesian Evidence ($E$) by capturing the raw, lossless semantic output from a ToolInvocationEvent or environmental shift.\n\nCAUSAL AFFORDANCE: Injects verified exogenous truth into the EpistemicLedgerState. The payload is linked to its source via `triggering_invocation_cid`.\n\nEPISTEMIC BOUNDS: The `payload` dictionary is physically constrained against OOM exhaustion via the `@field_validator` `enforce_payload_topology`. Hardware attestation and zero-knowledge proofs provide cryptographic integrity.\n\nMCP ROUTING TRIGGERS: Bayesian Evidence, Neurosymbolic Binding, Exogenous Truth, Epistemic Grounding, Payload Topological Bounding",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -14253,22 +13776,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The RFC 8785 Canonical hash of the immediate causal ancestor.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "The precise temporal coordinate of the event realization.",
@@ -14800,28 +14307,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: A cryptographically frozen historical fact representing the absolute Write-Ahead Logging (WAL) serialization of an ephemeral state differential to durable cold-storage.\n\nCAUSAL AFFORDANCE: Commits the internal `committed_temporal_crdt_cid` into the macroscopic Apache Iceberg or Delta Lake backing store, yielding a verifiable `lakehouse_snapshot_cid` to guarantee Eventual Consistency.\n\nEPISTEMIC BOUNDS: `lakehouse_snapshot_cid` and `committed_temporal_crdt_cid` are rigorously clamped by `max_length=128` and a strict CID regex (`^[a-zA-Z0-9_.:-]+$`), mathematically preventing path traversal injections.\n\nMCP ROUTING TRIGGERS: Event Sourcing, Write-Ahead Logging, Two-Phase Commit, Lakehouse Serialization, State Differential Flush",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -14888,22 +14379,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The RFC 8785 Canonical hash of the immediate causal ancestor.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "The precise temporal coordinate of the event realization.",
@@ -15342,28 +14817,12 @@
           "type": "string"
         },
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -15967,21 +15426,6 @@
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "maximum": 253402300799.0,
@@ -16861,28 +16305,12 @@
           "type": "string"
         },
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The RFC 8785 Canonical hash of the immediate causal ancestor, securing the Merkle-DAG.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "The precise temporal coordinate of the event realization.",
@@ -18479,28 +17907,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Acts as a structural terminal state mapping a Byzantine Fault or catastrophic topological execution collapse within the distributed system.\n\nCAUSAL AFFORDANCE: Instructs the orchestrator's circuit breakers to completely sever the active execution branch and quarantine the associated probability wave, preventing failure contagion.\n\nEPISTEMIC BOUNDS: Inherits strict temporal and spatial bounds from CoreasonBaseState. Its semantic geometry is permanently constrained to the strict Literal automaton `[\"system_fault\"]`.\n\nMCP ROUTING TRIGGERS: Byzantine Fault Tolerance, Circuit Breaker, Terminal State, Execution Collapse, Fault Isolation",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -19529,28 +18941,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Landauer's Principle of thermodynamic computing within the neurosymbolic network, serving as a lock-free, cryptographically frozen record of irreversible token and energy expenditure.\n\nCAUSAL AFFORDANCE: Deducts exact computational magnitude from the agent's localized Proof-of-Stake (PoS) execution escrow, progressively narrowing its available search depth. Bound to causal origin via `tool_invocation_cid`.\n\nEPISTEMIC BOUNDS: Integer bounds (`ge=0, le=18446744073709551615`) on `input_tokens`, `output_tokens`, and `burn_magnitude` mathematically prevent integer overflow and fractional bypasses during ledger tallying.\n\nMCP ROUTING TRIGGERS: Landauer's Principle, Thermodynamic Compute, Token Burn, Resource Exhaustion, Lock-Free Tallying",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",
@@ -19612,28 +19008,12 @@
       "description": "CoReason Shared Kernel Ontology\n\nAGENT INSTRUCTION: Formalizes Judea Pearl's Do-Operator ($do(X=x)$) on an external or internal toolset, acting as an A Priori Kinetic Commitment.\n\nCAUSAL AFFORDANCE: Transitions the swarm from internal epistemic deliberation to kinetic execution. Targets a specific `tool_name` with bound parameters, demanding a valid `agent_attestation` identity.\n\nEPISTEMIC BOUNDS: `parameters` payload is volumetrically capped by `enforce_payload_topology`. To prevent infinite compute loops, `authorized_budget_magnitude` is mandated `ge=1`. `zk_proof` serves as mathematical authorization proof.\n\nMCP ROUTING TRIGGERS: Pearlian Do-Operator, Kinetic Commitment, Active Inference, Thermodynamic Escrow, Zero-Trust Actuation",
       "properties": {
         "event_cid": {
-          "description": "A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+          "description": "A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
           "maxLength": 128,
           "minLength": 1,
           "pattern": "^[a-zA-Z0-9_.:-]+$",
           "title": "Event Cid",
           "type": "string"
-        },
-        "prior_event_hash": {
-          "anyOf": [
-            {
-              "maxLength": 128,
-              "minLength": 1,
-              "pattern": "^[a-f0-9]{64}$",
-              "type": "string"
-            },
-            {
-              "type": "null"
-            }
-          ],
-          "default": null,
-          "description": "The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
-          "title": "Prior Event Hash"
         },
         "timestamp": {
           "description": "Causal Ancestry markers required to resolve decentralized event ordering.",

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -3583,13 +3583,7 @@ class SystemFaultEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -3948,13 +3942,7 @@ class CausalExplanationEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -4049,13 +4037,7 @@ class CircuitBreakerEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -4162,13 +4144,7 @@ class CounterfactualRegretEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -4749,13 +4725,7 @@ class BargeInInterruptEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -4872,13 +4842,7 @@ class EpistemicPromotionEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -4986,9 +4950,6 @@ class CrosswalkResolutionReceipt(CoreasonBaseState):
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         ...
     )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(default=None)
     timestamp: float = Field(ge=0.0, le=253402300799.0)
 
     topology_class: Literal["crosswalk_resolution"] = "crosswalk_resolution"
@@ -5604,13 +5565,7 @@ class BudgetExhaustionEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -5642,13 +5597,7 @@ class TokenBurnReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -6539,11 +6488,8 @@ class FormalVerificationReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG."
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore."
     )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(default=None, description="The RFC 8785 Canonical hash of the immediate causal ancestor.")
     timestamp: float = Field(ge=0.0, description="The precise temporal coordinate of the event realization.")
 
     topology_class: Literal["formal_verification_receipt"] = Field(default="formal_verification_receipt")
@@ -6613,13 +6559,7 @@ class BeliefModulationReceipt(CoreasonBaseState):
     topology_class: Literal["belief_modulation"] = "belief_modulation"
     receipt_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -6681,9 +6621,6 @@ class SPARQLQueryResultReceipt(CoreasonBaseState):
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         ...
     )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(default=None)
     timestamp: float = Field(ge=0.0, le=253402300799.0)
 
     topology_class: Literal["sparql_query_result"] = "sparql_query_result"
@@ -6727,13 +6664,7 @@ class RDFExportReceipt(CoreasonBaseState):
     topology_class: Literal["rdf_export_receipt"] = "rdf_export_receipt"
     export_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")]
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -8443,7 +8374,7 @@ class NeuralAuditAttestationReceipt(CoreasonBaseState):
     """
 
     audit_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     hook_activations: dict[str, list[SaeFeatureActivationState]] = Field(
         description="A mapping of specific TransformerLens hook points to their top-k activated SAE features."
@@ -8678,13 +8609,7 @@ class PersistenceCommitReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -9274,13 +9199,7 @@ class ExogenousEpistemicEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -9498,13 +9417,7 @@ class HypothesisGenerationEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -9750,13 +9663,7 @@ class EpistemicLogEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     topology_class: Literal["epistemic_log"] = Field(
         default="epistemic_log", description="Discriminator type for a log event."
@@ -10036,13 +9943,7 @@ class ToolInvocationEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -12241,13 +12142,7 @@ class BeliefMutationEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -12340,13 +12235,7 @@ class ObservationEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -12438,9 +12327,6 @@ class ArtifactCorruptionEvent(CoreasonBaseState):
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         ...
     )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(default=None)
     timestamp: float = Field(ge=0.0, le=253402300799.0)
 
     topology_class: Literal["artifact_corruption"] = "artifact_corruption"
@@ -12464,13 +12350,7 @@ class EpistemicTelemetryEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -12592,13 +12472,7 @@ class CognitivePredictionReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -12639,13 +12513,7 @@ class IntentClassificationReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -12680,13 +12548,7 @@ class EpistemicAxiomVerificationReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -13021,13 +12883,7 @@ class EpistemicFlowStateReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -13091,9 +12947,6 @@ class PostCoordinatedSemanticState(CoreasonBaseState):
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         description="Cryptographic Lineage Watermark binding this node to the Merkle-DAG."
     )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(default=None, description="The RFC 8785 Canonical hash of the immediate causal ancestor.")
     timestamp: float = Field(description="The precise temporal coordinate of the event realization.")
     concept_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         description="The unique geometric coordinate representing this specific assembled concept."
@@ -13159,13 +13012,7 @@ class AtomicPropositionState(CoreasonBaseState):
 
     topology_class: Literal["atomic_proposition"] = Field(default="atomic_proposition")
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG."
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The RFC 8785 Canonical hash of the immediate causal ancestor, securing the Merkle-DAG.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore."
     )
     timestamp: float = Field(description="The precise temporal coordinate of the event realization.")
     proposition_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = (
@@ -13212,13 +13059,7 @@ class EpistemicRejectionReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -13263,13 +13104,7 @@ class AdjudicationReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -13304,13 +13139,7 @@ class CustodyReceipt(CoreasonBaseState):
 
     model_config = ConfigDict(frozen=True)
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -13353,13 +13182,7 @@ class DefeasibleAttackEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -13403,13 +13226,7 @@ class InterventionReceipt(CoreasonBaseState):
 
     topology_class: Literal["verdict"] = Field(default="verdict", description="The type of the intervention payload.")
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -13458,13 +13275,7 @@ class EpistemicZeroTrustReceipt(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,
@@ -13502,13 +13313,7 @@ class MCPToolDefinition(CoreasonBaseState):
     topology_class: Literal["mcp_tool_definition"] = Field(default="mcp_tool_definition")
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         default="mcp_tool_cid",
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The RFC 8785 Canonical hash of the immediate causal ancestor event. Null for genesis nodes.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(default=0.0)
     name: Annotated[str, StringConstraints(max_length=64, pattern="^[a-zA-Z0-9_-]+$")]
@@ -13742,9 +13547,6 @@ class EpistemicStarvationEvent(CoreasonBaseState):
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         ...
     )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(default=None)
     timestamp: float = Field(ge=0.0, le=253402300799.0)
 
     topology_class: Literal["epistemic_starvation"] = "epistemic_starvation"
@@ -13783,9 +13585,6 @@ class OntologicalReificationReceipt(CoreasonBaseState):
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
         description="Cryptographic Lineage Watermark binding this node to the Merkle-DAG."
     )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(default=None, description="The RFC 8785 Canonical hash of the immediate causal ancestor.")
     timestamp: float = Field(description="The precise temporal coordinate of the event realization.")
     source_data_hash: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] = Field(
         description="The undeniable SHA-256 hash of the pre-transmutation artifact, unstructured text chunk, or telemetry row."
@@ -13818,13 +13617,7 @@ class SemanticRelationalVectorState(CoreasonBaseState):
 
     topology_class: Literal["semantic_relational_record"] = Field(default="semantic_relational_record")
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The RFC 8785 Canonical hash of the immediate causal ancestor, securing the Merkle-DAG.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(description="The precise temporal coordinate of the event realization.")
     ontology_class: UpperOntologyClassProfile = Field(
@@ -13952,13 +13745,13 @@ class SpeculativeExecutionPolicy(CoreasonBaseState):
 
 class EpistemicLedgerState(CoreasonBaseState):
     r"""
-    AGENT INSTRUCTION: Formalizes Event Sourcing and the Merkle-DAG structure as the absolute, immutable source of truth for the swarm, fully partitioned from volatile memory.
+    AGENT INSTRUCTION: Formalizes Event Sourcing as the absolute, immutable source of truth for the swarm, fully partitioned from volatile memory. Provenance is delegated to Sigstore (Cosign + Rekor transparency log) via the CI/CD pipeline.
 
     CAUSAL AFFORDANCE: Permanently crystallizes validated events into the `history` log. Applies Truth Maintenance, context eviction, and tracks active `DefeasibleCascadeEvents` and `RollbackIntents`.
 
     EPISTEMIC BOUNDS: The `@model_validator` `_enforce_canonical_sort` deterministically sorts history by timestamp, checkpoints by ID, and active cascades—guaranteeing invariant RFC 8785 canonical hashing. Validation prevents epistemic paradoxes (child before parent).
 
-    MCP ROUTING TRIGGERS: Event Sourcing, Merkle-DAG, Immutable Ledger, Truth Crystallization, Chronological Sort
+    MCP ROUTING TRIGGERS: Event Sourcing, Sigstore, Rekor Transparency Log, Immutable Ledger, Truth Crystallization, Chronological Sort
 
     """
 
@@ -14030,12 +13823,6 @@ class EpistemicLedgerState(CoreasonBaseState):
         )
         return self
 
-    @model_validator(mode="after")
-    def verify_merkle_chain(self) -> Self:
-        for i in range(1, len(self.history)):
-            if getattr(self.history[i], "prior_event_hash", None) is None:
-                raise ValueError("Merkle Chain Broken: Event missing prior_event_hash")
-        return self
 
     @model_validator(mode="after")
     def enforce_defeasible_quarantine(self) -> Self:
@@ -14061,13 +13848,7 @@ class GuardrailViolationEvent(CoreasonBaseState):
     """
 
     event_cid: Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-zA-Z0-9_.:-]+$")] = Field(
-        description="A Content Identifier (CID) acting as a cryptographic Lineage Watermark binding this node to the Merkle-DAG.",
-    )
-    prior_event_hash: (
-        Annotated[str, StringConstraints(min_length=1, max_length=128, pattern="^[a-f0-9]{64}$")] | None
-    ) = Field(
-        default=None,
-        description="The SHA-256 hash of the temporally preceding event, establishing the Merkle-DAG chain.",
+        description="A Content Identifier (CID) acting as a unique Lineage Watermark for this event. Cryptographic provenance is established via Sigstore.",
     )
     timestamp: float = Field(
         ge=0.0,

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -13823,7 +13823,6 @@ class EpistemicLedgerState(CoreasonBaseState):
         )
         return self
 
-
     @model_validator(mode="after")
     def enforce_defeasible_quarantine(self) -> Self:
         quarantined_cids: set[str] = set()

--- a/tests/algebra/test_properties.py
+++ b/tests/algebra/test_properties.py
@@ -42,7 +42,6 @@ from coreason_manifest.utils.algebra import (
         st.builds(
             TokenBurnReceipt,
             event_cid=st.from_regex(r"^[a-zA-Z0-9_.:-]+$", fullmatch=True),
-            prior_event_hash=st.from_regex(r"^[a-f0-9]{64}$", fullmatch=True),
             timestamp=st.floats(min_value=0.0, max_value=253402300799.0),
             burn_magnitude=st.integers(min_value=0, max_value=10000),
             tool_invocation_cid=st.from_regex(r"^[a-zA-Z0-9_.:-]+$", fullmatch=True),


### PR DESCRIPTION
…fy_merkle_chain validator

BREAKING CHANGE: All Event classes no longer carry prior_event_hash field. The verify_merkle_chain validator on EpistemicLedgerState is removed. Cryptographic provenance is now delegated to Sigstore (Cosign + Rekor).

- Remove 39 prior_event_hash field declarations across 39 Event classes
- Remove verify_merkle_chain @model_validator from EpistemicLedgerState
- Update event_cid descriptions to reference Sigstore instead of Merkle-DAG
- Update EpistemicLedgerState docstring for Sigstore alignment
- Update test_properties.py to remove prior_event_hash from hypothesis strategies