### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS vulnerability via integer bit-shifts in AST parser

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -6385,6 +6385,10 @@ class EpistemicConstraintPolicy(CoreasonBaseState):
                     )  # pragma: no cover
                 if isinstance(node, ast.Pow):
                     raise ValueError("Kinetic execution bleed detected: Forbidden AST node Pow")  # pragma: no cover
+                if isinstance(node, (ast.LShift, ast.RShift)):
+                    raise ValueError(
+                        f"Kinetic execution bleed detected: Forbidden AST node {type(node).__name__}"
+                    )  # pragma: no cover
                 if isinstance(node, ast.Attribute) and node.attr.startswith("__"):
                     raise ValueError(
                         f"Kinetic execution bleed detected: Forbidden attribute {node.attr}"

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -390,6 +390,8 @@ def verify_ast_safety(payload: str) -> bool:
             raise ValueError(f"Kinetic execution bleed detected. Forbidden AST node: {type(node).__name__}")
         if isinstance(node, ast.Pow):
             raise ValueError("Kinetic execution bleed detected. Forbidden AST node: Pow")
+        if isinstance(node, (ast.LShift, ast.RShift)):
+            raise ValueError(f"Kinetic execution bleed detected. Forbidden AST node: {type(node).__name__}")
 
     return True
 

--- a/tests/algebra/test_core_algebra.py
+++ b/tests/algebra/test_core_algebra.py
@@ -547,6 +547,10 @@ def test_verify_ast_safety() -> None:
         verify_ast_safety("__import__('os')")
     with pytest.raises(ValueError, match="Forbidden AST node: Pow"):
         verify_ast_safety("2 ** 100")
+    with pytest.raises(ValueError, match="Forbidden AST node: LShift"):
+        verify_ast_safety("1 << 100000")
+    with pytest.raises(ValueError, match="Forbidden AST node: RShift"):
+        verify_ast_safety("1 >> 100000")
     with pytest.raises(ValueError, match="not valid syntax"):
         verify_ast_safety("invalid syntax +")
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The safe AST evaluation functions (`verify_ast_safety` and `validate_ast_safety`) lacked restrictions on the Bitwise Left Shift (`ast.LShift`) and Right Shift (`ast.RShift`) operators. An attacker could exploit this by supplying a short payload like `1 << 100000000` which executes synchronously, leading to CPU stalls and potentially massive memory consumption (Denial of Service).
🎯 **Impact**: The application could crash or freeze due to memory exhaustion and CPU lock-ups when parsing these payloads. 
🔧 **Fix**: Explicitly added `ast.LShift` and `ast.RShift` to the forbidden blocklist in both AST validation methods within `coreason_manifest`.
✅ **Verification**: Run `uv run pytest tests/algebra/test_core_algebra.py` and observe that `test_verify_ast_safety` successfully handles and rejects the newly added test cases containing large shifts.

---
*PR created automatically by Jules for task [799669173340244902](https://jules.google.com/task/799669173340244902) started by @gowthamrao*