### PR TITLE
🛡️ Sentinel: [HIGH] Fix regex newline bypass in hash validation

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -3247,7 +3247,7 @@ class EphemeralNamespacePartitionState(CoreasonBaseState):
     @model_validator(mode="after")
     def validate_cryptographic_hashes(self) -> Self:
         for h in self.authorized_bytecode_hashes:
-            if not re.match("^[a-f0-9]{64}$", h):
+            if not re.fullmatch(r"^[a-f0-9]{64}$", h):
                 raise ValueError(f"Invalid SHA-256 hash in whitelist: {h}")
         return self
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: `re.match` combined with `$` allows for a trailing newline to pass validation, enabling an attacker to submit hashes that appear valid but are not exactly 64 characters long (e.g., length becomes 65).
🎯 Impact: Attackers could bypass cryptographic validations by appending a newline character, leading to potential spoofing or unhandled string sizes downstream in `EphemeralNamespacePartitionState`.
🔧 Fix: Replaced `re.match` with `re.fullmatch(r"...", string)` to strictly enforce the entire string matches the 64-character hash pattern with no trailing newlines.
✅ Verification: Tested locally by passing a 64-char hash with `\n` to the patched validator, verifying it correctly rejects the input. Verified full test suite and type safety.

---
*PR created automatically by Jules for task [9746762609565979990](https://jules.google.com/task/9746762609565979990) started by @gowthamrao*