### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF vulnerability in ontology compiler

### DIFF
--- a/scripts/universal_ontology_compiler.py
+++ b/scripts/universal_ontology_compiler.py
@@ -11,11 +11,14 @@
 
 import argparse
 import ast
+import ipaddress
 import json
 import re
+import socket
 import subprocess
 import sys
 import types
+import urllib.parse
 import urllib.request
 from pathlib import Path
 from typing import Annotated, Any, ForwardRef, TypeAliasType, Union, cast, get_args, get_origin, get_type_hints
@@ -590,6 +593,22 @@ def scan_epistemic_quarantine(source: str) -> None:
 
     try:
         if source.startswith(("http://", "https://")):
+            parsed_url = urllib.parse.urlparse(source)
+            if not parsed_url.hostname:
+                raise ValueError(f"Invalid URL: {source}")
+            try:
+                addr_info = socket.getaddrinfo(parsed_url.hostname, None)
+            except socket.gaierror as e:
+                raise ValueError(f"Could not resolve hostname: {parsed_url.hostname}") from e
+
+            for info in addr_info:
+                ip = info[4][0]
+                ip_obj = ipaddress.ip_address(ip)
+                if ip_obj.is_private or ip_obj.is_loopback or ip_obj.is_link_local:
+                    raise ValueError(
+                        f"SSRF Protection: Resolution of {parsed_url.hostname} points to a restricted IP: {ip}"
+                    )
+
             with urllib.request.urlopen(source, timeout=10) as response:  # noqa: S310 # nosec B310
                 schema_dict = json.loads(response.read().decode("utf-8"))
         else:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF). The script passed unverified, user-supplied URLs to `urllib.request.urlopen()`.
🎯 Impact: An attacker could pass a malicious URL like `http://localhost:8080/` or a domain that resolves to an internal network IP (DNS Rebinding to 169.254.169.254, etc) to scan local ports, abuse unauthenticated internal APIs, or exfiltrate metadata.
🔧 Fix: Used `urllib.parse` to extract the hostname, and `socket.getaddrinfo` to resolve *all* associated IP addresses for both IPv4 and IPv6. Checked each returned IP against `ipaddress.ip_address` to reject `is_private`, `is_loopback`, and `is_link_local` addresses.
✅ Verification: Tested the script by running `uv run python scripts/universal_ontology_compiler.py scan_epistemic_quarantine http://localhost:8080`. The script correctly prints `Error loading schema from http://localhost:8080: SSRF Protection: Resolution of localhost points to a restricted IP: ::1` and safely aborts. Test suite, format, and lint steps all pass.

---
*PR created automatically by Jules for task [9278988767895943176](https://jules.google.com/task/9278988767895943176) started by @gowthamrao*