### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF Quarantine Law bypass

### DIFF
--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -6054,6 +6054,13 @@ class HTTPTransportProfile(CoreasonBaseState):
 
     topology_class: Literal["http"] = Field(default="http", description="Type of transport.")
     uri: HttpUrl = Field(..., description="The HTTP URL endpoint for the stateless connection.")
+
+    @field_validator("uri", mode="after")
+    @classmethod
+    def _enforce_ssrf(cls, v: Any) -> Any:
+        from coreason_manifest.utils.algebra import _validate_ssrf_safety
+        return _validate_ssrf_safety(v)
+
     headers: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[str, StringConstraints(max_length=2000)]
     ] = Field(default_factory=dict, description="HTTP headers, strictly bounded for zero-trust credentials.")
@@ -6753,6 +6760,13 @@ class SPARQLQueryIntent(CoreasonBaseState):
 
     query_string: str
     target_endpoint: HttpUrl
+
+    @field_validator("target_endpoint", mode="after")
+    @classmethod
+    def _enforce_ssrf(cls, v: Any) -> Any:
+        from coreason_manifest.utils.algebra import _validate_ssrf_safety
+        return _validate_ssrf_safety(v)
+
     topology_class: Literal["sparql_query"] = "sparql_query"
 
 
@@ -9167,6 +9181,13 @@ class SSETransportProfile(CoreasonBaseState):
 
     topology_class: Literal["sse"] = Field(default="sse", description="Type of transport.")
     uri: HttpUrl = Field(..., description="The HTTP URL endpoint for the SSE connection.")
+
+    @field_validator("uri", mode="after")
+    @classmethod
+    def _enforce_ssrf(cls, v: Any) -> Any:
+        from coreason_manifest.utils.algebra import _validate_ssrf_safety
+        return _validate_ssrf_safety(v)
+
     headers: dict[
         Annotated[str, StringConstraints(max_length=255)], Annotated[str, StringConstraints(max_length=2000)]
     ] = Field(default_factory=dict, description="HTTP headers, e.g., for authentication.")
@@ -13878,6 +13899,13 @@ class EvidentiaryCitationState(CoreasonBaseState):
         description="Cryptographic anchor for the specific piece of evidence."
     )
     source_url: HttpUrl = Field(description="The canonical origin of the evidence.")
+
+    @field_validator("source_url", mode="after")
+    @classmethod
+    def _enforce_ssrf(cls, v: Any) -> Any:
+        from coreason_manifest.utils.algebra import _validate_ssrf_safety
+        return _validate_ssrf_safety(v)
+
     extracted_snippet: Annotated[str, StringConstraints(max_length=10000)] = Field(
         description="The exact text evaluated by the NLI model."
     )

--- a/src/coreason_manifest/spec/ontology.py
+++ b/src/coreason_manifest/spec/ontology.py
@@ -6059,6 +6059,7 @@ class HTTPTransportProfile(CoreasonBaseState):
     @classmethod
     def _enforce_ssrf(cls, v: Any) -> Any:
         from coreason_manifest.utils.algebra import _validate_ssrf_safety
+
         return _validate_ssrf_safety(v)
 
     headers: dict[
@@ -6765,6 +6766,7 @@ class SPARQLQueryIntent(CoreasonBaseState):
     @classmethod
     def _enforce_ssrf(cls, v: Any) -> Any:
         from coreason_manifest.utils.algebra import _validate_ssrf_safety
+
         return _validate_ssrf_safety(v)
 
     topology_class: Literal["sparql_query"] = "sparql_query"
@@ -9186,6 +9188,7 @@ class SSETransportProfile(CoreasonBaseState):
     @classmethod
     def _enforce_ssrf(cls, v: Any) -> Any:
         from coreason_manifest.utils.algebra import _validate_ssrf_safety
+
         return _validate_ssrf_safety(v)
 
     headers: dict[
@@ -13904,6 +13907,7 @@ class EvidentiaryCitationState(CoreasonBaseState):
     @classmethod
     def _enforce_ssrf(cls, v: Any) -> Any:
         from coreason_manifest.utils.algebra import _validate_ssrf_safety
+
         return _validate_ssrf_safety(v)
 
     extracted_snippet: Annotated[str, StringConstraints(max_length=10000)] = Field(

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -449,7 +449,9 @@ def _validate_ssrf_safety(url: Any) -> Any:
 
         # Hardcode block for localhost and local domains
         if hostname.lower() in ["localhost", "localhost.localdomain"] or hostname.lower().endswith(".localhost"):
-            raise ValueError(f"SSRF Security Violation: The target hostname '{hostname}' resolves to the local loopback network.")
+            raise ValueError(
+                f"SSRF Security Violation: The target hostname '{hostname}' resolves to the local loopback network."
+            )
 
         # Remove IPv6 brackets if present
         if hostname.startswith("[") and hostname.endswith("]"):

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -8,6 +8,7 @@
 #
 # Source Code: <https://github.com/CoReason-AI/coreason-manifest>
 
+
 """AGENT INSTRUCTION: This module contains pure data transformations of the Hollow Data Plane."""
 
 # Copyright (c) 2026 CoReason, Inc
@@ -24,8 +25,10 @@ import ast
 import base64
 import copy
 import hashlib
+import ipaddress
 import math
 import typing
+import urllib.parse
 from collections.abc import Sequence
 from typing import Any, Literal, cast
 
@@ -429,3 +432,52 @@ def transmute_to_pycrdt_doc(manifest: ontology.TemporalGraphCRDTManifest) -> Any
     map_node["terminate_set"] = pycrdt.Array([term.target_edge_cid for term in manifest.terminate_set])
 
     return doc
+
+
+def _validate_ssrf_safety(url: Any) -> Any:
+    """
+    Mechanistically evaluates an HttpUrl or AnyUrl to prevent Server-Side Request Forgery (SSRF).
+    Mathematically blocks local, loopback, private, and bogon IP space without invoking dynamic DNS resolution.
+    """
+    try:
+        url_str = str(url)
+        parsed = urllib.parse.urlparse(url_str)
+        hostname = parsed.hostname
+
+        if not hostname:
+            return url
+
+        # Hardcode block for localhost and local domains
+        if hostname.lower() in ["localhost", "localhost.localdomain"] or hostname.lower().endswith(".localhost"):
+            raise ValueError(f"SSRF Security Violation: The target hostname '{hostname}' resolves to the local loopback network.")
+
+        # Remove IPv6 brackets if present
+        if hostname.startswith("[") and hostname.endswith("]"):
+            hostname = hostname[1:-1]
+
+        try:
+            ip = ipaddress.ip_address(hostname)
+        except ValueError:
+            # Not an IP address, so no IP-based check is possible without DNS resolution,
+            # which is forbidden by the Air-Gap Mandate.
+            return url
+
+        if (
+            not ip.is_global
+            or ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_multicast
+            or ip.is_unspecified
+            or ip.is_reserved
+        ):
+            raise ValueError(
+                f"SSRF Security Violation: The target IP address '{hostname}' is not a valid global routing address."
+            )
+
+    except Exception as e:
+        if isinstance(e, ValueError) and "SSRF" in str(e):
+            raise
+        raise ValueError(f"Invalid URL for SSRF validation: {e}") from e
+
+    return url

--- a/tests/utils/test_algebra.py
+++ b/tests/utils/test_algebra.py
@@ -1,0 +1,23 @@
+import pytest
+from pydantic import AnyUrl
+
+from coreason_manifest.utils.algebra import _validate_ssrf_safety
+
+
+def test_validate_ssrf_safety() -> None:
+    # Valid global URLs
+    assert _validate_ssrf_safety(AnyUrl("https://example.com"))
+    assert _validate_ssrf_safety(AnyUrl("http://8.8.8.8"))
+
+    # Invalid private/local URLs
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://127.0.0.1/api"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://169.254.169.254/latest/meta-data/"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://10.0.0.1/"))
+
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://localhost/api"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://localhost.localdomain/api"))


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: Server-Side Request Forgery (SSRF) bypass due to missing enforcement of "The SSRF Quarantine Law" required by `AGENTS.md`. Previously, fields acting as egress bounds for zero-trust components were not validating if targets pointed to local network architectures.
🎯 **Impact**: Allowed the swarm to perform lateral movement to local IP addresses and `localhost`, risking internal data exposure or recursive loops.
🔧 **Fix**: Implemented `_validate_ssrf_safety` in `algebra.py` to block private/local/bogon IPs and hardcoded `localhost` bypassing. Added `@field_validator(..., mode="after")` to `SPARQLQueryIntent.target_endpoint`, `HTTPTransportProfile.uri`, `SSETransportProfile.uri`, and `EvidentiaryCitationState.source_url`.
✅ **Verification**: Run `uv run pytest` to ensure `test_validate_ssrf_safety` passes and all `HttpUrl` constraints block private IPs.

---
*PR created automatically by Jules for task [13263105034150538299](https://jules.google.com/task/13263105034150538299) started by @gowthamrao*