### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF validation bypass

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -465,7 +465,7 @@ def _validate_ssrf_safety(url: Any) -> Any:
                 # Catch non-standard IP formats (octal, hex, integer, etc) that bypass ipaddress but not the OS
                 packed = socket.inet_aton(hostname)
                 ip = ipaddress.IPv4Address(packed)
-            except OSError, TypeError:
+            except (OSError, TypeError):
                 # Not an IP address, so no IP-based check is possible without DNS resolution,
                 # which is forbidden by the Air-Gap Mandate.
                 return url

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -27,6 +27,7 @@ import copy
 import hashlib
 import ipaddress
 import math
+import socket
 import typing
 import urllib.parse
 from collections.abc import Sequence
@@ -460,9 +461,14 @@ def _validate_ssrf_safety(url: Any) -> Any:
         try:
             ip = ipaddress.ip_address(hostname)
         except ValueError:
-            # Not an IP address, so no IP-based check is possible without DNS resolution,
-            # which is forbidden by the Air-Gap Mandate.
-            return url
+            try:
+                # Catch non-standard IP formats (octal, hex, integer, etc) that bypass ipaddress but not the OS
+                packed = socket.inet_aton(hostname)
+                ip = ipaddress.IPv4Address(packed)
+            except (OSError, TypeError):
+                # Not an IP address, so no IP-based check is possible without DNS resolution,
+                # which is forbidden by the Air-Gap Mandate.
+                return url
 
         if (
             not ip.is_global

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -465,7 +465,7 @@ def _validate_ssrf_safety(url: Any) -> Any:
                 # Catch non-standard IP formats (octal, hex, integer, etc) that bypass ipaddress but not the OS
                 packed = socket.inet_aton(hostname)
                 ip = ipaddress.IPv4Address(packed)
-            except (OSError, TypeError):
+            except OSError, TypeError:
                 # Not an IP address, so no IP-based check is possible without DNS resolution,
                 # which is forbidden by the Air-Gap Mandate.
                 return url

--- a/tests/utils/test_algebra.py
+++ b/tests/utils/test_algebra.py
@@ -31,3 +31,13 @@ def test_validate_ssrf_safety() -> None:
         _validate_ssrf_safety(AnyUrl("http://localhost/api"))
     with pytest.raises(ValueError, match="SSRF"):
         _validate_ssrf_safety(AnyUrl("http://localhost.localdomain/api"))
+
+    # Bypass formats for 127.0.0.1
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://127.1/api"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://2130706433/api"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://0x7f000001/api"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://0177.0.0.1/api"))


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Server-Side Request Forgery (SSRF) blocklist bypass using non-standard IP formats (integer, hex, octal).
🎯 Impact: Attackers could provide obfuscated internal IPs (like `http://0x7f000001` or `http://2130706433`) which underlying clients resolve to `127.0.0.1`, bypassing the `ipaddress` check blocklist and successfully targeting internal services.
🔧 Fix: Added a fallback check using `socket.inet_aton` combined with `ipaddress.IPv4Address` to correctly identify and block non-standard IP formats identical to OS resolution. Caught `TypeError` to maintain safe behavior with empty hostnames.
✅ Verification: Covered by unit tests in `tests/utils/test_algebra.py` preventing bypass for loopback and other restricted addresses.

---
*PR created automatically by Jules for task [1794076237797146428](https://jules.google.com/task/1794076237797146428) started by @gowthamrao*