### PR TITLE
⚡ Bolt: Optimize compute_merkle_directory_cid fast-path

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -392,7 +392,8 @@ def compute_merkle_directory_cid(file_contents: dict[str, bytes]) -> str:
     file_hashes: list[str] = []
     for filename in sorted(file_contents.keys()):
         content = file_contents[filename]
-        if _is_text_bytes(content):
+        # ⚡ Bolt Optimization: Fast-path to avoid expensive UTF-8 decoding for files that don't contain \r\n
+        if b"\r\n" in content and _is_text_bytes(content):
             content = content.replace(b"\r\n", b"\n")
         file_hash = hashlib.sha256(content).hexdigest()
         file_hashes.append(f"{filename}:{file_hash}")


### PR DESCRIPTION
💡 What: Added a fast-path check `b"\r\n" in content` to `compute_merkle_directory_cid` before executing the expensive UTF-8 validation.
🎯 Why: Without this check, large binary payloads or standard UNIX text files were being fully decoded into UTF-8 just to determine if carriage return replacement was necessary, which was an O(N) performance bottleneck.
📊 Impact: Reduces processing time for UNIX text and binary payloads during Merkle directory hashing.
🔬 Measurement: Verified via benchmarking (`uv run python bench.py`), retaining standard hashing equivalence tests via `uv run pytest`.

---
*PR created automatically by Jules for task [16044854301542993077](https://jules.google.com/task/16044854301542993077) started by @gowthamrao*