### PR TITLE
🛡️ Sentinel: [HIGH] Fix exception syntax in SSRF validation

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -531,7 +531,7 @@ def _validate_ssrf_safety(url: Any) -> Any:
                 # Catch non-standard IP formats (octal, hex, integer, etc) that bypass ipaddress but not the OS
                 packed = socket.inet_aton(hostname)
                 ip = ipaddress.IPv4Address(packed)
-            except OSError, TypeError:
+            except (OSError, TypeError):
                 # Not an IP address, so no IP-based check is possible without DNS resolution,
                 # which is forbidden by the Air-Gap Mandate.
                 return url


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: A Python 2 style exception handling syntax `except OSError, TypeError:` was present in the `_validate_ssrf_safety` function, which acts as a foundational security check against Server-Side Request Forgery. In Python 3, this is a SyntaxError. Furthermore, it fails to catch `TypeError` properly (binding `OSError` to `TypeError` in older python versions).
🎯 Impact: This could cause unhandled exceptions or syntax errors when specific malicious/edge case inputs are encountered, breaking the SSRF validation and bypassing the security check.
🔧 Fix: Updated the exception handling tuple to be correctly parenthesized: `except (OSError, TypeError):`.
✅ Verification: Ran the full test suite (`uv run pytest tests/`) and verified that the SSRF validation test coverage and correctness were maintained. Added a learning entry to `.jules/sentinel.md` to document the finding.

---
*PR created automatically by Jules for task [9036349341160374470](https://jules.google.com/task/9036349341160374470) started by @gowthamrao*