### PR TITLE
🛡️ Sentinel: [HIGH] Fix SyntaxError in SSRF validation

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -531,7 +531,7 @@ def _validate_ssrf_safety(url: Any) -> Any:
                 # Catch non-standard IP formats (octal, hex, integer, etc) that bypass ipaddress but not the OS
                 packed = socket.inet_aton(hostname)
                 ip = ipaddress.IPv4Address(packed)
-            except OSError, TypeError:
+            except (OSError, TypeError):
                 # Not an IP address, so no IP-based check is possible without DNS resolution,
                 # which is forbidden by the Air-Gap Mandate.
                 return url


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: The `_validate_ssrf_safety` function inside `src/coreason_manifest/utils/algebra.py` contained a Python 2 exception syntax (`except OSError, TypeError:`), which is a `SyntaxError` in Python 3. This would prevent the application from importing the module or executing the SSRF protection when those exceptions hit.
* 🎯 Impact: If not fixed, the `SyntaxError` would crash the application or bypass the `_validate_ssrf_safety` check, exposing the server to SSRF (Server-Side Request Forgery) attacks. 
* 🔧 Fix: Updated the syntax to properly use a parenthesized tuple: `except (OSError, TypeError):`.
* ✅ Verification: Verified the file compiles successfully in Python 3. `pytest` passes with high coverage. Recorded in Sentinel journal.

---
*PR created automatically by Jules for task [12715481969088082207](https://jules.google.com/task/12715481969088082207) started by @gowthamrao*