### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix syntax error in SSRF validation logic

### DIFF
--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -531,7 +531,7 @@ def _validate_ssrf_safety(url: Any) -> Any:
                 # Catch non-standard IP formats (octal, hex, integer, etc) that bypass ipaddress but not the OS
                 packed = socket.inet_aton(hostname)
                 ip = ipaddress.IPv4Address(packed)
-            except OSError, TypeError:
+            except (OSError, TypeError):
                 # Not an IP address, so no IP-based check is possible without DNS resolution,
                 # which is forbidden by the Air-Gap Mandate.
                 return url


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: A Python SyntaxError (`except OSError, TypeError:`) existed in `_validate_ssrf_safety` inside `src/coreason_manifest/utils/algebra.py`. This syntax is invalid in Python 3 and prevented the code from being interpreted correctly if executed outside of certain tolerant environments, completely breaking the Server-Side Request Forgery (SSRF) validation layer.
🎯 **Impact**: The application could fail to initialize or the SSRF validation could be bypassed/skipped if the file failed to parse.
🔧 **Fix**: Updated the legacy Python 2 exception syntax to standard Python 3 syntax: `except (OSError, TypeError):`.
✅ **Verification**: Verified using `python -m py_compile src/coreason_manifest/utils/algebra.py` and by running the full test suite (`pytest tests/`), ensuring no syntax errors remain and tests successfully pass. Documented the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [2532595755514662852](https://jules.google.com/task/2532595755514662852) started by @gowthamrao*