### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix SSRF obfuscated IP bypass

### DIFF
--- a/scripts/generate_cross_language_bindings.py
+++ b/scripts/generate_cross_language_bindings.py
@@ -21,7 +21,6 @@ The CI drift guillotine (`git diff --exit-code bindings/`) enforces that committ
 bindings always match the current schema.
 """
 
-import argparse
 import json
 import os
 import re
@@ -276,20 +275,6 @@ def _update_lockfiles(project_root: Path) -> None:
 
 def main() -> None:
     raise NotImplementedError("This script has been disabled and retained for future use only.")
-
-    # Ensure we are working from the project root
-    # project_root = Path(__file__).resolve().parent.parent
-    # os.chdir(project_root)
-
-    # parser = argparse.ArgumentParser(description="Cross-language binding generator.")
-    # parser.add_argument(
-    #     "--version",
-    #     help="Override the package version to synchronize across Cargo.toml and package.json.",
-    # )
-    # args = parser.parse_args()
-
-    _sync_versions(project_root, override_version=args.version)
-    _update_lockfiles(project_root)
 
     schema_file = "coreason_ontology.schema.json"
     ts_out = "bindings/typescript/src/ontology.ts"

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -434,6 +434,60 @@ def transmute_to_pycrdt_doc(manifest: ontology.TemporalGraphCRDTManifest) -> Any
     return doc
 
 
+def _parse_relaxed_ipv4(hostname: str) -> ipaddress.IPv4Address | None:
+    parts = hostname.split(".")
+    if len(parts) > 4:
+        return None
+
+    parsed_parts = []
+    for part in parts:
+        if not part:
+            return None
+        # Handle hex
+        if part.lower().startswith("0x"):
+            try:
+                val = int(part, 16)
+            except ValueError:
+                return None
+        # Handle octal
+        elif part.startswith("0") and len(part) > 1:
+            try:
+                val = int(part, 8)
+            except ValueError:
+                return None
+        # Handle decimal
+        else:
+            try:
+                val = int(part, 10)
+            except ValueError:
+                return None
+        parsed_parts.append(val)
+
+    if len(parsed_parts) == 4:
+        if any(p > 255 for p in parsed_parts):
+            return None
+        val = (parsed_parts[0] << 24) | (parsed_parts[1] << 16) | (parsed_parts[2] << 8) | parsed_parts[3]
+    elif len(parsed_parts) == 3:
+        if parsed_parts[0] > 255 or parsed_parts[1] > 255 or parsed_parts[2] > 65535:
+            return None
+        val = (parsed_parts[0] << 24) | (parsed_parts[1] << 16) | parsed_parts[2]
+    elif len(parsed_parts) == 2:
+        if parsed_parts[0] > 255 or parsed_parts[1] > 16777215:
+            return None
+        val = (parsed_parts[0] << 24) | parsed_parts[1]
+    elif len(parsed_parts) == 1:
+        if parsed_parts[0] > 4294967295:
+            return None
+        val = parsed_parts[0]
+    else:
+        return None
+
+    try:
+        return ipaddress.IPv4Address(val)
+    except ValueError:
+        return None
+
+
 def _validate_ssrf_safety(url: Any) -> Any:
     """
     Mechanistically evaluates an HttpUrl or AnyUrl to prevent Server-Side Request Forgery (SSRF).
@@ -457,9 +511,14 @@ def _validate_ssrf_safety(url: Any) -> Any:
         if hostname.startswith("[") and hostname.endswith("]"):
             hostname = hostname[1:-1]
 
+        ip = None
         try:
             ip = ipaddress.ip_address(hostname)
         except ValueError:
+            # Try relaxed IPv4 parsing for SSRF obfuscation
+            ip = _parse_relaxed_ipv4(hostname)
+
+        if not ip:
             # Not an IP address, so no IP-based check is possible without DNS resolution,
             # which is forbidden by the Air-Gap Mandate.
             return url


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** SSRF Mitigation Bypass via Obfuscated IPs. The application relied entirely on `ipaddress.ip_address` for IP validation, which strictly rejects standard relaxed representations like `0x7f000001`, `0177.0.0.1`, or `2130706433`.
🎯 **Impact:** Attackers could bypass SSRF checks and access internal network interfaces, loopback (127.0.0.1), or private AWS metadata URLs by obfuscating the IPv4 address.
🔧 **Fix:** Introduced custom logic to parse POSIX `inet_aton` equivalent relaxed forms of IPv4 back into `ipaddress.IPv4Address` boundaries so the existing security validations effectively trigger.
✅ **Verification:** Obfuscated formats are correctly caught and yield `ValueError("SSRF Security Violation...")`. Covered by local `pytest` pipeline without touching `socket` APIs.

---
*PR created automatically by Jules for task [4814637487715827856](https://jules.google.com/task/4814637487715827856) started by @gowthamrao*