### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via IP encoding

### DIFF
--- a/scripts/generate_cross_language_bindings.py
+++ b/scripts/generate_cross_language_bindings.py
@@ -275,6 +275,5 @@ def main() -> None:
     raise NotImplementedError("This script has been disabled and retained for future use only.")
 
 
-
 if __name__ == "__main__":
     main()

--- a/scripts/generate_cross_language_bindings.py
+++ b/scripts/generate_cross_language_bindings.py
@@ -21,14 +21,11 @@ The CI drift guillotine (`git diff --exit-code bindings/`) enforces that committ
 bindings always match the current schema.
 """
 
-import argparse
 import json
 import os
 import re
 import shutil
 import subprocess
-import sys
-import tempfile
 import tomllib
 import typing
 from pathlib import Path
@@ -277,64 +274,6 @@ def _update_lockfiles(project_root: Path) -> None:
 def main() -> None:
     raise NotImplementedError("This script has been disabled and retained for future use only.")
 
-    # Ensure we are working from the project root
-    # project_root = Path(__file__).resolve().parent.parent
-    # os.chdir(project_root)
-
-    # parser = argparse.ArgumentParser(description="Cross-language binding generator.")
-    # parser.add_argument(
-    #     "--version",
-    #     help="Override the package version to synchronize across Cargo.toml and package.json.",
-    # )
-    # args = parser.parse_args()
-
-    _sync_versions(project_root, override_version=args.version)
-    _update_lockfiles(project_root)
-
-    schema_file = "coreason_ontology.schema.json"
-    ts_out = "bindings/typescript/src/ontology.ts"
-    rust_out = "bindings/rust/src/ontology.rs"
-
-    print("Projecting fresh ontology manifold...")
-    from universal_ontology_compiler import project_ontology_manifold
-
-    project_ontology_manifold()
-
-    if not os.path.exists(schema_file):
-        print(f"Error: Schema file {schema_file} failed to generate.")
-        sys.exit(1)
-
-    # Build the rooted wrapper schema (the raw schema is $defs-only)
-    wrapper_path = os.path.join(tempfile.gettempdir(), "coreason_ontology_rooted.schema.json")
-    print("Building rooted wrapper schema...")
-    _build_rooted_schema(schema_file, wrapper_path)
-
-    # Configure npm/npx environment to suppress all warnings and prompts
-    node_env = os.environ.copy()
-    node_env["npm_config_loglevel"] = "error"
-    node_env["npm_config_fund"] = "false"
-    node_env["npm_config_audit"] = "false"
-    node_env["npm_config_update_notifier"] = "false"
-    node_env["npm_config_yes"] = "true"
-    node_options = node_env.get("NODE_OPTIONS", "")
-    node_env["NODE_OPTIONS"] = f"{node_options} --no-deprecation".strip()
-
-    npx_cmd = "npx.cmd" if os.name == "nt" else "npx"
-
-    # TypeScript generation
-    if shutil.which(npx_cmd):
-        _generate_typescript(wrapper_path, ts_out, node_env)
-    else:
-        print(f"Warning: {npx_cmd} not found in PATH. Skipping TypeScript bindings generation.")
-
-    # Rust generation
-    _generate_rust(wrapper_path, rust_out)
-
-    # Cleanup
-    if os.path.exists(wrapper_path):
-        os.unlink(wrapper_path)
-
-    print("Cross-language bindings generated successfully.")
 
 
 if __name__ == "__main__":

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -28,6 +28,7 @@ import hashlib
 import ipaddress
 import math
 import typing
+import socket
 import urllib.parse
 from collections.abc import Sequence
 from typing import Any, Literal, cast
@@ -458,7 +459,11 @@ def _validate_ssrf_safety(url: Any) -> Any:
             hostname = hostname[1:-1]
 
         try:
-            ip = ipaddress.ip_address(hostname)
+            try:
+                standardized_ip = socket.inet_ntoa(socket.inet_aton(hostname))
+                ip = ipaddress.ip_address(standardized_ip)
+            except (OSError, ValueError):
+                ip = ipaddress.ip_address(hostname)
         except ValueError:
             # Not an IP address, so no IP-based check is possible without DNS resolution,
             # which is forbidden by the Air-Gap Mandate.

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -462,7 +462,7 @@ def _validate_ssrf_safety(url: Any) -> Any:
             try:
                 standardized_ip = socket.inet_ntoa(socket.inet_aton(hostname))
                 ip = ipaddress.ip_address(standardized_ip)
-            except (OSError, ValueError):
+            except OSError, ValueError:
                 ip = ipaddress.ip_address(hostname)
         except ValueError:
             # Not an IP address, so no IP-based check is possible without DNS resolution,

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -27,8 +27,8 @@ import copy
 import hashlib
 import ipaddress
 import math
-import typing
 import socket
+import typing
 import urllib.parse
 from collections.abc import Sequence
 from typing import Any, Literal, cast

--- a/tests/utils/test_algebra.py
+++ b/tests/utils/test_algebra.py
@@ -31,3 +31,15 @@ def test_validate_ssrf_safety() -> None:
         _validate_ssrf_safety(AnyUrl("http://localhost/api"))
     with pytest.raises(ValueError, match="SSRF"):
         _validate_ssrf_safety(AnyUrl("http://localhost.localdomain/api"))
+
+    # Octal, Hex, and integer bypass attempts
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://0177.0.0.1/api"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://0x7f.0.0.1/api"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://127.1/api"))
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://012.0.0.1/api")) # 10.0.0.1
+    with pytest.raises(ValueError, match="SSRF"):
+        _validate_ssrf_safety(AnyUrl("http://0xa.0.0.1/api")) # 10.0.0.1

--- a/tests/utils/test_algebra.py
+++ b/tests/utils/test_algebra.py
@@ -40,6 +40,6 @@ def test_validate_ssrf_safety() -> None:
     with pytest.raises(ValueError, match="SSRF"):
         _validate_ssrf_safety(AnyUrl("http://127.1/api"))
     with pytest.raises(ValueError, match="SSRF"):
-        _validate_ssrf_safety(AnyUrl("http://012.0.0.1/api")) # 10.0.0.1
+        _validate_ssrf_safety(AnyUrl("http://012.0.0.1/api"))  # 10.0.0.1
     with pytest.raises(ValueError, match="SSRF"):
-        _validate_ssrf_safety(AnyUrl("http://0xa.0.0.1/api")) # 10.0.0.1
+        _validate_ssrf_safety(AnyUrl("http://0xa.0.0.1/api"))  # 10.0.0.1


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The URL validation logic used for SSRF protection relied solely on `ipaddress.ip_address()`, which fails to parse octal (e.g., `0177.0.0.1`), hexadecimal (`0x7f.0.0.1`), and integer (`127.1`) representations of IPv4 addresses. This allowed malicious payloads to bypass the localhost check and reach internal services.
🎯 Impact: Attackers could bypass SSRF restrictions to interact with localhost/internal systems.
🔧 Fix: Normalize IPv4 addresses using `socket.inet_ntoa(socket.inet_aton(hostname))` before validation to ensure standard dotted-quad representation and prevent bypasses.
✅ Verification: Added unit tests validating SSRF restrictions for octal, hex, and int encodings in `tests/utils/test_algebra.py`. Run `uv run pytest tests/utils/test_algebra.py` to confirm.

---
*PR created automatically by Jules for task [2165479633753599725](https://jules.google.com/task/2165479633753599725) started by @gowthamrao*