### PR TITLE
🛡️ Sentinel: [HIGH] Fix SSRF bypass via IP obfuscation

### DIFF
--- a/scripts/generate_cross_language_bindings.py
+++ b/scripts/generate_cross_language_bindings.py
@@ -21,7 +21,6 @@ The CI drift guillotine (`git diff --exit-code bindings/`) enforces that committ
 bindings always match the current schema.
 """
 
-import argparse
 import json
 import os
 import re
@@ -278,15 +277,16 @@ def main() -> None:
     raise NotImplementedError("This script has been disabled and retained for future use only.")
 
     # Ensure we are working from the project root
-    # project_root = Path(__file__).resolve().parent.parent
-    # os.chdir(project_root)
+    project_root = Path(__file__).resolve().parent.parent
+    os.chdir(project_root)
 
-    # parser = argparse.ArgumentParser(description="Cross-language binding generator.")
-    # parser.add_argument(
-    #     "--version",
-    #     help="Override the package version to synchronize across Cargo.toml and package.json.",
-    # )
-    # args = parser.parse_args()
+    import argparse
+    parser = argparse.ArgumentParser(description="Cross-language binding generator.")
+    parser.add_argument(
+        "--version",
+        help="Override the package version to synchronize across Cargo.toml and package.json.",
+    )
+    args = parser.parse_args()
 
     _sync_versions(project_root, override_version=args.version)
     _update_lockfiles(project_root)

--- a/scripts/generate_cross_language_bindings.py
+++ b/scripts/generate_cross_language_bindings.py
@@ -277,19 +277,18 @@ def main() -> None:
     raise NotImplementedError("This script has been disabled and retained for future use only.")
 
     # Ensure we are working from the project root
-    project_root = Path(__file__).resolve().parent.parent
-    os.chdir(project_root)
+    # project_root = Path(__file__).resolve().parent.parent
+    # os.chdir(project_root)
 
-    import argparse
-    parser = argparse.ArgumentParser(description="Cross-language binding generator.")
-    parser.add_argument(
-        "--version",
-        help="Override the package version to synchronize across Cargo.toml and package.json.",
-    )
-    args = parser.parse_args()
+    # parser = argparse.ArgumentParser(description="Cross-language binding generator.")
+    # parser.add_argument(
+    #     "--version",
+    #     help="Override the package version to synchronize across Cargo.toml and package.json.",
+    # )
+    # args = parser.parse_args()
 
-    _sync_versions(project_root, override_version=args.version)
-    _update_lockfiles(project_root)
+    # _sync_versions(project_root, override_version=args.version)
+    # _update_lockfiles(project_root)
 
     schema_file = "coreason_ontology.schema.json"
     ts_out = "bindings/typescript/src/ontology.ts"

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -463,18 +463,19 @@ def _validate_ssrf_safety(url: Any) -> Any:
             ip = ipaddress.ip_address(hostname)
         except ValueError:
             ip = None
-            try:
-                ip_bytes = socket.inet_aton(hostname)
-                ip = ipaddress.ip_address(socket.inet_ntoa(ip_bytes))
-            except (socket.error, ValueError):
-                pass
-
-            if not ip and hasattr(socket, "AF_INET6"):
+            if hostname:
                 try:
-                    ip_bytes = socket.inet_pton(socket.AF_INET6, hostname)
-                    ip = ipaddress.ip_address(socket.inet_ntop(socket.AF_INET6, ip_bytes))
-                except (socket.error, ValueError):
+                    ip_bytes = socket.inet_aton(hostname)
+                    ip = ipaddress.ip_address(socket.inet_ntoa(ip_bytes))
+                except (OSError, ValueError, TypeError):
                     pass
+
+                if not ip and hasattr(socket, "AF_INET6"):
+                    try:
+                        ip_bytes = socket.inet_pton(socket.AF_INET6, hostname)
+                        ip = ipaddress.ip_address(socket.inet_ntop(socket.AF_INET6, ip_bytes))
+                    except (OSError, ValueError, TypeError):
+                        pass
 
             if not ip:
                 # Not an IP address, so no IP-based check is possible without DNS resolution,

--- a/src/coreason_manifest/utils/algebra.py
+++ b/src/coreason_manifest/utils/algebra.py
@@ -439,6 +439,8 @@ def _validate_ssrf_safety(url: Any) -> Any:
     Mechanistically evaluates an HttpUrl or AnyUrl to prevent Server-Side Request Forgery (SSRF).
     Mathematically blocks local, loopback, private, and bogon IP space without invoking dynamic DNS resolution.
     """
+    import socket
+
     try:
         url_str = str(url)
         parsed = urllib.parse.urlparse(url_str)
@@ -460,9 +462,24 @@ def _validate_ssrf_safety(url: Any) -> Any:
         try:
             ip = ipaddress.ip_address(hostname)
         except ValueError:
-            # Not an IP address, so no IP-based check is possible without DNS resolution,
-            # which is forbidden by the Air-Gap Mandate.
-            return url
+            ip = None
+            try:
+                ip_bytes = socket.inet_aton(hostname)
+                ip = ipaddress.ip_address(socket.inet_ntoa(ip_bytes))
+            except (socket.error, ValueError):
+                pass
+
+            if not ip and hasattr(socket, "AF_INET6"):
+                try:
+                    ip_bytes = socket.inet_pton(socket.AF_INET6, hostname)
+                    ip = ipaddress.ip_address(socket.inet_ntop(socket.AF_INET6, ip_bytes))
+                except (socket.error, ValueError):
+                    pass
+
+            if not ip:
+                # Not an IP address, so no IP-based check is possible without DNS resolution,
+                # which is forbidden by the Air-Gap Mandate.
+                return url
 
         if (
             not ip.is_global


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `_validate_ssrf_safety` filter relied on `ipaddress.ip_address()` which only parses standard IP formats. It failed to identify obfuscated IPs (like `127.1`, `0177.0.0.1`, `0x7f.0.0.1`), allowing them to bypass the loopback/private checks.
🎯 Impact: Attackers could bypass SSRF restrictions by providing obfuscated IPs, potentially reaching internal network services.
🔧 Fix: Updated the function to attempt parsing with `socket.inet_aton` and `socket.inet_pton`, which normalize non-standard formats, correctly identifying them as IPs before checking their routability limits.
✅ Verification: Ensure tests pass and the IP extraction works via `uv run pytest`.

---
*PR created automatically by Jules for task [4511048339017620945](https://jules.google.com/task/4511048339017620945) started by @gowthamrao*